### PR TITLE
feat: dynamic TMDB movie poster background for hero section

### DIFF
--- a/src/app/api/poster-urls/route.ts
+++ b/src/app/api/poster-urls/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server';
+
+import logger from '@/lib/logger';
+
+const TMDB_API_BASE = 'https://api.themoviedb.org/3';
+const TMDB_IMAGE_BASE = 'https://image.tmdb.org/t/p/w300';
+
+export interface PosterUrlsResponse {
+  posters: string[];
+}
+
+export async function GET() {
+  const apiKey = process.env.TMDB_API_KEY;
+  if (!apiKey) {
+    logger.warn('TMDB_API_KEY is not set — returning empty poster list');
+    return NextResponse.json<PosterUrlsResponse>({ posters: [] });
+  }
+
+  try {
+    const pages = await Promise.allSettled(
+      [1, 2].map((page) =>
+        fetch(`${TMDB_API_BASE}/movie/popular?page=${page}`, {
+          headers: { Authorization: `Bearer ${apiKey}` },
+          next: { revalidate: 86400 }, // cache the TMDB response for 24h at the edge
+        })
+          .then((r) => {
+            if (!r.ok) throw new Error(`TMDB responded with ${r.status}`);
+            return r.json() as Promise<{ results: Array<{ poster_path: string | null }> }>;
+          })
+          .then((data) => data.results ?? []),
+      ),
+    );
+
+    const posters = pages
+      .flatMap((r) => (r.status === 'fulfilled' ? r.value : []))
+      .map((m) => m.poster_path)
+      .filter((p): p is string => Boolean(p))
+      .map((path) => `${TMDB_IMAGE_BASE}${path}`);
+
+    return NextResponse.json<PosterUrlsResponse>(
+      { posters },
+      {
+        headers: { 'Cache-Control': 'public, s-maxage=86400, stale-while-revalidate=3600' },
+      },
+    );
+  } catch (err) {
+    logger.error({ err }, 'Failed to fetch poster URLs from TMDB');
+    return NextResponse.json<PosterUrlsResponse>({ posters: [] });
+  }
+}

--- a/src/app/components/HeroSection.tsx
+++ b/src/app/components/HeroSection.tsx
@@ -3,18 +3,20 @@
 import { Play, Sparkles } from 'lucide-react';
 import { motion } from 'motion/react';
 import dynamic from 'next/dynamic';
-import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 
 import { Mascot } from '@/components/Mascot';
 import { usePCTheme } from '@/hooks/usePCTheme';
 import { useLanguage } from '@/i18n';
 
-const CINEMA_BG =
-  'https://images.unsplash.com/photo-1759230766134-e3ff1c27d20e?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxkYXJrJTIwY2luZW1hJTIwdGhlYXRlciUyMHNlYXRzJTIwZHJhbWF0aWN8ZW58MXx8fHwxNzc0ODk0MzUxfDA&ixlib=rb-4.1.0&q=80&w=1080';
-
 // Loaded client-side only so Math.random() does not cause hydration mismatches
 const FilmParticles = dynamic(() => import('./FilmParticles'), { ssr: false });
+
+// Poster grid is client-only: localStorage cache + TMDB fetch happen post-hydration
+const PosterBackground = dynamic(
+  () => import('./PosterBackground').then((m) => m.PosterBackground),
+  { ssr: false },
+);
 
 export function HeroSection() {
   const router = useRouter();
@@ -27,19 +29,11 @@ export function HeroSection() {
 
   return (
     <section className="relative min-h-[92vh] flex flex-col items-center justify-center px-5 overflow-hidden">
-      {/* Background image */}
-      <div className="absolute inset-0">
-        <Image
-          src={CINEMA_BG}
-          alt=""
-          fill
-          sizes="100vw"
-          className="object-cover"
-          style={{ opacity: isDark ? 0.18 : 0.1 }}
-          priority
-        />
-        <div className="absolute inset-0" style={{ background: heroOverlay }} />
-      </div>
+      {/* Poster background grid + overlay */}
+      <PosterBackground />
+
+      {/* Theme-aware gradient: gold tint at center, page colour fade at top/bottom */}
+      <div className="absolute inset-0 pointer-events-none" style={{ background: heroOverlay }} />
 
       <FilmParticles />
 

--- a/src/app/components/PosterBackground.tsx
+++ b/src/app/components/PosterBackground.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { motion } from 'motion/react';
+
+import { useIsMobile } from '@/hooks/useIsMobile';
+import { usePosterPosters } from '@/hooks/usePosterPosters';
+
+// 8 cols × 5 rows = 40 cells on desktop (5 rows covers tall viewports after scale).
+// Mobile uses 5 columns so 40 cells = 8 rows — more than enough coverage.
+const CELL_COUNT = 40;
+
+interface PosterBackgroundProps {
+  /** Pre-fetched poster URLs for SSR hydration (optional). */
+  posters?: string[];
+}
+
+/**
+ * Full-viewport movie poster grid for the hero section background.
+ *
+ * Three absolutely-positioned layers:
+ *  1. Grid layer   — animated (y drift), no CSS filter (Safari GPU fix).
+ *  2. Blur layer   — static backdrop-filter sibling; blurs/dims the grid at
+ *                    compositing time so Safari never re-rasterises per frame.
+ *  3. Overlay div  — radial gradient; fades edges to background colour.
+ */
+export function PosterBackground({ posters: initialPosters }: PosterBackgroundProps) {
+  const posters = usePosterPosters(initialPosters);
+  const isMobile = useIsMobile();
+  // Treat null (pre-measurement) as desktop to avoid rotation flash on mobile
+  const mobile = isMobile === true;
+
+  const cells = Array.from({ length: CELL_COUNT }, (_, i) => posters[i % posters.length]);
+
+  return (
+    <>
+      {/* Layer 1: grid — zero CSS filters on the animated element.
+          Chrome/Safari can promote this to a GPU layer and move it without
+          any per-frame rasterisation. */}
+      <div aria-hidden="true" className="absolute -inset-5 pointer-events-none">
+        <motion.div
+          className="w-full grid grid-cols-5 sm:grid-cols-8"
+          style={{
+            rotate: mobile ? 0 : -4,
+            scale: mobile ? 1 : 1.15,
+            willChange: 'transform',
+          }}
+          animate={{ y: -20 }}
+          transition={{
+            duration: 30,
+            ease: 'easeInOut',
+            repeat: Infinity,
+            repeatType: 'mirror',
+          }}
+        >
+          {cells.map((src, i) => (
+            <div key={i} className="overflow-hidden aspect-2/3">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                // key change on src remounts the element, resetting opacity-0
+                // so the SVG→real-poster swap fades in rather than snapping.
+                key={src}
+                src={src}
+                alt=""
+                loading="lazy"
+                decoding="async"
+                className="w-full h-full object-cover opacity-0 transition-opacity duration-700"
+                onLoad={(e) => {
+                  (e.currentTarget as HTMLImageElement).style.opacity = '1';
+                }}
+              />
+            </div>
+          ))}
+        </motion.div>
+      </div>
+
+      {/* Layer 2: backdrop-filter blur/dim — static sibling, not a parent/child
+          of the animated grid. Applied at GPU compositing time, so Safari never
+          has to re-rasterise the filtered content on every animation frame. */}
+      <div
+        aria-hidden="true"
+        className={[
+          'absolute -inset-5 pointer-events-none',
+          'backdrop-blur-[1px] backdrop-brightness-[0.8] backdrop-saturate-[0.9]',
+          'sm:backdrop-blur-[2px]',
+          'dark:backdrop-brightness-[0.65] dark:backdrop-saturate-[1.3]',
+        ].join(' ')}
+      />
+
+      {/* Layer 3: radial gradient overlay — separate div, intentionally no filter */}
+      <div
+        aria-hidden="true"
+        className={[
+          'absolute inset-0 pointer-events-none',
+          // Light mode: fade edges to cream background colour
+          'bg-[radial-gradient(ellipse_70%_70%_at_50%_50%,rgba(247,245,238,0.05)_0%,rgba(247,245,238,0.82)_100%)]',
+          // Dark mode: fade edges to dark background colour
+          'dark:bg-[radial-gradient(ellipse_70%_70%_at_50%_50%,rgba(9,9,15,0.05)_0%,rgba(9,9,15,0.70)_100%)]',
+        ].join(' ')}
+      />
+    </>
+  );
+}

--- a/src/hooks/usePosterPosters.ts
+++ b/src/hooks/usePosterPosters.ts
@@ -1,0 +1,117 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+const CACHE_KEY = 'pc_poster_bg_v1';
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+// Solid-colour SVG placeholders shaped like movie posters (2:3 ratio).
+// Shown instantly before the TMDB fetch resolves — guarantees the background
+// is never blank, even when the API is unreachable.
+export const FALLBACK_POSTERS: string[] = [
+  '#1a1a2e',
+  '#16213e',
+  '#0f3460',
+  '#533483',
+  '#2c003e',
+  '#1b1b2f',
+  '#0d1117',
+  '#0a0a14',
+].map(
+  (color) =>
+    `data:image/svg+xml,${encodeURIComponent(
+      `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 450"><rect width="300" height="450" fill="${color}"/></svg>`,
+    )}`,
+);
+
+interface CacheEntry {
+  posters: string[];
+  ts: number;
+}
+
+function readCache(): string[] | null {
+  try {
+    const raw = localStorage.getItem(CACHE_KEY);
+    if (!raw) return null;
+    const entry = JSON.parse(raw) as CacheEntry;
+    if (Date.now() - entry.ts > CACHE_TTL_MS) return null;
+    return entry.posters.length > 0 ? entry.posters : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(posters: string[]): void {
+  try {
+    localStorage.setItem(
+      CACHE_KEY,
+      JSON.stringify({ posters, ts: Date.now() } satisfies CacheEntry),
+    );
+  } catch {
+    // localStorage unavailable (private browsing, storage full, etc.) — ignore
+  }
+}
+
+async function fetchPosterURLs(): Promise<string[]> {
+  // Calls the internal API route, which uses the server-side TMDB_API_KEY
+  // Bearer token — the key never reaches the browser.
+  const r = await fetch('/api/poster-urls');
+  if (!r.ok) throw new Error(`/api/poster-urls responded with ${r.status}`);
+  const data = (await r.json()) as { posters: string[] };
+  return data.posters ?? [];
+}
+
+/**
+ * Pick the best available poster set synchronously (for `useState` lazy init).
+ * Priority: SSR-prefetched → localStorage cache → fallback SVGs.
+ * This runs client-side only because the component is loaded with `ssr: false`.
+ */
+function resolveInitialPosters(initialPosters?: string[]): string[] {
+  if (initialPosters && initialPosters.length > 0) return initialPosters;
+  if (typeof window !== 'undefined') {
+    const cached = readCache();
+    if (cached) return cached;
+  }
+  return FALLBACK_POSTERS;
+}
+
+/**
+ * Returns an array of poster image URLs for the hero background grid.
+ *
+ * - Initialises immediately with the best available data (SSR prop → cache →
+ *   fallback SVGs), so the background is visible on the very first render.
+ * - On mount, fetches from TMDB when no cached data exists, then persists the
+ *   result with a 24-hour TTL.
+ * - Falls back silently to placeholder SVGs if the API is unreachable.
+ *
+ * @param initialPosters Optional server-fetched URLs to hydrate without flash.
+ */
+export function usePosterPosters(initialPosters?: string[]): string[] {
+  // Lazy init reads cache synchronously — avoids calling setState inside an effect.
+  const [posters, setPosters] = useState<string[]>(() => resolveInitialPosters(initialPosters));
+
+  // Use a ref so the effect closure captures a stable reference without
+  // needing to list `initialPosters` in the exhaustive-deps array.
+  const initialPostersRef = useRef(initialPosters);
+
+  useEffect(() => {
+    // Skip fetch when the component already has real poster data:
+    // either from SSR pre-fetch or from the localStorage cache hit in useState.
+    if (initialPostersRef.current && initialPostersRef.current.length > 0) return;
+    if (readCache()) return;
+
+    fetchPosterURLs()
+      .then((urls) => {
+        if (urls.length >= 8) {
+          setPosters(urls);
+          writeCache(urls);
+        }
+        // Fewer than 8 results → keep showing fallback SVGs
+      })
+      .catch(() => {
+        // Keep the existing fallback posters when the API is unreachable.
+      });
+  }, []); // Intentionally empty: fetch once on mount only
+
+  return posters;
+}


### PR DESCRIPTION
## Summary

- Replaces the static Unsplash cinema image in the hero section with a live grid of movie poster images fetched from the TMDB API
- Adds `GET /api/poster-urls` — fetches TMDB `/movie/popular` pages 1–2 server-side using the existing `TMDB_API_KEY` Bearer token; edge-cached for 24 h via `next: { revalidate: 86400 }`
- Adds `usePosterPosters` hook — reads a 24 h localStorage cache on mount (lazy `useState` init, no `setState` in effect); fetches on miss; falls back instantly to solid-colour SVG placeholders so the background is never blank
- Adds `PosterBackground` component — 8-column × 5-row grid with `aspect-2/3` cells, slow vertical drift via `motion/react`, theme-aware filter + radial gradient overlay (light/dark mode), responsive (5 cols + no rotation on mobile < 640 px)
- Preserves the existing `heroOverlay` gradient in `HeroSection` for the gold-tint and page-colour top/bottom fade

## Visual layer stack (bottom → top)

1. `PosterBackground` grid — `blur brightness saturate` filter
2. `PosterBackground` radial overlay — fades edges to `--pc-bg` colour (no filter)
3. `HeroSection` `heroOverlay` — gold tint + top/bottom fade to page colour
4. `FilmParticles`, film grain, hero content

## Test plan

- [ ] Dark mode: posters visible and recognisable through the blur/dim treatment
- [ ] Light mode: overlay fades to cream (`#f7f5ee`), no dark-edge clash
- [ ] First load (no cache, no API key set): fallback SVG placeholders show immediately
- [ ] First load (API key set, no cache): real posters appear within ~1 s, no layout shift
- [ ] Subsequent loads: localStorage cache hit, posters render instantly
- [ ] Mobile (< 640 px): 5 columns, no rotation, softer blur
- [ ] Hero CTA buttons and text remain legible over the background

🤖 Generated with [Claude Code](https://claude.com/claude-code)