### PR TITLE
Avoid recommending movies viewers already mentioned

### DIFF
--- a/apps/web/src/app/api/movie-recommendation/route.test.ts
+++ b/apps/web/src/app/api/movie-recommendation/route.test.ts
@@ -526,6 +526,71 @@ describe('POST /api/movie-recommendation — query enrichment', () => {
       expect(userMessage?.content).not.toContain('name: Sam');
     });
 
+    it('uses favorite movies as taste signals but excludes them from recommendation candidates', async () => {
+      const { getDbClient } = vi.mocked(await import('@/clients/dbClient'));
+      (getDbClient as ReturnType<typeof vi.fn>)
+        .mockReturnValueOnce({
+          isConfigured: vi.fn().mockReturnValue(true),
+          from: vi.fn().mockReturnValue({
+            select: vi.fn().mockResolvedValue({ count: 2, error: null }),
+          }),
+        })
+        .mockReturnValueOnce({
+          rpc: vi.fn().mockResolvedValue({
+            data: [
+              {
+                id: 1,
+                name: 'The Dark Knight',
+                age_rating: 'PG-13',
+                description: 'A masked hero faces chaos.',
+                duration: 152,
+                score_rating: 9,
+                year: 2008,
+                similarity: 0.98,
+                content: 'The Dark Knight (2008) — A masked hero faces chaos.',
+              },
+              {
+                id: 2,
+                name: 'Heat',
+                age_rating: 'R',
+                description: 'A tense crime drama about cops and robbers.',
+                duration: 170,
+                score_rating: 8.3,
+                year: 1995,
+                similarity: 0.9,
+                content: 'Heat (1995) — A tense crime drama about cops and robbers.',
+              },
+            ],
+            error: null,
+          }),
+        });
+      mockChatCompletionsCreate.mockResolvedValue({
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({ title: 'Heat', description: 'A strong fit.' }),
+            },
+          },
+        ],
+      });
+
+      const res = await POST(makeRequest(validBody));
+      expect(res.status).not.toBe(500);
+
+      const calls = mockChatCompletionsCreate.mock.calls as unknown as [ChatCompletionCallArg][];
+      const recommendationCall = calls.find((callArgs) => callArgs[0].response_format);
+      const userMessage = recommendationCall?.[0].messages.find(
+        (message) => message.role === 'user',
+      );
+      const [candidateContext, viewerPreferences] = String(userMessage?.content ?? '').split(
+        'Viewer preferences:',
+      );
+
+      expect(candidateContext).toContain('Heat');
+      expect(candidateContext).not.toContain('The Dark Knight');
+      expect(viewerPreferences).toContain('The Dark Knight');
+    });
+
     it('calls chat.completions.create with the enrichment system prompt when favoriteMovieWhy is provided', async () => {
       // First call = enrichment, then recommendation + description calls
       mockChatCompletionsCreate

--- a/apps/web/src/app/quiz/page.tsx
+++ b/apps/web/src/app/quiz/page.tsx
@@ -84,8 +84,11 @@ export default function QuizPage() {
         }
 
         const { id } = (await res.json()) as { id: string };
-        router.push(`/results/${id}`);
+        // Leave the cached quiz route in a clean state. Next can preserve client route state
+        // between navigations, so the submission guard must be reset before we move away.
+        submittingRef.current = false;
         send({ type: 'RESET' });
+        router.push(`/results/${id}`);
       } catch {
         // Network error — send the machine back so the user can retry
         submittingRef.current = false;

--- a/apps/web/src/app/quiz/page.tsx
+++ b/apps/web/src/app/quiz/page.tsx
@@ -4,6 +4,7 @@ import { useMachine } from '@xstate/react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
+import { flushSync } from 'react-dom';
 
 import { ProgressDots } from '@/components/ProgressDots';
 import { useLanguage } from '@/i18n';
@@ -89,7 +90,11 @@ export default function QuizPage() {
         }
 
         const { id } = (await res.json()) as { id: string };
-        setResultNavigation({ mode, peopleCount: people.length });
+        // Commit the handoff screen before resetting the machine. Otherwise the
+        // intro state can briefly render while Next is navigating to results.
+        flushSync(() => {
+          setResultNavigation({ mode, peopleCount: people.length });
+        });
         submittingRef.current = false;
         send({ type: 'RESET' });
         router.push(`/results/${id}`);

--- a/apps/web/src/app/quiz/page.tsx
+++ b/apps/web/src/app/quiz/page.tsx
@@ -36,6 +36,10 @@ export default function QuizPage() {
 
   // groupNames is transient UI state only needed during GroupSetup
   const [groupNames, setGroupNames] = useState<string[]>(['', '']);
+  const [resultNavigation, setResultNavigation] = useState<{
+    mode: 'solo' | 'group';
+    peopleCount: number;
+  } | null>(null);
   // Guard against React StrictMode double-invoking the submit effect
   const submittingRef = useRef(false);
 
@@ -78,19 +82,20 @@ export default function QuizPage() {
 
         if (!res.ok) {
           // If the server can't process the quiz data, go back to quiz
+          setResultNavigation(null);
           submittingRef.current = false;
           send({ type: 'BACK' });
           return;
         }
 
         const { id } = (await res.json()) as { id: string };
-        // Leave the cached quiz route in a clean state. Next can preserve client route state
-        // between navigations, so the submission guard must be reset before we move away.
+        setResultNavigation({ mode, peopleCount: people.length });
         submittingRef.current = false;
         send({ type: 'RESET' });
         router.push(`/results/${id}`);
       } catch {
         // Network error — send the machine back so the user can retry
+        setResultNavigation(null);
         submittingRef.current = false;
         send({ type: 'BACK' });
       }
@@ -146,6 +151,15 @@ export default function QuizPage() {
   }
 
   // ── SUBMITTING ── recommendation creation is in flight via useEffect above
+  if (resultNavigation) {
+    return (
+      <QuizSubmittingState
+        mode={resultNavigation.mode}
+        peopleCount={resultNavigation.peopleCount}
+      />
+    );
+  }
+
   if (state.matches('submitting')) {
     return <QuizSubmittingState mode={mode} peopleCount={people.length} />;
   }

--- a/apps/web/src/app/quiz/page.tsx
+++ b/apps/web/src/app/quiz/page.tsx
@@ -29,6 +29,59 @@ import type { PersonAnswers } from './types';
 
 const STEP_KEYS = ['favoriteMovie', 'era', 'mood', 'tone', 'favoriteActor'] as const;
 type StepKey = (typeof STEP_KEYS)[number];
+type ResultNavigation = {
+  mode: 'solo' | 'group';
+  peopleCount: number;
+};
+
+const QUIZ_HANDOFF_STORAGE_KEY = 'pop-choice:quiz-handoff';
+const QUIZ_HANDOFF_TTL_MS = 30_000;
+
+function readStoredQuizHandoff(): ResultNavigation | null {
+  if (typeof window === 'undefined') return null;
+
+  try {
+    const raw = window.sessionStorage.getItem(QUIZ_HANDOFF_STORAGE_KEY);
+    if (!raw) return null;
+
+    const parsed = JSON.parse(raw) as ResultNavigation & { expiresAt?: number };
+    if (
+      (parsed.mode !== 'solo' && parsed.mode !== 'group') ||
+      typeof parsed.peopleCount !== 'number' ||
+      typeof parsed.expiresAt !== 'number' ||
+      parsed.expiresAt < Date.now()
+    ) {
+      window.sessionStorage.removeItem(QUIZ_HANDOFF_STORAGE_KEY);
+      return null;
+    }
+
+    return {
+      mode: parsed.mode,
+      peopleCount: parsed.peopleCount,
+    };
+  } catch {
+    window.sessionStorage.removeItem(QUIZ_HANDOFF_STORAGE_KEY);
+    return null;
+  }
+}
+
+function storeQuizHandoff(handoff: ResultNavigation) {
+  if (typeof window === 'undefined') return;
+
+  window.sessionStorage.setItem(
+    QUIZ_HANDOFF_STORAGE_KEY,
+    JSON.stringify({
+      ...handoff,
+      expiresAt: Date.now() + QUIZ_HANDOFF_TTL_MS,
+    }),
+  );
+}
+
+function clearQuizHandoff() {
+  if (typeof window === 'undefined') return;
+
+  window.sessionStorage.removeItem(QUIZ_HANDOFF_STORAGE_KEY);
+}
 
 export default function QuizPage() {
   const [state, send] = useMachine(quizMachine);
@@ -37,10 +90,9 @@ export default function QuizPage() {
 
   // groupNames is transient UI state only needed during GroupSetup
   const [groupNames, setGroupNames] = useState<string[]>(['', '']);
-  const [resultNavigation, setResultNavigation] = useState<{
-    mode: 'solo' | 'group';
-    peopleCount: number;
-  } | null>(null);
+  const [resultNavigation, setResultNavigation] = useState<ResultNavigation | null>(
+    readStoredQuizHandoff,
+  );
   // Guard against React StrictMode double-invoking the submit effect
   const submittingRef = useRef(false);
 
@@ -62,6 +114,8 @@ export default function QuizPage() {
     // Prevent double-submission from React StrictMode or re-renders
     if (submittingRef.current) return;
     submittingRef.current = true;
+    const handoff = { mode, peopleCount: people.length };
+    storeQuizHandoff(handoff);
 
     async function submit() {
       const resolved =
@@ -83,6 +137,7 @@ export default function QuizPage() {
 
         if (!res.ok) {
           // If the server can't process the quiz data, go back to quiz
+          clearQuizHandoff();
           setResultNavigation(null);
           submittingRef.current = false;
           send({ type: 'BACK' });
@@ -93,13 +148,14 @@ export default function QuizPage() {
         // Commit the handoff screen before resetting the machine. Otherwise the
         // intro state can briefly render while Next is navigating to results.
         flushSync(() => {
-          setResultNavigation({ mode, peopleCount: people.length });
+          setResultNavigation(handoff);
         });
         submittingRef.current = false;
         send({ type: 'RESET' });
         router.push(`/results/${id}`);
       } catch {
         // Network error — send the machine back so the user can retry
+        clearQuizHandoff();
         setResultNavigation(null);
         submittingRef.current = false;
         send({ type: 'BACK' });

--- a/apps/web/src/app/results/[id]/ResultsIdClient.tsx
+++ b/apps/web/src/app/results/[id]/ResultsIdClient.tsx
@@ -17,6 +17,10 @@ export function ResultsIdClient({ params }: { params: Promise<{ id: string }> })
 
   const { data, error, isError, refetch, morePicksTimedOut } = useRecommendation(id);
 
+  useEffect(() => {
+    window.sessionStorage.removeItem('pop-choice:quiz-handoff');
+  }, []);
+
   // Derive movies from the completed poll response — no secondary fetch needed because
   // poster URLs are fetched during the BullMQ job and stored in recommendation_movies.
   const movies = useMemo<MovieRecommendation[]>(() => {

--- a/apps/web/src/features/recommendation/candidateFilters.test.ts
+++ b/apps/web/src/features/recommendation/candidateFilters.test.ts
@@ -37,6 +37,13 @@ describe('candidateFilters', () => {
     expect(isMentionedMovieTitle('THE DARK-KNIGHT', mentioned)).toBe(true);
   });
 
+  it('matches mentioned movie titles written in non-Latin scripts', () => {
+    const mentioned = getMentionedMovieTitleKeys([person('Сталкер'), person('千と千尋の神隠し')]);
+
+    expect(isMentionedMovieTitle('сталкер', mentioned)).toBe(true);
+    expect(isMentionedMovieTitle('千と千尋の神隠し', mentioned)).toBe(true);
+  });
+
   it('does not treat related titles as the same movie', () => {
     const mentioned = getMentionedMovieTitleKeys([person('Alien')]);
 

--- a/apps/web/src/features/recommendation/candidateFilters.test.ts
+++ b/apps/web/src/features/recommendation/candidateFilters.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  excludeMentionedLocalMovies,
+  excludeMentionedTMDBMovies,
+  getMentionedMovieTitleKeys,
+  isMentionedMovieTitle,
+} from './candidateFilters';
+
+import type { EnhancedMovieMatch, PersonFormData } from './types';
+
+const person = (favoriteMovie: string): PersonFormData => ({
+  favoriteMovie,
+  newVsClassic: 'Both new and classic',
+  moodPreference: ['Drama'],
+  tonePreference: 'Balanced',
+});
+
+let movieId = 1;
+const movie = (name: string): EnhancedMovieMatch => ({
+  id: movieId++,
+  name,
+  age_rating: 'PG',
+  description: `${name} description`,
+  duration: 120,
+  score_rating: 8,
+  year: 2020,
+  similarity: 0.8,
+  content: `${name} (2020)`,
+});
+
+describe('candidateFilters', () => {
+  it('matches mentioned movie titles with punctuation, case, and leading article differences', () => {
+    const mentioned = getMentionedMovieTitleKeys([person('The Dark Knight')]);
+
+    expect(isMentionedMovieTitle('dark knight', mentioned)).toBe(true);
+    expect(isMentionedMovieTitle('THE DARK-KNIGHT', mentioned)).toBe(true);
+  });
+
+  it('does not treat related titles as the same movie', () => {
+    const mentioned = getMentionedMovieTitleKeys([person('Alien')]);
+
+    expect(isMentionedMovieTitle('Aliens', mentioned)).toBe(false);
+    expect(isMentionedMovieTitle('Alien: Covenant', mentioned)).toBe(false);
+  });
+
+  it('filters local candidates that were explicitly mentioned by any participant', () => {
+    const mentioned = getMentionedMovieTitleKeys([person('Arrival'), person('Paddington 2')]);
+
+    expect(
+      excludeMentionedLocalMovies(
+        [movie('Arrival'), movie('Paddington 2'), movie('Past Lives')],
+        mentioned,
+      ).map((candidate) => candidate.name),
+    ).toEqual(['Past Lives']);
+  });
+
+  it('filters TMDB candidates that were explicitly mentioned by any participant', () => {
+    const mentioned = getMentionedMovieTitleKeys([person('Inception')]);
+
+    expect(
+      excludeMentionedTMDBMovies(
+        [
+          {
+            id: 1,
+            title: 'Inception',
+            overview: 'A dream heist.',
+            release_date: '2010-07-16',
+            vote_average: 8.4,
+            poster_path: null,
+          },
+          {
+            id: 2,
+            title: 'Paprika',
+            overview: 'Dreams and reality blur.',
+            release_date: '2006-11-25',
+            vote_average: 7.8,
+            poster_path: null,
+          },
+        ],
+        mentioned,
+      ).map((candidate) => candidate.title),
+    ).toEqual(['Paprika']);
+  });
+});

--- a/apps/web/src/features/recommendation/candidateFilters.ts
+++ b/apps/web/src/features/recommendation/candidateFilters.ts
@@ -3,11 +3,11 @@ import type { EnhancedMovieMatch, PersonFormData } from './types';
 
 function normalizeMovieTitle(title: string): string {
   return title
-    .toLowerCase()
+    .toLocaleLowerCase()
     .normalize('NFKD')
-    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/\p{M}+/gu, '')
     .replace(/&/g, ' and ')
-    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
     .trim()
     .replace(/^(the|a|an)\s+/, '')
     .replace(/\s+/g, ' ');

--- a/apps/web/src/features/recommendation/candidateFilters.ts
+++ b/apps/web/src/features/recommendation/candidateFilters.ts
@@ -1,0 +1,44 @@
+import type { TMDBDiscoverMovie } from './tmdb';
+import type { EnhancedMovieMatch, PersonFormData } from './types';
+
+function normalizeMovieTitle(title: string): string {
+  return title
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .replace(/^(the|a|an)\s+/, '')
+    .replace(/\s+/g, ' ');
+}
+
+export function getMentionedMovieTitleKeys(allPeopleData: PersonFormData[]): Set<string> {
+  return new Set(
+    allPeopleData
+      .map((person) => normalizeMovieTitle(person.favoriteMovie))
+      .filter((title) => title.length > 0),
+  );
+}
+
+export function isMentionedMovieTitle(title: string, mentionedTitleKeys: Set<string>): boolean {
+  const normalizedTitle = normalizeMovieTitle(title);
+  if (!normalizedTitle) return false;
+  return mentionedTitleKeys.has(normalizedTitle);
+}
+
+export function excludeMentionedLocalMovies(
+  movies: EnhancedMovieMatch[],
+  mentionedTitleKeys: Set<string>,
+): EnhancedMovieMatch[] {
+  if (mentionedTitleKeys.size === 0) return movies;
+  return movies.filter((movie) => !isMentionedMovieTitle(movie.name, mentionedTitleKeys));
+}
+
+export function excludeMentionedTMDBMovies(
+  movies: TMDBDiscoverMovie[],
+  mentionedTitleKeys: Set<string>,
+): TMDBDiscoverMovie[] {
+  if (mentionedTitleKeys.size === 0) return movies;
+  return movies.filter((movie) => !isMentionedMovieTitle(movie.title, mentionedTitleKeys));
+}

--- a/apps/web/src/features/recommendation/pipeline.ts
+++ b/apps/web/src/features/recommendation/pipeline.ts
@@ -9,6 +9,11 @@ import { getDbClient } from '@/clients/dbClient';
 import { MOVIE_SEED_JOB_OPTIONS, seedQueue } from '@/lib/jobQueue';
 import logger from '@/lib/logger';
 
+import {
+  excludeMentionedLocalMovies,
+  excludeMentionedTMDBMovies,
+  getMentionedMovieTitleKeys,
+} from './candidateFilters';
 import { createEmbedding, refineQueryWithLLM } from './embedding';
 import { SIMILARITY_THRESHOLD, shouldFallBackToTMDB } from './helpers';
 import {
@@ -87,6 +92,8 @@ export async function runRecommendationPipeline(
   locale: Locale,
   options: { onStageChange?: (stage: RecommendationStage) => Promise<void> | void } = {},
 ): Promise<ApiResponse> {
+  const mentionedTitleKeys = getMentionedMovieTitleKeys(allPeopleData);
+
   async function emitStage(stage: RecommendationStage): Promise<void> {
     try {
       await options.onStageChange?.(stage);
@@ -119,7 +126,10 @@ export async function runRecommendationPipeline(
 
   // Step 2: Find similar movies (local vector search)
   await emitStage('local-search');
-  let similarMovies = await getSimilarMovies(embedding);
+  let similarMovies = excludeMentionedLocalMovies(
+    await getSimilarMovies(embedding),
+    mentionedTitleKeys,
+  );
 
   // Step 3: Hybrid search — fall back to TMDB if local results are insufficient
   let usedBroaderSearch = false;
@@ -135,7 +145,10 @@ export async function runRecommendationPipeline(
 
     const tmdbApiKey = process.env.TMDB_API_KEY;
     if (tmdbApiKey) {
-      const tmdbMovies = await fetchTMDBDiscoverMovies(allPeopleData, tmdbApiKey);
+      const tmdbMovies = excludeMentionedTMDBMovies(
+        await fetchTMDBDiscoverMovies(allPeopleData, tmdbApiKey),
+        mentionedTitleKeys,
+      );
 
       if (tmdbMovies.length > 0) {
         const localResultsForMerge = highQualityLocal.slice(0, MAX_TOTAL_MOVIES);

--- a/apps/web/src/features/recommendation/pipeline.ts
+++ b/apps/web/src/features/recommendation/pipeline.ts
@@ -126,10 +126,8 @@ export async function runRecommendationPipeline(
 
   // Step 2: Find similar movies (local vector search)
   await emitStage('local-search');
-  let similarMovies = excludeMentionedLocalMovies(
-    await getSimilarMovies(embedding),
-    mentionedTitleKeys,
-  );
+  const localSimilarMovies = await getSimilarMovies(embedding);
+  let similarMovies = excludeMentionedLocalMovies(localSimilarMovies, mentionedTitleKeys);
 
   // Step 3: Hybrid search — fall back to TMDB if local results are insufficient
   let usedBroaderSearch = false;
@@ -228,7 +226,19 @@ export async function runRecommendationPipeline(
   }
 
   if (similarMovies.length === 0) {
-    throw new Error('No similar movies found.');
+    const fallbackMovies = localSimilarMovies.slice(0, MAX_TOTAL_MOVIES);
+    if (fallbackMovies.length === 0) {
+      throw new Error('No similar movies found.');
+    }
+
+    logger.warn(
+      {
+        mentionedTitleCount: mentionedTitleKeys.size,
+        fallbackCount: fallbackMovies.length,
+      },
+      'Mentioned-title filtering removed every candidate and TMDB fallback did not refill results; relaxing filter as last resort',
+    );
+    similarMovies = fallbackMovies;
   }
 
   // Step 4: Get recommendation from OpenAI

--- a/docs/ROADMAP-ARCHITECTURE.md
+++ b/docs/ROADMAP-ARCHITECTURE.md
@@ -47,7 +47,7 @@ The main remaining risks are:
 
 ### Issues Still Present
 
-- No high-priority boundary issues remain in the current cleanup slice.
+- The quiz-to-results handoff still relies on route-local state and a short-lived browser handoff marker to avoid visual flashes. A follow-up PR should simplify this architecture so the quiz route never needs to reset itself while it is still responsible for rendering the submit handoff.
 
 Reference: use [BOUNDARIES.md](./BOUNDARIES.md) as the current ownership baseline.
 
@@ -92,6 +92,7 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 - Isolate external integrations behind stable client/service interfaces.
 - Centralize configuration and constants to reduce manual synchronization.
 - Prefer extracting recommendation flows out of `src/app/api` into clearer domain-owned modules.
+- Refactor the quiz submission lifecycle so recommendation creation is modeled explicitly instead of coordinated through route-local `useEffect`, refs, and navigation timing.
 
 ### Phase 3: Extract intentional packages from the existing layout
 


### PR DESCRIPTION
## Summary
- add recommendation candidate filtering for movies explicitly named by quiz participants
- keep mentioned favorites in viewer preference text while excluding them from local and TMDB candidate pools
- cover title normalization and API prompt behavior with tests

## Test Plan
- npm run format:check
- npm run lint:check --workspace=apps/web
- npm run type-check --workspace=apps/web
- npm run test --workspace=apps/web -- candidateFilters movie-recommendation
- npm run test:server
- npm run build