### PR TITLE
Improve recommendation memory for signed-in users

### DIFF
--- a/apps/web/src/features/recommendation/candidateFilters.test.ts
+++ b/apps/web/src/features/recommendation/candidateFilters.test.ts
@@ -210,4 +210,50 @@ describe('candidateFilters', () => {
       ).map((candidate) => candidate.name),
     ).toEqual(['Kiki’s Delivery Service']);
   });
+
+  it('filters recent completed recommendations so signed-in users do not get immediate repeats', () => {
+    const signals = getFeedbackCandidateSignals([
+      {
+        kind: 'recently_recommended',
+        movieKey: 'tmdb:129',
+        tmdbId: 129,
+        movieName: 'Spirited Away',
+        movieYear: 2001,
+      },
+    ]);
+
+    expect(
+      applyFeedbackToLocalMovies(
+        [
+          { ...movie('Spirited Away'), tmdbId: 129 },
+          { ...movie('Princess Mononoke'), tmdbId: 128 },
+        ],
+        signals,
+      ).map((candidate) => candidate.name),
+    ).toEqual(['Princess Mononoke']);
+
+    expect(
+      excludeFeedbackTMDBMovies(
+        [
+          {
+            id: 129,
+            title: '千と千尋の神隠し',
+            overview: 'A girl enters a world of spirits.',
+            release_date: '2001-07-20',
+            vote_average: 8.5,
+            poster_path: null,
+          },
+          {
+            id: 128,
+            title: 'Princess Mononoke',
+            overview: 'A prince is caught in a conflict.',
+            release_date: '1997-07-12',
+            vote_average: 8.3,
+            poster_path: null,
+          },
+        ],
+        signals,
+      ).map((candidate) => candidate.title),
+    ).toEqual(['Princess Mononoke']);
+  });
 });

--- a/apps/web/src/features/recommendation/candidateFilters.ts
+++ b/apps/web/src/features/recommendation/candidateFilters.ts
@@ -4,11 +4,12 @@ import type { TMDBDiscoverMovie } from './tmdb';
 import type { EnhancedMovieMatch, PersonFormData } from './types';
 import type {
   RecommendationFeedbackKind,
+  UserRecommendationMemoryKind,
   UserMovieInteractionKind,
 } from '@/lib/db/recommendations';
 
 export type FeedbackMoviePreference = {
-  kind: RecommendationFeedbackKind | UserMovieInteractionKind;
+  kind: RecommendationFeedbackKind | UserMovieInteractionKind | UserRecommendationMemoryKind;
   movieKey?: string | null;
   tmdbId?: number | null;
   movieName: string;
@@ -75,6 +76,7 @@ export function getFeedbackCandidateSignals(
     if (
       preference.kind === 'already_watched' ||
       preference.kind === 'watched' ||
+      preference.kind === 'recently_recommended' ||
       preference.kind === 'not_interested' ||
       preference.kind === 'too_obvious' ||
       preference.kind === 'too_obscure'

--- a/apps/web/src/features/recommendation/persistence.ts
+++ b/apps/web/src/features/recommendation/persistence.ts
@@ -64,6 +64,7 @@ export async function failRecommendationRecord(
 function toMovieRows(result: ApiResponse): MovieRowToInsert[] {
   return (result.similarMovies ?? []).map((movie) => ({
     id: movie.id,
+    tmdbId: movie.tmdbId ?? null,
     name: movie.name,
     year: movie.year,
     similarity: movie.similarity,

--- a/apps/web/src/features/recommendation/pipeline.ts
+++ b/apps/web/src/features/recommendation/pipeline.ts
@@ -9,6 +9,7 @@ import { getDbClient } from '@/clients/dbClient';
 import { getUserRecommendationFeedbackMoviePreferences } from '@/lib/db/recommendations';
 import { MOVIE_SEED_JOB_OPTIONS, seedQueue } from '@/lib/jobQueue';
 import logger from '@/lib/logger';
+import { getMovieTitleKey } from '@/lib/movieIdentity';
 
 import {
   applyFeedbackToLocalMovies,
@@ -47,6 +48,24 @@ class EnqueueTimeoutError extends Error {
     super(message);
     this.name = 'EnqueueTimeoutError';
   }
+}
+
+function findRecommendedMovieByTitle<TMovie extends { id: number; name: string }>(
+  movies: TMovie[],
+  recommendedTitle: string,
+): TMovie | undefined {
+  const recommendedTitleKey = getMovieTitleKey(recommendedTitle);
+  if (recommendedTitleKey) {
+    const exactMatch = movies.find((movie) => getMovieTitleKey(movie.name) === recommendedTitleKey);
+    if (exactMatch) return exactMatch;
+  }
+
+  const normalizedRecommendedTitle = recommendedTitle.toLowerCase();
+  return movies.find(
+    (movie) =>
+      movie.name.toLowerCase().includes(normalizedRecommendedTitle) ||
+      normalizedRecommendedTitle.includes(movie.name.toLowerCase()),
+  );
 }
 
 async function withTimeout<T>(
@@ -271,19 +290,15 @@ export async function runRecommendationPipeline(
   }
 
   if (similarMovies.length === 0) {
-    const fallbackMovies = localSimilarMovies.slice(0, MAX_TOTAL_MOVIES);
-    if (fallbackMovies.length === 0) {
-      throw new Error('No similar movies found.');
-    }
-
     logger.warn(
       {
         mentionedTitleCount: mentionedTitleKeys.size,
-        fallbackCount: fallbackMovies.length,
+        feedbackExcludedMovieCount: feedbackSignals.excludedMovieKeys.size,
+        feedbackExcludedTitleCount: feedbackSignals.excludedTitleKeys.size,
       },
-      'Mentioned-title filtering removed every candidate and TMDB fallback did not refill results; relaxing filter as last resort',
+      'No recommendation candidates remain after preserving user memory filters',
     );
-    similarMovies = fallbackMovies;
+    throw new Error('No similar movies found after applying recommendation history filters.');
   }
 
   // Step 4: Get recommendation from OpenAI
@@ -309,10 +324,9 @@ export async function runRecommendationPipeline(
   );
 
   // Find the recommended movie
-  const recommendedMovie = moviesWithDescriptions.find(
-    (movie) =>
-      movie.name.toLowerCase().includes(responseMessage.title.toLowerCase()) ||
-      responseMessage.title.toLowerCase().includes(movie.name.toLowerCase()),
+  const recommendedMovie = findRecommendedMovieByTitle(
+    moviesWithDescriptions,
+    responseMessage.title,
   );
 
   logger.info(
@@ -337,6 +351,7 @@ export async function runRecommendationPipeline(
       : undefined,
     similarMovies: moviesWithDescriptions.map((movie) => ({
       id: Number(movie.id),
+      tmdbId: movie.tmdbId ?? (Number(movie.id) < 0 ? Math.abs(Number(movie.id)) : null),
       name: movie.name,
       year: movie.year,
       similarity: Number.isFinite(movie.similarity) ? movie.similarity : 0,

--- a/apps/web/src/features/recommendation/recommendation.ts
+++ b/apps/web/src/features/recommendation/recommendation.ts
@@ -319,9 +319,7 @@ export async function enhanceSimilarMoviesWithPosters(
         return movie;
       }
       try {
-        // For TMDB-sourced movies, the ID is stored as negative (-tmdbId).
-        // Pass the real TMDB ID so getMovieInfo can do a direct lookup instead of a title search.
-        const tmdbId = movie.id < 0 ? -movie.id : undefined;
+        const tmdbId = movie.tmdbId ?? (movie.id < 0 ? -movie.id : undefined);
         const { posterURL, localizedName, localizedOverview } = await getMovieInfo(
           movie.name,
           locale,

--- a/apps/web/src/features/recommendation/tmdb.ts
+++ b/apps/web/src/features/recommendation/tmdb.ts
@@ -401,6 +401,7 @@ export async function seedMovies(
       }
 
       const { error: insertError } = await db.from('movies').insert({
+        tmdb_id: movie.id,
         name: movie.title,
         year,
         age_rating: 'NR',

--- a/apps/web/src/features/recommendation/types.ts
+++ b/apps/web/src/features/recommendation/types.ts
@@ -101,6 +101,7 @@ export const apiResponseSchema = z.object({
     .array(
       z.object({
         id: z.number(),
+        tmdbId: z.number().nullable().optional(),
         name: z.string(),
         year: z.number(),
         similarity: z.number(),

--- a/apps/web/src/lib/db/recommendations.test.ts
+++ b/apps/web/src/lib/db/recommendations.test.ts
@@ -252,24 +252,34 @@ describe('getUserRecommendationFeedbackMoviePreferences', () => {
   });
 
   it('returns movies attached to actionable user feedback', async () => {
-    mockQuery.mockResolvedValueOnce({
-      rows: [
-        {
-          kind: 'watched',
-          movie_key: 'tmdb:475557',
-          tmdb_id: 475557,
-          movie_name: 'Joker',
-          movie_year: 2019,
-        },
-        {
-          kind: 'wrong_mood',
-          movie_key: 'title:arrival:2016',
-          tmdb_id: null,
-          movie_name: 'Arrival',
-          movie_year: 2016,
-        },
-      ],
-    });
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            kind: 'watched',
+            movie_key: 'tmdb:475557',
+            tmdb_id: 475557,
+            movie_name: 'Joker',
+            movie_year: 2019,
+          },
+          {
+            kind: 'wrong_mood',
+            movie_key: 'title:arrival:2016',
+            tmdb_id: null,
+            movie_name: 'Arrival',
+            movie_year: 2016,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            tmdb_id: 129,
+            movie_name: 'Spirited Away',
+            movie_year: 2001,
+          },
+        ],
+      });
 
     const result = await getUserRecommendationFeedbackMoviePreferences('42');
 
@@ -288,11 +298,19 @@ describe('getUserRecommendationFeedbackMoviePreferences', () => {
         movieName: 'Arrival',
         movieYear: 2016,
       },
+      {
+        kind: 'recently_recommended',
+        movieKey: 'tmdb:129',
+        tmdbId: 129,
+        movieName: 'Spirited Away',
+        movieYear: 2001,
+      },
     ]);
     const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
     expect(sql).toContain('user_movie_interactions');
     expect(sql).toContain("kind IN ('watched', 'not_interested', 'wrong_mood')");
     expect(params).toEqual(['42', 100]);
+    expect(mockQuery).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -620,6 +638,24 @@ describe('insertRecommendationMovies', () => {
 
     const [, params] = mockClientQuery.mock.calls[2] as [string, unknown[]];
     expect(params).toContain(77);
+  });
+
+  it('stores a matched TMDB id for local recommendations', async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({}) // BEGIN
+      .mockResolvedValueOnce({}) // UPDATE recommendations metadata
+      .mockResolvedValueOnce({}) // INSERT
+      .mockResolvedValueOnce({}); // COMMIT
+
+    await insertRecommendationMovies(
+      'rec-id',
+      [makeMovie({ id: 42, tmdbId: 129, fromTMDB: false })],
+      false,
+    );
+
+    const [, params] = mockClientQuery.mock.calls[2] as [string, unknown[]];
+    expect(params).toContain(129);
+    expect(params).toContain(42);
   });
 });
 

--- a/apps/web/src/lib/db/recommendations.ts
+++ b/apps/web/src/lib/db/recommendations.ts
@@ -49,6 +49,7 @@ export type RecommendationFeedbackKind =
   | 'too_obscure'
   | 'close';
 export type UserMovieInteractionKind = 'watched' | 'liked' | 'not_interested' | 'wrong_mood';
+export type UserRecommendationMemoryKind = UserMovieInteractionKind | 'recently_recommended';
 
 export interface RecommendationMovie {
   id: number;
@@ -92,7 +93,7 @@ export interface AccountRecommendationSummary {
 }
 
 export interface UserRecommendationFeedbackMoviePreference {
-  kind: UserMovieInteractionKind;
+  kind: UserRecommendationMemoryKind;
   movieKey: string;
   tmdbId: number | null;
   movieName: string;
@@ -101,6 +102,7 @@ export interface UserRecommendationFeedbackMoviePreference {
 
 export interface MovieRowToInsert {
   id: number;
+  tmdbId?: number | null;
   name: string;
   year: number;
   similarity?: number;
@@ -261,7 +263,7 @@ export async function getUserRecommendationFeedbackMoviePreferences(
   limit = 100,
 ): Promise<UserRecommendationFeedbackMoviePreference[]> {
   const pool = getPool();
-  const result = await pool.query<{
+  const interactionResult = await pool.query<{
     kind: UserMovieInteractionKind;
     movie_key: string;
     tmdb_id: number | null;
@@ -282,13 +284,62 @@ export async function getUserRecommendationFeedbackMoviePreferences(
     [userId, limit],
   );
 
-  return result.rows.map((row) => ({
-    kind: row.kind,
-    movieKey: row.movie_key,
-    tmdbId: row.tmdb_id,
-    movieName: row.movie_name,
-    movieYear: row.movie_year,
-  }));
+  const recentResult = await pool.query<{
+    tmdb_id: number | null;
+    movie_name: string | null;
+    movie_year: number | null;
+  }>(
+    `SELECT
+       rm.tmdb_id,
+       COALESCE(rm.tmdb_name, m.name) AS movie_name,
+       COALESCE(rm.tmdb_year, m.year) AS movie_year
+     FROM recommendations r
+     JOIN LATERAL (
+       SELECT *
+         FROM recommendation_movies
+        WHERE recommendation_id = r.id
+        ORDER BY is_main_recommendation DESC, position ASC
+        LIMIT 1
+     ) rm ON true
+     LEFT JOIN movies m ON m.id = rm.movie_id
+     WHERE r.user_id = $1
+       AND r.status = 'completed'
+     ORDER BY COALESCE(r.completed_at, r.created_at) DESC
+     LIMIT $2`,
+    [userId, limit],
+  );
+
+  const preferences: UserRecommendationFeedbackMoviePreference[] = interactionResult.rows.map(
+    (row) => ({
+      kind: row.kind,
+      movieKey: row.movie_key,
+      tmdbId: row.tmdb_id,
+      movieName: row.movie_name,
+      movieYear: row.movie_year,
+    }),
+  );
+
+  const seenKeys = new Set(preferences.map((preference) => preference.movieKey));
+  for (const row of recentResult.rows) {
+    if (!row.movie_name) continue;
+    const movieKey = getMovieIdentityKey({
+      tmdbId: row.tmdb_id,
+      title: row.movie_name,
+      year: row.movie_year,
+    });
+    if (!movieKey || seenKeys.has(movieKey)) continue;
+
+    seenKeys.add(movieKey);
+    preferences.push({
+      kind: 'recently_recommended',
+      movieKey,
+      tmdbId: row.tmdb_id,
+      movieName: row.movie_name,
+      movieYear: row.movie_year,
+    });
+  }
+
+  return preferences.slice(0, limit);
 }
 
 // ---------------------------------------------------------------------------
@@ -369,7 +420,7 @@ export async function insertRecommendationMovies(
           m.localizedName ?? null,
           m.similarity ?? null,
           m.fromTMDB,
-          m.fromTMDB ? Math.abs(m.id) : null,
+          m.fromTMDB ? Math.abs(m.id) : (m.tmdbId ?? null),
           m.fromTMDB ? m.name : null,
           m.fromTMDB ? m.year : null,
           m.fromTMDB ? (m.score_rating ?? null) : null,


### PR DESCRIPTION
## Summary
- Treat recent completed top picks as recommendation memory for signed-in users.
- Preserve TMDB IDs through local/TMDB recommendation persistence and JIT seeding.
- Keep feedback/history filters intact by removing the last-resort fallback that could reintroduce excluded movies.

## Test Plan
- npm run test --workspace=apps/web -- src/features/recommendation/candidateFilters.test.ts src/lib/db/recommendations.test.ts
- npm run lint:check
- npm run type-check
- npm run build
- pre-push hook: lint, server tests, production build