### PR TITLE
feat: add living style guide and style guide nav link

### DIFF
--- a/src/app/components/HeroSection.tsx
+++ b/src/app/components/HeroSection.tsx
@@ -24,8 +24,8 @@ export function HeroSection() {
   const { t } = useLanguage();
 
   const heroOverlay = isDark
-    ? 'radial-gradient(ellipse 80% 60% at 50% 40%, rgba(245,197,24,0.06) 0%, transparent 70%), linear-gradient(180deg, #09090F 0%, rgba(9,9,15,0.4) 30%, rgba(9,9,15,0.6) 70%, #09090F 100%)'
-    : 'radial-gradient(ellipse 80% 60% at 50% 40%, rgba(196,149,10,0.06) 0%, transparent 70%), linear-gradient(180deg, #F7F5EE 0%, rgba(247,245,238,0.35) 30%, rgba(247,245,238,0.55) 70%, #F7F5EE 100%)';
+    ? 'radial-gradient(ellipse 80% 60% at 50% 40%, rgba(245,197,24,0.06) 0%, transparent 70%), linear-gradient(180deg, #09090F 0%, rgba(9,9,15,0.58) 30%, rgba(9,9,15,0.78) 70%, #09090F 100%)'
+    : 'radial-gradient(ellipse 80% 60% at 50% 40%, rgba(196,149,10,0.06) 0%, transparent 70%), linear-gradient(180deg, #F7F5EE 0%, rgba(247,245,238,0.72) 30%, rgba(247,245,238,0.86) 70%, #F7F5EE 100%)';
 
   return (
     <section className="relative min-h-[92vh] flex flex-col items-center justify-center px-5 overflow-hidden">
@@ -102,7 +102,11 @@ export function HeroSection() {
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.6, delay: 0.3 }}
           className="mb-10 max-w-lg"
-          style={{ color: 'var(--pc-t2)', fontSize: '1.1rem', lineHeight: 1.7 }}
+          style={{
+            color: isDark ? 'var(--pc-t2)' : 'var(--pc-t1)',
+            fontSize: '1.1rem',
+            lineHeight: 1.7,
+          }}
         >
           {t.hero.descriptionPre}{' '}
           <span style={{ color: 'var(--pc-gold-text)' }}>{t.hero.perfectMovie}</span>{' '}
@@ -165,7 +169,7 @@ export function HeroSection() {
           animate={{ opacity: 1 }}
           transition={{ duration: 0.6, delay: 0.6 }}
           className="mt-8 text-xs"
-          style={{ color: 'var(--pc-t4)' }}
+          style={{ color: isDark ? 'var(--pc-t4)' : 'var(--pc-t2)' }}
         >
           {t.hero.noSignup}
         </motion.p>

--- a/src/app/style-guide/_components/index.tsx
+++ b/src/app/style-guide/_components/index.tsx
@@ -1,0 +1,41 @@
+// Shared layout helpers for style-guide pages.
+// Keep these server-compatible (no client hooks).
+
+export function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="mb-16">
+      <h2
+        className="mb-6 text-xs font-bold uppercase tracking-[0.2em]"
+        style={{ color: 'var(--pc-gold)', fontFamily: "var(--font-oswald), 'Oswald', sans-serif" }}
+      >
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+export function Card({
+  children,
+  className = '',
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={`rounded-xl p-6 ${className}`}
+      style={{ background: 'var(--pc-surface)', border: '1px solid var(--pc-bd2)' }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function Label({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="mt-2 text-xs" style={{ color: 'var(--pc-t3)', fontFamily: 'monospace' }}>
+      {children}
+    </p>
+  );
+}

--- a/src/app/style-guide/components/page.tsx
+++ b/src/app/style-guide/components/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Sparkles, Play, Users, Zap, Smile, Moon, Clock, Clapperboard } from 'lucide-react';
+import Link from 'next/link';
 import { useState } from 'react';
 
 import { QuizNavigation } from '@/app/quiz/components';
@@ -250,10 +251,12 @@ function EraOption({
 // ── Text Input ─────────────────────────────────────────────────────────────────
 
 function StyledInput({ placeholder, label }: { placeholder: string; label?: string }) {
+  const inputId = label ? `input-${label.toLowerCase().replace(/\s+/g, '-')}` : undefined;
   return (
     <div className="flex flex-col gap-1.5">
       {label && (
         <label
+          htmlFor={inputId}
           className="text-xs font-semibold uppercase tracking-wider"
           style={{ color: 'var(--pc-t3)' }}
         >
@@ -261,6 +264,7 @@ function StyledInput({ placeholder, label }: { placeholder: string; label?: stri
         </label>
       )}
       <input
+        id={inputId}
         placeholder={placeholder}
         className="w-full px-4 py-3 rounded-xl outline-none transition-all duration-200 text-sm"
         style={{
@@ -480,15 +484,13 @@ export default function StyleGuideComponentsPage() {
       <div className="mx-auto max-w-5xl px-6 py-16">
         {/* Header */}
         <div className="mb-4">
-          <a
+          <Link
             href="/style-guide"
-            className="text-xs uppercase tracking-widest font-semibold transition-colors"
+            className="text-xs uppercase tracking-widest font-semibold transition-colors hover:text-(--pc-gold)"
             style={{ color: 'var(--pc-t3)' }}
-            onMouseEnter={(e) => ((e.target as HTMLElement).style.color = 'var(--pc-gold)')}
-            onMouseLeave={(e) => ((e.target as HTMLElement).style.color = 'var(--pc-t3)')}
           >
             ← Style Guide
-          </a>
+          </Link>
         </div>
         <div className="mb-16">
           <p
@@ -527,8 +529,8 @@ export default function StyleGuideComponentsPage() {
             <div className="pt-4">
               <p className="text-xs" style={{ color: 'var(--pc-t3)' }}>
                 Click the mascot to trigger confetti. Accepts{' '}
-                <code className="text-(--pc-gold)">width</code> and{' '}
-                <code className="text-(--pc-gold)">height</code> props.
+                <code style={{ color: 'var(--pc-gold)' }}>width</code> and{' '}
+                <code style={{ color: 'var(--pc-gold)' }}>height</code> props.
               </p>
             </div>
           </Card>
@@ -609,7 +611,7 @@ export default function StyleGuideComponentsPage() {
             <div className="pt-3">
               <p className="text-xs" style={{ color: 'var(--pc-t3)' }}>
                 Neutral pill used in movie cards. For semantic color ratings use{' '}
-                <code className="text-(--pc-gold)">AgeRatingChip</code>.
+                <code style={{ color: 'var(--pc-gold)' }}>AgeRatingChip</code>.
               </p>
             </div>
           </Card>
@@ -620,8 +622,8 @@ export default function StyleGuideComponentsPage() {
           <div className="mb-4">
             <p className="text-xs mb-4" style={{ color: 'var(--pc-t3)' }}>
               Click to toggle active state.{' '}
-              <code className="text-(--pc-gold)">SmallSuggestionCard</code> is used in the results
-              scroll row.
+              <code style={{ color: 'var(--pc-gold)' }}>SmallSuggestionCard</code> is used in the
+              results scroll row.
             </p>
             <div className="flex gap-4 flex-wrap">
               {MOCK_MOVIES.map((movie, i) => (
@@ -642,8 +644,8 @@ export default function StyleGuideComponentsPage() {
           <div className="space-y-6">
             <div>
               <p className="text-xs mb-3" style={{ color: 'var(--pc-t3)' }}>
-                <code className="text-(--pc-gold)">MoviesTableSkeleton</code> — shown while table
-                data loads
+                <code style={{ color: 'var(--pc-gold)' }}>MoviesTableSkeleton</code> — shown while
+                table data loads
               </p>
               <MoviesTableSkeleton />
             </div>
@@ -725,7 +727,7 @@ export default function StyleGuideComponentsPage() {
           <Card>
             <p className="text-xs mb-4" style={{ color: 'var(--pc-t3)' }}>
               Multi-select. Click to toggle genres. Used in{' '}
-              <code className="text-(--pc-gold)">MoodStep</code>.
+              <code style={{ color: 'var(--pc-gold)' }}>MoodStep</code>.
             </p>
             <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
               {GENRES.map((g) => (
@@ -752,7 +754,7 @@ export default function StyleGuideComponentsPage() {
           <Card>
             <p className="text-xs mb-4" style={{ color: 'var(--pc-t3)' }}>
               Single-select. Click to choose a tone. Used in{' '}
-              <code className="text-(--pc-gold)">ToneStep</code>.
+              <code style={{ color: 'var(--pc-gold)' }}>ToneStep</code>.
             </p>
             <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
               {TONES.map((tone) => (
@@ -777,7 +779,7 @@ export default function StyleGuideComponentsPage() {
           <Card>
             <p className="text-xs mb-4" style={{ color: 'var(--pc-t3)' }}>
               Single-select. Click to pick a film era. Used in{' '}
-              <code className="text-(--pc-gold)">EraStep</code>.
+              <code style={{ color: 'var(--pc-gold)' }}>EraStep</code>.
             </p>
             <div className="flex flex-col gap-3 max-w-sm">
               {ERAS.map((era) => (
@@ -835,7 +837,8 @@ export default function StyleGuideComponentsPage() {
             </ComponentRow>
             <div className="pt-3">
               <p className="text-xs" style={{ color: 'var(--pc-t3)' }}>
-                Used in <code className="text-(--pc-gold)">GroupSetup</code> to label participants.
+                Used in <code style={{ color: 'var(--pc-gold)' }}>GroupSetup</code> to label
+                participants.
               </p>
             </div>
           </Card>
@@ -953,15 +956,13 @@ export default function StyleGuideComponentsPage() {
           style={{ borderTop: '1px solid var(--pc-bd1)', color: 'var(--pc-footer)' }}
         >
           <span>PopChoice Components</span>
-          <a
+          <Link
             href="/style-guide"
-            className="text-xs uppercase tracking-widest font-semibold transition-colors"
+            className="text-xs uppercase tracking-widest font-semibold transition-colors hover:text-(--pc-gold)"
             style={{ color: 'var(--pc-t3)' }}
-            onMouseEnter={(e) => ((e.target as HTMLElement).style.color = 'var(--pc-gold)')}
-            onMouseLeave={(e) => ((e.target as HTMLElement).style.color = 'var(--pc-t3)')}
           >
             ← Back to Style Guide
-          </a>
+          </Link>
         </div>
       </div>
     </div>

--- a/src/app/style-guide/components/page.tsx
+++ b/src/app/style-guide/components/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Sparkles, Play, Users, Zap, Smile, Moon, Clock, Clapperboard } from 'lucide-react';
+import { Clapperboard, Clock, Moon, Play, Smile, Sparkles, Users, Zap } from 'lucide-react';
 import Link from 'next/link';
 import { useState } from 'react';
 

--- a/src/app/style-guide/components/page.tsx
+++ b/src/app/style-guide/components/page.tsx
@@ -1,0 +1,969 @@
+'use client';
+
+import { Sparkles, Play, Users, Zap, Smile, Moon, Clock, Clapperboard } from 'lucide-react';
+import { useState } from 'react';
+
+import { QuizNavigation } from '@/app/quiz/components';
+import { AgeRatingPill } from '@/app/results/components/AgeRatingPill';
+import { SimilarityBadge } from '@/app/results/components/SimilarityBadge';
+import { SmallSuggestionCard } from '@/app/results/components/SmallSuggestionCard';
+import { StarRating } from '@/app/results/components/StarRating';
+import { LanguageSwitcher } from '@/components/LanguageSwitcher';
+import { Mascot } from '@/components/Mascot';
+import { MoviesTableSkeleton } from '@/components/MoviesTable';
+import { ThemeToggle } from '@/components/ThemeToggle';
+import { TMDBAttribution } from '@/components/TMDBAttribution';
+import { palette } from '@/styles/designTokens';
+
+import type { MovieRecommendation } from '@/utils/client';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="mb-16">
+      <h2
+        className="mb-6 text-xs font-bold uppercase tracking-[0.2em]"
+        style={{ color: 'var(--pc-gold)', fontFamily: "var(--font-oswald), 'Oswald', sans-serif" }}
+      >
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+function Card({ children, className = '' }: { children: React.ReactNode; className?: string }) {
+  return (
+    <div
+      className={`rounded-xl p-6 ${className}`}
+      style={{ background: 'var(--pc-surface)', border: '1px solid var(--pc-bd2)' }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function Label({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="mt-2 text-xs" style={{ color: 'var(--pc-t3)', fontFamily: 'monospace' }}>
+      {children}
+    </p>
+  );
+}
+
+function ComponentRow({
+  label,
+  children,
+  code,
+}: {
+  label: string;
+  children: React.ReactNode;
+  code?: string;
+}) {
+  return (
+    <div
+      className="flex flex-wrap items-center gap-6 py-5"
+      style={{ borderBottom: '1px solid var(--pc-bd1)' }}
+    >
+      <div className="w-36 shrink-0">
+        <p className="text-xs font-semibold" style={{ color: 'var(--pc-t3)' }}>
+          {label}
+        </p>
+        {code && (
+          <code className="text-xs" style={{ color: 'var(--pc-t4)' }}>
+            {code}
+          </code>
+        )}
+      </div>
+      <div className="flex flex-wrap items-center gap-3">{children}</div>
+    </div>
+  );
+}
+
+// ── Feature Card ──────────────────────────────────────────────────────────────
+
+function FeatureCard({
+  icon: Icon,
+  title,
+  desc,
+  color,
+}: {
+  icon: React.ElementType;
+  title: string;
+  desc: string;
+  color: string;
+}) {
+  return (
+    <div
+      className="p-6 rounded-2xl flex flex-col gap-4"
+      style={{ background: 'var(--pc-surface)', border: '1px solid var(--pc-bd1)' }}
+    >
+      <div
+        className="w-10 h-10 rounded-xl flex items-center justify-center"
+        style={{ background: `${color}18`, color }}
+      >
+        <Icon size={20} />
+      </div>
+      <div>
+        <div className="font-bold text-sm mb-1" style={{ color: 'var(--pc-t1)' }}>
+          {title}
+        </div>
+        <div className="text-xs leading-relaxed" style={{ color: 'var(--pc-t3)' }}>
+          {desc}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Genre Chip ─────────────────────────────────────────────────────────────────
+
+function GenreChip({
+  icon: Icon,
+  label,
+  color,
+  selected,
+  onToggle,
+}: {
+  icon: React.ElementType;
+  label: string;
+  color: string;
+  selected: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      onClick={onToggle}
+      className="flex items-center gap-3 p-3.5 rounded-xl text-left transition-all duration-200"
+      style={{
+        background: selected ? `${color}18` : 'var(--pc-surface)',
+        border: selected ? `1.5px solid ${color}50` : '1px solid var(--pc-bd1)',
+      }}
+    >
+      <div
+        className="w-8 h-8 rounded-lg flex items-center justify-center shrink-0"
+        style={{
+          background: selected ? `${color}25` : 'var(--pc-ghost)',
+          color: selected ? color : 'var(--pc-t3)',
+        }}
+      >
+        <Icon size={16} />
+      </div>
+      <span className="text-sm font-semibold" style={{ color: selected ? color : 'var(--pc-t1)' }}>
+        {label}
+      </span>
+    </button>
+  );
+}
+
+// ── Tone Card ─────────────────────────────────────────────────────────────────
+
+function ToneCard({
+  icon: Icon,
+  label,
+  desc,
+  color,
+  grad,
+  selected,
+  onSelect,
+}: {
+  icon: React.ElementType;
+  label: string;
+  desc: string;
+  color: string;
+  grad: string;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      onClick={onSelect}
+      className="flex flex-col items-start gap-3 p-4 rounded-2xl text-left transition-all duration-200"
+      style={{
+        background: selected ? grad : 'var(--pc-surface)',
+        border: selected ? `1.5px solid ${color}50` : '1px solid var(--pc-bd1)',
+        boxShadow: selected ? `0 0 20px ${color}14` : 'none',
+      }}
+    >
+      <div
+        className="w-9 h-9 rounded-xl flex items-center justify-center"
+        style={{
+          background: selected ? `${color}20` : 'var(--pc-ghost)',
+          color: selected ? color : 'var(--pc-t3)',
+        }}
+      >
+        <Icon size={16} />
+      </div>
+      <div>
+        <div className="text-sm font-semibold" style={{ color: selected ? color : 'var(--pc-t1)' }}>
+          {label}
+        </div>
+        <div className="text-xs mt-0.5" style={{ color: 'var(--pc-t3)' }}>
+          {desc}
+        </div>
+      </div>
+    </button>
+  );
+}
+
+// ── Era Option ─────────────────────────────────────────────────────────────────
+
+function EraOption({
+  emoji,
+  title,
+  desc,
+  color,
+  selected,
+  onSelect,
+}: {
+  emoji: string;
+  title: string;
+  desc: string;
+  color: string;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      onClick={onSelect}
+      className="flex items-center gap-4 p-4 rounded-2xl text-left transition-all duration-200 w-full"
+      style={{
+        background: selected ? `${color}18` : 'var(--pc-surface)',
+        border: selected ? `1.5px solid ${color}60` : '1px solid var(--pc-bd2)',
+        boxShadow: selected ? `0 0 20px ${color}18` : 'none',
+      }}
+    >
+      <div className="text-2xl">{emoji}</div>
+      <div>
+        <div className="font-semibold text-sm" style={{ color: selected ? color : 'var(--pc-t1)' }}>
+          {title}
+        </div>
+        <div className="text-xs" style={{ color: 'var(--pc-t3)' }}>
+          {desc}
+        </div>
+      </div>
+    </button>
+  );
+}
+
+// ── Text Input ─────────────────────────────────────────────────────────────────
+
+function StyledInput({ placeholder, label }: { placeholder: string; label?: string }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      {label && (
+        <label
+          className="text-xs font-semibold uppercase tracking-wider"
+          style={{ color: 'var(--pc-t3)' }}
+        >
+          {label}
+        </label>
+      )}
+      <input
+        placeholder={placeholder}
+        className="w-full px-4 py-3 rounded-xl outline-none transition-all duration-200 text-sm"
+        style={{
+          background: 'var(--pc-bg)',
+          border: '1px solid var(--pc-bd2)',
+          color: 'var(--pc-t1)',
+        }}
+        onFocus={(e) => {
+          (e.target as HTMLInputElement).style.borderColor = 'var(--pc-gold-bd)';
+          (e.target as HTMLInputElement).style.boxShadow = 'var(--pc-gold-ring)';
+        }}
+        onBlur={(e) => {
+          (e.target as HTMLInputElement).style.borderColor = 'var(--pc-bd2)';
+          (e.target as HTMLInputElement).style.boxShadow = 'none';
+        }}
+      />
+    </div>
+  );
+}
+
+// ── Skeleton Card ──────────────────────────────────────────────────────────────
+
+function SkeletonCard() {
+  return (
+    <div
+      className="rounded-2xl overflow-hidden"
+      style={{ background: 'var(--pc-surface)', border: '1px solid var(--pc-bd2)', width: 220 }}
+    >
+      <div className="h-32 animate-pulse" style={{ background: 'var(--pc-surface-deep)' }} />
+      <div className="p-3 space-y-2">
+        <div
+          className="h-3 rounded animate-pulse"
+          style={{ width: '70%', background: 'var(--pc-bd2)' }}
+        />
+        <div
+          className="h-2.5 rounded animate-pulse"
+          style={{ width: '40%', background: 'var(--pc-bd1)' }}
+        />
+        <div className="flex gap-2 mt-1">
+          <div
+            className="h-2.5 rounded-full animate-pulse"
+            style={{ width: 48, background: 'var(--pc-bd2)' }}
+          />
+          <div
+            className="h-2.5 rounded-full animate-pulse"
+            style={{ width: 32, background: 'var(--pc-bd1)' }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+function NumberBadge({ n }: { n: number }) {
+  return (
+    <div
+      className="w-8 h-8 rounded-full flex items-center justify-center text-xs font-bold shrink-0"
+      style={{ background: `${palette.purple}33`, color: palette.purpleLight }}
+    >
+      {n}
+    </div>
+  );
+}
+
+// ── Alert / Toast ──────────────────────────────────────────────────────────────
+
+function AlertBanner({
+  type,
+  children,
+}: {
+  type: 'info' | 'warning' | 'error';
+  children: React.ReactNode;
+}) {
+  const styles = {
+    info: { bg: `${palette.blue}15`, bd: `${palette.blue}35`, color: palette.blue },
+    warning: {
+      bg: `${palette.gold}12`,
+      bd: 'var(--pc-gold-bd-subtle)',
+      color: 'var(--pc-gold-text)',
+    },
+    error: { bg: `${palette.red}12`, bd: `${palette.red}35`, color: palette.red },
+  }[type];
+
+  return (
+    <div
+      className="px-4 py-3 rounded-xl text-sm"
+      style={{ background: styles.bg, border: `1px solid ${styles.bd}`, color: styles.color }}
+    >
+      {children}
+    </div>
+  );
+}
+
+// ── AI Content Block ───────────────────────────────────────────────────────────
+
+function AIBlock({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      className="px-5 py-4 rounded-xl text-sm leading-relaxed"
+      style={{
+        background: 'var(--pc-ai-bg)',
+        border: '1px solid var(--pc-ai-bd)',
+        color: 'var(--pc-t2)',
+      }}
+    >
+      <div className="flex items-center gap-2 mb-2">
+        <Sparkles size={12} style={{ color: 'var(--pc-gold)' }} />
+        <span
+          className="text-xs font-semibold uppercase tracking-wider"
+          style={{ color: 'var(--pc-gold-text)' }}
+        >
+          AI Pick
+        </span>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+// ── Number Badge (GroupSetup) ──────────────────────────────────────────────────
+
+export default function StyleGuideComponentsPage() {
+  // Selectable demo state
+  const [selectedGenres, setSelectedGenres] = useState<string[]>(['comedy']);
+  const [selectedTone, setSelectedTone] = useState<string>('light');
+  const [selectedEra, setSelectedEra] = useState<string>('both');
+  const [activeCard, setActiveCard] = useState<number>(0);
+
+  const MOCK_MOVIES: MovieRecommendation[] = [
+    {
+      id: 1,
+      name: 'Inception',
+      year: 2010,
+      similarity: 0.97,
+      score_rating: 8.8,
+      age_rating: 'PG-13',
+      duration: 148,
+    },
+    {
+      id: 2,
+      name: 'Interstellar',
+      year: 2014,
+      similarity: 0.94,
+      score_rating: 8.6,
+      age_rating: 'PG-13',
+      duration: 169,
+    },
+    {
+      id: 3,
+      name: 'The Dark Knight',
+      year: 2008,
+      similarity: 0.91,
+      score_rating: 9.0,
+      age_rating: 'PG-13',
+      duration: 152,
+    },
+  ];
+
+  const GENRES = [
+    { id: 'action', label: 'Action', icon: Zap, color: palette.amber },
+    { id: 'comedy', label: 'Comedy', icon: Smile, color: palette.gold },
+    { id: 'drama', label: 'Drama', icon: Play, color: palette.purple },
+    { id: 'scifi', label: 'Sci-Fi', icon: Sparkles, color: palette.teal },
+  ];
+
+  const TONES = [
+    {
+      id: 'light',
+      label: 'Light & Fun',
+      desc: 'Easy going, uplifting',
+      icon: Sparkles,
+      color: palette.gold,
+      grad: `linear-gradient(135deg, ${palette.gold}18, ${palette.amber}18)`,
+    },
+    {
+      id: 'balanced',
+      label: 'Balanced',
+      desc: 'Mix of everything',
+      icon: Play,
+      color: palette.teal,
+      grad: `linear-gradient(135deg, ${palette.teal}18, ${palette.blue}18)`,
+    },
+    {
+      id: 'serious',
+      label: 'Serious',
+      desc: 'Deep and meaningful',
+      icon: Moon,
+      color: palette.purple,
+      grad: `linear-gradient(135deg, ${palette.purple}18, ${palette.purpleLight}18)`,
+    },
+    {
+      id: 'dark',
+      label: 'Dark',
+      desc: 'Intense and gritty',
+      icon: Moon,
+      color: palette.gray,
+      grad: `linear-gradient(135deg, ${palette.gray}18, ${palette.red}18)`,
+    },
+  ];
+
+  const ERAS = [
+    { id: 'new', emoji: '✨', title: 'New Releases', desc: 'Post-2010', color: palette.teal },
+    { id: 'classic', emoji: '🎞️', title: 'Classics', desc: 'Pre-2000', color: palette.gold },
+    { id: 'both', emoji: '🎬', title: 'Any Era', desc: 'No preference', color: palette.purple },
+  ];
+
+  return (
+    <div
+      className="min-h-screen"
+      style={{
+        background: 'var(--pc-bg)',
+        fontFamily: "var(--font-manrope), 'Manrope', sans-serif",
+      }}
+    >
+      <div className="mx-auto max-w-5xl px-6 py-16">
+        {/* Header */}
+        <div className="mb-4">
+          <a
+            href="/style-guide"
+            className="text-xs uppercase tracking-widest font-semibold transition-colors"
+            style={{ color: 'var(--pc-t3)' }}
+            onMouseEnter={(e) => ((e.target as HTMLElement).style.color = 'var(--pc-gold)')}
+            onMouseLeave={(e) => ((e.target as HTMLElement).style.color = 'var(--pc-t3)')}
+          >
+            ← Style Guide
+          </a>
+        </div>
+        <div className="mb-16">
+          <p
+            className="mb-2 text-xs font-bold uppercase tracking-[0.25em]"
+            style={{ color: 'var(--pc-gold)' }}
+          >
+            PopChoice
+          </p>
+          <h1
+            className="mb-4 text-5xl font-bold"
+            style={{
+              fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
+              color: 'var(--pc-t1)',
+            }}
+          >
+            Components
+          </h1>
+          <p className="max-w-xl text-lg" style={{ color: 'var(--pc-t2)' }}>
+            All reusable UI components with their props and states.
+          </p>
+        </div>
+
+        {/* ── Mascot ──────────────────────────────────────────────────── */}
+        <Section title="Mascot">
+          <Card>
+            <ComponentRow label="Default" code="<Mascot />">
+              <div className="flex items-end gap-8 flex-wrap">
+                {[24, 40, 64, 96].map((size) => (
+                  <div key={size} className="flex flex-col items-center gap-2">
+                    <Mascot width={size} height={size} />
+                    <Label>{size}px</Label>
+                  </div>
+                ))}
+              </div>
+            </ComponentRow>
+            <div className="pt-4">
+              <p className="text-xs" style={{ color: 'var(--pc-t3)' }}>
+                Click the mascot to trigger confetti. Accepts{' '}
+                <code className="text-(--pc-gold)">width</code> and{' '}
+                <code className="text-(--pc-gold)">height</code> props.
+              </p>
+            </div>
+          </Card>
+        </Section>
+
+        {/* ── Header Controls ──────────────────────────────────────────── */}
+        <Section title="Header Controls">
+          <Card>
+            <ComponentRow label="ThemeToggle" code="<ThemeToggle />">
+              <ThemeToggle />
+            </ComponentRow>
+            <ComponentRow label="LanguageSwitcher" code="<LanguageSwitcher />">
+              <LanguageSwitcher />
+            </ComponentRow>
+            <ComponentRow label="Combined (header)" code="nav controls">
+              <div
+                className="flex items-center gap-2 px-4 py-2 rounded-xl"
+                style={{ background: 'var(--pc-header-bg)', border: '1px solid var(--pc-bd1)' }}
+              >
+                <LanguageSwitcher />
+                <ThemeToggle />
+              </div>
+            </ComponentRow>
+          </Card>
+        </Section>
+
+        {/* ── TMDB Attribution ─────────────────────────────────────────── */}
+        <Section title="TMDB Attribution">
+          <Card className="max-w-sm">
+            <TMDBAttribution />
+            <Label>&lt;TMDBAttribution /&gt;</Label>
+          </Card>
+        </Section>
+
+        {/* ── SimilarityBadge ──────────────────────────────────────────── */}
+        <Section title="Similarity Badge">
+          <Card>
+            <ComponentRow label="95%+ — Teal" code="similarity={0.97}">
+              <SimilarityBadge similarity={0.97} />
+            </ComponentRow>
+            <ComponentRow label="90–94% — Gold" code="similarity={0.92}">
+              <SimilarityBadge similarity={0.92} />
+            </ComponentRow>
+            <ComponentRow label="85–89% — Amber" code="similarity={0.87}">
+              <SimilarityBadge similarity={0.87} />
+            </ComponentRow>
+            <ComponentRow label="< 85% — Purple" code="similarity={0.80}">
+              <SimilarityBadge similarity={0.8} />
+            </ComponentRow>
+          </Card>
+        </Section>
+
+        {/* ── StarRating ───────────────────────────────────────────────── */}
+        <Section title="Star Rating">
+          <Card>
+            {[10, 8.5, 7, 5, 2].map((score) => (
+              <ComponentRow key={score} label={`${score}/10`} code={`score={${score}}`}>
+                <StarRating score={score} />
+                <span className="text-sm font-semibold" style={{ color: 'var(--pc-gold-text)' }}>
+                  {score.toFixed(1)}/10
+                </span>
+              </ComponentRow>
+            ))}
+          </Card>
+        </Section>
+
+        {/* ── AgeRatingPill ────────────────────────────────────────────── */}
+        <Section title="Age Rating Pill">
+          <Card>
+            <ComponentRow label="All ratings" code="<AgeRatingPill />">
+              {['G', 'PG', 'PG-13', 'R', '18+', 'NR'].map((r) => (
+                <div key={r} className="flex flex-col items-center gap-1">
+                  <AgeRatingPill label={r} />
+                  <Label>{r}</Label>
+                </div>
+              ))}
+            </ComponentRow>
+            <div className="pt-3">
+              <p className="text-xs" style={{ color: 'var(--pc-t3)' }}>
+                Neutral pill used in movie cards. For semantic color ratings use{' '}
+                <code className="text-(--pc-gold)">AgeRatingChip</code>.
+              </p>
+            </div>
+          </Card>
+        </Section>
+
+        {/* ── Movie Cards ──────────────────────────────────────────────── */}
+        <Section title="Movie Cards">
+          <div className="mb-4">
+            <p className="text-xs mb-4" style={{ color: 'var(--pc-t3)' }}>
+              Click to toggle active state.{' '}
+              <code className="text-(--pc-gold)">SmallSuggestionCard</code> is used in the results
+              scroll row.
+            </p>
+            <div className="flex gap-4 flex-wrap">
+              {MOCK_MOVIES.map((movie, i) => (
+                <SmallSuggestionCard
+                  key={movie.id}
+                  movie={movie}
+                  active={activeCard === i}
+                  onClick={() => setActiveCard(i)}
+                />
+              ))}
+            </div>
+          </div>
+          <Label>SmallSuggestionCard — active / inactive states</Label>
+        </Section>
+
+        {/* ── Skeleton States ──────────────────────────────────────────── */}
+        <Section title="Skeleton / Loading States">
+          <div className="space-y-6">
+            <div>
+              <p className="text-xs mb-3" style={{ color: 'var(--pc-t3)' }}>
+                <code className="text-(--pc-gold)">MoviesTableSkeleton</code> — shown while table
+                data loads
+              </p>
+              <MoviesTableSkeleton />
+            </div>
+            <div style={{ borderTop: '1px solid var(--pc-bd1)', paddingTop: '1.5rem' }}>
+              <p className="text-xs mb-3" style={{ color: 'var(--pc-t3)' }}>
+                Generic card skeleton pattern
+              </p>
+              <div className="flex gap-4 flex-wrap">
+                {[1, 2, 3].map((i) => (
+                  <SkeletonCard key={i} />
+                ))}
+              </div>
+            </div>
+          </div>
+        </Section>
+
+        {/* ── AI Content Block ─────────────────────────────────────────── */}
+        <Section title="AI Content Block">
+          <Card>
+            <AIBlock>
+              Christopher Nolan&apos;s mind-bending thriller follows a skilled thief who steals
+              secrets from dreams. A perfect match for fans of cerebral sci-fi with breathtaking
+              visuals.
+            </AIBlock>
+            <Label>var(--pc-ai-bg) / var(--pc-ai-bd) — used for AI-generated descriptions</Label>
+          </Card>
+        </Section>
+
+        {/* ── Alert Banners ────────────────────────────────────────────── */}
+        <Section title="Alert Banners">
+          <Card>
+            <div className="space-y-3">
+              <AlertBanner type="info">
+                Movie database is loading — showing cached results.
+              </AlertBanner>
+              <AlertBanner type="warning">
+                Some poster images couldn&apos;t be loaded from TMDB.
+              </AlertBanner>
+              <AlertBanner type="error">
+                Recommendation service unavailable. Please try again.
+              </AlertBanner>
+            </div>
+          </Card>
+        </Section>
+
+        {/* ── Feature Cards ────────────────────────────────────────────── */}
+        <Section title="Feature Cards">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5">
+            <FeatureCard
+              icon={Sparkles}
+              title="AI Powered"
+              desc="Uses OpenAI embeddings for smart recommendations"
+              color={palette.gold}
+            />
+            <FeatureCard
+              icon={Play}
+              title="5 Questions"
+              desc="Answer a short quiz to get personalized picks"
+              color={palette.amber}
+            />
+            <FeatureCard
+              icon={Users}
+              title="Group Mode"
+              desc="Find a movie everyone in your group will enjoy"
+              color={palette.purple}
+            />
+            <FeatureCard
+              icon={Zap}
+              title="Instant Results"
+              desc="Get recommendations in seconds, not minutes"
+              color={palette.teal}
+            />
+          </div>
+          <Label>FeatureCard — FeaturesSection pattern: icon + title + description</Label>
+        </Section>
+
+        {/* ── Genre Selector ───────────────────────────────────────────── */}
+        <Section title="Genre Selector">
+          <Card>
+            <p className="text-xs mb-4" style={{ color: 'var(--pc-t3)' }}>
+              Multi-select. Click to toggle genres. Used in{' '}
+              <code className="text-(--pc-gold)">MoodStep</code>.
+            </p>
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+              {GENRES.map((g) => (
+                <GenreChip
+                  key={g.id}
+                  icon={g.icon}
+                  label={g.label}
+                  color={g.color}
+                  selected={selectedGenres.includes(g.id)}
+                  onToggle={() =>
+                    setSelectedGenres((prev) =>
+                      prev.includes(g.id) ? prev.filter((x) => x !== g.id) : [...prev, g.id],
+                    )
+                  }
+                />
+              ))}
+            </div>
+            <Label>GenreChip — selected: [{selectedGenres.join(', ')}]</Label>
+          </Card>
+        </Section>
+
+        {/* ── Tone Selector ────────────────────────────────────────────── */}
+        <Section title="Tone Selector">
+          <Card>
+            <p className="text-xs mb-4" style={{ color: 'var(--pc-t3)' }}>
+              Single-select. Click to choose a tone. Used in{' '}
+              <code className="text-(--pc-gold)">ToneStep</code>.
+            </p>
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+              {TONES.map((tone) => (
+                <ToneCard
+                  key={tone.id}
+                  icon={tone.icon}
+                  label={tone.label}
+                  desc={tone.desc}
+                  color={tone.color}
+                  grad={tone.grad}
+                  selected={selectedTone === tone.id}
+                  onSelect={() => setSelectedTone(tone.id)}
+                />
+              ))}
+            </div>
+            <Label>ToneCard — selected: {selectedTone}</Label>
+          </Card>
+        </Section>
+
+        {/* ── Era Selector ─────────────────────────────────────────────── */}
+        <Section title="Era Selector">
+          <Card>
+            <p className="text-xs mb-4" style={{ color: 'var(--pc-t3)' }}>
+              Single-select. Click to pick a film era. Used in{' '}
+              <code className="text-(--pc-gold)">EraStep</code>.
+            </p>
+            <div className="flex flex-col gap-3 max-w-sm">
+              {ERAS.map((era) => (
+                <EraOption
+                  key={era.id}
+                  emoji={era.emoji}
+                  title={era.title}
+                  desc={era.desc}
+                  color={era.color}
+                  selected={selectedEra === era.id}
+                  onSelect={() => setSelectedEra(era.id)}
+                />
+              ))}
+            </div>
+            <Label>EraOption — selected: {selectedEra}</Label>
+          </Card>
+        </Section>
+
+        {/* ── Text Inputs ──────────────────────────────────────────────── */}
+        <Section title="Text Inputs">
+          <Card>
+            <div className="grid gap-5 sm:grid-cols-2 max-w-xl">
+              <StyledInput placeholder="e.g. The Matrix" label="Favourite Movie" />
+              <StyledInput placeholder="e.g. Leonardo DiCaprio" label="Favourite Actor" />
+              <StyledInput placeholder="Your name" />
+              <div>
+                <p
+                  className="text-xs font-semibold uppercase tracking-wider mb-1.5"
+                  style={{ color: 'var(--pc-t3)' }}
+                >
+                  With number badge
+                </p>
+                <div className="flex items-center gap-3">
+                  <NumberBadge n={1} />
+                  <div className="flex-1">
+                    <StyledInput placeholder="Player name" />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <Label>Default · focus: gold border + ring · used in quiz steps</Label>
+          </Card>
+        </Section>
+
+        {/* ── Number Badge ─────────────────────────────────────────────── */}
+        <Section title="Number Badge">
+          <Card>
+            <ComponentRow label="Sizes" code="NumberBadge">
+              {[1, 2, 3, 4].map((n) => (
+                <div key={n} className="flex flex-col items-center gap-1">
+                  <NumberBadge n={n} />
+                  <Label>#{n}</Label>
+                </div>
+              ))}
+            </ComponentRow>
+            <div className="pt-3">
+              <p className="text-xs" style={{ color: 'var(--pc-t3)' }}>
+                Used in <code className="text-(--pc-gold)">GroupSetup</code> to label participants.
+              </p>
+            </div>
+          </Card>
+        </Section>
+
+        {/* ── Quiz Navigation ──────────────────────────────────────────── */}
+        <Section title="Quiz Navigation">
+          <Card>
+            <div className="space-y-4 -mx-6">
+              <div>
+                <p className="text-xs mb-2 px-6" style={{ color: 'var(--pc-t3)' }}>
+                  Can proceed · mid-quiz
+                </p>
+                <QuizNavigation
+                  onBack={() => {}}
+                  onNext={() => {}}
+                  canProceed={true}
+                  isSubmitting={false}
+                  isLastStep={false}
+                  isLastPerson={false}
+                />
+              </div>
+              <div style={{ borderTop: '1px solid var(--pc-bd1)' }}>
+                <p className="text-xs mt-4 mb-2 px-6" style={{ color: 'var(--pc-t3)' }}>
+                  Cannot proceed
+                </p>
+                <QuizNavigation
+                  onBack={() => {}}
+                  onNext={() => {}}
+                  canProceed={false}
+                  isSubmitting={false}
+                  isLastStep={false}
+                  isLastPerson={false}
+                />
+              </div>
+              <div style={{ borderTop: '1px solid var(--pc-bd1)' }}>
+                <p className="text-xs mt-4 mb-2 px-6" style={{ color: 'var(--pc-t3)' }}>
+                  Last step · submitting
+                </p>
+                <QuizNavigation
+                  onBack={() => {}}
+                  onNext={() => {}}
+                  canProceed={true}
+                  isSubmitting={true}
+                  isLastStep={true}
+                  isLastPerson={true}
+                />
+              </div>
+            </div>
+          </Card>
+        </Section>
+
+        {/* ── Step Header Pattern ──────────────────────────────────────── */}
+        <Section title="Step Header Pattern">
+          <Card>
+            <p className="text-xs mb-6" style={{ color: 'var(--pc-t3)' }}>
+              Icon badge + Oswald heading used across all quiz step headers.
+            </p>
+            <div className="space-y-6">
+              {[
+                {
+                  icon: Smile,
+                  color: palette.purple,
+                  title: "What's your mood?",
+                  bg: `${palette.purple}15`,
+                },
+                {
+                  icon: Moon,
+                  color: palette.gold,
+                  title: 'Pick a tone',
+                  bg: 'rgba(245,197,24,0.15)',
+                },
+                {
+                  icon: Clock,
+                  color: palette.amber,
+                  title: 'Choose an era',
+                  bg: 'rgba(255,159,28,0.15)',
+                },
+                {
+                  icon: Clapperboard,
+                  color: palette.teal,
+                  title: 'Favourite movie',
+                  bg: `${palette.teal}15`,
+                },
+              ].map(({ icon: Icon, color, title, bg }) => (
+                <div key={title} className="flex items-center gap-3">
+                  <div
+                    className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0"
+                    style={{ background: bg, color }}
+                  >
+                    <Icon size={20} />
+                  </div>
+                  <h2
+                    style={{
+                      fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
+                      fontWeight: '600',
+                      textTransform: 'uppercase',
+                      fontSize: '1.8rem',
+                      letterSpacing: '0.04em',
+                      color: 'var(--pc-t1)',
+                      lineHeight: 1.1,
+                    }}
+                  >
+                    {title}
+                  </h2>
+                </div>
+              ))}
+            </div>
+          </Card>
+        </Section>
+
+        {/* Footer */}
+        <div
+          className="mt-8 pt-8 text-center text-sm flex items-center justify-between"
+          style={{ borderTop: '1px solid var(--pc-bd1)', color: 'var(--pc-footer)' }}
+        >
+          <span>PopChoice Components</span>
+          <a
+            href="/style-guide"
+            className="text-xs uppercase tracking-widest font-semibold transition-colors"
+            style={{ color: 'var(--pc-t3)' }}
+            onMouseEnter={(e) => ((e.target as HTMLElement).style.color = 'var(--pc-gold)')}
+            onMouseLeave={(e) => ((e.target as HTMLElement).style.color = 'var(--pc-t3)')}
+          >
+            ← Back to Style Guide
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/style-guide/components/page.tsx
+++ b/src/app/style-guide/components/page.tsx
@@ -447,8 +447,7 @@ export default function StyleGuideComponentsPage() {
         <div className="mb-4">
           <Link
             href="/style-guide"
-            className="text-xs uppercase tracking-widest font-semibold transition-colors hover:text-(--pc-gold)"
-            style={{ color: 'var(--pc-t3)' }}
+            className="text-(--pc-t3) text-xs uppercase tracking-widest font-semibold transition-colors hover:text-(--pc-gold)"
           >
             ← Style Guide
           </Link>
@@ -919,8 +918,7 @@ export default function StyleGuideComponentsPage() {
           <span>PopChoice Components</span>
           <Link
             href="/style-guide"
-            className="text-xs uppercase tracking-widest font-semibold transition-colors hover:text-(--pc-gold)"
-            style={{ color: 'var(--pc-t3)' }}
+            className="text-(--pc-t3) text-xs uppercase tracking-widest font-semibold transition-colors hover:text-(--pc-gold)"
           >
             ← Back to Style Guide
           </Link>

--- a/src/app/style-guide/components/page.tsx
+++ b/src/app/style-guide/components/page.tsx
@@ -16,42 +16,11 @@ import { ThemeToggle } from '@/components/ThemeToggle';
 import { TMDBAttribution } from '@/components/TMDBAttribution';
 import { palette } from '@/styles/designTokens';
 
+import { Card, Label, Section } from '../_components';
+
 import type { MovieRecommendation } from '@/utils/client';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
-
-function Section({ title, children }: { title: string; children: React.ReactNode }) {
-  return (
-    <section className="mb-16">
-      <h2
-        className="mb-6 text-xs font-bold uppercase tracking-[0.2em]"
-        style={{ color: 'var(--pc-gold)', fontFamily: "var(--font-oswald), 'Oswald', sans-serif" }}
-      >
-        {title}
-      </h2>
-      {children}
-    </section>
-  );
-}
-
-function Card({ children, className = '' }: { children: React.ReactNode; className?: string }) {
-  return (
-    <div
-      className={`rounded-xl p-6 ${className}`}
-      style={{ background: 'var(--pc-surface)', border: '1px solid var(--pc-bd2)' }}
-    >
-      {children}
-    </div>
-  );
-}
-
-function Label({ children }: { children: React.ReactNode }) {
-  return (
-    <p className="mt-2 text-xs" style={{ color: 'var(--pc-t3)', fontFamily: 'monospace' }}>
-      {children}
-    </p>
-  );
-}
 
 function ComponentRow({
   label,
@@ -135,6 +104,7 @@ function GenreChip({
 }) {
   return (
     <button
+      type="button"
       onClick={onToggle}
       className="flex items-center gap-3 p-3.5 rounded-xl text-left transition-all duration-200"
       style={{
@@ -179,6 +149,7 @@ function ToneCard({
 }) {
   return (
     <button
+      type="button"
       onClick={onSelect}
       className="flex flex-col items-start gap-3 p-4 rounded-2xl text-left transition-all duration-200"
       style={{
@@ -227,6 +198,7 @@ function EraOption({
 }) {
   return (
     <button
+      type="button"
       onClick={onSelect}
       className="flex items-center gap-4 p-4 rounded-2xl text-left transition-all duration-200 w-full"
       style={{
@@ -266,20 +238,7 @@ function StyledInput({ placeholder, label }: { placeholder: string; label?: stri
       <input
         id={inputId}
         placeholder={placeholder}
-        className="w-full px-4 py-3 rounded-xl outline-none transition-all duration-200 text-sm"
-        style={{
-          background: 'var(--pc-bg)',
-          border: '1px solid var(--pc-bd2)',
-          color: 'var(--pc-t1)',
-        }}
-        onFocus={(e) => {
-          (e.target as HTMLInputElement).style.borderColor = 'var(--pc-gold-bd)';
-          (e.target as HTMLInputElement).style.boxShadow = 'var(--pc-gold-ring)';
-        }}
-        onBlur={(e) => {
-          (e.target as HTMLInputElement).style.borderColor = 'var(--pc-bd2)';
-          (e.target as HTMLInputElement).style.boxShadow = 'none';
-        }}
+        className="w-full rounded-xl border border-(--pc-bd2) bg-(--pc-bg) px-4 py-3 text-sm text-(--pc-t1) outline-none transition-all duration-200 focus-visible:border-(--pc-gold-bd) focus-visible:shadow-(--pc-gold-ring)"
       />
     </div>
   );
@@ -386,6 +345,86 @@ function AIBlock({ children }: { children: React.ReactNode }) {
   );
 }
 
+// ── Static demo data (hoisted to avoid recreation on every render) ─────────────
+
+const MOCK_MOVIES: MovieRecommendation[] = [
+  {
+    id: 1,
+    name: 'Inception',
+    year: 2010,
+    similarity: 0.97,
+    score_rating: 8.8,
+    age_rating: 'PG-13',
+    duration: 148,
+  },
+  {
+    id: 2,
+    name: 'Interstellar',
+    year: 2014,
+    similarity: 0.94,
+    score_rating: 8.6,
+    age_rating: 'PG-13',
+    duration: 169,
+  },
+  {
+    id: 3,
+    name: 'The Dark Knight',
+    year: 2008,
+    similarity: 0.91,
+    score_rating: 9.0,
+    age_rating: 'PG-13',
+    duration: 152,
+  },
+];
+
+const GENRES = [
+  { id: 'action', label: 'Action', icon: Zap, color: palette.amber },
+  { id: 'comedy', label: 'Comedy', icon: Smile, color: palette.gold },
+  { id: 'drama', label: 'Drama', icon: Play, color: palette.purple },
+  { id: 'scifi', label: 'Sci-Fi', icon: Sparkles, color: palette.teal },
+];
+
+const TONES = [
+  {
+    id: 'light',
+    label: 'Light & Fun',
+    desc: 'Easy going, uplifting',
+    icon: Sparkles,
+    color: palette.gold,
+    grad: `linear-gradient(135deg, ${palette.gold}18, ${palette.amber}18)`,
+  },
+  {
+    id: 'balanced',
+    label: 'Balanced',
+    desc: 'Mix of everything',
+    icon: Play,
+    color: palette.teal,
+    grad: `linear-gradient(135deg, ${palette.teal}18, ${palette.blue}18)`,
+  },
+  {
+    id: 'serious',
+    label: 'Serious',
+    desc: 'Deep and meaningful',
+    icon: Moon,
+    color: palette.purple,
+    grad: `linear-gradient(135deg, ${palette.purple}18, ${palette.purpleLight}18)`,
+  },
+  {
+    id: 'dark',
+    label: 'Dark',
+    desc: 'Intense and gritty',
+    icon: Moon,
+    color: palette.gray,
+    grad: `linear-gradient(135deg, ${palette.gray}18, ${palette.red}18)`,
+  },
+];
+
+const ERAS = [
+  { id: 'new', emoji: '✨', title: 'New Releases', desc: 'Post-2010', color: palette.teal },
+  { id: 'classic', emoji: '🎞️', title: 'Classics', desc: 'Pre-2000', color: palette.gold },
+  { id: 'both', emoji: '🎬', title: 'Any Era', desc: 'No preference', color: palette.purple },
+];
+
 // ── Number Badge (GroupSetup) ──────────────────────────────────────────────────
 
 export default function StyleGuideComponentsPage() {
@@ -394,84 +433,6 @@ export default function StyleGuideComponentsPage() {
   const [selectedTone, setSelectedTone] = useState<string>('light');
   const [selectedEra, setSelectedEra] = useState<string>('both');
   const [activeCard, setActiveCard] = useState<number>(0);
-
-  const MOCK_MOVIES: MovieRecommendation[] = [
-    {
-      id: 1,
-      name: 'Inception',
-      year: 2010,
-      similarity: 0.97,
-      score_rating: 8.8,
-      age_rating: 'PG-13',
-      duration: 148,
-    },
-    {
-      id: 2,
-      name: 'Interstellar',
-      year: 2014,
-      similarity: 0.94,
-      score_rating: 8.6,
-      age_rating: 'PG-13',
-      duration: 169,
-    },
-    {
-      id: 3,
-      name: 'The Dark Knight',
-      year: 2008,
-      similarity: 0.91,
-      score_rating: 9.0,
-      age_rating: 'PG-13',
-      duration: 152,
-    },
-  ];
-
-  const GENRES = [
-    { id: 'action', label: 'Action', icon: Zap, color: palette.amber },
-    { id: 'comedy', label: 'Comedy', icon: Smile, color: palette.gold },
-    { id: 'drama', label: 'Drama', icon: Play, color: palette.purple },
-    { id: 'scifi', label: 'Sci-Fi', icon: Sparkles, color: palette.teal },
-  ];
-
-  const TONES = [
-    {
-      id: 'light',
-      label: 'Light & Fun',
-      desc: 'Easy going, uplifting',
-      icon: Sparkles,
-      color: palette.gold,
-      grad: `linear-gradient(135deg, ${palette.gold}18, ${palette.amber}18)`,
-    },
-    {
-      id: 'balanced',
-      label: 'Balanced',
-      desc: 'Mix of everything',
-      icon: Play,
-      color: palette.teal,
-      grad: `linear-gradient(135deg, ${palette.teal}18, ${palette.blue}18)`,
-    },
-    {
-      id: 'serious',
-      label: 'Serious',
-      desc: 'Deep and meaningful',
-      icon: Moon,
-      color: palette.purple,
-      grad: `linear-gradient(135deg, ${palette.purple}18, ${palette.purpleLight}18)`,
-    },
-    {
-      id: 'dark',
-      label: 'Dark',
-      desc: 'Intense and gritty',
-      icon: Moon,
-      color: palette.gray,
-      grad: `linear-gradient(135deg, ${palette.gray}18, ${palette.red}18)`,
-    },
-  ];
-
-  const ERAS = [
-    { id: 'new', emoji: '✨', title: 'New Releases', desc: 'Post-2010', color: palette.teal },
-    { id: 'classic', emoji: '🎞️', title: 'Classics', desc: 'Pre-2000', color: palette.gold },
-    { id: 'both', emoji: '🎬', title: 'Any Era', desc: 'No preference', color: palette.purple },
-  ];
 
   return (
     <div

--- a/src/app/style-guide/page.tsx
+++ b/src/app/style-guide/page.tsx
@@ -5,43 +5,7 @@ import { Button } from '@/components/Button';
 import { ProgressDots } from '@/components/ProgressDots';
 import { palette } from '@/styles/designTokens';
 
-// ── Helpers ──────────────────────────────────────────────────────────────────
-
-function Section({ title, children }: { title: string; children: React.ReactNode }) {
-  return (
-    <section className="mb-16">
-      <h2
-        className="mb-6 text-xs font-bold uppercase tracking-[0.2em]"
-        style={{ color: 'var(--pc-gold)', fontFamily: "var(--font-oswald), 'Oswald', sans-serif" }}
-      >
-        {title}
-      </h2>
-      {children}
-    </section>
-  );
-}
-
-function Card({ children, className = '' }: { children: React.ReactNode; className?: string }) {
-  return (
-    <div
-      className={`rounded-xl p-6 ${className}`}
-      style={{
-        background: 'var(--pc-surface)',
-        border: '1px solid var(--pc-bd2)',
-      }}
-    >
-      {children}
-    </div>
-  );
-}
-
-function Label({ children }: { children: React.ReactNode }) {
-  return (
-    <p className="mt-2 text-xs" style={{ color: 'var(--pc-t3)', fontFamily: 'monospace' }}>
-      {children}
-    </p>
-  );
-}
+import { Card, Label, Section } from './_components';
 
 // ── Color Swatch ──────────────────────────────────────────────────────────────
 

--- a/src/app/style-guide/page.tsx
+++ b/src/app/style-guide/page.tsx
@@ -557,8 +557,7 @@ export default function StyleGuidePage() {
           <span>PopChoice Style Guide &mdash; design tokens &amp; components</span>
           <Link
             href="/style-guide/components"
-            className="text-xs uppercase tracking-widest font-semibold transition-colors"
-            style={{ color: 'var(--pc-t3)' }}
+            className="text-(--pc-t3) text-xs uppercase tracking-widest font-semibold transition-colors hover:text-(--pc-gold)"
           >
             Components →
           </Link>

--- a/src/app/style-guide/page.tsx
+++ b/src/app/style-guide/page.tsx
@@ -1,0 +1,607 @@
+'use client';
+
+import { AgeRatingChip } from '@/components/AgeRatingChip';
+import { Button } from '@/components/Button';
+import { ProgressDots } from '@/components/ProgressDots';
+import { palette } from '@/styles/designTokens';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="mb-16">
+      <h2
+        className="mb-6 text-xs font-bold uppercase tracking-[0.2em]"
+        style={{ color: 'var(--pc-gold)', fontFamily: "var(--font-oswald), 'Oswald', sans-serif" }}
+      >
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+function Card({ children, className = '' }: { children: React.ReactNode; className?: string }) {
+  return (
+    <div
+      className={`rounded-xl p-6 ${className}`}
+      style={{
+        background: 'var(--pc-surface)',
+        border: '1px solid var(--pc-bd2)',
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function Label({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="mt-2 text-xs" style={{ color: 'var(--pc-t3)', fontFamily: 'monospace' }}>
+      {children}
+    </p>
+  );
+}
+
+// ── Color Swatch ──────────────────────────────────────────────────────────────
+
+function ColorSwatch({
+  color,
+  name,
+  token,
+  isVar = false,
+}: {
+  color: string;
+  name: string;
+  token: string;
+  isVar?: boolean;
+}) {
+  const bg = isVar ? undefined : color;
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div
+        className="h-14 w-full rounded-lg border"
+        style={{
+          background: isVar ? `var(${color})` : bg,
+          borderColor: 'var(--pc-bd2)',
+        }}
+      />
+      <p className="text-sm font-semibold" style={{ color: 'var(--pc-t1)' }}>
+        {name}
+      </p>
+      <p className="text-xs font-mono" style={{ color: 'var(--pc-t3)' }}>
+        {token}
+      </p>
+    </div>
+  );
+}
+
+// ── Token Row ─────────────────────────────────────────────────────────────────
+
+function TokenRow({ token, description }: { token: string; description: string }) {
+  return (
+    <div
+      className="flex items-center gap-4 py-3"
+      style={{ borderBottom: '1px solid var(--pc-bd1)' }}
+    >
+      <div
+        className="h-8 w-8 shrink-0 rounded-md border"
+        style={{ background: `var(${token})`, borderColor: 'var(--pc-bd2)' }}
+      />
+      <code className="min-w-55 text-xs" style={{ color: 'var(--pc-gold)' }}>
+        {token}
+      </code>
+      <span className="text-sm" style={{ color: 'var(--pc-t2)' }}>
+        {description}
+      </span>
+    </div>
+  );
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+export default function StyleGuidePage() {
+  return (
+    <div
+      className="min-h-screen"
+      style={{
+        background: 'var(--pc-bg)',
+        fontFamily: "var(--font-manrope), 'Manrope', sans-serif",
+      }}
+    >
+      <div className="mx-auto max-w-5xl px-6 py-16">
+        {/* Header */}
+        <div className="mb-16">
+          <p
+            className="mb-2 text-xs font-bold uppercase tracking-[0.25em]"
+            style={{ color: 'var(--pc-gold)' }}
+          >
+            PopChoice
+          </p>
+          <h1
+            className="mb-4 text-5xl font-bold"
+            style={{
+              fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
+              color: 'var(--pc-t1)',
+            }}
+          >
+            Style Guide
+          </h1>
+          <p className="max-w-xl text-lg" style={{ color: 'var(--pc-t2)' }}>
+            Design tokens, components, and patterns that make up the PopChoice visual language.
+          </p>
+          <div className="mt-6 flex gap-3">
+            <a
+              href="/style-guide/components"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-semibold transition-all duration-200"
+              style={{
+                background: 'var(--pc-gold-subtle)',
+                border: '1px solid var(--pc-gold-bd-subtle)',
+                color: 'var(--pc-gold-text)',
+              }}
+            >
+              Components →
+            </a>
+          </div>
+        </div>
+
+        {/* ── Brand Palette ──────────────────────────────────────────────── */}
+        <Section title="Brand Palette">
+          <Card>
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-5">
+              {(Object.entries(palette) as [string, string][]).map(([key, value]) => (
+                <ColorSwatch key={key} color={value} name={key} token={value} />
+              ))}
+            </div>
+          </Card>
+        </Section>
+
+        {/* ── Theme Backgrounds ──────────────────────────────────────────── */}
+        <Section title="Backgrounds">
+          <Card>
+            <TokenRow token="--pc-bg" description="Page background" />
+            <TokenRow token="--pc-surface" description="Card / surface" />
+            <TokenRow token="--pc-surface-hover" description="Hovered surface" />
+            <TokenRow token="--pc-surface-deep" description="Deep / nested surface" />
+            <TokenRow token="--pc-ghost" description="Subtle interactive fill" />
+          </Card>
+        </Section>
+
+        {/* ── Text ──────────────────────────────────────────────────────── */}
+        <Section title="Text Colors">
+          <Card>
+            <div className="space-y-3">
+              {[
+                { token: '--pc-t1', label: 'Primary text', size: 'text-2xl', weight: 'font-bold' },
+                {
+                  token: '--pc-t2',
+                  label: 'Secondary text',
+                  size: 'text-xl',
+                  weight: 'font-semibold',
+                },
+                {
+                  token: '--pc-t3',
+                  label: 'Tertiary text',
+                  size: 'text-base',
+                  weight: 'font-normal',
+                },
+                { token: '--pc-t4', label: 'Muted text', size: 'text-sm', weight: 'font-normal' },
+                {
+                  token: '--pc-gold-text',
+                  label: 'Gold text (accessible)',
+                  size: 'text-base',
+                  weight: 'font-semibold',
+                },
+                {
+                  token: '--pc-amber-text',
+                  label: 'Amber text (accessible)',
+                  size: 'text-base',
+                  weight: 'font-semibold',
+                },
+              ].map(({ token, label, size, weight }) => (
+                <div key={token} className="flex items-baseline gap-4">
+                  <span
+                    className={`${size} ${weight}`}
+                    style={{ color: `var(${token})`, minWidth: 240 }}
+                  >
+                    {label}
+                  </span>
+                  <code
+                    className="text-xs"
+                    style={{ color: 'var(--pc-t3)', fontFamily: 'monospace' }}
+                  >
+                    {token}
+                  </code>
+                </div>
+              ))}
+            </div>
+          </Card>
+        </Section>
+
+        {/* ── Brand Colors ──────────────────────────────────────────────── */}
+        <Section title="Brand Colors">
+          <Card>
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+              <ColorSwatch isVar color="--pc-gold" name="Gold" token="--pc-gold" />
+              <ColorSwatch isVar color="--pc-amber" name="Amber" token="--pc-amber" />
+              <ColorSwatch
+                isVar
+                color="--pc-gold-subtle"
+                name="Gold Subtle"
+                token="--pc-gold-subtle"
+              />
+              <ColorSwatch isVar color="--pc-gold-wash" name="Gold Wash" token="--pc-gold-wash" />
+            </div>
+          </Card>
+        </Section>
+
+        {/* ── Gradients ─────────────────────────────────────────────────── */}
+        <Section title="Gradients">
+          <div className="grid gap-4 sm:grid-cols-3">
+            {[
+              { label: 'CTA', token: '--pc-cta', style: { background: 'var(--pc-cta)' } },
+              {
+                label: 'CTA Horizontal',
+                token: '--pc-cta-h',
+                style: { background: 'var(--pc-cta-h)' },
+              },
+              {
+                label: 'Progress',
+                token: '--pc-progress',
+                style: { background: 'var(--pc-progress)' },
+              },
+            ].map(({ label, token, style }) => (
+              <div key={token}>
+                <div className="h-16 w-full rounded-xl" style={style} />
+                <Label>{token}</Label>
+                <p className="mt-0.5 text-sm" style={{ color: 'var(--pc-t2)' }}>
+                  {label}
+                </p>
+              </div>
+            ))}
+          </div>
+        </Section>
+
+        {/* ── Typography ────────────────────────────────────────────────── */}
+        <Section title="Typography">
+          <Card>
+            <div className="space-y-8">
+              {/* Oswald */}
+              <div>
+                <p
+                  className="mb-4 text-xs font-semibold uppercase tracking-widest"
+                  style={{ color: 'var(--pc-t3)' }}
+                >
+                  Oswald — Display / Headings
+                </p>
+                <div
+                  className="space-y-3"
+                  style={{ fontFamily: "var(--font-oswald), 'Oswald', sans-serif" }}
+                >
+                  {[
+                    { text: 'Heading 1', size: 'text-5xl', weight: 'font-bold' },
+                    { text: 'Heading 2', size: 'text-4xl', weight: 'font-bold' },
+                    { text: 'Heading 3', size: 'text-3xl', weight: 'font-semibold' },
+                    { text: 'Heading 4', size: 'text-2xl', weight: 'font-medium' },
+                  ].map(({ text, size, weight }) => (
+                    <div key={text} className="flex items-baseline gap-4">
+                      <span
+                        className={`${size} ${weight}`}
+                        style={{ color: 'var(--pc-t1)', minWidth: 200 }}
+                      >
+                        {text}
+                      </span>
+                      <code className="text-xs" style={{ color: 'var(--pc-t3)' }}>
+                        {size} {weight}
+                      </code>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div style={{ borderTop: '1px solid var(--pc-bd1)', paddingTop: '2rem' }}>
+                <p
+                  className="mb-4 text-xs font-semibold uppercase tracking-widest"
+                  style={{ color: 'var(--pc-t3)' }}
+                >
+                  Manrope — Body / UI
+                </p>
+                <div className="space-y-3">
+                  {[
+                    { text: 'Body Large', size: 'text-xl', weight: 'font-normal' },
+                    { text: 'Body Base', size: 'text-base', weight: 'font-normal' },
+                    { text: 'Body Small', size: 'text-sm', weight: 'font-normal' },
+                    { text: 'Label Bold', size: 'text-sm', weight: 'font-bold' },
+                    { text: 'Caption', size: 'text-xs', weight: 'font-normal' },
+                  ].map(({ text, size, weight }) => (
+                    <div key={text} className="flex items-baseline gap-4">
+                      <span
+                        className={`${size} ${weight}`}
+                        style={{ color: 'var(--pc-t1)', minWidth: 200 }}
+                      >
+                        {text}
+                      </span>
+                      <code className="text-xs" style={{ color: 'var(--pc-t3)' }}>
+                        {size} {weight}
+                      </code>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </Card>
+        </Section>
+
+        {/* ── Buttons ───────────────────────────────────────────────────── */}
+        <Section title="Buttons">
+          <Card>
+            <div className="grid gap-6 sm:grid-cols-3">
+              <div>
+                <Button variant="cta">CTA Button</Button>
+                <Label>variant=&quot;cta&quot;</Label>
+              </div>
+              <div>
+                <Button variant="default">Default Button</Button>
+                <Label>variant=&quot;default&quot;</Label>
+              </div>
+              <div>
+                <Button variant="ghost">Ghost Button</Button>
+                <Label>variant=&quot;ghost&quot;</Label>
+              </div>
+            </div>
+            <div
+              className="mt-6 grid gap-6 sm:grid-cols-3"
+              style={{ paddingTop: '1.5rem', borderTop: '1px solid var(--pc-bd1)' }}
+            >
+              <div>
+                <Button variant="cta" disabled>
+                  CTA Disabled
+                </Button>
+                <Label>variant=&quot;cta&quot; disabled</Label>
+              </div>
+              <div>
+                <Button variant="default" disabled>
+                  Default Disabled
+                </Button>
+                <Label>variant=&quot;default&quot; disabled</Label>
+              </div>
+              <div>
+                <Button variant="ghost" disabled>
+                  Ghost Disabled
+                </Button>
+                <Label>variant=&quot;ghost&quot; disabled</Label>
+              </div>
+            </div>
+          </Card>
+        </Section>
+
+        {/* ── Age Rating Chips ──────────────────────────────────────────── */}
+        <Section title="Age Rating Chips">
+          <Card>
+            {/* Sizes */}
+            <div className="mb-8">
+              <p
+                className="mb-4 text-xs font-semibold uppercase tracking-widest"
+                style={{ color: 'var(--pc-t3)' }}
+              >
+                Sizes
+              </p>
+              <div className="flex flex-wrap items-center gap-4">
+                <div className="flex flex-col items-center gap-2">
+                  <AgeRatingChip rating="PG-13" size="sm" />
+                  <Label>sm</Label>
+                </div>
+                <div className="flex flex-col items-center gap-2">
+                  <AgeRatingChip rating="PG-13" size="md" />
+                  <Label>md</Label>
+                </div>
+                <div className="flex flex-col items-center gap-2">
+                  <AgeRatingChip rating="PG-13" size="lg" />
+                  <Label>lg</Label>
+                </div>
+              </div>
+            </div>
+
+            {/* All ratings */}
+            <div style={{ borderTop: '1px solid var(--pc-bd1)', paddingTop: '1.5rem' }}>
+              <p
+                className="mb-4 text-xs font-semibold uppercase tracking-widest"
+                style={{ color: 'var(--pc-t3)' }}
+              >
+                All Ratings
+              </p>
+              <div className="flex flex-wrap gap-3">
+                {(['G', 'PG', 'PG-13', 'R', '12+', '15', '16+', '18+', 'NR'] as const).map(
+                  (rating) => (
+                    <div key={rating} className="flex flex-col items-center gap-2">
+                      <AgeRatingChip rating={rating} />
+                      <Label>{rating}</Label>
+                    </div>
+                  ),
+                )}
+              </div>
+            </div>
+          </Card>
+        </Section>
+
+        {/* ── Progress Dots ─────────────────────────────────────────────── */}
+        <Section title="Progress Dots">
+          <Card>
+            <div className="space-y-6">
+              {[
+                { current: 0, total: 5, label: 'Step 1 of 5' },
+                { current: 2, total: 5, label: 'Step 3 of 5' },
+                { current: 4, total: 5, label: 'Step 5 of 5' },
+              ].map(({ current, total, label }) => (
+                <div key={label} className="flex items-center gap-6">
+                  <ProgressDots current={current} total={total} />
+                  <span className="text-sm" style={{ color: 'var(--pc-t3)' }}>
+                    {label}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </Card>
+        </Section>
+
+        {/* ── Borders ───────────────────────────────────────────────────── */}
+        <Section title="Borders">
+          <div className="grid gap-4 sm:grid-cols-4">
+            {[
+              { token: '--pc-bd1', label: 'bd1 — subtle' },
+              { token: '--pc-bd2', label: 'bd2 — default' },
+              { token: '--pc-bd3', label: 'bd3 — medium' },
+              { token: '--pc-bd4', label: 'bd4 — strong' },
+            ].map(({ token, label }) => (
+              <div key={token}>
+                <div
+                  className="h-20 w-full rounded-xl"
+                  style={{
+                    background: 'var(--pc-surface)',
+                    border: `2px solid var(${token})`,
+                  }}
+                />
+                <Label>{token}</Label>
+                <p className="mt-0.5 text-sm" style={{ color: 'var(--pc-t2)' }}>
+                  {label}
+                </p>
+              </div>
+            ))}
+          </div>
+        </Section>
+
+        {/* ── Shadows ───────────────────────────────────────────────────── */}
+        <Section title="Shadows">
+          <div className="grid gap-8 sm:grid-cols-3">
+            {[
+              { token: '--pc-card-shadow', label: 'Card Shadow' },
+              { token: '--pc-cta-shadow', label: 'CTA Shadow' },
+              { token: '--pc-cta-shadow-hover', label: 'CTA Shadow Hover' },
+            ].map(({ token, label }) => (
+              <div key={token}>
+                <div
+                  className="h-20 w-full rounded-xl"
+                  style={{
+                    background: 'var(--pc-surface)',
+                    boxShadow: `var(${token})`,
+                  }}
+                />
+                <Label>{token}</Label>
+                <p className="mt-0.5 text-sm" style={{ color: 'var(--pc-t2)' }}>
+                  {label}
+                </p>
+              </div>
+            ))}
+          </div>
+        </Section>
+
+        {/* ── Gold Accent States ────────────────────────────────────────── */}
+        <Section title="Gold Accent States">
+          <Card>
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+              {[
+                '--pc-gold-subtle',
+                '--pc-gold-tint',
+                '--pc-gold-wash',
+                '--pc-gold-focus',
+                '--pc-gold-bd-subtle',
+                '--pc-gold-bd',
+                '--pc-gold-bd-strong',
+                '--pc-ai-bg',
+              ].map((token) => (
+                <ColorSwatch
+                  key={token}
+                  isVar
+                  color={token}
+                  name={token.replace('--pc-', '')}
+                  token={token}
+                />
+              ))}
+            </div>
+          </Card>
+        </Section>
+
+        {/* ── Spacing Scale ─────────────────────────────────────────────── */}
+        <Section title="Spacing Scale">
+          <Card>
+            <div className="space-y-3">
+              {[
+                { size: '4px', tailwind: 'p-1 / gap-1', px: 4 },
+                { size: '8px', tailwind: 'p-2 / gap-2', px: 8 },
+                { size: '12px', tailwind: 'p-3 / gap-3', px: 12 },
+                { size: '16px', tailwind: 'p-4 / gap-4', px: 16 },
+                { size: '24px', tailwind: 'p-6 / gap-6', px: 24 },
+                { size: '32px', tailwind: 'p-8 / gap-8', px: 32 },
+                { size: '48px', tailwind: 'p-12 / gap-12', px: 48 },
+                { size: '64px', tailwind: 'p-16 / gap-16', px: 64 },
+              ].map(({ size, tailwind, px }) => (
+                <div key={size} className="flex items-center gap-4">
+                  <div
+                    className="h-4 rounded-sm shrink-0"
+                    style={{
+                      width: px,
+                      background: 'var(--pc-cta)',
+                    }}
+                  />
+                  <code className="w-12 text-xs" style={{ color: 'var(--pc-t1)' }}>
+                    {size}
+                  </code>
+                  <code className="text-xs" style={{ color: 'var(--pc-t3)' }}>
+                    {tailwind}
+                  </code>
+                </div>
+              ))}
+            </div>
+          </Card>
+        </Section>
+
+        {/* ── Border Radius ─────────────────────────────────────────────── */}
+        <Section title="Border Radius">
+          <div className="flex flex-wrap items-end gap-8">
+            {[
+              { label: 'sm', radius: '0.125rem', class: 'rounded-sm', px: 40 },
+              { label: 'md', radius: '0.375rem', class: 'rounded-md', px: 52 },
+              { label: 'lg', radius: '0.5rem', class: 'rounded-lg', px: 64 },
+              { label: 'xl', radius: '0.75rem', class: 'rounded-xl', px: 72 },
+              { label: '2xl', radius: '1rem', class: 'rounded-2xl', px: 80 },
+              { label: 'full', radius: '9999px', class: 'rounded-full', px: 56 },
+            ].map(({ label, radius, class: cls, px }) => (
+              <div key={label} className="flex flex-col items-center gap-2">
+                <div
+                  className={cls}
+                  style={{
+                    width: px,
+                    height: px,
+                    background: 'var(--pc-surface)',
+                    border: '2px solid var(--pc-bd3)',
+                  }}
+                />
+                <Label>{label}</Label>
+                <p className="text-xs" style={{ color: 'var(--pc-t3)' }}>
+                  {radius}
+                </p>
+              </div>
+            ))}
+          </div>
+        </Section>
+
+        {/* Footer */}
+        <div
+          className="mt-8 pt-8 text-sm flex items-center justify-between"
+          style={{ borderTop: '1px solid var(--pc-bd1)', color: 'var(--pc-footer)' }}
+        >
+          <span>PopChoice Style Guide &mdash; design tokens &amp; components</span>
+          <a
+            href="/style-guide/components"
+            className="text-xs uppercase tracking-widest font-semibold transition-colors"
+            style={{ color: 'var(--pc-t3)' }}
+            onMouseEnter={(e) => ((e.target as HTMLElement).style.color = 'var(--pc-gold)')}
+            onMouseLeave={(e) => ((e.target as HTMLElement).style.color = 'var(--pc-t3)')}
+          >
+            Components →
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/style-guide/page.tsx
+++ b/src/app/style-guide/page.tsx
@@ -1,4 +1,4 @@
-'use client';
+import Link from 'next/link';
 
 import { AgeRatingChip } from '@/components/AgeRatingChip';
 import { Button } from '@/components/Button';
@@ -88,7 +88,7 @@ function TokenRow({ token, description }: { token: string; description: string }
         className="h-8 w-8 shrink-0 rounded-md border"
         style={{ background: `var(${token})`, borderColor: 'var(--pc-bd2)' }}
       />
-      <code className="min-w-55 text-xs" style={{ color: 'var(--pc-gold)' }}>
+      <code className="min-w-56 text-xs" style={{ color: 'var(--pc-gold)' }}>
         {token}
       </code>
       <span className="text-sm" style={{ color: 'var(--pc-t2)' }}>
@@ -131,7 +131,7 @@ export default function StyleGuidePage() {
             Design tokens, components, and patterns that make up the PopChoice visual language.
           </p>
           <div className="mt-6 flex gap-3">
-            <a
+            <Link
               href="/style-guide/components"
               className="inline-flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-semibold transition-all duration-200"
               style={{
@@ -141,7 +141,7 @@ export default function StyleGuidePage() {
               }}
             >
               Components →
-            </a>
+            </Link>
           </div>
         </div>
 
@@ -591,15 +591,13 @@ export default function StyleGuidePage() {
           style={{ borderTop: '1px solid var(--pc-bd1)', color: 'var(--pc-footer)' }}
         >
           <span>PopChoice Style Guide &mdash; design tokens &amp; components</span>
-          <a
+          <Link
             href="/style-guide/components"
             className="text-xs uppercase tracking-widest font-semibold transition-colors"
             style={{ color: 'var(--pc-t3)' }}
-            onMouseEnter={(e) => ((e.target as HTMLElement).style.color = 'var(--pc-gold)')}
-            onMouseLeave={(e) => ((e.target as HTMLElement).style.color = 'var(--pc-t3)')}
           >
             Components →
-          </a>
+          </Link>
         </div>
       </div>
     </div>

--- a/src/components/PCLayout/PCLayout.tsx
+++ b/src/components/PCLayout/PCLayout.tsx
@@ -80,8 +80,10 @@ export function PCLayout({ children }: { children: React.ReactNode }) {
               href={link.href}
               className="px-3 py-2 rounded-xl text-sm transition-colors duration-200"
               style={{
-                color: pathname === link.href ? 'var(--pc-gold-text)' : 'var(--pc-t3)',
-                background: pathname === link.href ? 'var(--pc-gold-subtle)' : 'transparent',
+                color: pathname.startsWith(link.href) ? 'var(--pc-gold-text)' : 'var(--pc-t3)',
+                background: pathname.startsWith(link.href)
+                  ? 'var(--pc-gold-subtle)'
+                  : 'transparent',
               }}
             >
               {link.label}
@@ -181,9 +183,11 @@ export function PCLayout({ children }: { children: React.ReactNode }) {
               onClick={() => setMobileMenuOpen(false)}
               className="px-3 py-2.5 rounded-xl text-sm transition-colors duration-200"
               style={{
-                color: pathname === link.href ? 'var(--pc-gold-text)' : 'var(--pc-t2)',
-                background: pathname === link.href ? 'var(--pc-gold-subtle)' : 'transparent',
-                fontWeight: pathname === link.href ? 600 : 400,
+                color: pathname.startsWith(link.href) ? 'var(--pc-gold-text)' : 'var(--pc-t2)',
+                background: pathname.startsWith(link.href)
+                  ? 'var(--pc-gold-subtle)'
+                  : 'transparent',
+                fontWeight: pathname.startsWith(link.href) ? 600 : 400,
               }}
             >
               {link.label}

--- a/src/components/PCLayout/PCLayout.tsx
+++ b/src/components/PCLayout/PCLayout.tsx
@@ -28,6 +28,7 @@ export function PCLayout({ children }: { children: React.ReactNode }) {
   const navLinks = [
     { href: '/about', label: t.nav.howItWorks },
     { href: '/available-movies', label: t.nav.availableMovies },
+    { href: '/style-guide', label: t.nav.styleGuide },
   ];
 
   return (

--- a/src/components/PCLayout/PCLayout.tsx
+++ b/src/components/PCLayout/PCLayout.tsx
@@ -80,8 +80,8 @@ export function PCLayout({ children }: { children: React.ReactNode }) {
               href={link.href}
               className="px-3 py-2 rounded-xl text-sm transition-colors duration-200"
               style={{
-                color: pathname.startsWith(link.href) ? 'var(--pc-gold-text)' : 'var(--pc-t3)',
-                background: pathname.startsWith(link.href)
+                color: pathname?.startsWith(link.href) ? 'var(--pc-gold-text)' : 'var(--pc-t3)',
+                background: pathname?.startsWith(link.href)
                   ? 'var(--pc-gold-subtle)'
                   : 'transparent',
               }}
@@ -183,11 +183,11 @@ export function PCLayout({ children }: { children: React.ReactNode }) {
               onClick={() => setMobileMenuOpen(false)}
               className="px-3 py-2.5 rounded-xl text-sm transition-colors duration-200"
               style={{
-                color: pathname.startsWith(link.href) ? 'var(--pc-gold-text)' : 'var(--pc-t2)',
-                background: pathname.startsWith(link.href)
+                color: pathname?.startsWith(link.href) ? 'var(--pc-gold-text)' : 'var(--pc-t2)',
+                background: pathname?.startsWith(link.href)
                   ? 'var(--pc-gold-subtle)'
                   : 'transparent',
-                fontWeight: pathname.startsWith(link.href) ? 600 : 400,
+                fontWeight: pathname?.startsWith(link.href) ? 600 : 400,
               }}
             >
               {link.label}

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -7,6 +7,7 @@ export const en = {
     switchLanguage: 'Switch language',
     openMenu: 'Open menu',
     closeMenu: 'Close menu',
+    styleGuide: 'Style Guide',
   },
   footer: {
     builtBy: 'Built by',

--- a/src/i18n/locales/fi.ts
+++ b/src/i18n/locales/fi.ts
@@ -9,6 +9,7 @@ export const fi: Translations = {
     switchLanguage: 'Vaihda kieli',
     openMenu: 'Avaa valikko',
     closeMenu: 'Sulje valikko',
+    styleGuide: 'Tyyliopas',
   },
   footer: {
     builtBy: 'Rakentanut',

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -9,6 +9,7 @@ export const ru: Translations = {
     switchLanguage: 'Переключить язык',
     openMenu: 'Открыть меню',
     closeMenu: 'Закрыть меню',
+    styleGuide: 'Гайдлайн',
   },
   footer: {
     builtBy: 'Сделал',


### PR DESCRIPTION
## Summary

Adds a living style guide to the app documenting all design tokens and reusable components.

## Changes

### New pages
- **`/style-guide`** — Design tokens reference: brand palette, backgrounds, text colors, gradients, typography (Oswald + Manrope scales), buttons, age rating chips, progress dots, borders, shadows, gold accent states, spacing scale, border radius
- **`/style-guide/components`** — Component showcase with interactive states: `SmallSuggestionCard`, `Mascot`, `ThemeToggle`, `LanguageSwitcher`, `TMDBAttribution`, `AgeRatingPill`, `StarRating`, `SimilarityBadge`, `MoviesTableSkeleton`, `QuizNavigation`, plus inline pattern documentation for quiz UI elements

### Navbar
- Added **Style Guide** link to desktop nav and mobile drawer
- Added `styleGuide` i18n key to all three locales (EN: `Style Guide`, RU: `Гайдлайн`, FI: `Tyyliopas`)

## Notes
- All color swatches and component previews connect to existing CSS custom properties (`--pc-*`) and real component implementations — no new design tokens or duplicate components were introduced