### PR TITLE
Improve Coolify health checks and deployment docs

### DIFF
--- a/apps/web/src/app/api/health/route.test.ts
+++ b/apps/web/src/app/api/health/route.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockPgQuery = vi.fn();
+const mockPgEnd = vi.fn();
+const mockPgPool = vi.fn(function MockPool() {
+  return {
+    query: mockPgQuery,
+    end: mockPgEnd,
+  };
+});
+
+const mockRedisConnect = vi.fn();
+const mockRedisPing = vi.fn();
+const mockRedisQuit = vi.fn();
+const mockRedisDestroy = vi.fn();
+const mockRedisClient = {
+  connect: mockRedisConnect,
+  ping: mockRedisPing,
+  quit: mockRedisQuit,
+  destroy: mockRedisDestroy,
+  isOpen: true,
+};
+const mockCreateClient = vi.fn();
+const mockLoggerWarn = vi.fn();
+
+vi.mock('pg', () => ({
+  default: { Pool: mockPgPool },
+  Pool: mockPgPool,
+}));
+
+vi.mock('redis', () => ({
+  createClient: mockCreateClient,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  default: {
+    warn: (...args: Parameters<typeof mockLoggerWarn>) => mockLoggerWarn(...args),
+  },
+}));
+
+const { GET } = await import('./route');
+
+describe('GET /api/health', () => {
+  beforeEach(() => {
+    vi.stubEnv('DATABASE_URL', 'postgres://user:pass@db:5432/popchoice');
+    vi.stubEnv('REDIS_URL', 'redis://redis:6379');
+
+    mockPgQuery.mockResolvedValue({ rows: [{ '?column?': 1 }] });
+    mockPgEnd.mockResolvedValue(undefined);
+    mockRedisConnect.mockResolvedValue(undefined);
+    mockRedisPing.mockResolvedValue('PONG');
+    mockRedisQuit.mockResolvedValue('OK');
+    mockRedisDestroy.mockReturnValue(undefined);
+    mockRedisClient.isOpen = true;
+    mockCreateClient.mockReturnValue(mockRedisClient);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it('returns 200 when PostgreSQL and Redis are reachable', async () => {
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(body).toMatchObject({
+      status: 'ok',
+      checks: {
+        postgres: 'ok',
+        redis: 'ok',
+      },
+    });
+    expect(body.timestamp).toEqual(expect.any(String));
+    expect(mockPgQuery).toHaveBeenCalledWith('SELECT 1');
+    expect(mockRedisPing).toHaveBeenCalled();
+  });
+
+  it('returns 503 when PostgreSQL is unavailable', async () => {
+    mockPgQuery.mockRejectedValueOnce(new Error('postgres password is super-secret'));
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body).toMatchObject({
+      status: 'error',
+      checks: {
+        postgres: 'error',
+        redis: 'ok',
+      },
+    });
+  });
+
+  it('returns 503 when Redis is unavailable', async () => {
+    mockRedisPing.mockRejectedValueOnce(new Error('redis://secret@redis:6379 failed'));
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body).toMatchObject({
+      status: 'error',
+      checks: {
+        postgres: 'ok',
+        redis: 'error',
+      },
+    });
+  });
+
+  it('does not expose raw dependency errors in the response', async () => {
+    mockPgQuery.mockRejectedValueOnce(new Error('postgres://user:secret@db:5432/popchoice'));
+    mockRedisPing.mockRejectedValueOnce(new Error('redis://secret@redis:6379'));
+
+    const response = await GET();
+    const body = await response.json();
+    const serialized = JSON.stringify(body);
+
+    expect(response.status).toBe(503);
+    expect(serialized).not.toContain('secret');
+    expect(serialized).not.toContain('postgres://');
+    expect(serialized).not.toContain('redis://');
+  });
+});

--- a/apps/web/src/app/api/health/route.test.ts
+++ b/apps/web/src/app/api/health/route.test.ts
@@ -38,10 +38,11 @@ vi.mock('@/lib/logger', () => ({
   },
 }));
 
-const { GET } = await import('./route');
+const { GET, resetHealthCheckCacheForTests } = await import('./route');
 
 describe('GET /api/health', () => {
   beforeEach(() => {
+    resetHealthCheckCacheForTests();
     vi.stubEnv('DATABASE_URL', 'postgres://user:pass@db:5432/popchoice');
     vi.stubEnv('REDIS_URL', 'redis://redis:6379');
 
@@ -76,6 +77,18 @@ describe('GET /api/health', () => {
     expect(body.timestamp).toEqual(expect.any(String));
     expect(mockPgQuery).toHaveBeenCalledWith('SELECT 1');
     expect(mockRedisPing).toHaveBeenCalled();
+  });
+
+  it('reuses a short-lived cached result to avoid dependency churn', async () => {
+    const firstResponse = await GET();
+    const secondResponse = await GET();
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(200);
+    expect(mockPgPool).toHaveBeenCalledTimes(1);
+    expect(mockPgQuery).toHaveBeenCalledTimes(1);
+    expect(mockCreateClient).toHaveBeenCalledTimes(1);
+    expect(mockRedisPing).toHaveBeenCalledTimes(1);
   });
 
   it('returns 503 when PostgreSQL is unavailable', async () => {
@@ -122,5 +135,21 @@ describe('GET /api/health', () => {
     expect(serialized).not.toContain('secret');
     expect(serialized).not.toContain('postgres://');
     expect(serialized).not.toContain('redis://');
+  });
+
+  it('does not log raw dependency errors', async () => {
+    const postgresError = new Error('postgres://user:secret@db:5432/popchoice');
+    Object.assign(postgresError, { code: 'ECONNREFUSED' });
+    mockPgQuery.mockRejectedValueOnce(postgresError);
+    mockRedisPing.mockRejectedValueOnce(new Error('redis://secret@redis:6379'));
+
+    const response = await GET();
+    const logged = JSON.stringify(mockLoggerWarn.mock.calls);
+
+    expect(response.status).toBe(503);
+    expect(logged).toContain('ECONNREFUSED');
+    expect(logged).not.toContain('secret');
+    expect(logged).not.toContain('postgres://');
+    expect(logged).not.toContain('redis://');
   });
 });

--- a/apps/web/src/app/api/health/route.ts
+++ b/apps/web/src/app/api/health/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from 'next/server';
+import pg from 'pg';
+import { createClient } from 'redis';
+
+import logger from '@/lib/logger';
+
+const { Pool } = pg;
+const CHECK_TIMEOUT_MS = 2_000;
+
+type CheckStatus = 'ok' | 'error';
+
+type HealthResponse = {
+  status: CheckStatus;
+  checks: {
+    postgres: CheckStatus;
+    redis: CheckStatus;
+  };
+  timestamp: string;
+};
+
+async function checkPostgres(): Promise<CheckStatus> {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) return 'error';
+
+  const pool = new Pool({
+    connectionString,
+    allowExitOnIdle: true,
+    connectionTimeoutMillis: CHECK_TIMEOUT_MS,
+    max: 1,
+  });
+
+  try {
+    await pool.query('SELECT 1');
+    return 'ok';
+  } catch (error) {
+    logger.warn({ err: error }, 'Health check failed: PostgreSQL unavailable');
+    return 'error';
+  } finally {
+    await pool.end().catch((error: unknown) => {
+      logger.warn({ err: error }, 'Health check failed to close PostgreSQL pool');
+    });
+  }
+}
+
+async function checkRedis(): Promise<CheckStatus> {
+  const redisUrl = process.env.REDIS_URL;
+  if (!redisUrl) return 'error';
+
+  const client = createClient({
+    url: redisUrl,
+    socket: {
+      connectTimeout: CHECK_TIMEOUT_MS,
+      reconnectStrategy: false,
+    },
+  });
+
+  try {
+    await client.connect();
+    await client.ping();
+    return 'ok';
+  } catch (error) {
+    logger.warn({ err: error }, 'Health check failed: Redis unavailable');
+    return 'error';
+  } finally {
+    if (client.isOpen) {
+      await client.quit().catch((error: unknown) => {
+        logger.warn({ err: error }, 'Health check failed to close Redis client');
+      });
+    } else {
+      client.destroy();
+    }
+  }
+}
+
+export async function GET(): Promise<Response> {
+  const [postgres, redis] = await Promise.all([checkPostgres(), checkRedis()]);
+  const status: CheckStatus = postgres === 'ok' && redis === 'ok' ? 'ok' : 'error';
+  const body: HealthResponse = {
+    status,
+    checks: {
+      postgres,
+      redis,
+    },
+    timestamp: new Date().toISOString(),
+  };
+
+  return NextResponse.json(body, {
+    status: status === 'ok' ? 200 : 503,
+    headers: {
+      'Cache-Control': 'no-store',
+    },
+  });
+}

--- a/apps/web/src/app/api/health/route.ts
+++ b/apps/web/src/app/api/health/route.ts
@@ -6,6 +6,7 @@ import logger from '@/lib/logger';
 
 const { Pool } = pg;
 const CHECK_TIMEOUT_MS = 2_000;
+const HEALTH_CACHE_TTL_MS = 5_000;
 
 type CheckStatus = 'ok' | 'error';
 
@@ -17,6 +18,46 @@ type HealthResponse = {
   };
   timestamp: string;
 };
+
+type CachedHealthResponse = {
+  body: HealthResponse;
+  expiresAt: number;
+  status: 200 | 503;
+};
+
+type HealthErrorMetadata = {
+  name: string;
+  code?: string;
+  causeCode?: string;
+};
+
+let cachedHealthResponse: CachedHealthResponse | null = null;
+
+function healthErrorMetadata(error: unknown): HealthErrorMetadata {
+  if (!(error instanceof Error)) {
+    return { name: typeof error };
+  }
+
+  const errorWithMetadata = error as Error & {
+    code?: unknown;
+    cause?: { code?: unknown };
+  };
+  const metadata: HealthErrorMetadata = { name: error.name };
+
+  if (typeof errorWithMetadata.code === 'string') {
+    metadata.code = errorWithMetadata.code;
+  }
+
+  if (typeof errorWithMetadata.cause?.code === 'string') {
+    metadata.causeCode = errorWithMetadata.cause.code;
+  }
+
+  return metadata;
+}
+
+function logHealthCheckWarning(message: string, error: unknown): void {
+  logger.warn({ error: healthErrorMetadata(error) }, message);
+}
 
 async function checkPostgres(): Promise<CheckStatus> {
   const connectionString = process.env.DATABASE_URL;
@@ -33,11 +74,11 @@ async function checkPostgres(): Promise<CheckStatus> {
     await pool.query('SELECT 1');
     return 'ok';
   } catch (error) {
-    logger.warn({ err: error }, 'Health check failed: PostgreSQL unavailable');
+    logHealthCheckWarning('Health check failed: PostgreSQL unavailable', error);
     return 'error';
   } finally {
     await pool.end().catch((error: unknown) => {
-      logger.warn({ err: error }, 'Health check failed to close PostgreSQL pool');
+      logHealthCheckWarning('Health check failed to close PostgreSQL pool', error);
     });
   }
 }
@@ -59,12 +100,12 @@ async function checkRedis(): Promise<CheckStatus> {
     await client.ping();
     return 'ok';
   } catch (error) {
-    logger.warn({ err: error }, 'Health check failed: Redis unavailable');
+    logHealthCheckWarning('Health check failed: Redis unavailable', error);
     return 'error';
   } finally {
     if (client.isOpen) {
       await client.quit().catch((error: unknown) => {
-        logger.warn({ err: error }, 'Health check failed to close Redis client');
+        logHealthCheckWarning('Health check failed to close Redis client', error);
       });
     } else {
       client.destroy();
@@ -72,7 +113,7 @@ async function checkRedis(): Promise<CheckStatus> {
   }
 }
 
-export async function GET(): Promise<Response> {
+async function getHealthResponse(): Promise<CachedHealthResponse> {
   const [postgres, redis] = await Promise.all([checkPostgres(), checkRedis()]);
   const status: CheckStatus = postgres === 'ok' && redis === 'ok' ? 'ok' : 'error';
   const body: HealthResponse = {
@@ -84,8 +125,25 @@ export async function GET(): Promise<Response> {
     timestamp: new Date().toISOString(),
   };
 
-  return NextResponse.json(body, {
+  return {
+    body,
+    expiresAt: Date.now() + HEALTH_CACHE_TTL_MS,
     status: status === 'ok' ? 200 : 503,
+  };
+}
+
+export function resetHealthCheckCacheForTests(): void {
+  cachedHealthResponse = null;
+}
+
+export async function GET(): Promise<Response> {
+  const now = Date.now();
+  if (!cachedHealthResponse || cachedHealthResponse.expiresAt <= now) {
+    cachedHealthResponse = await getHealthResponse();
+  }
+
+  return NextResponse.json(cachedHealthResponse.body, {
+    status: cachedHealthResponse.status,
     headers: {
       'Cache-Control': 'no-store',
     },

--- a/coolify.compose.yml
+++ b/coolify.compose.yml
@@ -59,7 +59,7 @@ services:
       test:
         [
           'CMD-SHELL',
-          'node -e "fetch(''http://127.0.0.1:3000'').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"',
+          'node -e "fetch(''http://127.0.0.1:3000/api/health'').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"',
         ]
       interval: 30s
       timeout: 10s
@@ -78,6 +78,16 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'node -e "const pg=require(''pg''); const Redis=require(''ioredis''); const pool=new pg.Pool({connectionString:process.env.DATABASE_URL,connectionTimeoutMillis:2000,max:1}); const redis=new Redis(process.env.REDIS_URL,{maxRetriesPerRequest:null,connectTimeout:2000,lazyConnect:true}); Promise.all([pool.query(''SELECT 1''),redis.connect().then(()=>redis.ping())]).then(()=>process.exit(0)).catch(()=>process.exit(1)).finally(()=>Promise.allSettled([pool.end(),redis.quit()]))"',
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
 
   bull-board:
     build:

--- a/docs/COOLIFY.md
+++ b/docs/COOLIFY.md
@@ -56,6 +56,36 @@ Set `NEXT_PUBLIC_BASE_URL` to the URL users see in their browser, without a
 trailing slash. Even though the Coolify domain field includes `:3000` for proxy
 routing, the app's public URL is usually just `https://your-domain.example`.
 
+### API key variables
+
+`VALID_API_KEYS` is not a plaintext key. It must contain one or more
+comma-separated scrypt digests generated with `API_KEY_HMAC_SECRET`.
+
+Generate a production API key and digest locally:
+
+```bash
+API_KEY_HMAC_SECRET="$(openssl rand -hex 32)" node -e "const {randomBytes,scryptSync}=require('crypto'); const secret=process.env.API_KEY_HMAC_SECRET; const key=randomBytes(32).toString('hex'); const hash=scryptSync(key, secret, 32, {N:16384,r:8,p:1}).toString('hex'); console.log('API_KEY_HMAC_SECRET='+secret); console.log('PLAINTEXT_API_KEY='+key); console.log('VALID_API_KEYS='+hash)"
+```
+
+Store only these values in Coolify:
+
+```env
+API_KEY_HMAC_SECRET=<API_KEY_HMAC_SECRET output>
+VALID_API_KEYS=<VALID_API_KEYS output>
+```
+
+Keep `PLAINTEXT_API_KEY` outside Coolify in a password manager or secret store.
+External callers send that plaintext value as `Authorization: Bearer <key>` or
+`X-API-Key: <key>`.
+
+If you store these as project shared variables, reference them from the Docker
+Compose resource environment:
+
+```env
+API_KEY_HMAC_SECRET={{ project.API_KEY_HMAC_SECRET }}
+VALID_API_KEYS={{ project.VALID_API_KEYS }}
+```
+
 ## First deploy
 
 Deploy the stack from Coolify. The startup order is:
@@ -65,6 +95,61 @@ Deploy the stack from Coolify. The startup order is:
    starts Next.js.
 3. `workers` and `bull-board` start against the same internal Redis and
    PostgreSQL services.
+
+After deployment, set the Coolify health check path for the `web` service to:
+
+```txt
+/api/health
+```
+
+The endpoint returns `200` only when the Next.js app can reach both PostgreSQL
+and Redis. It returns a sanitized `503` response when either dependency is not
+available.
+
+## Post-deploy smoke checklist
+
+Run this checklist after production deploys and after any infrastructure change:
+
+- `https://pop-choice.shchilkin.dev` loads with a trusted certificate.
+- `https://pop-choice.shchilkin.dev/api/health` returns `200`.
+- A quiz submission creates and completes a recommendation.
+- Worker logs show Redis readiness and recommendation job completion.
+- The latest PostgreSQL backup exists in the configured backup destination.
+
+## Pull request previews
+
+Use Coolify's GitHub App integration for PR previews so deployments can be
+created from pull requests and reported back to GitHub.
+
+1. Add a wildcard DNS record pointing at the VPS:
+
+   ```txt
+   *.preview.pop-choice.shchilkin.dev A 178.105.60.238
+   ```
+
+2. Enable preview deployments for repository members, collaborators, and
+   contributors only. Keep public PR preview deployments disabled.
+3. Use this preview URL template:
+
+   ```txt
+   https://{{pr_id}}.preview.pop-choice.shchilkin.dev:3000
+   ```
+
+4. Keep previews as full isolated stacks. Each PR should get its own `web`,
+   `workers`, `db`, `redis`, and named volumes.
+5. Configure preview environment variables separately from production. Use
+   limited-quota `OPENAI_API_KEY` and `TMDB_API_KEY` values when possible, and
+   generate preview-only values for `POSTGRES_PASSWORD`,
+   `AUTH_SESSION_SECRET`, `API_KEY_HMAC_SECRET`, and `VALID_API_KEYS`.
+6. Set preview `NEXT_PUBLIC_BASE_URL` from Coolify's generated web service URL
+   for port `3000`.
+7. Leave `bull-board` without a preview domain unless temporarily debugging a
+   PR.
+
+Before relying on previews, verify that opening a PR creates a preview
+deployment and GitHub comment, the preview URL loads over HTTPS, quiz submission
+completes without touching production data, and closing or merging the PR
+removes the preview deployment.
 
 ## Seeding movie data
 
@@ -104,3 +189,8 @@ so enable it deliberately to avoid surprise API usage.
 Configure Coolify backups for the PostgreSQL volume before relying on this in
 production. The application state lives primarily in PostgreSQL; Redis is used
 for queues and rate limiting.
+
+Store backups in S3-compatible storage rather than only on the VPS. Enable
+Coolify notifications for failed deploys, failed backups, and server disk or
+resource warnings. On the Hetzner firewall, expose only the public ports needed
+by this setup: `22`, `80`, and `443`; do not expose PostgreSQL or Redis.

--- a/docs/COOLIFY.md
+++ b/docs/COOLIFY.md
@@ -110,8 +110,8 @@ available.
 
 Run this checklist after production deploys and after any infrastructure change:
 
-- `https://pop-choice.shchilkin.dev` loads with a trusted certificate.
-- `https://pop-choice.shchilkin.dev/api/health` returns `200`.
+- `https://your-domain.example` loads with a trusted certificate.
+- `https://your-domain.example/api/health` returns `200`.
 - A quiz submission creates and completes a recommendation.
 - Worker logs show Redis readiness and recommendation job completion.
 - The latest PostgreSQL backup exists in the configured backup destination.
@@ -124,7 +124,7 @@ created from pull requests and reported back to GitHub.
 1. Add a wildcard DNS record pointing at the VPS:
 
    ```txt
-   *.preview.pop-choice.shchilkin.dev A 178.105.60.238
+   *.preview.your-domain.example A <VPS_PUBLIC_IP>
    ```
 
 2. Enable preview deployments for repository members, collaborators, and
@@ -132,7 +132,7 @@ created from pull requests and reported back to GitHub.
 3. Use this preview URL template:
 
    ```txt
-   https://{{pr_id}}.preview.pop-choice.shchilkin.dev:3000
+   https://{{pr_id}}.preview.your-domain.example:3000
    ```
 
 4. Keep previews as full isolated stacks. Each PR should get its own `web`,

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -121,7 +121,13 @@ Keys are stored as **scrypt digests** in the `VALID_API_KEYS` environment variab
 
 1. **Generate a random key** (e.g. using `openssl rand -hex 32`)
 2. **Set `API_KEY_HMAC_SECRET`** in your environment (e.g. `openssl rand -hex 32`). This secret must stay the same across restarts.
-3. **Hash the key** using the utility exported from `src/lib/apiAuth.ts`:
+3. **Hash the key** using the utility exported from `src/lib/apiAuth.ts`, or generate both values with this command:
+
+   ```bash
+   API_KEY_HMAC_SECRET="$(openssl rand -hex 32)" node -e "const {randomBytes,scryptSync}=require('crypto'); const secret=process.env.API_KEY_HMAC_SECRET; const key=randomBytes(32).toString('hex'); const hash=scryptSync(key, secret, 32, {N:16384,r:8,p:1}).toString('hex'); console.log('API_KEY_HMAC_SECRET='+secret); console.log('PLAINTEXT_API_KEY='+key); console.log('VALID_API_KEYS='+hash)"
+   ```
+
+   Or from application code:
 
    ```ts
    import { hashApiKey } from '@/lib/apiAuth';
@@ -135,7 +141,7 @@ Keys are stored as **scrypt digests** in the `VALID_API_KEYS` environment variab
    VALID_API_KEYS=<scrypt-digest-of-key1>,<scrypt-digest-of-key2>
    ```
 
-5. **Distribute the plaintext key** to your API consumers — they send it in the header; the server only ever sees the hash.
+5. **Distribute the plaintext key** to your API consumers — they send it in the header; store the digest in the server environment.
 
 #### Development mode
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -121,7 +121,7 @@ Keys are stored as **scrypt digests** in the `VALID_API_KEYS` environment variab
 
 1. **Generate a random key** (e.g. using `openssl rand -hex 32`)
 2. **Set `API_KEY_HMAC_SECRET`** in your environment (e.g. `openssl rand -hex 32`). This secret must stay the same across restarts.
-3. **Hash the key** using the utility exported from `src/lib/apiAuth.ts`, or generate both values with this command:
+3. **Hash the key** using the utility exported from `apps/web/src/lib/apiAuth.ts`, or generate both values with this command:
 
    ```bash
    API_KEY_HMAC_SECRET="$(openssl rand -hex 32)" node -e "const {randomBytes,scryptSync}=require('crypto'); const secret=process.env.API_KEY_HMAC_SECRET; const key=randomBytes(32).toString('hex'); const hash=scryptSync(key, secret, 32, {N:16384,r:8,p:1}).toString('hex'); console.log('API_KEY_HMAC_SECRET='+secret); console.log('PLAINTEXT_API_KEY='+key); console.log('VALID_API_KEYS='+hash)"


### PR DESCRIPTION
## Summary
- add a public sanitized /api/health endpoint that checks Postgres and Redis
- point Coolify web healthchecks at /api/health and add a worker dependency healthcheck
- document Coolify smoke checks, PR preview setup, backups, firewall guidance, and API key generation

## Verification
- npm run lint:check
- npm run type-check
- npm run test:server --workspace=apps/web
- npm run test
- npm run build
- npm run format:check
- docker compose -f coolify.compose.yml config --quiet with required envs