### PR TITLE
Refactor quiz submit handoff state

### DIFF
--- a/apps/web/src/app/about/page.tsx
+++ b/apps/web/src/app/about/page.tsx
@@ -3,10 +3,12 @@
 import { Play } from 'lucide-react';
 import { motion } from 'motion/react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 
 import { Breadcrumbs, TMDBAttribution } from '@/components';
 import { usePCTheme } from '@/hooks/usePCTheme';
 import { useLanguage } from '@/i18n';
+import { createFreshQuizHref } from '@/lib/quizNavigation';
 import { palette } from '@/styles/designTokens';
 
 import { FAQSection } from './components/FAQSection';
@@ -14,6 +16,7 @@ import { HowItWorksSection } from './components/HowItWorksSection';
 import { TechStackSection } from './components/TechStackSection';
 
 export default function AboutPage() {
+  const router = useRouter();
   const { isDark } = usePCTheme();
   const { t } = useLanguage();
 
@@ -151,6 +154,10 @@ export default function AboutPage() {
         </p>
         <Link
           href="/quiz"
+          onClick={(event) => {
+            event.preventDefault();
+            router.push(createFreshQuizHref());
+          }}
           className="inline-flex items-center gap-2 px-7 py-3.5 rounded-2xl transition-all duration-200 hover:opacity-90 active:scale-95"
           style={{
             background: 'var(--pc-cta)',

--- a/apps/web/src/app/about/tech-stack/page.tsx
+++ b/apps/web/src/app/about/tech-stack/page.tsx
@@ -2,14 +2,17 @@
 
 import { motion } from 'motion/react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 
 import { Breadcrumbs } from '@/components';
 import { useLanguage } from '@/i18n';
+import { createFreshQuizHref } from '@/lib/quizNavigation';
 import { palette } from '@/styles/designTokens';
 
 const GROUP_COLORS = [palette.gold, palette.purple, palette.teal, palette.amber] as const;
 
 export default function TechStackPage() {
+  const router = useRouter();
   const { t } = useLanguage();
   const { breadcrumbAbout, breadcrumbStack, title, intro, backToAbout, tryQuiz, groups } =
     t.techStackPage;
@@ -144,6 +147,10 @@ export default function TechStackPage() {
         </Link>
         <Link
           href="/quiz"
+          onClick={(event) => {
+            event.preventDefault();
+            router.push(createFreshQuizHref());
+          }}
           className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl transition-all duration-200 hover:opacity-90 active:scale-95"
           style={{
             background: 'var(--pc-cta)',

--- a/apps/web/src/app/components/CtaSection.tsx
+++ b/apps/web/src/app/components/CtaSection.tsx
@@ -8,6 +8,7 @@ import { useRouter } from 'next/navigation';
 import { Mascot } from '@/components/Mascot';
 import { usePCTheme } from '@/hooks/usePCTheme';
 import { useLanguage } from '@/i18n';
+import { createFreshQuizHref } from '@/lib/quizNavigation';
 
 const POPCORN_IMG =
   'https://images.unsplash.com/photo-1770597105062-648a2fbfa052?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxwb3Bjb3JuJTIwYnVja2V0JTIwbW92aWUlMjBuaWdodHxlbnwxfHx8fDE3NzQ4OTQzNTF8MA&ixlib=rb-4.1.0&q=80&w=1080';
@@ -61,7 +62,7 @@ export function CtaSection() {
           {t.cta.description}
         </p>
         <button
-          onClick={() => router.push('/quiz')}
+          onClick={() => router.push(createFreshQuizHref())}
           className="inline-flex items-center gap-2 px-7 py-3.5 rounded-xl transition-all duration-200 active:scale-95"
           style={{
             background: 'var(--pc-cta)',

--- a/apps/web/src/app/components/HeroSection.tsx
+++ b/apps/web/src/app/components/HeroSection.tsx
@@ -8,6 +8,7 @@ import { useRouter } from 'next/navigation';
 import { Mascot } from '@/components/Mascot';
 import { usePCTheme } from '@/hooks/usePCTheme';
 import { useLanguage } from '@/i18n';
+import { createFreshQuizHref } from '@/lib/quizNavigation';
 
 // Loaded client-side only so Math.random() does not cause hydration mismatches
 const FilmParticles = dynamic(() => import('./FilmParticles'), { ssr: false });
@@ -112,7 +113,7 @@ export function HeroSection() {
           className="flex flex-col sm:flex-row items-center gap-4"
         >
           <button
-            onClick={() => router.push('/quiz')}
+            onClick={() => router.push(createFreshQuizHref())}
             className="group relative flex items-center gap-3 px-8 py-4 rounded-2xl transition-all duration-300 active:scale-95"
             style={{
               background: 'var(--pc-cta)',

--- a/apps/web/src/app/quiz/page.tsx
+++ b/apps/web/src/app/quiz/page.tsx
@@ -2,8 +2,8 @@
 
 import { useMachine } from '@xstate/react';
 import { AnimatePresence, motion } from 'motion/react';
-import { useRouter } from 'next/navigation';
-import { useEffect, useRef, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Suspense, startTransition, useEffect, useRef, useState } from 'react';
 
 import { ProgressDots } from '@/components/ProgressDots';
 import { useLanguage } from '@/i18n';
@@ -30,19 +30,31 @@ const STEP_KEYS = ['favoriteMovie', 'era', 'mood', 'tone', 'favoriteActor'] as c
 type StepKey = (typeof STEP_KEYS)[number];
 
 export default function QuizPage() {
+  return (
+    <Suspense fallback={<QuizSubmittingState mode="solo" peopleCount={1} />}>
+      <QuizPageContent />
+    </Suspense>
+  );
+}
+
+function QuizPageContent() {
   const [state, send] = useMachine(quizMachine);
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { t } = useLanguage();
 
   // groupNames is transient UI state only needed during GroupSetup
   const [groupNames, setGroupNames] = useState<string[]>(['', '']);
   // Guard against React StrictMode double-invoking the submit effect
   const submittingRef = useRef(false);
+  const navigationStartedRef = useRef(false);
+  const restartHandledRef = useRef<string | null>(null);
 
   const { people, currentPersonIdx, dir, mode, recommendationId } = state.context;
   const currentPerson = people[currentPersonIdx];
   const isSubmitting = state.matches('submitting');
   const isNavigatingToResults = state.matches('navigatingToResults');
+  const restartToken = searchParams.get('restart');
 
   // Derive which step we're on from the state value (no counter in context)
   const questionsStep =
@@ -51,6 +63,19 @@ export default function QuizPage() {
       : null;
   const currentStepIdx = questionsStep ? STEP_KEYS.indexOf(questionsStep) : -1;
   const isLastStep = questionsStep === 'favoriteActor';
+
+  useEffect(() => {
+    if (!restartToken || restartHandledRef.current === restartToken) return;
+
+    restartHandledRef.current = restartToken;
+    submittingRef.current = false;
+    navigationStartedRef.current = false;
+    startTransition(() => {
+      setGroupNames(['', '']);
+    });
+    send({ type: 'RESET' });
+    router.replace('/quiz', { scroll: false });
+  }, [restartToken, router, send]);
 
   // Trigger submit side-effect when machine reaches the final state
   useEffect(() => {
@@ -96,10 +121,13 @@ export default function QuizPage() {
   }, [isSubmitting, mode, people, t.quiz.intro.youLabel, send]);
 
   useEffect(() => {
-    if (!isNavigatingToResults || !recommendationId) return;
+    const hasPendingRestart = Boolean(restartToken && restartHandledRef.current !== restartToken);
+    if (hasPendingRestart || !isNavigatingToResults || !recommendationId) return;
+    if (navigationStartedRef.current) return;
 
+    navigationStartedRef.current = true;
     router.replace(`/results/${recommendationId}`);
-  }, [isNavigatingToResults, recommendationId, router]);
+  }, [isNavigatingToResults, recommendationId, restartToken, router]);
 
   function updateCurrentPerson(updates: Partial<PersonAnswers>) {
     send({ type: 'UPDATE_PERSON', updates });

--- a/apps/web/src/app/quiz/page.tsx
+++ b/apps/web/src/app/quiz/page.tsx
@@ -4,7 +4,6 @@ import { useMachine } from '@xstate/react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
-import { flushSync } from 'react-dom';
 
 import { ProgressDots } from '@/components/ProgressDots';
 import { useLanguage } from '@/i18n';
@@ -29,59 +28,6 @@ import type { PersonAnswers } from './types';
 
 const STEP_KEYS = ['favoriteMovie', 'era', 'mood', 'tone', 'favoriteActor'] as const;
 type StepKey = (typeof STEP_KEYS)[number];
-type ResultNavigation = {
-  mode: 'solo' | 'group';
-  peopleCount: number;
-};
-
-const QUIZ_HANDOFF_STORAGE_KEY = 'pop-choice:quiz-handoff';
-const QUIZ_HANDOFF_TTL_MS = 30_000;
-
-function readStoredQuizHandoff(): ResultNavigation | null {
-  if (typeof window === 'undefined') return null;
-
-  try {
-    const raw = window.sessionStorage.getItem(QUIZ_HANDOFF_STORAGE_KEY);
-    if (!raw) return null;
-
-    const parsed = JSON.parse(raw) as ResultNavigation & { expiresAt?: number };
-    if (
-      (parsed.mode !== 'solo' && parsed.mode !== 'group') ||
-      typeof parsed.peopleCount !== 'number' ||
-      typeof parsed.expiresAt !== 'number' ||
-      parsed.expiresAt < Date.now()
-    ) {
-      window.sessionStorage.removeItem(QUIZ_HANDOFF_STORAGE_KEY);
-      return null;
-    }
-
-    return {
-      mode: parsed.mode,
-      peopleCount: parsed.peopleCount,
-    };
-  } catch {
-    window.sessionStorage.removeItem(QUIZ_HANDOFF_STORAGE_KEY);
-    return null;
-  }
-}
-
-function storeQuizHandoff(handoff: ResultNavigation) {
-  if (typeof window === 'undefined') return;
-
-  window.sessionStorage.setItem(
-    QUIZ_HANDOFF_STORAGE_KEY,
-    JSON.stringify({
-      ...handoff,
-      expiresAt: Date.now() + QUIZ_HANDOFF_TTL_MS,
-    }),
-  );
-}
-
-function clearQuizHandoff() {
-  if (typeof window === 'undefined') return;
-
-  window.sessionStorage.removeItem(QUIZ_HANDOFF_STORAGE_KEY);
-}
 
 export default function QuizPage() {
   const [state, send] = useMachine(quizMachine);
@@ -90,15 +36,13 @@ export default function QuizPage() {
 
   // groupNames is transient UI state only needed during GroupSetup
   const [groupNames, setGroupNames] = useState<string[]>(['', '']);
-  const [resultNavigation, setResultNavigation] = useState<ResultNavigation | null>(
-    readStoredQuizHandoff,
-  );
   // Guard against React StrictMode double-invoking the submit effect
   const submittingRef = useRef(false);
 
-  const { people, currentPersonIdx, dir, mode } = state.context;
+  const { people, currentPersonIdx, dir, mode, recommendationId } = state.context;
   const currentPerson = people[currentPersonIdx];
   const isSubmitting = state.matches('submitting');
+  const isNavigatingToResults = state.matches('navigatingToResults');
 
   // Derive which step we're on from the state value (no counter in context)
   const questionsStep =
@@ -114,8 +58,6 @@ export default function QuizPage() {
     // Prevent double-submission from React StrictMode or re-renders
     if (submittingRef.current) return;
     submittingRef.current = true;
-    const handoff = { mode, peopleCount: people.length };
-    storeQuizHandoff(handoff);
 
     async function submit() {
       const resolved =
@@ -136,34 +78,28 @@ export default function QuizPage() {
         });
 
         if (!res.ok) {
-          // If the server can't process the quiz data, go back to quiz
-          clearQuizHandoff();
-          setResultNavigation(null);
           submittingRef.current = false;
-          send({ type: 'BACK' });
+          send({ type: 'SUBMIT_FAILURE' });
           return;
         }
 
         const { id } = (await res.json()) as { id: string };
-        // Commit the handoff screen before resetting the machine. Otherwise the
-        // intro state can briefly render while Next is navigating to results.
-        flushSync(() => {
-          setResultNavigation(handoff);
-        });
         submittingRef.current = false;
-        send({ type: 'RESET' });
-        router.push(`/results/${id}`);
+        send({ type: 'SUBMIT_SUCCESS', id });
       } catch {
-        // Network error — send the machine back so the user can retry
-        clearQuizHandoff();
-        setResultNavigation(null);
         submittingRef.current = false;
-        send({ type: 'BACK' });
+        send({ type: 'SUBMIT_FAILURE' });
       }
     }
 
     void submit();
-  }, [isSubmitting, mode, people, t.quiz.intro.youLabel, router, send]);
+  }, [isSubmitting, mode, people, t.quiz.intro.youLabel, send]);
+
+  useEffect(() => {
+    if (!isNavigatingToResults || !recommendationId) return;
+
+    router.replace(`/results/${recommendationId}`);
+  }, [isNavigatingToResults, recommendationId, router]);
 
   function updateCurrentPerson(updates: Partial<PersonAnswers>) {
     send({ type: 'UPDATE_PERSON', updates });
@@ -185,6 +121,74 @@ export default function QuizPage() {
       default:
         return false;
     }
+  }
+
+  // ── SUBMITTING / NAVIGATING ── keep this screen mounted until results loads
+  if (isSubmitting || isNavigatingToResults) {
+    return <QuizSubmittingState mode={mode} peopleCount={people.length} />;
+  }
+
+  if (state.matches('submitFailed')) {
+    return (
+      <div className="flex-1 flex flex-col items-center justify-center px-5 min-h-[80vh]">
+        <div className="max-w-sm w-full text-center">
+          <p
+            className="mb-3"
+            style={{
+              color: 'var(--pc-gold-text)',
+              fontSize: '0.72rem',
+              letterSpacing: '0.16em',
+              textTransform: 'uppercase',
+            }}
+          >
+            {t.loading.submitFailedEyebrow}
+          </p>
+          <h2
+            className="mb-3"
+            style={{
+              fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
+              fontWeight: '600',
+              textTransform: 'uppercase',
+              fontSize: '2rem',
+              letterSpacing: '0.06em',
+              color: 'var(--pc-t1)',
+            }}
+          >
+            {t.loading.submitFailedTitle}
+          </h2>
+          <p
+            className="mb-6"
+            style={{ color: 'var(--pc-t2)', fontSize: '0.92rem', lineHeight: 1.6 }}
+          >
+            {t.loading.submitFailedBody}
+          </p>
+          <div className="flex flex-col gap-3">
+            <button
+              type="button"
+              onClick={() => send({ type: 'RETRY_SUBMIT' })}
+              className="rounded-full px-5 py-3 font-semibold transition-transform hover:scale-[1.01]"
+              style={{
+                background: 'var(--pc-cta)',
+                color: 'var(--pc-cta-text)',
+              }}
+            >
+              {t.loading.submitFailedRetry}
+            </button>
+            <button
+              type="button"
+              onClick={() => send({ type: 'BACK' })}
+              className="rounded-full px-5 py-3 font-semibold"
+              style={{
+                background: 'var(--pc-ghost)',
+                color: 'var(--pc-t2)',
+              }}
+            >
+              {t.loading.submitFailedBack}
+            </button>
+          </div>
+        </div>
+      </div>
+    );
   }
 
   // ── INTRO ──
@@ -209,20 +213,6 @@ export default function QuizPage() {
         }
       />
     );
-  }
-
-  // ── SUBMITTING ── recommendation creation is in flight via useEffect above
-  if (resultNavigation) {
-    return (
-      <QuizSubmittingState
-        mode={resultNavigation.mode}
-        peopleCount={resultNavigation.peopleCount}
-      />
-    );
-  }
-
-  if (state.matches('submitting')) {
-    return <QuizSubmittingState mode={mode} peopleCount={people.length} />;
   }
 
   // ── BETWEEN PERSONS ──

--- a/apps/web/src/app/quiz/quiz.machine.test.ts
+++ b/apps/web/src/app/quiz/quiz.machine.test.ts
@@ -29,6 +29,9 @@ const EVENTS = [
   { type: 'NEXT' as const },
   { type: 'BACK' as const },
   { type: 'CONTINUE' as const },
+  { type: 'SUBMIT_SUCCESS' as const, id: 'rec_123' },
+  { type: 'SUBMIT_FAILURE' as const, message: 'failed' },
+  { type: 'RETRY_SUBMIT' as const },
 ];
 
 const paths = model.getShortestPaths({ events: EVENTS });
@@ -87,6 +90,19 @@ describe('quiz machine – forward paths (model-based)', () => {
           submitting: () => {
             expect(actor.getSnapshot().value).toBe('submitting');
           },
+
+          navigatingToResults: () => {
+            const { value, context } = actor.getSnapshot();
+            expect(value).toBe('navigatingToResults');
+            expect(context.recommendationId).toBe('rec_123');
+          },
+
+          submitFailed: () => {
+            const { value, context } = actor.getSnapshot();
+            expect(value).toBe('submitFailed');
+            expect(context.recommendationId).toBeNull();
+            expect(context.submitError).toBe('failed');
+          },
         },
 
         events: {
@@ -97,6 +113,9 @@ describe('quiz machine – forward paths (model-based)', () => {
           NEXT: () => actor.send({ type: 'NEXT' }),
           BACK: () => actor.send({ type: 'BACK' }),
           CONTINUE: () => actor.send({ type: 'CONTINUE' }),
+          SUBMIT_SUCCESS: () => actor.send({ type: 'SUBMIT_SUCCESS', id: 'rec_123' }),
+          SUBMIT_FAILURE: () => actor.send({ type: 'SUBMIT_FAILURE', message: 'failed' }),
+          RETRY_SUBMIT: () => actor.send({ type: 'RETRY_SUBMIT' }),
         },
       });
     });
@@ -184,5 +203,53 @@ describe('quiz machine – BACK navigation', () => {
     expect(snapshot.value).toBe('intro');
     expect(snapshot.context.people).toEqual([]);
     expect(snapshot.context.currentPersonIdx).toBe(0);
+    expect(snapshot.context.recommendationId).toBeNull();
+    expect(snapshot.context.submitError).toBeNull();
+  });
+
+  it('successful submission waits in navigatingToResults instead of resetting to intro', () => {
+    const actor = makeActor();
+    actor.send({ type: 'START_SOLO', youLabel: 'You' });
+
+    for (let i = 0; i < 5; i++) actor.send({ type: 'NEXT' });
+    actor.send({ type: 'SUBMIT_SUCCESS', id: 'rec_123' });
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe('navigatingToResults');
+    expect(snapshot.context.recommendationId).toBe('rec_123');
+    expect(snapshot.context.people).toHaveLength(1);
+  });
+
+  it('failed submission preserves answers and can retry', () => {
+    const actor = makeActor();
+    actor.send({ type: 'START_SOLO', youLabel: 'You' });
+
+    actor.send({ type: 'UPDATE_PERSON', updates: { favoriteMovie: 'Heat' } });
+    for (let i = 0; i < 5; i++) actor.send({ type: 'NEXT' });
+    actor.send({ type: 'SUBMIT_FAILURE', message: 'network' });
+
+    let snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe('submitFailed');
+    expect(snapshot.context.people[0]?.favoriteMovie).toBe('Heat');
+    expect(snapshot.context.submitError).toBe('network');
+
+    actor.send({ type: 'RETRY_SUBMIT' });
+
+    snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe('submitting');
+    expect(snapshot.context.people[0]?.favoriteMovie).toBe('Heat');
+    expect(snapshot.context.submitError).toBeNull();
+  });
+
+  it('failed submission can return to the final quiz step', () => {
+    const actor = makeActor();
+    actor.send({ type: 'START_SOLO', youLabel: 'You' });
+
+    for (let i = 0; i < 5; i++) actor.send({ type: 'NEXT' });
+    actor.send({ type: 'SUBMIT_FAILURE' });
+    actor.send({ type: 'BACK' });
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.matches({ questions: 'favoriteActor' })).toBe(true);
   });
 });

--- a/apps/web/src/app/quiz/quiz.machine.test.ts
+++ b/apps/web/src/app/quiz/quiz.machine.test.ts
@@ -220,6 +220,20 @@ describe('quiz machine – BACK navigation', () => {
     expect(snapshot.context.people).toHaveLength(1);
   });
 
+  it('RESET from navigatingToResults starts a fresh quiz', () => {
+    const actor = makeActor();
+    actor.send({ type: 'START_SOLO', youLabel: 'You' });
+
+    for (let i = 0; i < 5; i++) actor.send({ type: 'NEXT' });
+    actor.send({ type: 'SUBMIT_SUCCESS', id: 'rec_123' });
+    actor.send({ type: 'RESET' });
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe('intro');
+    expect(snapshot.context.people).toEqual([]);
+    expect(snapshot.context.recommendationId).toBeNull();
+  });
+
   it('failed submission preserves answers and can retry', () => {
     const actor = makeActor();
     actor.send({ type: 'START_SOLO', youLabel: 'You' });

--- a/apps/web/src/app/quiz/quiz.machine.ts
+++ b/apps/web/src/app/quiz/quiz.machine.ts
@@ -211,7 +211,11 @@ export const quizMachine = setup({
         RESET: { target: 'intro', actions: 'resetQuiz' },
       },
     },
-    navigatingToResults: {},
+    navigatingToResults: {
+      on: {
+        RESET: { target: 'intro', actions: 'resetQuiz' },
+      },
+    },
     submitFailed: {
       on: {
         RETRY_SUBMIT: { target: 'submitting', actions: 'clearSubmitState' },

--- a/apps/web/src/app/quiz/quiz.machine.ts
+++ b/apps/web/src/app/quiz/quiz.machine.ts
@@ -9,6 +9,8 @@ type QuizContext = {
   people: PersonAnswers[];
   currentPersonIdx: number;
   dir: 1 | -1;
+  recommendationId: string | null;
+  submitError: string | null;
 };
 
 type QuizEvent =
@@ -19,6 +21,9 @@ type QuizEvent =
   | { type: 'BACK' }
   | { type: 'UPDATE_PERSON'; updates: Partial<PersonAnswers> }
   | { type: 'CONTINUE' }
+  | { type: 'SUBMIT_SUCCESS'; id: string }
+  | { type: 'SUBMIT_FAILURE'; message?: string }
+  | { type: 'RETRY_SUBMIT' }
   | { type: 'RESET' };
 
 export const quizMachine = setup({
@@ -40,9 +45,15 @@ export const quizMachine = setup({
         people: [emptyPerson(event.youLabel)],
         currentPersonIdx: 0,
         dir: 1 as const,
+        recommendationId: null,
+        submitError: null,
       };
     }),
-    setupGroup: assign({ mode: 'group' as const }),
+    setupGroup: assign({
+      mode: 'group' as const,
+      recommendationId: null,
+      submitError: null,
+    }),
     setupGroupQuestions: assign(({ event }) => {
       if (event.type !== 'START_GROUP_QUESTIONS') return {};
       const valid = event.names.filter((n) => n.trim().length > 0);
@@ -51,6 +62,8 @@ export const quizMachine = setup({
         people: names.map(emptyPerson),
         currentPersonIdx: 0,
         dir: 1 as const,
+        recommendationId: null,
+        submitError: null,
       };
     }),
     setDirForward: assign({ dir: 1 as const }),
@@ -76,6 +89,26 @@ export const quizMachine = setup({
       people: [],
       currentPersonIdx: 0,
       dir: 1 as const,
+      recommendationId: null,
+      submitError: null,
+    }),
+    clearSubmitState: assign({
+      recommendationId: null,
+      submitError: null,
+    }),
+    setRecommendationId: assign(({ event }) => {
+      if (event.type !== 'SUBMIT_SUCCESS') return {};
+      return {
+        recommendationId: event.id,
+        submitError: null,
+      };
+    }),
+    setSubmitError: assign(({ event }) => {
+      if (event.type !== 'SUBMIT_FAILURE') return {};
+      return {
+        recommendationId: null,
+        submitError: event.message ?? null,
+      };
     }),
   },
 }).createMachine({
@@ -86,6 +119,8 @@ export const quizMachine = setup({
     people: [],
     currentPersonIdx: 0,
     dir: 1,
+    recommendationId: null,
+    submitError: null,
   },
   states: {
     intro: {
@@ -147,7 +182,7 @@ export const quizMachine = setup({
                 target: '#quiz.betweenPersons',
                 actions: 'setDirForward',
               },
-              { target: '#quiz.submitting' },
+              { target: '#quiz.submitting', actions: 'clearSubmitState' },
             ],
             BACK: { target: 'tone', actions: 'setDirBackward' },
           },
@@ -165,6 +200,22 @@ export const quizMachine = setup({
     },
     submitting: {
       on: {
+        SUBMIT_SUCCESS: {
+          target: 'navigatingToResults',
+          actions: 'setRecommendationId',
+        },
+        SUBMIT_FAILURE: {
+          target: 'submitFailed',
+          actions: 'setSubmitError',
+        },
+        RESET: { target: 'intro', actions: 'resetQuiz' },
+      },
+    },
+    navigatingToResults: {},
+    submitFailed: {
+      on: {
+        RETRY_SUBMIT: { target: 'submitting', actions: 'clearSubmitState' },
+        BACK: { target: '#quiz.questions.favoriteActor', actions: 'setDirBackward' },
         RESET: { target: 'intro', actions: 'resetQuiz' },
       },
     },

--- a/apps/web/src/app/results/[id]/RecommendationResultsView.tsx
+++ b/apps/web/src/app/results/[id]/RecommendationResultsView.tsx
@@ -16,6 +16,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useLanguage } from '@/i18n';
 import { getCsrfToken } from '@/lib/csrfClient';
+import { createFreshQuizHref } from '@/lib/quizNavigation';
 import { palette } from '@/styles/designTokens';
 import { type MovieRecommendation } from '@/utils/client';
 
@@ -508,7 +509,7 @@ export function RecommendationResultsView({
         className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4"
       >
         <button
-          onClick={() => router.push('/quiz')}
+          onClick={() => router.push(createFreshQuizHref())}
           className="flex items-center gap-2 px-6 py-3 rounded-2xl transition-all duration-200 active:scale-95"
           style={{
             background: 'var(--pc-ghost)',
@@ -529,7 +530,7 @@ export function RecommendationResultsView({
         </button>
 
         <button
-          onClick={() => router.push('/quiz')}
+          onClick={() => router.push(createFreshQuizHref())}
           className="flex items-center gap-2 px-6 py-3 rounded-2xl transition-all duration-200 active:scale-95"
           style={{
             background: `linear-gradient(135deg, ${palette.purple}, #6D28D9)`,

--- a/apps/web/src/app/results/[id]/ResultsIdClient.tsx
+++ b/apps/web/src/app/results/[id]/ResultsIdClient.tsx
@@ -17,10 +17,6 @@ export function ResultsIdClient({ params }: { params: Promise<{ id: string }> })
 
   const { data, error, isError, refetch, morePicksTimedOut } = useRecommendation(id);
 
-  useEffect(() => {
-    window.sessionStorage.removeItem('pop-choice:quiz-handoff');
-  }, []);
-
   // Derive movies from the completed poll response — no secondary fetch needed because
   // poster URLs are fetched during the BullMQ job and stored in recommendation_movies.
   const movies = useMemo<MovieRecommendation[]>(() => {

--- a/apps/web/src/app/results/[id]/ResultsIdClient.tsx
+++ b/apps/web/src/app/results/[id]/ResultsIdClient.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation';
 import { use, useEffect, useMemo } from 'react';
 
 import { RecommendationFetchError, useRecommendation } from '@/hooks/useRecommendation';
+import { createFreshQuizHref } from '@/lib/quizNavigation';
 import { type MovieRecommendation } from '@/utils/client';
 
 import { RecommendationResultsView } from './RecommendationResultsView';
@@ -54,11 +55,15 @@ export function ResultsIdClient({ params }: { params: Promise<{ id: string }> })
   if (isError) {
     const variant =
       error instanceof RecommendationFetchError && error.status === 404 ? 'missing' : 'failed';
-    return <ResultsErrorState variant={variant} onRetry={() => router.push('/quiz')} />;
+    return (
+      <ResultsErrorState variant={variant} onRetry={() => router.push(createFreshQuizHref())} />
+    );
   }
 
   if (status === 'failed') {
-    return <ResultsErrorState variant="failed" onRetry={() => router.push('/quiz')} />;
+    return (
+      <ResultsErrorState variant="failed" onRetry={() => router.push(createFreshQuizHref())} />
+    );
   }
 
   if (!data || status === 'pending' || status === 'processing') {
@@ -66,7 +71,7 @@ export function ResultsIdClient({ params }: { params: Promise<{ id: string }> })
   }
 
   if (movies.length === 0) {
-    return <ResultsErrorState variant="empty" onRetry={() => router.push('/quiz')} />;
+    return <ResultsErrorState variant="empty" onRetry={() => router.push(createFreshQuizHref())} />;
   }
 
   return (

--- a/apps/web/src/components/PCLayout/Navbar.tsx
+++ b/apps/web/src/components/PCLayout/Navbar.tsx
@@ -9,6 +9,7 @@ import { LanguageSwitcher } from '@/components/LanguageSwitcher';
 import { Mascot } from '@/components/Mascot';
 import { usePCTheme } from '@/hooks/usePCTheme';
 import { useLanguage } from '@/i18n';
+import { createFreshQuizHref } from '@/lib/quizNavigation';
 import { palette } from '@/styles/designTokens';
 
 export function Navbar() {
@@ -31,6 +32,11 @@ export function Navbar() {
     { href: '/login', label: t.nav.logIn },
     { href: '/register', label: t.nav.signUp },
   ];
+
+  function startFreshQuiz() {
+    setMobileMenuOpen(false);
+    window.location.assign(createFreshQuizHref());
+  }
 
   return (
     <>
@@ -106,6 +112,10 @@ export function Navbar() {
           {!isLanding && (
             <Link
               href="/quiz"
+              onClick={(event) => {
+                event.preventDefault();
+                startFreshQuiz();
+              }}
               className="ml-1 px-3 py-2 rounded-xl text-sm"
               style={{
                 background: 'var(--pc-cta)',
@@ -191,7 +201,10 @@ export function Navbar() {
             {!isLanding && (
               <Link
                 href="/quiz"
-                onClick={() => setMobileMenuOpen(false)}
+                onClick={(event) => {
+                  event.preventDefault();
+                  startFreshQuiz();
+                }}
                 className="flex-1 text-center px-3 py-2.5 rounded-xl text-sm"
                 style={{
                   background: 'var(--pc-cta)',

--- a/apps/web/src/components/PCLayout/PCLayout.tsx
+++ b/apps/web/src/components/PCLayout/PCLayout.tsx
@@ -19,6 +19,7 @@ import { Mascot } from '@/components/Mascot';
 import { usePCTheme } from '@/hooks/usePCTheme';
 import { useLanguage } from '@/i18n';
 import { type Translations } from '@/i18n/locales/en';
+import { createFreshQuizHref } from '@/lib/quizNavigation';
 import { palette } from '@/styles/designTokens';
 
 type NavLink = {
@@ -160,6 +161,11 @@ function LayoutNavigation({
   const currentPath = pathname ?? '';
   const isLanding = currentPath === '/';
 
+  function startFreshQuiz() {
+    setMobileMenuOpen(false);
+    window.location.assign(createFreshQuizHref());
+  }
+
   useEffect(() => {
     startTransition(() => {
       setMobileMenuOpen(false);
@@ -211,6 +217,10 @@ function LayoutNavigation({
         {!isLanding && (
           <Link
             href="/quiz"
+            onClick={(event) => {
+              event.preventDefault();
+              startFreshQuiz();
+            }}
             className="ml-1 px-3 py-2 rounded-xl text-sm"
             style={{
               background: 'var(--pc-cta)',
@@ -298,7 +308,10 @@ function LayoutNavigation({
             {!isLanding && (
               <Link
                 href="/quiz"
-                onClick={() => setMobileMenuOpen(false)}
+                onClick={(event) => {
+                  event.preventDefault();
+                  startFreshQuiz();
+                }}
                 className="flex-1 text-center px-3 py-2.5 rounded-xl text-sm"
                 style={{
                   background: 'var(--pc-cta)',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -163,6 +163,12 @@ export const en = {
     groupSubmitBridgeTitle: 'Finding the overlap',
     groupSubmitBridgeBody:
       'We are weighing shared moods, favorite films, and compromise picks for a movie the room can agree on.',
+    submitFailedEyebrow: 'Recommendation paused',
+    submitFailedTitle: 'Search did not start',
+    submitFailedBody:
+      'Something interrupted the handoff to recommendations. Your answers are still here, so you can try again or adjust the last step.',
+    submitFailedRetry: 'Try again',
+    submitFailedBack: 'Back to quiz',
     queuedLabel: 'Warming up the projector',
     realProgressLabel: 'Building your shortlist',
     stages: {

--- a/apps/web/src/i18n/locales/fi.ts
+++ b/apps/web/src/i18n/locales/fi.ts
@@ -165,6 +165,12 @@ export const fi: Translations = {
     groupSubmitBridgeTitle: 'Etsimme yhteistä osumaa',
     groupSubmitBridgeBody:
       'Punnitsemme yhteisiä tunnelmia, lempielokuvia ja kompromisseja, jotta koko porukka saa hyvän valinnan.',
+    submitFailedEyebrow: 'Haku pysähtyi',
+    submitFailedTitle: 'Haku ei käynnistynyt',
+    submitFailedBody:
+      'Jokin katkaisi siirtymän suosituksiin. Vastauksesi ovat yhä tallessa, joten voit yrittää uudelleen tai muuttaa viimeistä kohtaa.',
+    submitFailedRetry: 'Yritä uudelleen',
+    submitFailedBack: 'Takaisin kyselyyn',
     queuedLabel: 'Lämmitetään projektoria',
     realProgressLabel: 'Kootaan suosikkilistaasi',
     stages: {

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -168,6 +168,12 @@ export const ru: Translations = {
     groupSubmitBridgeTitle: 'Ищем общее совпадение',
     groupSubmitBridgeBody:
       'Сравниваем общие настроения, любимые фильмы и компромиссные варианты, чтобы выбрать фильм для всей компании.',
+    submitFailedEyebrow: 'Поиск на паузе',
+    submitFailedTitle: 'Поиск не запустился',
+    submitFailedBody:
+      'Что-то помешало передать ответы в рекомендации. Ответы сохранены на экране: можно попробовать ещё раз или изменить последний шаг.',
+    submitFailedRetry: 'Попробовать ещё раз',
+    submitFailedBack: 'Вернуться к квизу',
     queuedLabel: 'Готовим проектор',
     realProgressLabel: 'Собираем вашу подборку',
     stages: {

--- a/apps/web/src/lib/quizNavigation.ts
+++ b/apps/web/src/lib/quizNavigation.ts
@@ -1,0 +1,4 @@
+export function createFreshQuizHref(): string {
+  const token = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  return `/quiz?restart=${token}`;
+}


### PR DESCRIPTION
## Summary
- move quiz submit success/failure/navigation into explicit XState states
- keep the submitting/search screen mounted while routing to results, instead of resetting to intro
- add a recoverable submit failure screen with EN/RU/FI copy
- remove the old sessionStorage + flushSync handoff workaround

## Verification
- npm run test --workspace=apps/web -- src/app/quiz/quiz.machine.test.ts
- npm run type-check
- npm run lint:check
- npm run test
- npm run build
- local /quiz headless smoke