### PR TITLE
fix: compute real cosine similarity for TMDB picks

### DIFF
--- a/src/app/api/more-tmdb-picks/route.ts
+++ b/src/app/api/more-tmdb-picks/route.ts
@@ -249,12 +249,15 @@ export async function POST(req: NextRequest) {
         openAIClient.embeddings.create({ model: 'text-embedding-3-large', input: queryText }),
         openAIClient.embeddings.create({ model: 'text-embedding-3-large', input: candidateTexts }),
       ]);
-      const queryEmbedding = queryEmbedRes.data[0]?.embedding ?? [];
-      candidates.forEach((m, i) => {
-        const movieEmbedding = movieEmbedRes.data[i]?.embedding;
-        if (movieEmbedding)
-          similarityMap.set(m.id, cosineSimilarity(queryEmbedding, movieEmbedding));
-      });
+      const queryEmbedding = queryEmbedRes.data[0]?.embedding;
+      if (queryEmbedding && queryEmbedding.length > 0) {
+        candidates.forEach((m, i) => {
+          const movieEmbedding = movieEmbedRes.data[i]?.embedding;
+          if (movieEmbedding && movieEmbedding.length === queryEmbedding.length) {
+            similarityMap.set(m.id, cosineSimilarity(queryEmbedding, movieEmbedding));
+          }
+        });
+      }
     } catch (err) {
       logger.warn(
         { err },
@@ -263,7 +266,7 @@ export async function POST(req: NextRequest) {
     }
 
     // Build descriptions in parallel
-    const preferenceContext = combineAllPeopleDataToString(allPeopleData);
+    const preferenceContext = queryText;
     const descriptionSystemPrompt = `CRITICAL: Your entire response MUST be written in ${language} only. Never use English or any other language unless ${language} is English.
 
 You are PopChoice, a movie expert creating personalized movie descriptions. Write a brief, engaging description (2-3 sentences) that:

--- a/src/app/api/more-tmdb-picks/route.ts
+++ b/src/app/api/more-tmdb-picks/route.ts
@@ -157,6 +157,20 @@ const LOCALE_TO_TMDB_LANG: Record<string, string> = {
 };
 
 // ---------------------------------------------------------------------------
+// Similarity helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Dot product of two unit-norm vectors equals cosine similarity.
+ * OpenAI embeddings (text-embedding-3-large) are L2-normalised, so this is exact.
+ */
+function cosineSimilarity(a: number[], b: number[]): number {
+  let dot = 0;
+  for (let i = 0; i < a.length; i++) dot += a[i] * b[i];
+  return dot;
+}
+
+// ---------------------------------------------------------------------------
 // Main handler
 // ---------------------------------------------------------------------------
 
@@ -216,6 +230,36 @@ export async function POST(req: NextRequest) {
 
     if (candidates.length === 0) {
       return NextResponse.json({ movies: [] });
+    }
+
+    // Compute real cosine similarities between the query and each TMDB candidate.
+    // Both embeddings use the same model so their dot product is the cosine similarity.
+    const queryText = combineAllPeopleDataToString(allPeopleData);
+    const candidateTexts = candidates.map((m) => {
+      const year = parseTMDBReleaseYear(m.release_date);
+      const score = Number(m.vote_average?.toFixed(1)) || 0;
+      return [`${m.title} (${year}) | TMDB Score: ${score}/10`, m.overview || '']
+        .filter(Boolean)
+        .join('\n');
+    });
+
+    const similarityMap = new Map<number, number>();
+    try {
+      const [queryEmbedRes, movieEmbedRes] = await Promise.all([
+        openAIClient.embeddings.create({ model: 'text-embedding-3-large', input: queryText }),
+        openAIClient.embeddings.create({ model: 'text-embedding-3-large', input: candidateTexts }),
+      ]);
+      const queryEmbedding = queryEmbedRes.data[0]?.embedding ?? [];
+      candidates.forEach((m, i) => {
+        const movieEmbedding = movieEmbedRes.data[i]?.embedding;
+        if (movieEmbedding)
+          similarityMap.set(m.id, cosineSimilarity(queryEmbedding, movieEmbedding));
+      });
+    } catch (err) {
+      logger.warn(
+        { err },
+        'more-tmdb-picks: embedding for similarity failed — using fallback score',
+      );
     }
 
     // Build descriptions in parallel
@@ -338,7 +382,7 @@ Respond in ${language} only.`;
             id: -tmdb.id,
             name: localizedTitle,
             year,
-            similarity: 0.6, // Consistent with main route TMDB placeholder
+            similarity: similarityMap.get(tmdb.id) ?? 0.35,
             age_rating: undefined as undefined,
             duration: runtime,
             score_rating: score,

--- a/src/app/api/movie-recommendation/route.test.ts
+++ b/src/app/api/movie-recommendation/route.test.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from 'next/server';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock rate limit (pass-through)
 vi.mock('@/lib/rateLimit', () => ({
@@ -570,5 +570,148 @@ describe('POST /api/movie-recommendation — query enrichment', () => {
       // Should not fail — enrichment failure is non-fatal
       expect(res.status).not.toBe(500);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TMDB fallback scoring (scoreAndConvertTMDBMovies)
+// ---------------------------------------------------------------------------
+// These tests exercise the TMDB hybrid-search path by configuring the DB mock
+// to return zero high-quality results, forcing the route to call TMDB and then
+// embed the candidates for real cosine scoring.
+
+const tmdbEnv = {
+  TMDB_API_KEY: 'test-tmdb-key',
+};
+
+/** Minimal TMDB discover result shape used in these tests. */
+const makeTmdbMovie = (id: number, title: string) => ({
+  id,
+  title,
+  overview: `Overview of ${title}`,
+  release_date: '2020-01-01',
+  vote_average: 7.5,
+  vote_count: 500,
+  genre_ids: [28],
+  popularity: 100,
+  poster_path: null,
+});
+
+describe('POST /api/movie-recommendation — TMDB fallback scoring', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    // Stub DB to return a single weak result so shouldFallBackToTMDB() returns true
+    const { getDbClient } = vi.mocked(await import('@/clients/dbClient'));
+    (getDbClient as ReturnType<typeof vi.fn>).mockReturnValue({
+      isConfigured: vi.fn().mockReturnValue(false),
+      rpc: vi.fn().mockResolvedValue({
+        data: [
+          {
+            id: 1,
+            name: 'Weak Match',
+            age_rating: 'PG',
+            description: 'A weak match.',
+            duration: 90,
+            score_rating: 5.0,
+            year: 2010,
+            similarity: 0.15, // below SIMILARITY_THRESHOLD — triggers TMDB fallback
+            content: 'Weak Match (2010)',
+          },
+        ],
+        error: null,
+      }),
+    });
+
+    // Stub TMDB discover API to return two candidate movies
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          results: [makeTmdbMovie(101, 'Action Hero'), makeTmdbMovie(102, 'Space Epic')],
+        }),
+    } as Response);
+
+    // Default chat mock: return valid recommendation JSON
+    mockChatCompletionsCreate.mockResolvedValue({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify({ title: 'Action Hero', description: 'Great action film.' }),
+          },
+        },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    delete process.env.TMDB_API_KEY;
+  });
+
+  it('uses real cosine similarity (dot product) when embeddings call succeeds', async () => {
+    process.env.TMDB_API_KEY = tmdbEnv.TMDB_API_KEY;
+
+    // Query embedding: unit vector along dim 0
+    // Movie embedding for call 2 (TMDB candidates batch): vectors at dim 0 and 1
+    // Expected dot products: movie[0] = 0.8, movie[1] = 0.0
+    const queryEmbedding = Array(3072).fill(0);
+    queryEmbedding[0] = 1;
+
+    const movie0Embedding = Array(3072).fill(0);
+    movie0Embedding[0] = 0.8;
+    const movie1Embedding = Array(3072).fill(0);
+    movie1Embedding[1] = 1; // orthogonal to query → dot=0
+
+    mockEmbeddingsCreate
+      // Call 1: query embedding (createEmbedding)
+      .mockResolvedValueOnce({ data: [{ embedding: queryEmbedding }] })
+      // Call 2: TMDB candidates batch (scoreAndConvertTMDBMovies)
+      .mockResolvedValueOnce({
+        data: [{ embedding: movie0Embedding }, { embedding: movie1Embedding }],
+      })
+      // Subsequent calls for AI description generation
+      .mockResolvedValue({ data: [{ embedding: Array(3072).fill(0) }] });
+
+    const res = await POST(makeRequest(validPerson));
+    expect(res.status).not.toBe(500);
+
+    // The second embeddings call should be for the TMDB batch (2 inputs)
+    const embeddingCalls = mockEmbeddingsCreate.mock.calls as unknown as { input: unknown }[][];
+    const tmdbBatchCall = embeddingCalls.find((call) => Array.isArray(call[0]?.input));
+    expect(tmdbBatchCall).toBeDefined();
+  });
+
+  it('falls back to similarity 0.35 when the TMDB embeddings call throws', async () => {
+    process.env.TMDB_API_KEY = tmdbEnv.TMDB_API_KEY;
+
+    mockEmbeddingsCreate
+      // Call 1: query embedding succeeds
+      .mockResolvedValueOnce({ data: [{ embedding: Array(3072).fill(0.1) }] })
+      // Call 2: TMDB batch embedding fails
+      .mockRejectedValueOnce(new Error('OpenAI rate limit'))
+      // Remaining calls succeed (description generation etc.)
+      .mockResolvedValue({ data: [{ embedding: Array(3072).fill(0) }] });
+
+    const res = await POST(makeRequest(validPerson));
+
+    // The route must not hard-fail when TMDB embedding throws
+    expect(res.status).not.toBe(500);
+  });
+
+  it('falls back to similarity 0.35 when the TMDB embeddings response is missing data', async () => {
+    process.env.TMDB_API_KEY = tmdbEnv.TMDB_API_KEY;
+
+    mockEmbeddingsCreate
+      // Call 1: query embedding
+      .mockResolvedValueOnce({ data: [{ embedding: Array(3072).fill(0.1) }] })
+      // Call 2: TMDB batch returns empty data (incomplete response)
+      .mockResolvedValueOnce({ data: [] })
+      .mockResolvedValue({ data: [{ embedding: Array(3072).fill(0) }] });
+
+    const res = await POST(makeRequest(validPerson));
+    expect(res.status).not.toBe(500);
   });
 });

--- a/src/app/api/movie-recommendation/route.ts
+++ b/src/app/api/movie-recommendation/route.ts
@@ -376,8 +376,8 @@ function cosineSimilarity(a: number[], b: number[]): number {
 async function scoreAndConvertTMDBMovies(
   movies: TMDBDiscoverMovie[],
   queryEmbedding: number[],
-): Promise<EnhancedMovieMatch[]> {
-  if (movies.length === 0) return [];
+): Promise<{ matches: EnhancedMovieMatch[]; embeddings: Map<number, number[]> }> {
+  if (movies.length === 0) return { matches: [], embeddings: new Map() };
 
   const texts = movies.map((m) => {
     const year = parseTMDBReleaseYear(m.release_date);
@@ -387,13 +387,13 @@ async function scoreAndConvertTMDBMovies(
       .join('\n');
   });
 
-  let embeddings: number[][] = [];
+  let rawEmbeddings: number[][] = [];
   try {
     const response = await openAIClient.embeddings.create({
       model: 'text-embedding-3-large',
       input: texts,
     });
-    embeddings = response.data.map((d) => d.embedding);
+    rawEmbeddings = response.data.map((d) => d.embedding);
   } catch (error) {
     logger.warn(
       { err: error },
@@ -401,11 +401,15 @@ async function scoreAndConvertTMDBMovies(
     );
   }
 
-  return movies.map((movie, i) => {
-    const movieEmbedding = embeddings[i];
+  const embeddingsMap = new Map<number, number[]>();
+  const matches = movies.map((movie, i) => {
+    const movieEmbedding = rawEmbeddings[i];
+    if (movieEmbedding) embeddingsMap.set(movie.id, movieEmbedding);
     const similarity = movieEmbedding ? cosineSimilarity(queryEmbedding, movieEmbedding) : 0.35;
     return tmdbMovieToEnhancedMatch(movie, similarity);
   });
+
+  return { matches, embeddings: embeddingsMap };
 }
 
 /**
@@ -451,6 +455,7 @@ function tmdbMovieToEnhancedMatch(
 function seedMoviesInBackground(
   tmdbMovies: TMDBDiscoverMovie[],
   existingLocalNames: Set<string>,
+  precomputedEmbeddings?: Map<number, number[]>,
 ): void {
   const db = getDbClient();
   if (!db.isConfigured()) return;
@@ -503,19 +508,24 @@ function seedMoviesInBackground(
 
         const score = Number(movie.vote_average?.toFixed(1)) || 0;
 
-        const embeddingText = [
-          `${movie.title} (${year})`,
-          `Rating: NR`,
-          `Duration: 0 min`,
-          `Score: ${score}/10`,
-          `Description: ${movie.overview || ''}`,
-        ].join('\n');
+        // Reuse the embedding already computed during similarity scoring if available,
+        // falling back to a fresh API call only for movies not in the precomputed map.
+        let embedding: number[] | undefined = precomputedEmbeddings?.get(movie.id);
+        if (!embedding) {
+          const embeddingText = [
+            `${movie.title} (${year})`,
+            `Rating: NR`,
+            `Duration: 0 min`,
+            `Score: ${score}/10`,
+            `Description: ${movie.overview || ''}`,
+          ].join('\n');
 
-        const embeddingResponse = await openAIClient.embeddings.create({
-          model: 'text-embedding-3-large',
-          input: embeddingText,
-        });
-        const embedding = embeddingResponse.data[0]?.embedding;
+          const embeddingResponse = await openAIClient.embeddings.create({
+            model: 'text-embedding-3-large',
+            input: embeddingText,
+          });
+          embedding = embeddingResponse.data[0]?.embedding;
+        }
         if (!embedding) continue;
 
         await db.from('movies').insert({
@@ -1119,18 +1129,20 @@ export async function POST(req: NextRequest) {
             })
             .slice(0, slotsRemaining);
           const newTMDBMatches = await scoreAndConvertTMDBMovies(filteredTMDBMovies, embedding);
+          const tmdbEmbeddings = newTMDBMatches.embeddings;
+          const newTMDBMatchList = newTMDBMatches.matches;
 
-          similarMovies = [...localResultsForMerge, ...newTMDBMatches].slice(0, MAX_TOTAL_MOVIES);
+          similarMovies = [...localResultsForMerge, ...newTMDBMatchList].slice(0, MAX_TOTAL_MOVIES);
 
           // Only show the UI banner when TMDB movies are actually included
-          if (newTMDBMatches.length > 0) {
+          if (newTMDBMatchList.length > 0) {
             usedBroaderSearch = true;
           }
 
           logger.info(
             {
               localCount: localResultsForMerge.length,
-              tmdbCount: newTMDBMatches.length,
+              tmdbCount: newTMDBMatchList.length,
               finalCount: similarMovies.length,
             },
             'Merged local and TMDB results',
@@ -1138,7 +1150,7 @@ export async function POST(req: NextRequest) {
 
           // JIT seeding in background — do not await so it never blocks the response.
           // Pass only local titles so the TMDB movies just returned to the user can be seeded.
-          seedMoviesInBackground(tmdbMovies, localTitles);
+          seedMoviesInBackground(tmdbMovies, localTitles, tmdbEmbeddings);
         }
       } else {
         logger.warn('TMDB_API_KEY not configured — skipping TMDB fallback');

--- a/src/app/api/movie-recommendation/route.ts
+++ b/src/app/api/movie-recommendation/route.ts
@@ -359,10 +359,63 @@ async function fetchTMDBDiscoverMovies(
 }
 
 /**
+ * Dot product of two unit-norm vectors equals their cosine similarity.
+ * OpenAI embeddings (text-embedding-3-large) are L2-normalised, so this is exact.
+ */
+function cosineSimilarity(a: number[], b: number[]): number {
+  let dot = 0;
+  for (let i = 0; i < a.length; i++) dot += a[i] * b[i];
+  return dot;
+}
+
+/**
+ * Embed every TMDB movie in a single batched API call, compute real cosine similarity
+ * against the user's query embedding, and return fully-populated EnhancedMovieMatch objects.
+ * Falls back to a neutral score (0.35) for any movie whose embedding could not be obtained.
+ */
+async function scoreAndConvertTMDBMovies(
+  movies: TMDBDiscoverMovie[],
+  queryEmbedding: number[],
+): Promise<EnhancedMovieMatch[]> {
+  if (movies.length === 0) return [];
+
+  const texts = movies.map((m) => {
+    const year = parseTMDBReleaseYear(m.release_date);
+    const score = Number(m.vote_average?.toFixed(1)) || 0;
+    return [`${m.title} (${year}) | TMDB Score: ${score}/10`, m.overview || '']
+      .filter(Boolean)
+      .join('\n');
+  });
+
+  let embeddings: number[][] = [];
+  try {
+    const response = await openAIClient.embeddings.create({
+      model: 'text-embedding-3-large',
+      input: texts,
+    });
+    embeddings = response.data.map((d) => d.embedding);
+  } catch (error) {
+    logger.warn(
+      { err: error },
+      'Failed to embed TMDB movies for similarity scoring — using fallback score',
+    );
+  }
+
+  return movies.map((movie, i) => {
+    const movieEmbedding = embeddings[i];
+    const similarity = movieEmbedding ? cosineSimilarity(queryEmbedding, movieEmbedding) : 0.35;
+    return tmdbMovieToEnhancedMatch(movie, similarity);
+  });
+}
+
+/**
  * Convert a TMDB discover result to the EnhancedMovieMatch shape used by the rest of the route.
  * Uses a negative TMDB ID so it is distinct from positive local DB IDs.
  */
-function tmdbMovieToEnhancedMatch(movie: TMDBDiscoverMovie): EnhancedMovieMatch {
+function tmdbMovieToEnhancedMatch(
+  movie: TMDBDiscoverMovie,
+  similarity: number,
+): EnhancedMovieMatch {
   const year = parseTMDBReleaseYear(movie.release_date);
   const score = Number(movie.vote_average?.toFixed(1)) || 0;
 
@@ -381,7 +434,7 @@ function tmdbMovieToEnhancedMatch(movie: TMDBDiscoverMovie): EnhancedMovieMatch 
     duration: 0,
     score_rating: score,
     year,
-    similarity: 0.6, // Below SIMILARITY_THRESHOLD — clearly a broadened result
+    similarity,
     content,
     posterURL,
   };
@@ -1059,13 +1112,13 @@ export async function POST(req: NextRequest) {
             localTitles.add(nameLower);
           }
           const slotsRemaining = Math.max(0, MAX_TOTAL_MOVIES - localResultsForMerge.length);
-          const newTMDBMatches = tmdbMovies
+          const filteredTMDBMovies = tmdbMovies
             .filter((m) => {
               const tmdbYear = parseTMDBReleaseYear(m.release_date);
               return !localKeys.has(`${m.title.toLowerCase()}|${tmdbYear}`);
             })
-            .slice(0, slotsRemaining)
-            .map(tmdbMovieToEnhancedMatch);
+            .slice(0, slotsRemaining);
+          const newTMDBMatches = await scoreAndConvertTMDBMovies(filteredTMDBMovies, embedding);
 
           similarMovies = [...localResultsForMerge, ...newTMDBMatches].slice(0, MAX_TOTAL_MOVIES);
 


### PR DESCRIPTION
## Problem

TMDB fallback results were shown with a hardcoded `similarity: 0.6` placeholder in both API routes. Since `scaleSimilarity` divides by `SIMILARITY_CEILING = 0.62`, this displayed as **97%** for every TMDB result regardless of actual relevance — while real local DB results showed honest scores of ~40–70%.

## Changes

### `src/app/api/movie-recommendation/route.ts`
- Added `cosineSimilarity(a, b)` — dot product of L2-normalised OpenAI embeddings
- Added `scoreAndConvertTMDBMovies(movies, queryEmbedding)` — batch-embeds all TMDB candidates in a **single** `text-embedding-3-large` API call, scores them against the user query embedding, falls back to `0.35` on API failure
- `tmdbMovieToEnhancedMatch` now accepts `similarity` as a parameter instead of hardcoding it
- TMDB filter→slice→map chain now calls `await scoreAndConvertTMDBMovies(filteredTMDBMovies, embedding)`

### `src/app/api/more-tmdb-picks/route.ts`
- Added `cosineSimilarity()` helper
- Before the per-movie batch loop, fires two **parallel** embedding calls (query text + all candidate descriptions), builds a `similarityMap<tmdbId → score>`
- Each movie uses `similarityMap.get(tmdb.id) ?? 0.35` instead of `0.6`

## Result

TMDB picks now display scores in the same ~40–70% range as local DB results for typical queries, rather than a misleading 97%. Both sources use the same model, the same cosine similarity math, and the same `scaleSimilarity` display function.