### PR TITLE
fix: add db-migrate Railway service and recommendations schema migration

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -44,4 +44,4 @@ COPY apps/web/scripts ./apps/web/scripts
 COPY db/init ./db/init
 
 EXPOSE 3000
-CMD ["npm", "run", "start:with-migrations", "--workspace=apps/web"]
+CMD ["npm", "run", "start", "--workspace=apps/web"]

--- a/db/init/03_recommendations.sql
+++ b/db/init/03_recommendations.sql
@@ -30,9 +30,6 @@ UPDATE recommendations
 -- Enforce NOT NULL now that every row has a value
 ALTER TABLE recommendations ALTER COLUMN slug SET NOT NULL;
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_recommendations_slug
-  ON recommendations (slug);
-
 -- Individual movies linked to a recommendation
 CREATE TABLE IF NOT EXISTS recommendation_movies (
   id                      bigserial  PRIMARY KEY,
@@ -52,8 +49,6 @@ CREATE TABLE IF NOT EXISTS recommendation_movies (
   tmdb_duration           integer,
   tmdb_age_rating         text
 );
-
-ALTER TABLE recommendation_movies ADD COLUMN IF NOT EXISTS tmdb_id bigint;
 
 CREATE INDEX IF NOT EXISTS idx_recommendation_movies_rec_id
   ON recommendation_movies (recommendation_id);

--- a/db/init/03_recommendations.sql
+++ b/db/init/03_recommendations.sql
@@ -1,0 +1,59 @@
+-- Migration: recommendations and recommendation_movies tables.
+-- Keep in sync with db/recommendations.sql.
+-- All statements are idempotent (IF NOT EXISTS / ADD COLUMN IF NOT EXISTS).
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- Recommendations table
+CREATE TABLE IF NOT EXISTS recommendations (
+  id                  uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  slug                text        UNIQUE NOT NULL,
+  status              text        NOT NULL DEFAULT 'pending',
+  quiz_data           jsonb       NOT NULL,
+  error               text,
+  created_at          timestamptz NOT NULL DEFAULT now(),
+  completed_at        timestamptz,
+  used_broader_search boolean,
+  db_movie_count      integer,
+  more_picks_status   text
+);
+
+-- Idempotent column additions for databases created before slug / more_picks_status were added
+ALTER TABLE recommendations ADD COLUMN IF NOT EXISTS slug             text;
+ALTER TABLE recommendations ADD COLUMN IF NOT EXISTS more_picks_status text;
+
+-- Back-fill slug for any legacy rows that pre-date the column
+UPDATE recommendations
+   SET slug = REPLACE(id::text, '-', '')
+ WHERE slug IS NULL;
+
+-- Enforce NOT NULL now that every row has a value
+ALTER TABLE recommendations ALTER COLUMN slug SET NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_recommendations_slug
+  ON recommendations (slug);
+
+-- Individual movies linked to a recommendation
+CREATE TABLE IF NOT EXISTS recommendation_movies (
+  id                      bigserial  PRIMARY KEY,
+  recommendation_id       uuid       NOT NULL REFERENCES recommendations(id) ON DELETE CASCADE,
+  movie_id                bigint     REFERENCES movies(id),
+  position                integer    NOT NULL,
+  is_main_recommendation  boolean    NOT NULL DEFAULT false,
+  ai_description          text,
+  poster_url              text,
+  localized_name          text,
+  similarity              float,
+  from_tmdb               boolean    NOT NULL DEFAULT false,
+  tmdb_id                 bigint,
+  tmdb_name               text,
+  tmdb_year               integer,
+  tmdb_score_rating       float,
+  tmdb_duration           integer,
+  tmdb_age_rating         text
+);
+
+ALTER TABLE recommendation_movies ADD COLUMN IF NOT EXISTS tmdb_id bigint;
+
+CREATE INDEX IF NOT EXISTS idx_recommendation_movies_rec_id
+  ON recommendation_movies (recommendation_id);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5418,6 +5418,10 @@
         "node": "*"
       }
     },
+    "node_modules/db-migrate": {
+      "resolved": "services/db-migrate",
+      "link": true
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "license": "MIT",
@@ -12318,6 +12322,16 @@
       "devDependencies": {
         "@types/pg": "^8.20.0",
         "typescript": "6.0.3"
+      }
+    },
+    "services/db-migrate": {
+      "version": "1.0.0",
+      "dependencies": {
+        "pg": "^8.20.0"
+      },
+      "engines": {
+        "node": ">=24",
+        "npm": ">=11"
       }
     },
     "services/movie-backfill": {

--- a/railway.toml
+++ b/railway.toml
@@ -14,6 +14,7 @@
 #   • movie-discovery   — services/movie-discovery/Dockerfile
 #   • movie-seed        — services/movie-seed/Dockerfile
 #   • movie-backfill    — no Dockerfile yet; set up build in the dashboard
+#   • db-migrate        — services/db-migrate/Dockerfile (one-shot, railway.toml in service dir)
 
 [build]
 # All services are built from their own Dockerfiles.

--- a/services/db-migrate/Dockerfile
+++ b/services/db-migrate/Dockerfile
@@ -1,0 +1,28 @@
+# Build context: repo root
+# docker build -f services/db-migrate/Dockerfile .
+#
+# One-shot Railway job: applies all db/init/*.sql migrations and exits.
+# Configure in Railway dashboard:
+#   • Dockerfile Path: services/db-migrate/Dockerfile
+#   • Restart Policy: never  (Job runs once per deploy)
+
+FROM node:24-slim
+
+WORKDIR /app
+
+# Copy root workspace manifest + every service package.json so `npm ci`
+# can resolve the full workspace graph without errors.
+COPY package.json package-lock.json ./
+COPY packages/shared/package.json ./packages/shared/
+COPY apps/web/package.json ./apps/web/
+COPY services/db-migrate/package.json ./services/db-migrate/
+COPY services/movie-backfill/package.json ./services/movie-backfill/
+COPY services/movie-discovery/package.json ./services/movie-discovery/
+COPY services/movie-seed/package.json ./services/movie-seed/
+RUN npm ci --omit=dev --workspace=services/db-migrate
+
+# Migration script and SQL files
+COPY services/db-migrate/migrate.js ./services/db-migrate/
+COPY db/init/ ./db/init/
+
+CMD ["node", "services/db-migrate/migrate.js"]

--- a/services/db-migrate/migrate.js
+++ b/services/db-migrate/migrate.js
@@ -57,6 +57,6 @@ async function main() {
 }
 
 main().catch((error) => {
-  console.error('[db:migrate] Migration failed:', error.message);
+  console.error('[db:migrate] Migration failed:', error);
   process.exit(1);
 });

--- a/services/db-migrate/migrate.js
+++ b/services/db-migrate/migrate.js
@@ -1,0 +1,62 @@
+// Applies all SQL files from db/init/ against the database at DATABASE_URL.
+// Runs all migrations in a single transaction — rolls back everything on failure.
+// Designed to run as a one-shot Railway job before the web app starts.
+
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import pg from 'pg';
+
+const { Client } = pg;
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Dockerfile copies db/init/ to /app/db/init — two levels above this script.
+const migrationsDir = path.resolve(__dirname, '../../db/init');
+
+async function main() {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    console.error('[db:migrate] DATABASE_URL is not set.');
+    process.exit(1);
+  }
+
+  const client = new Client({ connectionString: databaseUrl });
+  await client.connect();
+
+  try {
+    const files = (await readdir(migrationsDir))
+      .filter((name) => name.endsWith('.sql'))
+      .sort((a, b) => a.localeCompare(b));
+
+    if (files.length === 0) {
+      console.warn('[db:migrate] No SQL files found in', migrationsDir);
+      return;
+    }
+
+    await client.query('BEGIN');
+    try {
+      for (const fileName of files) {
+        const filePath = path.join(migrationsDir, fileName);
+        const sql = await readFile(filePath, 'utf8');
+        console.log(`[db:migrate] Applying ${fileName}`);
+        await client.query(sql);
+      }
+      await client.query('COMMIT');
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    }
+
+    console.log('[db:migrate] All migrations applied successfully.');
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((error) => {
+  console.error('[db:migrate] Migration failed:', error.message);
+  process.exit(1);
+});

--- a/services/db-migrate/package.json
+++ b/services/db-migrate/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "db-migrate",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node migrate.js"
+  },
+  "dependencies": {
+    "pg": "^8.20.0"
+  },
+  "engines": {
+    "node": ">=24",
+    "npm": ">=11"
+  }
+}

--- a/services/db-migrate/railway.toml
+++ b/services/db-migrate/railway.toml
@@ -1,0 +1,13 @@
+# railway.toml — db-migrate one-shot service
+#
+# Build context: repo root
+# In the Railway dashboard set:
+#   Service Settings → Build → Dockerfile Path: services/db-migrate/Dockerfile
+
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "services/db-migrate/Dockerfile"
+
+[deploy]
+# NEVER: runs once on each deploy and exits — does not restart.
+restartPolicyType = "NEVER"


### PR DESCRIPTION
## Problem

Production deployments were failing for movie recommendations because the `recommendations` and `recommendation_movies` tables didn't exist in the Railway PostgreSQL instance. The `db/recommendations.sql` file existed but was never included in `db/init/` so the migration runner never applied it.

## Changes

### `db/init/03_recommendations.sql` (new)
Idempotent migration for `recommendations` and `recommendation_movies` tables. Uses `IF NOT EXISTS` and `ADD COLUMN IF NOT EXISTS` throughout — safe to re-run on every deploy.

### `services/db-migrate/` (new)
Standalone one-shot Railway service that runs all migrations before the web app boots:
- **`migrate.js`** — reads `db/init/*.sql` in alphabetical order, runs them in a single transaction, exits with code 1 on failure
- **`Dockerfile`** — lean `node:24-slim` image (no build stage needed, plain JS)
- **`railway.toml`** — `restartPolicyType = "NEVER"` so Railway treats it as a one-shot job

### `apps/web/Dockerfile`
CMD changed from `start:with-migrations` → `start` (plain `next start`). Migrations are now the responsibility of the dedicated `db-migrate` service.

### `railway.toml`
Updated service catalogue comment to include `db-migrate`.

## Railway Dashboard Setup (one-time)

1. Add a new service → **Dockerfile Path**: `services/db-migrate/Dockerfile`
2. **Restart Policy**: `Never`
3. Web app service → **Settings → Deploy → "Deploy on success of"** → select `db-migrate`