### PR TITLE
Polish group quiz handoff UX

### DIFF
--- a/apps/web/src/app/quiz/components/BetweenPersons.stories.tsx
+++ b/apps/web/src/app/quiz/components/BetweenPersons.stories.tsx
@@ -16,6 +16,8 @@ const meta: Meta<typeof BetweenPersons> = {
     },
   },
   args: {
+    completedCount: 1,
+    totalPeople: 3,
     onNext: () => {},
   },
 };

--- a/apps/web/src/app/quiz/components/BetweenPersons.tsx
+++ b/apps/web/src/app/quiz/components/BetweenPersons.tsx
@@ -7,10 +7,18 @@ import { useLanguage } from '@/i18n';
 interface BetweenPersonsProps {
   currentPersonName: string;
   nextPersonName: string;
+  completedCount: number;
+  totalPeople: number;
   onNext: () => void;
 }
 
-export function BetweenPersons({ currentPersonName, nextPersonName, onNext }: BetweenPersonsProps) {
+export function BetweenPersons({
+  currentPersonName,
+  nextPersonName,
+  completedCount,
+  totalPeople,
+  onNext,
+}: BetweenPersonsProps) {
   const { t } = useLanguage();
 
   return (
@@ -22,6 +30,19 @@ export function BetweenPersons({ currentPersonName, nextPersonName, onNext }: Be
         className="text-center max-w-sm"
       >
         <div className="text-5xl mb-5">🎬</div>
+        <p
+          className="mb-3"
+          style={{
+            color: 'var(--pc-gold-text)',
+            fontSize: '0.72rem',
+            letterSpacing: '0.14em',
+            textTransform: 'uppercase',
+          }}
+        >
+          {t.quiz.between.progress
+            .replace('{current}', String(completedCount))
+            .replace('{total}', String(totalPeople))}
+        </p>
         <h2
           className="mb-2"
           style={{

--- a/apps/web/src/app/quiz/components/GroupSetup.tsx
+++ b/apps/web/src/app/quiz/components/GroupSetup.tsx
@@ -16,7 +16,8 @@ interface GroupSetupProps {
 
 export function GroupSetup({ groupNames, onGroupNamesChange, onBack, onStart }: GroupSetupProps) {
   const { t } = useLanguage();
-  const namedPeopleCount = groupNames.filter((name) => name.trim().length > 0).length;
+  const namedPeople = groupNames.map((name) => name.trim()).filter(Boolean);
+  const namedPeopleCount = namedPeople.length;
   const canStart = namedPeopleCount >= 2;
 
   return (
@@ -43,6 +44,17 @@ export function GroupSetup({ groupNames, onGroupNamesChange, onBack, onStart }: 
           </h2>
           <p style={{ color: 'var(--pc-t3)', fontSize: '0.85rem', marginTop: 6 }}>
             {t.quiz.groupSetup.subtitle}
+          </p>
+          <p
+            className="mt-4 inline-flex rounded-full px-3 py-1 text-xs"
+            style={{
+              background: 'var(--pc-gold-wash)',
+              border: '1px solid var(--pc-gold-bd)',
+              color: 'var(--pc-gold-text)',
+              fontWeight: 700,
+            }}
+          >
+            {t.quiz.groupSetup.countLabel.replace('{count}', String(namedPeopleCount))}
           </p>
         </div>
 
@@ -120,6 +132,43 @@ export function GroupSetup({ groupNames, onGroupNamesChange, onBack, onStart }: 
           >
             <Plus size={15} /> {t.quiz.groupSetup.addPerson}
           </button>
+        )}
+
+        {namedPeople.length > 0 && (
+          <div className="mb-6">
+            <div className="mb-2 flex items-center justify-between gap-3">
+              <p
+                style={{
+                  color: 'var(--pc-t3)',
+                  fontSize: '0.7rem',
+                  fontWeight: 700,
+                  letterSpacing: '0.12em',
+                  textTransform: 'uppercase',
+                }}
+              >
+                {t.quiz.groupSetup.orderTitle}
+              </p>
+              <p style={{ color: 'var(--pc-t4)', fontSize: '0.72rem' }}>
+                {t.quiz.groupSetup.orderHint}
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {namedPeople.map((name, index) => (
+                <span
+                  key={`${name}-${index}`}
+                  className="rounded-full px-3 py-1 text-xs"
+                  style={{
+                    background: index === 0 ? 'var(--pc-gold-wash)' : 'var(--pc-ghost)',
+                    border: index === 0 ? '1px solid var(--pc-gold-bd)' : '1px solid var(--pc-bd2)',
+                    color: index === 0 ? 'var(--pc-gold-text)' : 'var(--pc-t3)',
+                    fontWeight: 700,
+                  }}
+                >
+                  {index + 1}. {name}
+                </span>
+              ))}
+            </div>
+          </div>
         )}
 
         {!canStart && (

--- a/apps/web/src/app/quiz/components/QuizNavigation.tsx
+++ b/apps/web/src/app/quiz/components/QuizNavigation.tsx
@@ -11,6 +11,7 @@ interface QuizNavigationProps {
   isSubmitting: boolean;
   isLastStep: boolean;
   isLastPerson: boolean;
+  nextPersonName?: string;
 }
 
 export function QuizNavigation({
@@ -20,8 +21,12 @@ export function QuizNavigation({
   isSubmitting,
   isLastStep,
   isLastPerson,
+  nextPersonName,
 }: QuizNavigationProps) {
   const { t } = useLanguage();
+  const nextPersonLabel = nextPersonName
+    ? t.quiz.nav.handTo.replace('{name}', nextPersonName)
+    : t.quiz.nav.nextPerson;
 
   return (
     <div className="px-5 py-6 max-w-xl mx-auto w-full flex gap-3">
@@ -54,7 +59,7 @@ export function QuizNavigation({
           <>{t.quiz.nav.findMyMovie}</>
         ) : isLastStep ? (
           <>
-            {t.quiz.nav.nextPerson} <ChevronRight size={16} />
+            {nextPersonLabel} <ChevronRight size={16} />
           </>
         ) : (
           <>

--- a/apps/web/src/app/quiz/components/QuizSubmittingState.tsx
+++ b/apps/web/src/app/quiz/components/QuizSubmittingState.tsx
@@ -5,8 +5,25 @@ import { motion } from 'motion/react';
 import { FilmReel } from '@/app/loading/components/FilmReel';
 import { useLanguage } from '@/i18n';
 
-export function QuizSubmittingState() {
+interface QuizSubmittingStateProps {
+  mode?: 'solo' | 'group';
+  peopleCount?: number;
+}
+
+export function QuizSubmittingState({ mode = 'solo', peopleCount = 1 }: QuizSubmittingStateProps) {
   const { t } = useLanguage();
+  const isGroup = mode === 'group' && peopleCount > 1;
+  const copy = isGroup
+    ? {
+        eyebrow: t.loading.groupSubmitBridgeEyebrow.replace('{count}', String(peopleCount)),
+        title: t.loading.groupSubmitBridgeTitle,
+        body: t.loading.groupSubmitBridgeBody,
+      }
+    : {
+        eyebrow: t.loading.submitBridgeEyebrow,
+        title: t.loading.submitBridgeTitle,
+        body: t.loading.submitBridgeBody,
+      };
 
   return (
     <div className="flex-1 flex flex-col items-center justify-center px-5 min-h-[80vh]">
@@ -29,7 +46,7 @@ export function QuizSubmittingState() {
             textTransform: 'uppercase',
           }}
         >
-          {t.loading.submitBridgeEyebrow}
+          {copy.eyebrow}
         </p>
 
         <h2
@@ -43,12 +60,10 @@ export function QuizSubmittingState() {
             color: 'var(--pc-t1)',
           }}
         >
-          {t.loading.submitBridgeTitle}
+          {copy.title}
         </h2>
 
-        <p style={{ color: 'var(--pc-t2)', fontSize: '0.92rem', lineHeight: 1.6 }}>
-          {t.loading.submitBridgeBody}
-        </p>
+        <p style={{ color: 'var(--pc-t2)', fontSize: '0.92rem', lineHeight: 1.6 }}>{copy.body}</p>
       </motion.div>
     </div>
   );

--- a/apps/web/src/app/quiz/page.tsx
+++ b/apps/web/src/app/quiz/page.tsx
@@ -143,7 +143,9 @@ export default function QuizPage() {
   }
 
   // ── SUBMITTING ── recommendation creation is in flight via useEffect above
-  if (state.matches('submitting')) return <QuizSubmittingState />;
+  if (state.matches('submitting')) {
+    return <QuizSubmittingState mode={mode} peopleCount={people.length} />;
+  }
 
   // ── BETWEEN PERSONS ──
   if (state.matches('betweenPersons')) {
@@ -153,6 +155,8 @@ export default function QuizPage() {
       <BetweenPersons
         currentPersonName={donePersonName}
         nextPersonName={nextPersonName}
+        completedCount={currentPersonIdx + 1}
+        totalPeople={people.length}
         onNext={() => send({ type: 'CONTINUE' })}
       />
     );
@@ -268,6 +272,7 @@ export default function QuizPage() {
         isSubmitting={isSubmitting}
         isLastStep={isLastStep}
         isLastPerson={isLastPerson}
+        nextPersonName={people[currentPersonIdx + 1]?.name}
       />
     </div>
   );

--- a/apps/web/src/app/results/components/GroupMatchBrief.tsx
+++ b/apps/web/src/app/results/components/GroupMatchBrief.tsx
@@ -13,6 +13,66 @@ function joinList(values: string[], locale: string): string {
   return new Intl.ListFormat(locale, { style: 'short', type: 'conjunction' }).format(values);
 }
 
+type TranslationCopy = ReturnType<typeof useLanguage>['t'];
+
+function normalizeChoice(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/&/g, 'and')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function translateMood(value: string, t: TranslationCopy): string {
+  const moodKey = normalizeChoice(value).replace(/\s+/g, '');
+  const aliases: Record<string, keyof typeof t.genres> = {
+    action: 'action',
+    adventure: 'adventure',
+    animation: 'animation',
+    comedy: 'comedy',
+    documentary: 'documentary',
+    drama: 'drama',
+    horror: 'horror',
+    romance: 'romance',
+    scifi: 'scifi',
+    sciencefiction: 'scifi',
+    thriller: 'thriller',
+  };
+  const key = aliases[moodKey];
+  return key ? t.genres[key] : value;
+}
+
+function translateTone(value: string, t: TranslationCopy): string {
+  const normalized = normalizeChoice(value);
+  const aliases: Record<string, keyof typeof t.tones> = {
+    balanced: 'balanced',
+    dark: 'dark',
+    'dark and intense': 'dark',
+    light: 'light',
+    'light and fun': 'light',
+    serious: 'serious',
+    'serious and thought provoking': 'serious',
+  };
+  const key = aliases[normalized];
+  return key ? t.tones[key].label : value;
+}
+
+function translateEra(value: string, t: TranslationCopy): string {
+  const normalized = normalizeChoice(value);
+  const aliases: Record<string, keyof Omit<typeof t.quiz.era, 'title'>> = {
+    both: 'both',
+    'both new and classic': 'both',
+    classic: 'classic',
+    'timeless classics': 'classic',
+    new: 'new',
+    'new releases': 'new',
+  };
+  const key = aliases[normalized];
+  return key ? t.quiz.era[key].title : value;
+}
+
 function BriefRow({ icon, label, value }: { icon: ReactNode; label: string; value: string }) {
   return (
     <div className="flex items-start gap-3">
@@ -43,15 +103,24 @@ export function GroupMatchBrief({ insights }: { insights: GroupResultInsights })
   const names = joinList(insights.participantNames, locale);
   const sharedMoods =
     insights.sharedMoods.length > 0
-      ? joinList(insights.sharedMoods, locale)
+      ? joinList(
+          insights.sharedMoods.map((mood) => translateMood(mood, t)),
+          locale,
+        )
       : t.results.groupBriefNoSharedMoods;
   const tones =
     insights.tonePreferences.length > 0
-      ? joinList(insights.tonePreferences, locale)
+      ? joinList(
+          insights.tonePreferences.map((tone) => translateTone(tone, t)),
+          locale,
+        )
       : t.results.groupBriefMixedSignals;
   const eras =
     insights.eraPreferences.length > 0
-      ? joinList(insights.eraPreferences, locale)
+      ? joinList(
+          insights.eraPreferences.map((era) => translateEra(era, t)),
+          locale,
+        )
       : t.results.groupBriefMixedSignals;
   const actors =
     insights.favoriteActors.length > 0 ? joinList(insights.favoriteActors, locale) : null;

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -76,10 +76,14 @@ export const en = {
       personPlaceholder: "Person {n}'s name",
       addPerson: 'Add another person',
       twoNamesHint: 'Add at least two names to start group mode.',
+      countLabel: '{count}/6 seats filled',
+      orderTitle: 'Turn order',
+      orderHint: 'Pass the device this way',
       back: 'Back',
       letsGo: "Let's go!",
     },
     between: {
+      progress: '{current} of {total} complete',
       turnDone: "{name}'s turn is done!",
       nowIts: "Now it's {name}'s turn. Hand over the phone!",
       ready: "I'm ready, {name}! →",
@@ -88,6 +92,7 @@ export const en = {
       back: 'Back',
       continue: 'Continue',
       nextPerson: 'Next Person',
+      handTo: 'Hand to {name}',
       findMyMovie: 'Find My Movie ✨',
       submitting: 'Submitting…',
       ofTotal: '{current} of {total}',
@@ -154,6 +159,10 @@ export const en = {
     submitBridgeTitle: 'Finding your film',
     submitBridgeBody:
       'We are matching your vibe against the collection and shaping a shortlist worth the wait.',
+    groupSubmitBridgeEyebrow: '{count} taste profiles locked',
+    groupSubmitBridgeTitle: 'Finding the overlap',
+    groupSubmitBridgeBody:
+      'We are weighing shared moods, favorite films, and compromise picks for a movie the room can agree on.',
     queuedLabel: 'Warming up the projector',
     realProgressLabel: 'Building your shortlist',
     stages: {

--- a/apps/web/src/i18n/locales/fi.ts
+++ b/apps/web/src/i18n/locales/fi.ts
@@ -76,10 +76,14 @@ export const fi: Translations = {
       personPlaceholder: 'Henkilön {n} nimi',
       addPerson: 'Lisää henkilö',
       twoNamesHint: 'Lisää vähintään kaksi nimeä aloittaaksesi ryhmätilan.',
+      countLabel: '{count}/6 paikkaa täytetty',
+      orderTitle: 'Vuorojärjestys',
+      orderHint: 'Anna laite tässä järjestyksessä',
       back: 'Takaisin',
       letsGo: 'Mennään!',
     },
     between: {
+      progress: '{current}/{total} valmiina',
       turnDone: '{name}n vuoro on ohi!',
       nowIts: 'Nyt on {name}n vuoro. Anna puhelin eteenpäin!',
       ready: 'Olen valmis, {name}! →',
@@ -88,6 +92,7 @@ export const fi: Translations = {
       back: 'Takaisin',
       continue: 'Jatka',
       nextPerson: 'Seuraava henkilö',
+      handTo: 'Anna laite: {name}',
       findMyMovie: 'Löydä elokuvani ✨',
       submitting: 'Lähetetään…',
       ofTotal: '{current} / {total}',
@@ -156,6 +161,10 @@ export const fi: Translations = {
     submitBridgeTitle: 'Etsimme elokuvaa',
     submitBridgeBody:
       'Sovitamme tunnelmasi kokoelmaan ja kokoamme listan, josta ilta on helppo aloittaa.',
+    groupSubmitBridgeEyebrow: '{count} makuprofiilia valmiina',
+    groupSubmitBridgeTitle: 'Etsimme yhteistä osumaa',
+    groupSubmitBridgeBody:
+      'Punnitsemme yhteisiä tunnelmia, lempielokuvia ja kompromisseja, jotta koko porukka saa hyvän valinnan.',
     queuedLabel: 'Lämmitetään projektoria',
     realProgressLabel: 'Kootaan suosikkilistaasi',
     stages: {

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -76,10 +76,14 @@ export const ru: Translations = {
       personPlaceholder: 'Имя участника {n}',
       addPerson: 'Добавить участника',
       twoNamesHint: 'Добавьте минимум два имени, чтобы начать групповой режим.',
+      countLabel: '{count}/6 мест заполнено',
+      orderTitle: 'Порядок ответов',
+      orderHint: 'Передавайте телефон по списку',
       back: 'Назад',
       letsGo: 'Поехали!',
     },
     between: {
+      progress: '{current} из {total} готовы',
       turnDone: '{name} ответил на все вопросы!',
       nowIts: 'Теперь черёд {name}. Передайте телефон!',
       ready: 'Вперёд, {name}! →',
@@ -88,6 +92,7 @@ export const ru: Translations = {
       back: 'Назад',
       continue: 'Продолжить',
       nextPerson: 'Следующий',
+      handTo: 'Передать: {name}',
       findMyMovie: 'Найти фильм ✨',
       submitting: 'Отправляем…',
       ofTotal: '{current} из {total}',
@@ -159,6 +164,10 @@ export const ru: Translations = {
     submitBridgeTitle: 'Подбираем фильм',
     submitBridgeBody:
       'Сверяем ваш вкус с коллекцией и собираем подборку, с которой приятно начать вечер.',
+    groupSubmitBridgeEyebrow: '{count} вкусовых профиля готовы',
+    groupSubmitBridgeTitle: 'Ищем общее совпадение',
+    groupSubmitBridgeBody:
+      'Сравниваем общие настроения, любимые фильмы и компромиссные варианты, чтобы выбрать фильм для всей компании.',
     queuedLabel: 'Готовим проектор',
     realProgressLabel: 'Собираем вашу подборку',
     stages: {


### PR DESCRIPTION
## Summary
- Add clearer group setup state with filled seats and visible turn order
- Make the final question CTA hand the device to the next named participant
- Add handoff progress and group-specific submission copy
- Keep English, Finnish, and Russian locale copy in sync

## Verification
- npm run lint:check
- npm run type-check
- npm run format:check
- npm run test --workspace=apps/web -- --run src/app/quiz/quiz.machine.test.ts
- npm run build
- local Playwright check on /quiz group setup, mobile viewport
- pre-push lint/server tests/build/storybook tests