### PR TITLE
Add recommendation memory MVP

### DIFF
--- a/apps/web/scripts/bull-board.ts
+++ b/apps/web/scripts/bull-board.ts
@@ -5,7 +5,7 @@ import { Queue } from 'bullmq';
 import express from 'express';
 import IORedis from 'ioredis';
 
-import { redisOptionsFromUrl } from '../src/lib/redisConnection';
+import { redisOptionsFromUrl } from '@/lib/redisConnection';
 
 const PORT = Number(process.env.PORT ?? process.env.BULL_BOARD_PORT ?? 3001);
 const REDIS_URL = process.env.REDIS_URL;

--- a/apps/web/scripts/bull-board.ts
+++ b/apps/web/scripts/bull-board.ts
@@ -5,7 +5,7 @@ import { Queue } from 'bullmq';
 import express from 'express';
 import IORedis from 'ioredis';
 
-import { redisOptionsFromUrl } from '@/lib/redisConnection';
+import type { RedisOptions } from 'ioredis';
 
 const PORT = Number(process.env.PORT ?? process.env.BULL_BOARD_PORT ?? 3001);
 const REDIS_URL = process.env.REDIS_URL;
@@ -13,6 +13,35 @@ const REDIS_URL = process.env.REDIS_URL;
 if (!REDIS_URL) {
   console.error('Error: REDIS_URL is not set. Add it to your .env file.');
   process.exit(1);
+}
+
+function redisOptionsFromUrl(redisUrl: string, overrides: RedisOptions = {}): RedisOptions {
+  const url = new URL(redisUrl);
+
+  if (url.protocol !== 'redis:' && url.protocol !== 'rediss:') {
+    throw new Error('REDIS_URL must use redis:// or rediss://');
+  }
+
+  const dbPath = url.pathname.replace(/^\/+/, '');
+  const db = dbPath ? Number.parseInt(dbPath, 10) : undefined;
+
+  if (dbPath && Number.isNaN(db)) {
+    throw new Error('REDIS_URL database index must be a number');
+  }
+
+  const family = url.searchParams.get('family');
+  const parsedFamily = family ? Number.parseInt(family, 10) : undefined;
+
+  return {
+    host: url.hostname,
+    port: url.port ? Number.parseInt(url.port, 10) : 6379,
+    ...(url.username ? { username: decodeURIComponent(url.username) } : {}),
+    ...(url.password ? { password: decodeURIComponent(url.password) } : {}),
+    ...(db !== undefined ? { db } : {}),
+    ...(url.protocol === 'rediss:' ? { tls: {} } : {}),
+    ...(parsedFamily !== undefined && !Number.isNaN(parsedFamily) ? { family: parsedFamily } : {}),
+    ...overrides,
+  };
 }
 
 const connection = new IORedis(redisOptionsFromUrl(REDIS_URL, { maxRetriesPerRequest: null }));

--- a/apps/web/src/features/recommendation/candidateFilters.test.ts
+++ b/apps/web/src/features/recommendation/candidateFilters.test.ts
@@ -95,7 +95,13 @@ describe('candidateFilters', () => {
 
   it('filters candidates the signed-in user marked as already watched', () => {
     const signals = getFeedbackCandidateSignals([
-      { kind: 'already_watched', movieName: 'The Matrix', movieYear: 1999 },
+      {
+        kind: 'watched',
+        movieKey: 'title:matrix:1999',
+        tmdbId: null,
+        movieName: 'The Matrix',
+        movieYear: 1999,
+      },
     ]);
 
     expect(
@@ -143,6 +149,43 @@ describe('candidateFilters', () => {
 
     const result = applyFeedbackToLocalMovies([arrival, interstellar, primer, pastLives], signals);
 
-    expect(result.map((candidate) => candidate.name)).toEqual(['Past Lives']);
+    expect(result.map((candidate) => candidate.name)).toEqual(['Past Lives', 'Arrival']);
+    expect(result.find((candidate) => candidate.name === 'Arrival')?.similarity).toBeCloseTo(0.83);
+  });
+
+  it('filters TMDB candidates by durable movie identity when available', () => {
+    const signals = getFeedbackCandidateSignals([
+      {
+        kind: 'watched',
+        movieKey: 'tmdb:475557',
+        tmdbId: 475557,
+        movieName: 'Joker',
+        movieYear: 2019,
+      },
+    ]);
+
+    expect(
+      excludeFeedbackTMDBMovies(
+        [
+          {
+            id: 475557,
+            title: 'A completely different localized title',
+            overview: 'A lonely comedian spirals.',
+            release_date: '2019-10-02',
+            vote_average: 8.1,
+            poster_path: null,
+          },
+          {
+            id: 603,
+            title: 'The Matrix',
+            overview: 'Reality bends.',
+            release_date: '1999-03-31',
+            vote_average: 8.2,
+            poster_path: null,
+          },
+        ],
+        signals,
+      ).map((candidate) => candidate.title),
+    ).toEqual(['The Matrix']);
   });
 });

--- a/apps/web/src/features/recommendation/candidateFilters.test.ts
+++ b/apps/web/src/features/recommendation/candidateFilters.test.ts
@@ -188,4 +188,26 @@ describe('candidateFilters', () => {
       ).map((candidate) => candidate.title),
     ).toEqual(['The Matrix']);
   });
+
+  it('filters local candidates by TMDB identity when the local row has been matched', () => {
+    const signals = getFeedbackCandidateSignals([
+      {
+        kind: 'already_watched',
+        movieKey: 'tmdb:129',
+        tmdbId: 129,
+        movieName: 'Spirited Away',
+        movieYear: 2001,
+      },
+    ]);
+
+    expect(
+      applyFeedbackToLocalMovies(
+        [
+          { ...movie('A localized title'), tmdbId: 129 },
+          { ...movie('Kiki’s Delivery Service'), tmdbId: 16859 },
+        ],
+        signals,
+      ).map((candidate) => candidate.name),
+    ).toEqual(['Kiki’s Delivery Service']);
+  });
 });

--- a/apps/web/src/features/recommendation/candidateFilters.ts
+++ b/apps/web/src/features/recommendation/candidateFilters.ts
@@ -93,7 +93,7 @@ export function getFeedbackCandidateSignals(
 }
 
 function getLocalMovieIdentityKey(movie: EnhancedMovieMatch): string | null {
-  return getMovieIdentityKey({ title: movie.name, year: movie.year });
+  return getMovieIdentityKey({ tmdbId: movie.tmdbId, title: movie.name, year: movie.year });
 }
 
 function getTMDBMovieIdentityKey(movie: TMDBDiscoverMovie): string | null {

--- a/apps/web/src/features/recommendation/candidateFilters.ts
+++ b/apps/web/src/features/recommendation/candidateFilters.ts
@@ -1,36 +1,28 @@
+import { getMovieIdentityKey, getMovieTitleKey, getYearFromReleaseDate } from '@/lib/movieIdentity';
+
 import type { TMDBDiscoverMovie } from './tmdb';
 import type { EnhancedMovieMatch, PersonFormData } from './types';
-import type { RecommendationFeedbackKind } from '@/lib/db/recommendations';
+import type {
+  RecommendationFeedbackKind,
+  UserMovieInteractionKind,
+} from '@/lib/db/recommendations';
 
 export type FeedbackMoviePreference = {
-  kind: RecommendationFeedbackKind;
+  kind: RecommendationFeedbackKind | UserMovieInteractionKind;
+  movieKey?: string | null;
+  tmdbId?: number | null;
   movieName: string;
   movieYear: number | null;
 };
 
 export type FeedbackCandidateSignals = {
+  excludedMovieKeys: Set<string>;
   excludedTitleKeys: Set<string>;
+  downrankMovieKeys: Set<string>;
   downrankTitleKeys: Set<string>;
 };
 
 const FEEDBACK_DOWNRANK_AMOUNT = 0.08;
-
-function normalizeMovieTitle(title: string): string {
-  return title
-    .toLocaleLowerCase()
-    .normalize('NFKD')
-    .replace(/\p{M}+/gu, '')
-    .replace(/&/g, ' and ')
-    .replace(/[^\p{L}\p{N}]+/gu, ' ')
-    .trim()
-    .replace(/^(the|a|an)\s+/, '')
-    .replace(/\s+/g, ' ');
-}
-
-function getMovieTitleKey(title: string): string | null {
-  const normalized = normalizeMovieTitle(title);
-  return normalized.length > 0 ? normalized : null;
-}
 
 export function getMentionedMovieTitleKeys(allPeopleData: PersonFormData[]): Set<string> {
   return new Set(
@@ -65,54 +57,106 @@ export function excludeMentionedTMDBMovies(
 export function getFeedbackCandidateSignals(
   preferences: FeedbackMoviePreference[],
 ): FeedbackCandidateSignals {
+  const excludedMovieKeys = new Set<string>();
   const excludedTitleKeys = new Set<string>();
+  const downrankMovieKeys = new Set<string>();
   const downrankTitleKeys = new Set<string>();
 
   for (const preference of preferences) {
+    const movieKey =
+      preference.movieKey ??
+      getMovieIdentityKey({
+        tmdbId: preference.tmdbId,
+        title: preference.movieName,
+        year: preference.movieYear,
+      });
     const titleKey = getMovieTitleKey(preference.movieName);
-    if (!titleKey) continue;
 
     if (
       preference.kind === 'already_watched' ||
-      preference.kind === 'wrong_mood' ||
+      preference.kind === 'watched' ||
+      preference.kind === 'not_interested' ||
       preference.kind === 'too_obvious' ||
       preference.kind === 'too_obscure'
     ) {
-      excludedTitleKeys.add(titleKey);
+      if (movieKey) excludedMovieKeys.add(movieKey);
+      if (titleKey) excludedTitleKeys.add(titleKey);
     }
 
-    if (preference.kind === 'wrong_mood' || preference.kind === 'too_obvious') {
-      downrankTitleKeys.add(titleKey);
+    if (preference.kind === 'wrong_mood') {
+      if (movieKey) downrankMovieKeys.add(movieKey);
+      if (titleKey) downrankTitleKeys.add(titleKey);
     }
   }
 
-  return { excludedTitleKeys, downrankTitleKeys };
+  return { excludedMovieKeys, excludedTitleKeys, downrankMovieKeys, downrankTitleKeys };
 }
 
-function isFeedbackExcludedTitle(title: string, signals: FeedbackCandidateSignals): boolean {
-  const titleKey = getMovieTitleKey(title);
-  if (!titleKey) return false;
-  return signals.excludedTitleKeys.has(titleKey);
+function getLocalMovieIdentityKey(movie: EnhancedMovieMatch): string | null {
+  return getMovieIdentityKey({ title: movie.name, year: movie.year });
 }
 
-function isFeedbackDownrankedTitle(title: string, signals: FeedbackCandidateSignals): boolean {
-  const titleKey = getMovieTitleKey(title);
-  if (!titleKey) return false;
-  return signals.downrankTitleKeys.has(titleKey);
+function getTMDBMovieIdentityKey(movie: TMDBDiscoverMovie): string | null {
+  return getMovieIdentityKey({
+    tmdbId: movie.id,
+    title: movie.title,
+    year: getYearFromReleaseDate(movie.release_date),
+  });
+}
+
+function isFeedbackExcludedLocalMovie(
+  movie: EnhancedMovieMatch,
+  signals: FeedbackCandidateSignals,
+): boolean {
+  const movieKey = getLocalMovieIdentityKey(movie);
+  const titleKey = getMovieTitleKey(movie.name);
+  return Boolean(
+    (movieKey && signals.excludedMovieKeys.has(movieKey)) ||
+    (titleKey && signals.excludedTitleKeys.has(titleKey)),
+  );
+}
+
+function isFeedbackDownrankedLocalMovie(
+  movie: EnhancedMovieMatch,
+  signals: FeedbackCandidateSignals,
+): boolean {
+  const movieKey = getLocalMovieIdentityKey(movie);
+  const titleKey = getMovieTitleKey(movie.name);
+  return Boolean(
+    (movieKey && signals.downrankMovieKeys.has(movieKey)) ||
+    (titleKey && signals.downrankTitleKeys.has(titleKey)),
+  );
+}
+
+function isFeedbackExcludedTMDBMovie(
+  movie: TMDBDiscoverMovie,
+  signals: FeedbackCandidateSignals,
+): boolean {
+  const movieKey = getTMDBMovieIdentityKey(movie);
+  const titleKey = getMovieTitleKey(movie.title);
+  return Boolean(
+    (movieKey && signals.excludedMovieKeys.has(movieKey)) ||
+    (titleKey && signals.excludedTitleKeys.has(titleKey)),
+  );
 }
 
 export function applyFeedbackToLocalMovies(
   movies: EnhancedMovieMatch[],
   signals: FeedbackCandidateSignals,
 ): EnhancedMovieMatch[] {
-  if (signals.excludedTitleKeys.size === 0 && signals.downrankTitleKeys.size === 0) {
+  if (
+    signals.excludedMovieKeys.size === 0 &&
+    signals.excludedTitleKeys.size === 0 &&
+    signals.downrankMovieKeys.size === 0 &&
+    signals.downrankTitleKeys.size === 0
+  ) {
     return movies;
   }
 
   return movies
-    .filter((movie) => !isFeedbackExcludedTitle(movie.name, signals))
+    .filter((movie) => !isFeedbackExcludedLocalMovie(movie, signals))
     .map((movie) => {
-      if (!isFeedbackDownrankedTitle(movie.name, signals)) return movie;
+      if (!isFeedbackDownrankedLocalMovie(movie, signals)) return movie;
 
       return {
         ...movie,
@@ -126,6 +170,6 @@ export function excludeFeedbackTMDBMovies(
   movies: TMDBDiscoverMovie[],
   signals: FeedbackCandidateSignals,
 ): TMDBDiscoverMovie[] {
-  if (signals.excludedTitleKeys.size === 0) return movies;
-  return movies.filter((movie) => !isFeedbackExcludedTitle(movie.title, signals));
+  if (signals.excludedMovieKeys.size === 0 && signals.excludedTitleKeys.size === 0) return movies;
+  return movies.filter((movie) => !isFeedbackExcludedTMDBMovie(movie, signals));
 }

--- a/apps/web/src/features/recommendation/recommendation.ts
+++ b/apps/web/src/features/recommendation/recommendation.ts
@@ -78,7 +78,10 @@ async function findNearestMatch(embedding: number[]): Promise<EnhancedMovieMatch
     return null;
   }
 
-  return data as EnhancedMovieMatch[];
+  return (data as Array<EnhancedMovieMatch & { tmdb_id?: number | null }>).map((movie) => ({
+    ...movie,
+    tmdbId: movie.tmdb_id ?? movie.tmdbId ?? null,
+  }));
 }
 
 /** Find similar movies in the local vector store. Returns an empty array if none found or DB unavailable. */

--- a/apps/web/src/features/recommendation/tmdb.ts
+++ b/apps/web/src/features/recommendation/tmdb.ts
@@ -261,6 +261,7 @@ function tmdbMovieToEnhancedMatch(
 
   return {
     id: -movie.id, // Negative ID distinguishes TMDB-sourced movies from local DB rows (positive bigserial IDs)
+    tmdbId: movie.id,
     name: movie.title,
     age_rating: 'NR',
     description: movie.overview || '',

--- a/apps/web/src/features/recommendation/types.ts
+++ b/apps/web/src/features/recommendation/types.ts
@@ -138,6 +138,7 @@ export type EnhancedMovieMatch = {
   duration: number;
   score_rating: number;
   year: number;
+  tmdbId?: number | null;
   similarity: number;
   content: string;
   /** Pre-populated poster URL, e.g. from TMDB discover response — skips re-lookup if set. */

--- a/apps/web/src/lib/db/recommendations.test.ts
+++ b/apps/web/src/lib/db/recommendations.test.ts
@@ -130,6 +130,7 @@ describe('getUserRecommendationSummaries', () => {
           quiz_data: [{ name: 'Alex' }, { name: 'Sam' }],
           poster_url: 'https://example.com/poster.jpg',
           localized_name: 'Localized Movie',
+          tmdb_id: 123,
           tmdb_name: null,
           tmdb_year: null,
           m_name: 'Movie',
@@ -167,7 +168,10 @@ describe('getUserRecommendationSummaries', () => {
 describe('createRecommendationFeedback', () => {
   beforeEach(() => {
     vi.stubEnv('DATABASE_URL', 'postgres://localhost/test');
-    mockQuery.mockReset();
+    mockConnect.mockReset();
+    mockClientQuery.mockReset();
+    mockRelease.mockReset();
+    mockConnect.mockResolvedValue(mockClient);
   });
 
   afterEach(() => {
@@ -175,7 +179,24 @@ describe('createRecommendationFeedback', () => {
   });
 
   it('stores feedback for a completed recommendation slug', async () => {
-    mockQuery.mockResolvedValueOnce({ rows: [{ id: 'feedback-id' }] });
+    mockClientQuery
+      .mockResolvedValueOnce({}) // BEGIN
+      .mockResolvedValueOnce({
+        rows: [{ id: 'feedback-id', recommendation_id: 'rec-id' }],
+      }) // INSERT feedback
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            tmdb_id: 123,
+            movie_name: 'Joker',
+            movie_year: 2019,
+            poster_url: 'https://example.com/poster.jpg',
+            localized_name: 'Джокер',
+          },
+        ],
+      }) // SELECT main movie
+      .mockResolvedValueOnce({}) // UPSERT interaction
+      .mockResolvedValueOnce({}); // COMMIT
 
     const result = await createRecommendationFeedback({
       slug: 'rec-slug',
@@ -184,14 +205,25 @@ describe('createRecommendationFeedback', () => {
     });
 
     expect(result).toEqual({ id: 'feedback-id' });
-    const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    const [sql, params] = mockClientQuery.mock.calls[1] as [string, unknown[]];
     expect(sql).toContain('recommendation_feedback');
     expect(sql).toContain("status = 'completed'");
     expect(params).toEqual(['rec-slug', '42', 'already_watched']);
+    const [interactionSql, interactionParams] = mockClientQuery.mock.calls[3] as [
+      string,
+      unknown[],
+    ];
+    expect(interactionSql).toContain('user_movie_interactions');
+    expect(interactionParams).toContain('tmdb:123');
+    expect(interactionParams).toContain('watched');
+    expect(mockRelease).toHaveBeenCalledOnce();
   });
 
   it('returns null when no completed recommendation is found', async () => {
-    mockQuery.mockResolvedValueOnce({ rows: [] });
+    mockClientQuery
+      .mockResolvedValueOnce({}) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // INSERT feedback
+      .mockResolvedValueOnce({}); // COMMIT
 
     const result = await createRecommendationFeedback({
       slug: 'missing',
@@ -199,8 +231,9 @@ describe('createRecommendationFeedback', () => {
     });
 
     expect(result).toBeNull();
-    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    const [, params] = mockClientQuery.mock.calls[1] as [string, unknown[]];
     expect(params).toEqual(['missing', null, 'wrong_mood']);
+    expect(mockClientQuery).toHaveBeenCalledTimes(3);
   });
 });
 
@@ -221,21 +254,44 @@ describe('getUserRecommendationFeedbackMoviePreferences', () => {
   it('returns movies attached to actionable user feedback', async () => {
     mockQuery.mockResolvedValueOnce({
       rows: [
-        { kind: 'already_watched', movie_name: 'Joker', movie_year: 2019 },
-        { kind: 'wrong_mood', movie_name: 'Arrival', movie_year: 2016 },
-        { kind: 'too_obvious', movie_name: null, movie_year: null },
+        {
+          kind: 'watched',
+          movie_key: 'tmdb:475557',
+          tmdb_id: 475557,
+          movie_name: 'Joker',
+          movie_year: 2019,
+        },
+        {
+          kind: 'wrong_mood',
+          movie_key: 'title:arrival:2016',
+          tmdb_id: null,
+          movie_name: 'Arrival',
+          movie_year: 2016,
+        },
       ],
     });
 
     const result = await getUserRecommendationFeedbackMoviePreferences('42');
 
     expect(result).toEqual([
-      { kind: 'already_watched', movieName: 'Joker', movieYear: 2019 },
-      { kind: 'wrong_mood', movieName: 'Arrival', movieYear: 2016 },
+      {
+        kind: 'watched',
+        movieKey: 'tmdb:475557',
+        tmdbId: 475557,
+        movieName: 'Joker',
+        movieYear: 2019,
+      },
+      {
+        kind: 'wrong_mood',
+        movieKey: 'title:arrival:2016',
+        tmdbId: null,
+        movieName: 'Arrival',
+        movieYear: 2016,
+      },
     ]);
     const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
-    expect(sql).toContain('recommendation_feedback');
-    expect(sql).toContain("rf.kind IN ('already_watched', 'wrong_mood', 'too_obvious')");
+    expect(sql).toContain('user_movie_interactions');
+    expect(sql).toContain("kind IN ('watched', 'not_interested', 'wrong_mood')");
     expect(params).toEqual(['42', 100]);
   });
 });

--- a/apps/web/src/lib/db/recommendations.ts
+++ b/apps/web/src/lib/db/recommendations.ts
@@ -14,6 +14,7 @@ import {
   hasFavoriteActorSignal,
 } from '@/features/recommendation/groupResultInsights';
 import logger from '@/lib/logger';
+import { getMovieIdentityKey } from '@/lib/movieIdentity';
 
 import type { RecommendationStage } from '@/features/recommendation/stages';
 import type { PersonFormData } from '@/features/recommendation/types';
@@ -47,6 +48,7 @@ export type RecommendationFeedbackKind =
   | 'too_obvious'
   | 'too_obscure'
   | 'close';
+export type UserMovieInteractionKind = 'watched' | 'liked' | 'not_interested' | 'wrong_mood';
 
 export interface RecommendationMovie {
   id: number;
@@ -90,7 +92,9 @@ export interface AccountRecommendationSummary {
 }
 
 export interface UserRecommendationFeedbackMoviePreference {
-  kind: RecommendationFeedbackKind;
+  kind: UserMovieInteractionKind;
+  movieKey: string;
+  tmdbId: number | null;
   movieName: string;
   movieYear: number | null;
 }
@@ -108,6 +112,24 @@ export interface MovieRowToInsert {
   localizedName?: string;
   isMainRecommendation: boolean;
   fromTMDB: boolean;
+}
+
+function getInteractionKindForFeedback(
+  kind: RecommendationFeedbackKind,
+): UserMovieInteractionKind | null {
+  switch (kind) {
+    case 'already_watched':
+      return 'watched';
+    case 'useful':
+      return 'liked';
+    case 'wrong_mood':
+      return 'wrong_mood';
+    case 'too_obvious':
+    case 'too_obscure':
+      return 'not_interested';
+    case 'close':
+      return null;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -136,6 +158,7 @@ export async function getUserRecommendationSummaries(
   limit = 20,
 ): Promise<AccountRecommendationSummary[]> {
   const pool = getPool();
+  const queryLimit = Math.min(Math.max(limit * 3, limit), 100);
   const result = await pool.query<{
     slug: string;
     status: RecommendationStatus;
@@ -145,6 +168,7 @@ export async function getUserRecommendationSummaries(
     quiz_data: unknown;
     poster_url: string | null;
     localized_name: string | null;
+    tmdb_id: number | null;
     tmdb_name: string | null;
     tmdb_year: number | null;
     m_name: string | null;
@@ -160,6 +184,7 @@ export async function getUserRecommendationSummaries(
        r.quiz_data,
        rm.poster_url,
        rm.localized_name,
+       rm.tmdb_id,
        rm.tmdb_name,
        rm.tmdb_year,
        m.name AS m_name,
@@ -185,28 +210,50 @@ export async function getUserRecommendationSummaries(
      WHERE r.user_id = $1
      ORDER BY r.created_at DESC
      LIMIT $2`,
-    [userId, limit],
+    [userId, queryLimit],
   );
 
-  return result.rows.map((row) => {
+  const summaries = result.rows.map((row) => {
     const createdAt =
       row.created_at instanceof Date ? row.created_at.toISOString() : row.created_at;
     const completedAt =
       row.completed_at instanceof Date ? row.completed_at.toISOString() : row.completed_at;
+    const movieName = row.localized_name ?? row.tmdb_name ?? row.m_name ?? null;
+    const movieYear = row.tmdb_year ?? row.m_year ?? null;
 
     return {
-      slug: row.slug,
-      status: row.status,
-      stage: row.stage ?? (row.status === 'completed' ? 'complete' : 'queued'),
-      createdAt,
-      completedAt,
-      peopleCount: getQuizPeopleCount(row.quiz_data),
-      movieName: row.localized_name ?? row.tmdb_name ?? row.m_name ?? null,
-      movieYear: row.tmdb_year ?? row.m_year ?? null,
-      posterURL: row.poster_url,
-      feedbackKind: row.feedback_kind,
+      movieKey: getMovieIdentityKey({
+        tmdbId: row.tmdb_id,
+        title: movieName,
+        year: movieYear,
+      }),
+      summary: {
+        slug: row.slug,
+        status: row.status,
+        stage: row.stage ?? (row.status === 'completed' ? 'complete' : 'queued'),
+        createdAt,
+        completedAt,
+        peopleCount: getQuizPeopleCount(row.quiz_data),
+        movieName,
+        movieYear,
+        posterURL: row.poster_url,
+        feedbackKind: row.feedback_kind,
+      },
     };
   });
+
+  const seenMovieKeys = new Set<string>();
+  const deduped: AccountRecommendationSummary[] = [];
+
+  for (const { movieKey, summary } of summaries) {
+    const key = movieKey ?? `slug:${summary.slug}`;
+    if (seenMovieKeys.has(key)) continue;
+    seenMovieKeys.add(key);
+    deduped.push(summary);
+    if (deduped.length >= limit) break;
+  }
+
+  return deduped;
 }
 
 export async function getUserRecommendationFeedbackMoviePreferences(
@@ -215,41 +262,33 @@ export async function getUserRecommendationFeedbackMoviePreferences(
 ): Promise<UserRecommendationFeedbackMoviePreference[]> {
   const pool = getPool();
   const result = await pool.query<{
-    kind: RecommendationFeedbackKind;
-    movie_name: string | null;
+    kind: UserMovieInteractionKind;
+    movie_key: string;
+    tmdb_id: number | null;
+    movie_name: string;
     movie_year: number | null;
   }>(
     `SELECT
-       rf.kind,
-       COALESCE(rm.localized_name, rm.tmdb_name, m.name) AS movie_name,
-       COALESCE(rm.tmdb_year, m.year) AS movie_year
-     FROM recommendation_feedback rf
-     JOIN recommendations r ON r.id = rf.recommendation_id
-     LEFT JOIN LATERAL (
-       SELECT *
-         FROM recommendation_movies
-        WHERE recommendation_id = r.id
-        ORDER BY is_main_recommendation DESC, position ASC
-        LIMIT 1
-     ) rm ON true
-     LEFT JOIN movies m ON m.id = rm.movie_id
-     WHERE rf.user_id = $1
-       AND rf.kind IN ('already_watched', 'wrong_mood', 'too_obvious')
-     ORDER BY rf.created_at DESC
+       kind,
+       movie_key,
+       tmdb_id,
+       movie_name,
+       movie_year
+     FROM user_movie_interactions
+     WHERE user_id = $1
+       AND kind IN ('watched', 'not_interested', 'wrong_mood')
+     ORDER BY updated_at DESC
      LIMIT $2`,
     [userId, limit],
   );
 
-  return result.rows.flatMap((row) => {
-    if (!row.movie_name) return [];
-    return [
-      {
-        kind: row.kind,
-        movieName: row.movie_name,
-        movieYear: row.movie_year,
-      },
-    ];
-  });
+  return result.rows.map((row) => ({
+    kind: row.kind,
+    movieKey: row.movie_key,
+    tmdbId: row.tmdb_id,
+    movieName: row.movie_name,
+    movieYear: row.movie_year,
+  }));
 }
 
 // ---------------------------------------------------------------------------
@@ -505,17 +544,99 @@ export async function createRecommendationFeedback({
   userId?: string;
 }): Promise<{ id: string } | null> {
   const pool = getPool();
-  const result = await pool.query<{ id: string }>(
-    `INSERT INTO recommendation_feedback (recommendation_id, user_id, kind)
-     SELECT id, $2, $3
-       FROM recommendations
-      WHERE slug = $1
-        AND status = 'completed'
-      RETURNING id`,
-    [slug, userId ?? null, kind],
-  );
+  const client = await pool.connect();
 
-  return result.rows[0] ?? null;
+  try {
+    await client.query('BEGIN');
+
+    const feedbackResult = await client.query<{ id: string; recommendation_id: string }>(
+      `INSERT INTO recommendation_feedback (recommendation_id, user_id, kind)
+       SELECT id, $2, $3
+         FROM recommendations
+        WHERE slug = $1
+          AND status = 'completed'
+        RETURNING id, recommendation_id`,
+      [slug, userId ?? null, kind],
+    );
+
+    const feedback = feedbackResult.rows[0];
+    if (!feedback) {
+      await client.query('COMMIT');
+      return null;
+    }
+
+    const interactionKind = userId ? getInteractionKindForFeedback(kind) : null;
+    if (interactionKind) {
+      const movieResult = await client.query<{
+        tmdb_id: number | null;
+        poster_url: string | null;
+        localized_name: string | null;
+        movie_name: string | null;
+        movie_year: number | null;
+      }>(
+        `SELECT
+           rm.tmdb_id,
+           rm.poster_url,
+           rm.localized_name,
+           COALESCE(rm.tmdb_name, m.name) AS movie_name,
+           COALESCE(rm.tmdb_year, m.year) AS movie_year
+         FROM recommendation_movies rm
+         LEFT JOIN movies m ON m.id = rm.movie_id
+         WHERE rm.recommendation_id = $1
+         ORDER BY rm.is_main_recommendation DESC, rm.position ASC
+         LIMIT 1`,
+        [feedback.recommendation_id],
+      );
+
+      const movie = movieResult.rows[0];
+      const movieKey = movie
+        ? getMovieIdentityKey({
+            tmdbId: movie.tmdb_id,
+            title: movie.movie_name,
+            year: movie.movie_year,
+          })
+        : null;
+
+      if (movie?.movie_name && movieKey) {
+        await client.query(
+          `INSERT INTO user_movie_interactions (
+             user_id, movie_key, tmdb_id, movie_name, movie_year, poster_url,
+             localized_name, kind, source_recommendation_id
+           )
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+           ON CONFLICT (user_id, movie_key)
+           DO UPDATE SET
+             tmdb_id = COALESCE(EXCLUDED.tmdb_id, user_movie_interactions.tmdb_id),
+             movie_name = EXCLUDED.movie_name,
+             movie_year = EXCLUDED.movie_year,
+             poster_url = COALESCE(EXCLUDED.poster_url, user_movie_interactions.poster_url),
+             localized_name = COALESCE(EXCLUDED.localized_name, user_movie_interactions.localized_name),
+             kind = EXCLUDED.kind,
+             source_recommendation_id = EXCLUDED.source_recommendation_id,
+             updated_at = now()`,
+          [
+            userId,
+            movieKey,
+            movie.tmdb_id,
+            movie.movie_name,
+            movie.movie_year,
+            movie.poster_url,
+            movie.localized_name,
+            interactionKind,
+            feedback.recommendation_id,
+          ],
+        );
+      }
+    }
+
+    await client.query('COMMIT');
+    return { id: feedback.id };
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  } finally {
+    client.release();
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/lib/movieIdentity.ts
+++ b/apps/web/src/lib/movieIdentity.ts
@@ -1,0 +1,45 @@
+export type MovieIdentityInput = {
+  tmdbId?: number | string | null;
+  title?: string | null;
+  year?: number | string | null;
+};
+
+export function normalizeMovieTitle(title: string): string {
+  return title
+    .toLocaleLowerCase()
+    .normalize('NFKD')
+    .replace(/\p{M}+/gu, '')
+    .replace(/&/g, ' and ')
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .trim()
+    .replace(/^(the|a|an)\s+/, '')
+    .replace(/\s+/g, ' ');
+}
+
+export function getMovieTitleKey(title: string | null | undefined): string | null {
+  if (!title) return null;
+  const normalized = normalizeMovieTitle(title);
+  return normalized.length > 0 ? normalized : null;
+}
+
+export function getMovieIdentityKey(input: MovieIdentityInput): string | null {
+  const tmdbId =
+    typeof input.tmdbId === 'string' ? Number.parseInt(input.tmdbId, 10) : input.tmdbId;
+  if (typeof tmdbId === 'number' && Number.isFinite(tmdbId) && tmdbId > 0) {
+    return `tmdb:${Math.trunc(tmdbId)}`;
+  }
+
+  const titleKey = getMovieTitleKey(input.title);
+  if (!titleKey) return null;
+
+  const parsedYear = typeof input.year === 'string' ? Number.parseInt(input.year, 10) : input.year;
+  const yearKey =
+    typeof parsedYear === 'number' && Number.isFinite(parsedYear) ? Math.trunc(parsedYear) : 'na';
+  return `title:${titleKey}:${yearKey}`;
+}
+
+export function getYearFromReleaseDate(releaseDate: string | null | undefined): number | null {
+  if (!releaseDate) return null;
+  const year = Number.parseInt(releaseDate.slice(0, 4), 10);
+  return Number.isFinite(year) ? year : null;
+}

--- a/db/createDB.sql
+++ b/db/createDB.sql
@@ -6,9 +6,36 @@
   duration integer not null,
   score_rating float not null,
   year int not null,
+  tmdb_id bigint,
+  tmdb_match_confidence float,
+  tmdb_match_source text,
+  tmdb_matched_at timestamptz,
   embedding vector(3072),
     UNIQUE(name, year)
 );
+
+ALTER TABLE movies
+  ADD COLUMN IF NOT EXISTS tmdb_id bigint;
+
+ALTER TABLE movies
+  ADD COLUMN IF NOT EXISTS tmdb_match_confidence float;
+
+ALTER TABLE movies
+  ADD COLUMN IF NOT EXISTS tmdb_match_source text;
+
+ALTER TABLE movies
+  ADD COLUMN IF NOT EXISTS tmdb_matched_at timestamptz;
+
+ALTER TABLE movies
+  DROP CONSTRAINT IF EXISTS movies_tmdb_match_source_check;
+
+ALTER TABLE movies
+  ADD CONSTRAINT movies_tmdb_match_source_check
+  CHECK (tmdb_match_source IS NULL OR tmdb_match_source IN ('tmdb_discovery', 'backfill_auto', 'manual'));
+
+CREATE UNIQUE INDEX IF NOT EXISTS movies_tmdb_id_unique
+  ON movies (tmdb_id)
+  WHERE tmdb_id IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS users (
   id bigserial PRIMARY KEY,

--- a/db/init/01_schema.sql
+++ b/db/init/01_schema.sql
@@ -11,9 +11,36 @@ CREATE TABLE IF NOT EXISTS movies (
   duration integer NOT NULL,
   score_rating float NOT NULL,
   year int NOT NULL,
+  tmdb_id bigint,
+  tmdb_match_confidence float,
+  tmdb_match_source text,
+  tmdb_matched_at timestamptz,
   embedding vector(3072),
   UNIQUE(name, year)
 );
+
+ALTER TABLE movies
+  ADD COLUMN IF NOT EXISTS tmdb_id bigint;
+
+ALTER TABLE movies
+  ADD COLUMN IF NOT EXISTS tmdb_match_confidence float;
+
+ALTER TABLE movies
+  ADD COLUMN IF NOT EXISTS tmdb_match_source text;
+
+ALTER TABLE movies
+  ADD COLUMN IF NOT EXISTS tmdb_matched_at timestamptz;
+
+ALTER TABLE movies
+  DROP CONSTRAINT IF EXISTS movies_tmdb_match_source_check;
+
+ALTER TABLE movies
+  ADD CONSTRAINT movies_tmdb_match_source_check
+  CHECK (tmdb_match_source IS NULL OR tmdb_match_source IN ('tmdb_discovery', 'backfill_auto', 'manual'));
+
+CREATE UNIQUE INDEX IF NOT EXISTS movies_tmdb_id_unique
+  ON movies (tmdb_id)
+  WHERE tmdb_id IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS users (
   id bigserial PRIMARY KEY,

--- a/db/init/02_match_movies.sql
+++ b/db/init/02_match_movies.sql
@@ -16,6 +16,7 @@ RETURNS TABLE (
   duration integer,
   score_rating float,
   year int,
+  tmdb_id bigint,
   similarity float,
   content text
 )
@@ -23,7 +24,7 @@ LANGUAGE sql STABLE
 AS $$
   SELECT
     movies.id, movies.name, movies.age_rating, movies.description,
-    movies.duration, movies.score_rating, movies.year,
+    movies.duration, movies.score_rating, movies.year, movies.tmdb_id,
     1 - (movies.embedding <=> query_embedding) AS similarity,
     format(
       '%s (%s) | %s | Duration: %s min | Rating: %s/10%s%s',

--- a/db/init/03_recommendations.sql
+++ b/db/init/03_recommendations.sql
@@ -112,3 +112,30 @@ CREATE INDEX IF NOT EXISTS idx_recommendation_feedback_rec_id
 CREATE INDEX IF NOT EXISTS idx_recommendation_feedback_user_id_created_at
   ON recommendation_feedback (user_id, created_at DESC)
   WHERE user_id IS NOT NULL;
+
+-- Durable per-user movie memory derived from feedback. This lets future
+-- recommendations avoid movies the signed-in user already marked as watched or
+-- not relevant, regardless of which recommendation produced that feedback.
+CREATE TABLE IF NOT EXISTS user_movie_interactions (
+  id                       uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id                  bigint      NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  movie_key                text        NOT NULL,
+  tmdb_id                  bigint,
+  movie_name               text        NOT NULL,
+  movie_year               integer,
+  poster_url               text,
+  localized_name           text,
+  kind                     text        NOT NULL,
+  source_recommendation_id uuid        REFERENCES recommendations(id) ON DELETE SET NULL,
+  created_at               timestamptz NOT NULL DEFAULT now(),
+  updated_at               timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT user_movie_interactions_kind_check CHECK (
+    kind IN ('watched', 'liked', 'not_interested', 'wrong_mood')
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_user_movie_interactions_user_key
+  ON user_movie_interactions (user_id, movie_key);
+
+CREATE INDEX IF NOT EXISTS idx_user_movie_interactions_user_kind_updated_at
+  ON user_movie_interactions (user_id, kind, updated_at DESC);

--- a/db/match_movies.sql
+++ b/db/match_movies.sql
@@ -15,6 +15,7 @@ returns table (
   duration integer,
   score_rating float,
   year int,
+  tmdb_id bigint,
   similarity float,
   content text
 )
@@ -28,6 +29,7 @@ as $$
     movies.duration,
     movies.score_rating,
     movies.year,
+    movies.tmdb_id,
     1 - (movies.embedding <=> query_embedding) as similarity,
     -- Format content for API consumption
     format(

--- a/db/recommendations.sql
+++ b/db/recommendations.sql
@@ -117,3 +117,30 @@ CREATE INDEX IF NOT EXISTS idx_recommendation_feedback_rec_id
 CREATE INDEX IF NOT EXISTS idx_recommendation_feedback_user_id_created_at
   ON recommendation_feedback (user_id, created_at DESC)
   WHERE user_id IS NOT NULL;
+
+-- Durable per-user movie memory derived from feedback. This lets future
+-- recommendations avoid movies the signed-in user already marked as watched or
+-- not relevant, regardless of which recommendation produced that feedback.
+CREATE TABLE IF NOT EXISTS user_movie_interactions (
+  id                       uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id                  bigint      NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  movie_key                text        NOT NULL,
+  tmdb_id                  bigint,
+  movie_name               text        NOT NULL,
+  movie_year               integer,
+  poster_url               text,
+  localized_name           text,
+  kind                     text        NOT NULL,
+  source_recommendation_id uuid        REFERENCES recommendations(id) ON DELETE SET NULL,
+  created_at               timestamptz NOT NULL DEFAULT now(),
+  updated_at               timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT user_movie_interactions_kind_check CHECK (
+    kind IN ('watched', 'liked', 'not_interested', 'wrong_mood')
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_user_movie_interactions_user_key
+  ON user_movie_interactions (user_id, movie_key);
+
+CREATE INDEX IF NOT EXISTS idx_user_movie_interactions_user_kind_updated_at
+  ON user_movie_interactions (user_id, kind, updated_at DESC);

--- a/packages/shared/src/db.ts
+++ b/packages/shared/src/db.ts
@@ -11,6 +11,9 @@ export interface MovieRecord {
   description: string;
   duration: number;
   score_rating: number;
+  tmdb_id?: number | null;
+  tmdb_match_confidence?: number | null;
+  tmdb_match_source?: 'tmdb_discovery' | 'backfill_auto' | 'manual' | null;
   embedding: number[];
 }
 
@@ -111,12 +114,43 @@ export async function ensureSchema(): Promise<void> {
       duration integer NOT NULL,
       score_rating float NOT NULL,
       year int NOT NULL,
+      tmdb_id bigint,
+      tmdb_match_confidence float,
+      tmdb_match_source text,
+      tmdb_matched_at timestamptz,
       embedding vector(3072),
       UNIQUE(name, year)
     );
   `);
 
   await getPool().query(`
+    ALTER TABLE movies
+      ADD COLUMN IF NOT EXISTS tmdb_id bigint;
+
+    ALTER TABLE movies
+      ADD COLUMN IF NOT EXISTS tmdb_match_confidence float;
+
+    ALTER TABLE movies
+      ADD COLUMN IF NOT EXISTS tmdb_match_source text;
+
+    ALTER TABLE movies
+      ADD COLUMN IF NOT EXISTS tmdb_matched_at timestamptz;
+
+    ALTER TABLE movies
+      DROP CONSTRAINT IF EXISTS movies_tmdb_match_source_check;
+
+    ALTER TABLE movies
+      ADD CONSTRAINT movies_tmdb_match_source_check
+      CHECK (tmdb_match_source IS NULL OR tmdb_match_source IN ('tmdb_discovery', 'backfill_auto', 'manual'));
+
+    CREATE UNIQUE INDEX IF NOT EXISTS movies_tmdb_id_unique
+      ON movies (tmdb_id)
+      WHERE tmdb_id IS NOT NULL;
+  `);
+
+  await getPool().query(`
+    DROP FUNCTION IF EXISTS match_movies(vector, float, int);
+
     CREATE OR REPLACE FUNCTION match_movies (
       query_embedding vector(3072),
       match_threshold float DEFAULT 0.1,
@@ -130,6 +164,7 @@ export async function ensureSchema(): Promise<void> {
       duration integer,
       score_rating float,
       year int,
+      tmdb_id bigint,
       similarity float,
       content text
     )
@@ -142,6 +177,7 @@ export async function ensureSchema(): Promise<void> {
         movies.duration,
         movies.score_rating,
         movies.year,
+        movies.tmdb_id,
         1 - (movies.embedding <=> query_embedding) AS similarity,
         format(
           '%s (%s) | %s | Duration: %s min | Rating: %s/10%s%s',
@@ -182,10 +218,15 @@ export async function insertMovies(
 
     try {
       const result = await getPool().query<{ id: number }>(
-        `INSERT INTO movies (name, year, age_rating, description, duration, score_rating, embedding)
-         SELECT n, y, ar, d, du, sr, e::vector
-         FROM unnest($1::text[], $2::int[], $3::text[], $4::text[], $5::int[], $6::float8[], $7::text[])
-           AS t(n, y, ar, d, du, sr, e)
+        `INSERT INTO movies (
+           name, year, age_rating, description, duration, score_rating,
+           tmdb_id, tmdb_match_confidence, tmdb_match_source, tmdb_matched_at, embedding
+         )
+         SELECT n, y, ar, d, du, sr, tid, conf, src, CASE WHEN tid IS NULL THEN NULL ELSE now() END, e::vector
+         FROM unnest(
+           $1::text[], $2::int[], $3::text[], $4::text[], $5::int[], $6::float8[],
+           $7::bigint[], $8::float8[], $9::text[], $10::text[]
+         ) AS t(n, y, ar, d, du, sr, tid, conf, src, e)
          ON CONFLICT (name, year) DO NOTHING
          RETURNING id`,
         [
@@ -195,6 +236,9 @@ export async function insertMovies(
           batch.map((m) => m.description),
           batch.map((m) => m.duration),
           batch.map((m) => m.score_rating),
+          batch.map((m) => m.tmdb_id ?? null),
+          batch.map((m) => m.tmdb_match_confidence ?? null),
+          batch.map((m) => m.tmdb_match_source ?? null),
           batch.map((m) => JSON.stringify(m.embedding)),
         ],
       );
@@ -212,8 +256,11 @@ export async function insertMovies(
       for (const movie of batch) {
         try {
           const result = await getPool().query<{ id: number }>(
-            `INSERT INTO movies (name, year, age_rating, description, duration, score_rating, embedding)
-             VALUES ($1, $2, $3, $4, $5, $6, $7::vector)
+            `INSERT INTO movies (
+               name, year, age_rating, description, duration, score_rating,
+               tmdb_id, tmdb_match_confidence, tmdb_match_source, tmdb_matched_at, embedding
+             )
+             VALUES ($1, $2, $3, $4, $5, $6, $7::bigint, $8::float8, $9::text, CASE WHEN $7 IS NULL THEN NULL ELSE now() END, $10::vector)
              ON CONFLICT (name, year) DO NOTHING
              RETURNING id`,
             [
@@ -223,6 +270,9 @@ export async function insertMovies(
               movie.description,
               movie.duration,
               movie.score_rating,
+              movie.tmdb_id ?? null,
+              movie.tmdb_match_confidence ?? null,
+              movie.tmdb_match_source ?? null,
               JSON.stringify(movie.embedding),
             ],
           );

--- a/services/movie-backfill/src/database.ts
+++ b/services/movie-backfill/src/database.ts
@@ -6,6 +6,7 @@ export interface IncompleteMovie {
   id: string;
   name: string;
   year: number;
+  duration: number;
   score_rating: number;
   description: string;
 }
@@ -13,13 +14,14 @@ export interface IncompleteMovie {
 export async function getIncompleteMovies(limit: number): Promise<IncompleteMovie[]> {
   const query =
     limit > 0
-      ? 'SELECT id, name, year, score_rating, description FROM movies WHERE duration = 0 ORDER BY id LIMIT $1'
-      : 'SELECT id, name, year, score_rating, description FROM movies WHERE duration = 0 ORDER BY id';
+      ? 'SELECT id, name, year, duration, score_rating, description FROM movies WHERE tmdb_id IS NULL OR duration = 0 ORDER BY id LIMIT $1'
+      : 'SELECT id, name, year, duration, score_rating, description FROM movies WHERE tmdb_id IS NULL OR duration = 0 ORDER BY id';
 
   const result = await getPool().query<{
     id: string;
     name: string;
     year: number;
+    duration: number;
     score_rating: number;
     description: string;
   }>(query, limit > 0 ? [limit] : []);
@@ -28,6 +30,7 @@ export async function getIncompleteMovies(limit: number): Promise<IncompleteMovi
     id: row.id,
     name: row.name,
     year: row.year,
+    duration: row.duration,
     score_rating: Number(row.score_rating),
     description: row.description,
   }));
@@ -37,11 +40,21 @@ export async function updateMovie(
   id: string,
   duration: number,
   ageRating: string,
+  tmdbId: number,
+  matchConfidence: number,
   embedding: number[],
 ): Promise<void> {
   await getPool().query(
-    `UPDATE movies SET duration = $1, age_rating = $2, embedding = $3::vector WHERE id = $4`,
-    [duration, ageRating, JSON.stringify(embedding), id],
+    `UPDATE movies
+        SET duration = $1,
+            age_rating = $2,
+            tmdb_id = $3,
+            tmdb_match_confidence = $4,
+            tmdb_match_source = 'backfill_auto',
+            tmdb_matched_at = now(),
+            embedding = $5::vector
+      WHERE id = $6`,
+    [duration, ageRating, tmdbId, matchConfidence, JSON.stringify(embedding), id],
   );
-  logger.debug('Movie updated in database', { id, duration, ageRating });
+  logger.debug('Movie updated in database', { id, duration, ageRating, tmdbId, matchConfidence });
 }

--- a/services/movie-backfill/src/index.ts
+++ b/services/movie-backfill/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * Movie Backfill Service — Entry Point
  *
- * Queries the database for movies with duration = 0 and backfills them
+ * Queries the database for movies missing TMDB identity or runtime and backfills them
  * by fetching runtime, age rating, and details from TMDB, then re-generates
  * embeddings and updates the database rows.
  *
@@ -29,16 +29,22 @@ import {
   extractUSCertification,
   fetchMovieDetails,
   movieToEmbeddingText,
-  searchMovie,
+  searchMovieMatch,
 } from './tmdb.js';
 
 /** A movie that passed all TMDB validations and is ready for embedding + DB update. */
 interface PendingUpdate {
   movie: IncompleteMovie;
   tmdbId: number;
+  matchConfidence: number;
   runtime: number;
   ageRating: string;
   embeddingText: string;
+}
+
+function isRuntimeCompatible(existingRuntime: number, tmdbRuntime: number): boolean {
+  if (existingRuntime <= 0) return true;
+  return Math.abs(existingRuntime - tmdbRuntime) <= 20;
 }
 
 async function main(): Promise<void> {
@@ -65,10 +71,12 @@ async function main(): Promise<void> {
     }
 
     const movies = await getIncompleteMovies(config.maxMovies);
-    logger.info('Fetched incomplete movies from database', { count: movies.length });
+    logger.info('Fetched movies needing TMDB identity or metadata backfill', {
+      count: movies.length,
+    });
 
     if (movies.length === 0) {
-      logger.info('No movies with missing duration found — nothing to do');
+      logger.info('No movies need TMDB identity or metadata backfill — nothing to do');
       return;
     }
 
@@ -87,37 +95,65 @@ async function main(): Promise<void> {
         batch.map(async (movie) => {
           totalProcessed++;
           try {
-            // 1. Search TMDB by title + year to get TMDB ID
-            const tmdbId = await searchMovie(config.tmdbApiKey, movie.name, movie.year);
-            if (tmdbId === null) {
-              logger.warn('Movie not found on TMDB — skipping', {
+            // 1. Search TMDB by title + year to get a conservative TMDB identity match.
+            const match = await searchMovieMatch(config.tmdbApiKey, movie.name, movie.year);
+            if (match.status === 'ambiguous') {
+              logger.warn('Ambiguous TMDB match — manual review needed', {
+                id: movie.id,
                 name: movie.name,
                 year: movie.year,
+                candidates: match.candidates,
+              });
+              totalSkipped++;
+              return;
+            }
+
+            if (match.status === 'not_found') {
+              logger.warn('Movie not confidently found on TMDB — skipping', {
+                id: movie.id,
+                name: movie.name,
+                year: movie.year,
+                candidates: match.candidates,
               });
               totalSkipped++;
               return;
             }
 
             // 2. Fetch full movie details
-            const details = await fetchMovieDetails(config.tmdbApiKey, tmdbId);
+            const details = await fetchMovieDetails(config.tmdbApiKey, match.tmdbId);
             if (!details) {
               logger.warn('Failed to fetch movie details from TMDB — skipping', {
                 name: movie.name,
                 year: movie.year,
-                tmdbId,
+                tmdbId: match.tmdbId,
               });
               totalSkipped++;
               return;
             }
 
-            // 3. Extract runtime — skip if not available
-            const runtime = details.runtime;
+            // 3. Extract runtime — skip if neither TMDB nor the database has it.
+            const runtime = details.runtime ?? movie.duration;
             if (!runtime || runtime === 0) {
               logger.warn('TMDB returned no runtime for movie — skipping', {
                 name: movie.name,
                 year: movie.year,
-                tmdbId,
+                tmdbId: match.tmdbId,
                 runtime,
+              });
+              totalSkipped++;
+              return;
+            }
+
+            if (!isRuntimeCompatible(movie.duration, runtime)) {
+              logger.warn('TMDB candidate runtime mismatch — manual review needed', {
+                id: movie.id,
+                name: movie.name,
+                year: movie.year,
+                existingRuntime: movie.duration,
+                tmdbId: match.tmdbId,
+                tmdbRuntime: runtime,
+                matchConfidence: match.confidence,
+                candidates: match.candidates,
               });
               totalSkipped++;
               return;
@@ -143,7 +179,8 @@ async function main(): Promise<void> {
                 id: movie.id,
                 name: movie.name,
                 year: movie.year,
-                tmdbId,
+                tmdbId: match.tmdbId,
+                matchConfidence: match.confidence,
                 runtime,
                 ageRating,
               });
@@ -152,7 +189,14 @@ async function main(): Promise<void> {
             }
 
             // Collect for batch embedding in Phase 2
-            pendingUpdates.push({ movie, tmdbId, runtime, ageRating, embeddingText });
+            pendingUpdates.push({
+              movie,
+              tmdbId: match.tmdbId,
+              matchConfidence: match.confidence,
+              runtime,
+              ageRating,
+              embeddingText,
+            });
           } catch (err) {
             logger.warn('Failed to backfill movie — skipping', {
               id: movie.id,
@@ -198,13 +242,21 @@ async function main(): Promise<void> {
           }
 
           try {
-            await updateMovie(update.movie.id, update.runtime, update.ageRating, embedding);
+            await updateMovie(
+              update.movie.id,
+              update.runtime,
+              update.ageRating,
+              update.tmdbId,
+              update.matchConfidence,
+              embedding,
+            );
 
             logger.info('Movie backfilled successfully', {
               id: update.movie.id,
               name: update.movie.name,
               year: update.movie.year,
               tmdbId: update.tmdbId,
+              matchConfidence: update.matchConfidence,
               runtime: update.runtime,
               ageRating: update.ageRating,
             });

--- a/services/movie-backfill/src/tmdb.test.ts
+++ b/services/movie-backfill/src/tmdb.test.ts
@@ -5,6 +5,7 @@ import {
   fetchMovieDetails,
   movieToEmbeddingText,
   searchMovie,
+  searchMovieMatch,
 } from './tmdb.js';
 
 import type { TMDBMovieDetails } from './tmdb.js';
@@ -167,10 +168,13 @@ describe('searchMovie', () => {
   }
 
   it('returns id of first result that matches year exactly', async () => {
-    mockFetch({ results: [{ id: 42, title: 'Inception', release_date: '2010-07-16' }] });
+    mockFetch(
+      { results: [{ id: 42, title: 'Inception', release_date: '2010-07-16' }] },
+      { results: [] },
+    );
     const id = await searchMovie(API_KEY, 'Inception', 2010);
     expect(id).toBe(42);
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledTimes(2);
     const options = vi.mocked(fetch).mock.calls[0][1];
     expect(options).toMatchObject({
       signal: expect.any(AbortSignal),
@@ -178,7 +182,10 @@ describe('searchMovie', () => {
   });
 
   it('accepts a result within ±1 year tolerance', async () => {
-    mockFetch({ results: [{ id: 7, title: 'Movie', release_date: '2011-01-01' }] });
+    mockFetch(
+      { results: [{ id: 7, title: 'Movie', release_date: '2011-01-01' }] },
+      { results: [] },
+    );
     const id = await searchMovie(API_KEY, 'Movie', 2010);
     expect(id).toBe(7);
   });
@@ -216,6 +223,23 @@ describe('searchMovie', () => {
     mockFetch({ results: [] });
     const id = await searchMovie(API_KEY, 'Ghost Movie', 0);
     expect(id).toBeNull();
+  });
+
+  it('reports ambiguous matches for manual review instead of auto-picking', async () => {
+    mockFetch(
+      {
+        results: [
+          { id: 1, title: 'Hamlet', release_date: '1996-12-25' },
+          { id: 2, title: 'Hamlet', release_date: '1996-05-10' },
+        ],
+      },
+      { results: [] },
+    );
+
+    const result = await searchMovieMatch(API_KEY, 'Hamlet', 1996);
+
+    expect(result.status).toBe('ambiguous');
+    expect(result.candidates.map((candidate) => candidate.id)).toEqual([1, 2]);
   });
 
   it('returns null when TMDB search response has an invalid shape', async () => {

--- a/services/movie-backfill/src/tmdb.ts
+++ b/services/movie-backfill/src/tmdb.ts
@@ -26,7 +26,9 @@ export interface TMDBMovieDetails {
 const tmdbSearchResultSchema = z.object({
   id: z.number(),
   title: z.string(),
+  original_title: z.string().optional(),
   release_date: z.string(),
+  popularity: z.number().optional(),
 });
 
 type TMDBSearchResult = z.infer<typeof tmdbSearchResultSchema>;
@@ -37,20 +39,94 @@ const tmdbSearchResponseSchema = z.object({
 
 /** Year tolerance (in years) when disambiguating TMDB search results. */
 const YEAR_TOLERANCE = 1;
+const CONFIDENT_MATCH_THRESHOLD = 0.9;
+const LOW_YEAR_CONFIDENT_MATCH_THRESHOLD = 0.82;
+const AMBIGUOUS_SCORE_GAP = 0.08;
 
-/**
- * Pick the first TMDB result whose release_date year is within YEAR_TOLERANCE of targetYear.
- */
-function pickByYear(results: TMDBSearchResult[], targetYear: number): number | null {
-  for (const result of results) {
-    const releaseYear = result.release_date
-      ? parseInt(result.release_date.substring(0, 4), 10)
-      : NaN;
-    if (!Number.isNaN(releaseYear) && Math.abs(releaseYear - targetYear) <= YEAR_TOLERANCE) {
-      return result.id;
+export type TMDBSearchCandidate = {
+  id: number;
+  title: string;
+  originalTitle?: string;
+  releaseYear: number | null;
+  confidence: number;
+};
+
+export type TMDBMovieSearchResult =
+  | {
+      status: 'matched';
+      tmdbId: number;
+      confidence: number;
+      title: string;
+      releaseYear: number | null;
+      candidates: TMDBSearchCandidate[];
     }
-  }
-  return null;
+  | {
+      status: 'ambiguous';
+      candidates: TMDBSearchCandidate[];
+    }
+  | {
+      status: 'not_found';
+      candidates: TMDBSearchCandidate[];
+    };
+
+function parseReleaseYear(releaseDate: string): number | null {
+  const year = releaseDate ? parseInt(releaseDate.substring(0, 4), 10) : NaN;
+  return Number.isFinite(year) ? year : null;
+}
+
+function normalizeTitle(title: string): string {
+  return title
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/&/g, ' and ')
+    .replace(/[^\p{Letter}\p{Number}]+/gu, ' ')
+    .trim()
+    .toLowerCase()
+    .replace(/^(the|a|an)\s+/, '')
+    .replace(/\s+/g, ' ');
+}
+
+function titleConfidence(candidate: TMDBSearchResult, targetTitle: string): number {
+  const target = normalizeTitle(targetTitle);
+  const title = normalizeTitle(candidate.title);
+  const originalTitle = candidate.original_title ? normalizeTitle(candidate.original_title) : '';
+
+  if (!target || (!title && !originalTitle)) return 0;
+  if (target === title || target === originalTitle) return 0.75;
+  return 0;
+}
+
+function yearConfidence(candidateYear: number | null, targetYear: number): number {
+  if (targetYear <= 0) return 0.1;
+  if (candidateYear === null) return 0;
+
+  const delta = Math.abs(candidateYear - targetYear);
+  if (delta === 0) return 0.25;
+  if (delta <= YEAR_TOLERANCE) return 0.15;
+  return -0.5;
+}
+
+function scoreCandidate(
+  candidate: TMDBSearchResult,
+  targetTitle: string,
+  targetYear: number,
+): number {
+  const releaseYear = parseReleaseYear(candidate.release_date);
+  return titleConfidence(candidate, targetTitle) + yearConfidence(releaseYear, targetYear);
+}
+
+function toCandidate(
+  candidate: TMDBSearchResult,
+  targetTitle: string,
+  targetYear: number,
+): TMDBSearchCandidate {
+  return {
+    id: candidate.id,
+    title: candidate.title,
+    originalTitle: candidate.original_title,
+    releaseYear: parseReleaseYear(candidate.release_date),
+    confidence: scoreCandidate(candidate, targetTitle, targetYear),
+  };
 }
 
 /**
@@ -121,20 +197,60 @@ export async function searchMovie(
   title: string,
   year: number,
 ): Promise<number | null> {
-  if (year > 0) {
-    // 1. Year-scoped search
-    const scopedResults = await tmdbSearch(apiKey, title, year);
-    const id = pickByYear(scopedResults, year);
-    if (id !== null) return id;
+  const match = await searchMovieMatch(apiKey, title, year);
+  return match.status === 'matched' ? match.tmdbId : null;
+}
 
-    // 2. Year-less fallback — TMDB may rank differently without the year filter
+export async function searchMovieMatch(
+  apiKey: string,
+  title: string,
+  year: number,
+): Promise<TMDBMovieSearchResult> {
+  const collected = new Map<number, TMDBSearchResult>();
+
+  if (year > 0) {
+    const scopedResults = await tmdbSearch(apiKey, title, year);
+    for (const result of scopedResults) collected.set(result.id, result);
+
     const broadResults = await tmdbSearch(apiKey, title, null);
-    return pickByYear(broadResults, year);
+    for (const result of broadResults) collected.set(result.id, result);
+  } else {
+    const results = await tmdbSearch(apiKey, title, null);
+    for (const result of results) collected.set(result.id, result);
   }
 
-  // year === 0 — year unknown, return first result without year validation
-  const results = await tmdbSearch(apiKey, title, null);
-  return results.length > 0 ? results[0].id : null;
+  const candidates = Array.from(collected.values())
+    .map((candidate) => toCandidate(candidate, title, year))
+    .filter((candidate) => candidate.confidence > 0)
+    .sort((a, b) => b.confidence - a.confidence)
+    .slice(0, 5);
+
+  const best = candidates[0];
+  if (!best) return { status: 'not_found', candidates };
+
+  const threshold = year > 0 ? CONFIDENT_MATCH_THRESHOLD : LOW_YEAR_CONFIDENT_MATCH_THRESHOLD;
+  const runnerUp = candidates[1];
+  const isAmbiguous =
+    runnerUp &&
+    runnerUp.confidence >= LOW_YEAR_CONFIDENT_MATCH_THRESHOLD &&
+    best.confidence - runnerUp.confidence <= AMBIGUOUS_SCORE_GAP;
+
+  if (isAmbiguous) {
+    return { status: 'ambiguous', candidates };
+  }
+
+  if (best.confidence < threshold) {
+    return { status: 'not_found', candidates };
+  }
+
+  return {
+    status: 'matched',
+    tmdbId: best.id,
+    confidence: best.confidence,
+    title: best.title,
+    releaseYear: best.releaseYear,
+    candidates,
+  };
 }
 
 /**

--- a/services/movie-discovery/src/sync.ts
+++ b/services/movie-discovery/src/sync.ts
@@ -164,6 +164,9 @@ export async function runSync(config: Config): Promise<void> {
       description: basic.overview || 'No description available.',
       duration: runtime,
       score_rating: basic.vote_average,
+      tmdb_id: basic.id,
+      tmdb_match_confidence: 1,
+      tmdb_match_source: 'tmdb_discovery',
     };
 
     finalPartialRecords.push(record);


### PR DESCRIPTION
## Summary
- add durable per-user movie memory from recommendation feedback
- use TMDB-first movie identity with title/year fallback for filtering and account history dedupe
- exclude watched/not-interested movies from future candidates and downrank wrong-mood movies

## Test Plan
- npm run test:server --workspace=apps/web -- recommendations.test.ts candidateFilters.test.ts
- npm run lint:check
- npm run type-check
- npm run format:check
- pre-push: npm run test:server, npm run build