### PR TITLE
Add editable account movie memory

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -37,25 +37,30 @@ WCAG AA compliance. Standard good practices: sufficient color contrast, keyboard
 
 ## Product Roadmap Notes
 
+Already implemented from this list:
+
+- Password recovery through the forgot/reset password flow.
+- Favorite/reference movies are used as taste signals but excluded from recommendation candidates.
+- Results can be shared through a stable recommendation URL.
+- Recommendation feedback is captured after results and stored alongside recommendation history.
+- Signed-in feedback is converted into durable movie memory for watched, liked, not-interested, and wrong-mood signals.
+- Account recommendation history is deduplicated by movie identity.
+
 - Continue improving account foundations:
   - Profile basics: display name, avatar, and a clear account settings surface.
   - Editable saved recommendations: let users add, remove, rename, annotate, or change saved items without leaving the account page.
-  - Password recovery: add a clear "forgot password" flow.
   - Magic-link login: let users sign in from an emailed one-time link without remembering a password.
   - Social login: support trusted providers such as Google once the local auth flow is stable.
-- Avoid recommending a film the user explicitly mentioned as a favorite or reference title. That signal should shape taste, not become the answer; in most cases the user has already seen it.
-- Improve the results share card so a user can create and copy a stable share link. Social sharing can follow later, but the core need is "send this recommendation to someone" without friction.
 - Loading states must be truthful and terminal. If recommendation polling hits authorization, missing-result, worker, or network failures, the UI should show an actionable error instead of returning to an earlier loading state or spinning indefinitely.
 - Add an account taste profile that becomes more useful over time:
-  - Store explicit likes, dislikes, skipped films, watched films, and feedback on individual recommendations.
+  - Make stored likes, dislikes, skipped films, watched films, and feedback inspectable and editable.
   - Derive lightweight taste signals from completed quizzes, opened results, saved picks, more-picks requests, and rejected suggestions.
   - Make the taste profile inspectable and editable, so users can correct PopChoice when it learns the wrong lesson.
-- Add recommendation feedback after every result:
-  - Capture whether the pick was useful, already watched, wrong mood, too obvious, too obscure, or close-but-not-quite.
-  - Store feedback alongside the recommendation inputs, selected movie, candidate list, match score, and model/version metadata.
-  - Use feedback first for analytics and debugging, then for ranking weights, exclusion rules, and personalized follow-up suggestions.
+- Continue improving recommendation feedback:
+  - Use `liked` feedback as a positive ranking signal, not only as stored memory.
+  - Make feedback history visible enough for analytics/debugging without exposing internal metadata awkwardly in the product UI.
+  - Use feedback for richer personalized follow-up suggestions.
 - Revise the recommendation flow around learning:
-  - Treat favorite movies as examples of taste unless the user explicitly says "recommend something like this but I have not seen it."
   - Add a "not this" or "seen it" action that reranks alternatives without forcing the user to retake the quiz.
   - Make the transition from quiz to results resilient: one source of truth for pending, completed, failed, and retry states.
   - Consider a Tinder-style discovery mode for logged-in users: quick swipe decisions that build taste without a full quiz.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -54,6 +54,7 @@ Already implemented from this list:
 - Loading states must be truthful and terminal. If recommendation polling hits authorization, missing-result, worker, or network failures, the UI should show an actionable error instead of returning to an earlier loading state or spinning indefinitely.
 - Add an account taste profile that becomes more useful over time:
   - Make stored likes, dislikes, skipped films, watched films, and feedback inspectable and editable.
+  - When movie memory grows beyond a handful of titles, replace the simple card grid with search, filters by signal, and a denser list/table mode.
   - Derive lightweight taste signals from completed quizzes, opened results, saved picks, more-picks requests, and rejected suggestions.
   - Make the taste profile inspectable and editable, so users can correct PopChoice when it learns the wrong lesson.
 - Continue improving recommendation feedback:

--- a/apps/web/src/app/account/page.tsx
+++ b/apps/web/src/app/account/page.tsx
@@ -3,10 +3,15 @@
 import {
   AlertCircle,
   ArrowRight,
+  Ban,
   Clapperboard,
+  Eye,
   Film,
+  Frown,
+  Heart,
   Sparkles,
   Trash2,
+  X,
   UserRound,
 } from 'lucide-react';
 import { motion } from 'motion/react';
@@ -15,6 +20,7 @@ import { useEffect, useState, type ReactNode } from 'react';
 
 import { useAuth } from '@/components/AuthProvider';
 import { useLanguage } from '@/i18n';
+import { getCsrfToken } from '@/lib/csrfClient';
 import { navigateToFreshQuiz } from '@/lib/quizNavigation';
 import { palette } from '@/styles/designTokens';
 
@@ -39,15 +45,34 @@ type RecommendationSummary = {
   feedbackKind: RecommendationFeedbackKind | null;
 };
 
+type UserMovieInteractionKind = 'watched' | 'liked' | 'not_interested' | 'wrong_mood';
+
+type MovieMemorySummary = {
+  movieKey: string;
+  tmdbId: number | null;
+  movieName: string;
+  movieYear: number | null;
+  posterURL: string | null;
+  localizedName: string | null;
+  kind: UserMovieInteractionKind;
+  updatedAt: string;
+};
+
 type AccountResponse = {
   user: { email: string };
   recommendations: RecommendationSummary[];
+  movieMemory: MovieMemorySummary[];
 };
 
 type LoadState =
   | { status: 'idle' }
   | { status: 'loaded'; data: AccountResponse }
   | { status: 'error' };
+
+type MemoryActionState =
+  | { status: 'forgetting'; movieKey: string }
+  | { status: 'error'; movieKey: string }
+  | null;
 
 const ACCOUNT_FETCH_TIMEOUT_MS = 10000;
 
@@ -56,6 +81,7 @@ export default function AccountPage() {
   const { locale, t } = useLanguage();
   const a = t.account;
   const [state, setState] = useState<LoadState>({ status: 'idle' });
+  const [memoryAction, setMemoryAction] = useState<MemoryActionState>(null);
 
   useEffect(() => {
     if (auth.status !== 'authenticated') {
@@ -86,7 +112,13 @@ export default function AccountPage() {
 
         const data = (await response.json()) as AccountResponse;
         if (!cancelled) {
-          setState({ status: 'loaded', data });
+          setState({
+            status: 'loaded',
+            data: {
+              ...data,
+              movieMemory: Array.isArray(data.movieMemory) ? data.movieMemory : [],
+            },
+          });
         }
       } catch {
         if (!cancelled || timedOut) {
@@ -194,7 +226,43 @@ export default function AccountPage() {
     return null;
   }
 
-  const { user, recommendations } = state.data;
+  async function handleForgetMovie(movieKey: string) {
+    setMemoryAction({ status: 'forgetting', movieKey });
+
+    try {
+      const response = await fetch('/api/account/movie-memory', {
+        method: 'DELETE',
+        cache: 'no-store',
+        credentials: 'same-origin',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-Token': getCsrfToken(),
+        },
+        body: JSON.stringify({ movieKey }),
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to forget movie memory');
+      }
+
+      setState((current) =>
+        current.status === 'loaded'
+          ? {
+              status: 'loaded',
+              data: {
+                ...current.data,
+                movieMemory: current.data.movieMemory.filter((item) => item.movieKey !== movieKey),
+              },
+            }
+          : current,
+      );
+      setMemoryAction(null);
+    } catch {
+      setMemoryAction({ status: 'error', movieKey });
+    }
+  }
+
+  const { user, recommendations, movieMemory } = state.data;
 
   return (
     <AccountShell>
@@ -305,6 +373,14 @@ export default function AccountPage() {
             </div>
           )}
         </section>
+
+        <MovieMemorySection
+          items={movieMemory}
+          labels={a}
+          locale={locale}
+          action={memoryAction}
+          onForget={handleForgetMovie}
+        />
       </motion.section>
     </AccountShell>
   );
@@ -446,6 +522,167 @@ function RecommendationRow({
       </div>
     </Link>
   );
+}
+
+function MovieMemorySection({
+  items,
+  labels,
+  locale,
+  action,
+  onForget,
+}: {
+  items: MovieMemorySummary[];
+  labels: ReturnType<typeof useLanguage>['t']['account'];
+  locale: string;
+  action: MemoryActionState;
+  onForget: (movieKey: string) => void;
+}) {
+  return (
+    <section className="mx-auto mt-12 max-w-4xl">
+      <div className="mb-4 flex items-center justify-center gap-3">
+        <Eye size={18} style={{ color: 'var(--pc-gold-text)' }} />
+        <h2
+          className="uppercase"
+          style={{
+            fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
+            letterSpacing: '0.12em',
+            color: 'var(--pc-gold-text)',
+          }}
+        >
+          {labels.memoryTitle}
+        </h2>
+      </div>
+      <p className="mx-auto mb-5 max-w-2xl text-center text-sm" style={{ color: 'var(--pc-t3)' }}>
+        {labels.memoryBody}
+      </p>
+
+      {action?.status === 'error' ? (
+        <div
+          className="mb-3 rounded-2xl px-4 py-3 text-sm"
+          style={{
+            background: `${palette.red}12`,
+            border: `1px solid ${palette.red}35`,
+            color: palette.red,
+          }}
+        >
+          {labels.memoryForgetError}
+        </div>
+      ) : null}
+
+      {items.length === 0 ? (
+        <div
+          className="rounded-2xl px-6 py-8 text-center"
+          style={{ background: 'var(--pc-surface)', border: '1px solid var(--pc-bd2)' }}
+        >
+          <h3 className="mb-2 text-base font-semibold" style={{ color: 'var(--pc-t1)' }}>
+            {labels.memoryEmptyTitle}
+          </h3>
+          <p className="mx-auto max-w-md text-sm" style={{ color: 'var(--pc-t2)' }}>
+            {labels.memoryEmptyBody}
+          </p>
+        </div>
+      ) : (
+        <div className="grid gap-3 md:grid-cols-2">
+          {items.map((item) => (
+            <MovieMemoryCard
+              key={item.movieKey}
+              item={item}
+              labels={labels}
+              locale={locale}
+              isForgetting={action?.status === 'forgetting' && action.movieKey === item.movieKey}
+              onForget={() => onForget(item.movieKey)}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function MovieMemoryCard({
+  item,
+  labels,
+  locale,
+  isForgetting,
+  onForget,
+}: {
+  item: MovieMemorySummary;
+  labels: ReturnType<typeof useLanguage>['t']['account'];
+  locale: string;
+  isForgetting: boolean;
+  onForget: () => void;
+}) {
+  const date = new Intl.DateTimeFormat(locale, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(new Date(item.updatedAt));
+  const title = item.localizedName ?? item.movieName;
+
+  return (
+    <div
+      className="grid grid-cols-[64px_1fr_auto] items-center gap-3 rounded-2xl p-3"
+      style={{ background: 'var(--pc-surface)', border: '1px solid var(--pc-bd2)' }}
+    >
+      <div
+        className="flex aspect-[2/3] w-16 items-center justify-center overflow-hidden rounded-xl"
+        style={{ background: 'var(--pc-ghost)' }}
+      >
+        {item.posterURL ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={item.posterURL} alt="" className="h-full w-full object-cover" loading="lazy" />
+        ) : (
+          <Film size={18} style={{ color: 'var(--pc-t3)' }} />
+        )}
+      </div>
+
+      <div className="min-w-0">
+        <div className="mb-1 flex flex-wrap items-center gap-2">
+          <span
+            className="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-semibold"
+            style={{
+              background: 'var(--pc-gold-subtle)',
+              border: '1px solid var(--pc-gold-bd)',
+              color: 'var(--pc-gold-text)',
+            }}
+          >
+            <MemoryKindIcon kind={item.kind} />
+            {labels.memoryKind[item.kind]}
+          </span>
+          <span className="text-xs" style={{ color: 'var(--pc-t4)' }}>
+            {date}
+          </span>
+        </div>
+        <h3 className="truncate text-sm font-semibold" style={{ color: 'var(--pc-t1)' }}>
+          {title}
+          {item.movieYear ? ` (${item.movieYear})` : ''}
+        </h3>
+      </div>
+
+      <button
+        type="button"
+        onClick={onForget}
+        disabled={isForgetting}
+        className="inline-flex h-10 w-10 items-center justify-center rounded-xl transition-opacity disabled:opacity-60"
+        style={{
+          background: 'var(--pc-ghost)',
+          border: '1px solid var(--pc-bd2)',
+          color: 'var(--pc-t2)',
+        }}
+        aria-label={labels.forgetMovie}
+        title={labels.forgetMovie}
+      >
+        <X size={17} />
+      </button>
+    </div>
+  );
+}
+
+function MemoryKindIcon({ kind }: { kind: UserMovieInteractionKind }) {
+  if (kind === 'watched') return <Eye size={12} />;
+  if (kind === 'liked') return <Heart size={12} />;
+  if (kind === 'wrong_mood') return <Frown size={12} />;
+  return <Ban size={12} />;
 }
 
 function statusBackground(status: RecommendationSummary['status']) {

--- a/apps/web/src/app/api/account/movie-memory/route.test.ts
+++ b/apps/web/src/app/api/account/movie-memory/route.test.ts
@@ -1,0 +1,100 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockGetSessionFromRequest, mockDeleteUserMovieMemory, mockApplyRateLimit } = vi.hoisted(
+  () => ({
+    mockGetSessionFromRequest: vi.fn(),
+    mockDeleteUserMovieMemory: vi.fn(),
+    mockApplyRateLimit: vi.fn(),
+  }),
+);
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionFromRequest: mockGetSessionFromRequest,
+}));
+
+vi.mock('@/lib/db/recommendations', () => ({
+  deleteUserMovieMemory: mockDeleteUserMovieMemory,
+}));
+
+vi.mock('@/lib/rateLimit', () => ({
+  applyRateLimit: mockApplyRateLimit,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  default: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { DELETE } from './route';
+
+function makeRequest(body: unknown, headers: Record<string, string> = {}) {
+  return new NextRequest('http://localhost/api/account/movie-memory', {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+      Origin: 'http://localhost',
+      'X-CSRF-Token': 'csrf-token',
+      Cookie: '__csrf=csrf-token',
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('DELETE /api/account/movie-memory', () => {
+  beforeEach(() => {
+    mockGetSessionFromRequest.mockReset();
+    mockDeleteUserMovieMemory.mockReset();
+    mockApplyRateLimit.mockReset();
+    mockApplyRateLimit.mockResolvedValue(null);
+  });
+
+  it('returns 401 without a session', async () => {
+    mockGetSessionFromRequest.mockReturnValue(null);
+
+    const response = await DELETE(makeRequest({ movieKey: 'tmdb:129' }));
+
+    expect(response.status).toBe(401);
+    expect(mockDeleteUserMovieMemory).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when CSRF validation fails', async () => {
+    mockGetSessionFromRequest.mockReturnValue({ sub: '42', exp: 9999999999 });
+
+    const response = await DELETE(
+      makeRequest({ movieKey: 'tmdb:129' }, { 'X-CSRF-Token': 'wrong-token' }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(mockDeleteUserMovieMemory).not.toHaveBeenCalled();
+  });
+
+  it('returns 422 for an invalid payload', async () => {
+    mockGetSessionFromRequest.mockReturnValue({ sub: '42', exp: 9999999999 });
+
+    const response = await DELETE(makeRequest({ movieKey: '' }));
+
+    expect(response.status).toBe(422);
+    expect(mockDeleteUserMovieMemory).not.toHaveBeenCalled();
+  });
+
+  it('deletes the selected movie memory item for the signed-in user', async () => {
+    mockGetSessionFromRequest.mockReturnValue({ sub: '42', exp: 9999999999 });
+    mockDeleteUserMovieMemory.mockResolvedValueOnce(true);
+
+    const response = await DELETE(makeRequest({ movieKey: 'tmdb:129' }));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ status: 'deleted' });
+    expect(mockDeleteUserMovieMemory).toHaveBeenCalledWith('42', 'tmdb:129');
+  });
+
+  it('returns 404 when the movie memory item is absent', async () => {
+    mockGetSessionFromRequest.mockReturnValue({ sub: '42', exp: 9999999999 });
+    mockDeleteUserMovieMemory.mockResolvedValueOnce(false);
+
+    const response = await DELETE(makeRequest({ movieKey: 'tmdb:129' }));
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/apps/web/src/app/api/account/movie-memory/route.ts
+++ b/apps/web/src/app/api/account/movie-memory/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { getSessionFromRequest } from '@/lib/auth/session';
+import { deleteUserMovieMemory } from '@/lib/db/recommendations';
+import logger from '@/lib/logger';
+import { applyRateLimit } from '@/lib/rateLimit';
+import { isSameOriginBrowserRequest } from '@/lib/withAuth';
+
+const privateResponseHeaders = {
+  'Cache-Control': 'no-store',
+  Vary: 'Cookie',
+};
+
+const deleteMovieMemorySchema = z
+  .object({
+    movieKey: z.string().min(1).max(160),
+  })
+  .strict();
+const CSRF_COOKIE = '__csrf';
+
+function movieMemoryJson(body: unknown, status: number): Response {
+  return NextResponse.json(body, { status, headers: privateResponseHeaders });
+}
+
+export async function DELETE(req: NextRequest): Promise<Response> {
+  const session = getSessionFromRequest(req);
+  if (!session) {
+    return movieMemoryJson({ error: 'Unauthorized' }, 401);
+  }
+
+  const rateLimitResponse = await applyRateLimit(req);
+  if (rateLimitResponse) return rateLimitResponse;
+
+  const csrfHeader = req.headers.get('x-csrf-token');
+  const csrfCookie = req.cookies.get(CSRF_COOKIE)?.value;
+  if (!csrfHeader || !csrfCookie || csrfHeader !== csrfCookie || !isSameOriginBrowserRequest(req)) {
+    logger.warn({ userId: session.sub }, 'Movie memory deletion rejected: CSRF check failed');
+    return movieMemoryJson({ error: 'Forbidden' }, 403);
+  }
+
+  const payload = await req.json().catch(() => null);
+  const parsed = deleteMovieMemorySchema.safeParse(payload);
+  if (!parsed.success) {
+    return movieMemoryJson({ error: 'Invalid movie memory item' }, 422);
+  }
+
+  try {
+    const deleted = await deleteUserMovieMemory(session.sub, parsed.data.movieKey);
+    if (!deleted) {
+      return movieMemoryJson({ error: 'Movie memory item not found' }, 404);
+    }
+
+    return movieMemoryJson({ status: 'deleted' }, 200);
+  } catch (err) {
+    logger.error({ err, userId: session.sub }, 'Failed to delete movie memory item');
+    return movieMemoryJson({ error: 'Failed to delete movie memory item' }, 500);
+  }
+}

--- a/apps/web/src/app/api/account/route.test.ts
+++ b/apps/web/src/app/api/account/route.test.ts
@@ -1,12 +1,17 @@
 import { NextRequest } from 'next/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockGetSessionFromRequest, mockGetDbClient, mockGetUserRecommendationSummaries } =
-  vi.hoisted(() => ({
-    mockGetSessionFromRequest: vi.fn(),
-    mockGetDbClient: vi.fn(),
-    mockGetUserRecommendationSummaries: vi.fn(),
-  }));
+const {
+  mockGetSessionFromRequest,
+  mockGetDbClient,
+  mockGetUserRecommendationSummaries,
+  mockGetUserMovieMemorySummaries,
+} = vi.hoisted(() => ({
+  mockGetSessionFromRequest: vi.fn(),
+  mockGetDbClient: vi.fn(),
+  mockGetUserRecommendationSummaries: vi.fn(),
+  mockGetUserMovieMemorySummaries: vi.fn(),
+}));
 
 vi.mock('@/lib/auth/session', () => ({
   getSessionFromRequest: mockGetSessionFromRequest,
@@ -18,6 +23,7 @@ vi.mock('@/clients/dbClient', () => ({
 
 vi.mock('@/lib/db/recommendations', () => ({
   getUserRecommendationSummaries: mockGetUserRecommendationSummaries,
+  getUserMovieMemorySummaries: mockGetUserMovieMemorySummaries,
 }));
 
 vi.mock('@/lib/logger', () => ({
@@ -31,6 +37,7 @@ describe('GET /api/account', () => {
     mockGetSessionFromRequest.mockReset();
     mockGetDbClient.mockReset();
     mockGetUserRecommendationSummaries.mockReset();
+    mockGetUserMovieMemorySummaries.mockReset();
   });
 
   it('returns 401 without a session', async () => {
@@ -63,6 +70,9 @@ describe('GET /api/account', () => {
     mockGetUserRecommendationSummaries.mockResolvedValueOnce([
       { slug: 'saved-rec', feedbackKind: 'already_watched' },
     ]);
+    mockGetUserMovieMemorySummaries.mockResolvedValueOnce([
+      { movieKey: 'tmdb:129', movieName: 'Spirited Away', kind: 'watched' },
+    ]);
 
     const response = await GET(new NextRequest('http://localhost/api/account'));
 
@@ -72,7 +82,9 @@ describe('GET /api/account', () => {
     await expect(response.json()).resolves.toEqual({
       user: { email: 'alex@example.com' },
       recommendations: [{ slug: 'saved-rec', feedbackKind: 'already_watched' }],
+      movieMemory: [{ movieKey: 'tmdb:129', movieName: 'Spirited Away', kind: 'watched' }],
     });
     expect(mockGetUserRecommendationSummaries).toHaveBeenCalledWith('42');
+    expect(mockGetUserMovieMemorySummaries).toHaveBeenCalledWith('42');
   });
 });

--- a/apps/web/src/app/api/account/route.ts
+++ b/apps/web/src/app/api/account/route.ts
@@ -2,7 +2,10 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { getDbClient } from '@/clients/dbClient';
 import { getSessionFromRequest } from '@/lib/auth/session';
-import { getUserRecommendationSummaries } from '@/lib/db/recommendations';
+import {
+  getUserMovieMemorySummaries,
+  getUserRecommendationSummaries,
+} from '@/lib/db/recommendations';
 import logger from '@/lib/logger';
 
 type UserRow = {
@@ -41,11 +44,15 @@ export async function GET(req: NextRequest): Promise<Response> {
       return accountJson({ error: 'Account not found' }, 404);
     }
 
-    const recommendations = await getUserRecommendationSummaries(session.sub);
+    const [recommendations, movieMemory] = await Promise.all([
+      getUserRecommendationSummaries(session.sub),
+      getUserMovieMemorySummaries(session.sub),
+    ]);
     return accountJson(
       {
         user: { email: user.email },
         recommendations,
+        movieMemory,
       },
       200,
     );

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -908,6 +908,13 @@ export const en = {
     savedTitle: 'Recommendation history',
     emptyTitle: 'No saved recommendations yet',
     emptyBody: 'Take the quiz while signed in and your results will appear here.',
+    memoryTitle: 'Movie memory',
+    memoryBody:
+      'PopChoice uses these signals to avoid repeating movies you have already seen or marked as a miss.',
+    memoryEmptyTitle: 'No movie memory yet',
+    memoryEmptyBody: 'Rate recommendations and PopChoice will learn what to avoid next time.',
+    forgetMovie: 'Forget this movie',
+    memoryForgetError: 'Could not forget this movie. Please try again.',
     pendingTitle: 'Recommendation in progress',
     untitledCompleted: 'Completed recommendation',
     peopleCount: '{count} taste profile(s)',
@@ -920,6 +927,12 @@ export const en = {
       too_obvious: 'Too obvious',
       too_obscure: 'Too obscure',
       close: 'Close',
+    },
+    memoryKind: {
+      watched: 'Seen it',
+      liked: 'Liked',
+      not_interested: 'Not interested',
+      wrong_mood: 'Wrong mood',
     },
     status: {
       pending: 'Pending',

--- a/apps/web/src/i18n/locales/fi.ts
+++ b/apps/web/src/i18n/locales/fi.ts
@@ -915,6 +915,14 @@ export const fi: Translations = {
     savedTitle: 'Suositushistoria',
     emptyTitle: 'Ei vielä tallennettuja suosituksia',
     emptyBody: 'Tee kysely kirjautuneena, niin tuloksesi ilmestyvät tänne.',
+    memoryTitle: 'Elokuvamuisti',
+    memoryBody:
+      'PopChoice käyttää näitä signaaleja, jotta se ei ehdota uudelleen elokuvia, jotka olet jo nähnyt tai merkinnyt hutivalinnaksi.',
+    memoryEmptyTitle: 'Elokuvamuisti on vielä tyhjä',
+    memoryEmptyBody:
+      'Arvioi suosituksia, niin PopChoice oppii, mitä kannattaa välttää seuraavalla kerralla.',
+    forgetMovie: 'Unohda tämä elokuva',
+    memoryForgetError: 'Elokuvaa ei voitu unohtaa. Yritä uudelleen.',
     pendingTitle: 'Suositus on kesken',
     untitledCompleted: 'Valmis suositus',
     peopleCount: '{count} makuprofiilia',
@@ -927,6 +935,12 @@ export const fi: Translations = {
       too_obvious: 'Liian ilmeinen',
       too_obscure: 'Liian outo',
       close: 'Lähellä',
+    },
+    memoryKind: {
+      watched: 'Nähty jo',
+      liked: 'Pidetty',
+      not_interested: 'Ei kiinnosta',
+      wrong_mood: 'Väärä tunnelma',
     },
     status: {
       pending: 'Odottaa',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -919,6 +919,13 @@ export const ru: Translations = {
     savedTitle: 'История рекомендаций',
     emptyTitle: 'Пока нет сохранённых рекомендаций',
     emptyBody: 'Пройдите квиз после входа в аккаунт, и результаты появятся здесь.',
+    memoryTitle: 'Память о фильмах',
+    memoryBody:
+      'PopChoice использует эти сигналы, чтобы не повторять фильмы, которые вы уже видели или отметили как промах.',
+    memoryEmptyTitle: 'Память о фильмах пока пуста',
+    memoryEmptyBody: 'Оценивайте рекомендации, и PopChoice запомнит, что лучше не предлагать.',
+    forgetMovie: 'Забыть этот фильм',
+    memoryForgetError: 'Не удалось забыть фильм. Попробуйте ещё раз.',
     pendingTitle: 'Рекомендация в процессе',
     untitledCompleted: 'Готовая рекомендация',
     peopleCount: '{count} вкусовых профилей',
@@ -931,6 +938,12 @@ export const ru: Translations = {
       too_obvious: 'Слишком очевидно',
       too_obscure: 'Слишком нишево',
       close: 'Почти',
+    },
+    memoryKind: {
+      watched: 'Уже смотрел(а)',
+      liked: 'Понравилось',
+      not_interested: 'Не интересно',
+      wrong_mood: 'Не то настроение',
     },
     status: {
       pending: 'В очереди',

--- a/apps/web/src/lib/db/recommendations.test.ts
+++ b/apps/web/src/lib/db/recommendations.test.ts
@@ -38,8 +38,10 @@ vi.mock('@/lib/logger', () => ({
 import {
   claimMorePicksSlot,
   createRecommendation,
+  deleteUserMovieMemory,
   getRecommendationTMDBExcludeIds,
   getRecommendationWithMovies,
+  getUserMovieMemorySummaries,
   getUserRecommendationSummaries,
   insertMorePicksMovies,
   insertRecommendationMovies,
@@ -311,6 +313,85 @@ describe('getUserRecommendationFeedbackMoviePreferences', () => {
     expect(sql).toContain("kind IN ('watched', 'not_interested', 'wrong_mood')");
     expect(params).toEqual(['42', 100]);
     expect(mockQuery).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// user movie memory summaries
+// ---------------------------------------------------------------------------
+
+describe('getUserMovieMemorySummaries', () => {
+  beforeEach(() => {
+    vi.stubEnv('DATABASE_URL', 'postgres://localhost/test');
+    mockQuery.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns explicit movie memory ordered by most recent update', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          kind: 'watched',
+          movie_key: 'tmdb:129',
+          tmdb_id: 129,
+          movie_name: 'Spirited Away',
+          movie_year: 2001,
+          poster_url: 'https://example.com/poster.jpg',
+          localized_name: 'Унесённые призраками',
+          updated_at: new Date('2026-05-17T10:00:00.000Z'),
+        },
+      ],
+    });
+
+    const result = await getUserMovieMemorySummaries('42');
+
+    expect(result).toEqual([
+      {
+        kind: 'watched',
+        movieKey: 'tmdb:129',
+        tmdbId: 129,
+        movieName: 'Spirited Away',
+        movieYear: 2001,
+        posterURL: 'https://example.com/poster.jpg',
+        localizedName: 'Унесённые призраками',
+        updatedAt: '2026-05-17T10:00:00.000Z',
+      },
+    ]);
+    const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('FROM user_movie_interactions');
+    expect(sql).toContain('ORDER BY updated_at DESC');
+    expect(params).toEqual(['42', 50]);
+  });
+});
+
+describe('deleteUserMovieMemory', () => {
+  beforeEach(() => {
+    vi.stubEnv('DATABASE_URL', 'postgres://localhost/test');
+    mockQuery.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('deletes one movie memory item for the user', async () => {
+    mockQuery.mockResolvedValueOnce({ rowCount: 1 });
+
+    const result = await deleteUserMovieMemory('42', 'tmdb:129');
+
+    expect(result).toBe(true);
+    const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('DELETE FROM user_movie_interactions');
+    expect(params).toEqual(['42', 'tmdb:129']);
+  });
+
+  it('returns false when no row was deleted', async () => {
+    mockQuery.mockResolvedValueOnce({ rowCount: 0 });
+
+    await expect(deleteUserMovieMemory('42', 'tmdb:129')).resolves.toBe(false);
   });
 });
 

--- a/apps/web/src/lib/db/recommendations.ts
+++ b/apps/web/src/lib/db/recommendations.ts
@@ -100,6 +100,17 @@ export interface UserRecommendationFeedbackMoviePreference {
   movieYear: number | null;
 }
 
+export interface UserMovieMemorySummary {
+  kind: UserMovieInteractionKind;
+  movieKey: string;
+  tmdbId: number | null;
+  movieName: string;
+  movieYear: number | null;
+  posterURL: string | null;
+  localizedName: string | null;
+  updatedAt: string;
+}
+
 export interface MovieRowToInsert {
   id: number;
   tmdbId?: number | null;
@@ -340,6 +351,61 @@ export async function getUserRecommendationFeedbackMoviePreferences(
   }
 
   return preferences.slice(0, limit);
+}
+
+export async function getUserMovieMemorySummaries(
+  userId: string,
+  limit = 50,
+): Promise<UserMovieMemorySummary[]> {
+  const pool = getPool();
+  const result = await pool.query<{
+    kind: UserMovieInteractionKind;
+    movie_key: string;
+    tmdb_id: number | null;
+    movie_name: string;
+    movie_year: number | null;
+    poster_url: string | null;
+    localized_name: string | null;
+    updated_at: Date | string;
+  }>(
+    `SELECT
+       kind,
+       movie_key,
+       tmdb_id,
+       movie_name,
+       movie_year,
+       poster_url,
+       localized_name,
+       updated_at
+     FROM user_movie_interactions
+     WHERE user_id = $1
+     ORDER BY updated_at DESC
+     LIMIT $2`,
+    [userId, Math.min(Math.max(limit, 1), 100)],
+  );
+
+  return result.rows.map((row) => ({
+    kind: row.kind,
+    movieKey: row.movie_key,
+    tmdbId: row.tmdb_id,
+    movieName: row.movie_name,
+    movieYear: row.movie_year,
+    posterURL: row.poster_url,
+    localizedName: row.localized_name,
+    updatedAt: row.updated_at instanceof Date ? row.updated_at.toISOString() : row.updated_at,
+  }));
+}
+
+export async function deleteUserMovieMemory(userId: string, movieKey: string): Promise<boolean> {
+  const pool = getPool();
+  const result = await pool.query(
+    `DELETE FROM user_movie_interactions
+      WHERE user_id = $1
+        AND movie_key = $2`,
+    [userId, movieKey],
+  );
+
+  return (result.rowCount ?? 0) > 0;
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/ROADMAP-ARCHITECTURE.md
+++ b/docs/ROADMAP-ARCHITECTURE.md
@@ -148,6 +148,7 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 - Design a provider identity model before adding magic-link or social login so local credentials and external providers can coexist cleanly.
 - Add saved-recommendation mutations for rename, annotate, remove, and organize actions without leaving the account page.
 - Make taste memory inspectable and editable so users can correct watched, liked, not-interested, and wrong-mood signals.
+- Plan scalable account memory views before the list grows: search, signal filters, pagination or virtualized lists, and compact rows for large watched/liked histories.
 
 ### Accessibility and UI Quality Track
 

--- a/docs/ROADMAP-ARCHITECTURE.md
+++ b/docs/ROADMAP-ARCHITECTURE.md
@@ -44,6 +44,13 @@ The main remaining risks are:
 - [x] The register route now delegates user-creation workflow to a feature module instead of owning DB writes directly.
 - [x] Poster utility routes now delegate TMDB fetch and proxy logic through the integration layer instead of owning raw fetch behavior.
 - [x] Recommendation feature modules now import concrete clients directly instead of relying on the broad `@/clients` barrel.
+- [x] A stable movie identity helper exists for recommendation memory, preferring TMDB ids and falling back to normalized title plus release year.
+- [x] Favorite/reference movies mentioned in the quiz are excluded from recommendation candidates while still contributing to taste matching.
+- [x] Recommendation feedback is captured from the results page and stored separately from generated recommendation payloads.
+- [x] Signed-in feedback is persisted into `user_movie_interactions` with upsert semantics for `watched`, `liked`, `not_interested`, and `wrong_mood`.
+- [x] Feedback-derived recommendation memory now filters watched/not-interested movies and down-ranks wrong-mood movies for signed-in users.
+- [x] Account recommendation history is deduplicated by movie identity so repeated recommendation attempts do not appear as separate discoveries.
+- [x] Result pages expose a share action that creates/copies a stable recommendation URL.
 
 ### Issues Still Present
 
@@ -116,16 +123,45 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 - Ship Docker/Coolify logs to a searchable log store once local log scrolling becomes painful.
 - Track lightweight operational metrics: recommendation success/failure counts, average recommendation duration, queue depth, failed jobs, OpenAI/TMDB timeout counts, and DB/Redis health failures.
 
+### Security and Reliability Track
+
+- Add per-call OpenAI timeout handling with cancellation where supported, and map upstream timeout failures to clear 504-style API responses.
+- Add request body size limits for externally facing routes before expensive parsing, moderation, embedding, or recommendation work begins.
+- Add retry/backoff and circuit-breaker behavior for expensive external dependencies where retrying is safe.
+- Sanitize client-facing error responses so internal exception details, upstream payloads, and infrastructure hints stay out of API responses.
+- Validate required environment variables on application startup for web, workers, and root services so misconfigured deployments fail early.
+- Clarify idempotency and retry behavior for recommendation creation, worker retries, more-picks jobs, and failed queue recovery.
+- Add dependency/security scanning, static security checks, and periodic security review expectations to CI or maintenance workflows.
+
+### Data Quality Track
+
+- Add a lightweight review path for TMDB backfill cases that are ambiguous, missing metadata, or rejected because runtime/year confidence is too low.
+- Track catalog health signals such as duplicate movie identities, missing posters, missing localized names/overviews, missing runtimes, and stale TMDB metadata.
+- Periodically refresh TMDB-backed metadata for older records without destabilizing existing recommendation history.
+- Make seed, discovery, and backfill responsibilities explicit enough that data-quality fixes do not duplicate or fight each other.
+- Define migration/versioning expectations for schema changes, including production migration safety, rollback notes, and seed/backfill coordination.
+
+### Account Platform Track
+
+- Add a user profile model for display name, avatar, and account settings metadata.
+- Add account settings APIs and UI for profile edits, saved recommendation edits, and taste-profile management.
+- Design a provider identity model before adding magic-link or social login so local credentials and external providers can coexist cleanly.
+- Add saved-recommendation mutations for rename, annotate, remove, and organize actions without leaving the account page.
+- Make taste memory inspectable and editable so users can correct watched, liked, not-interested, and wrong-mood signals.
+
+### Accessibility and UI Quality Track
+
+- Add recurring accessibility checks for keyboard navigation, focus states, labels, color contrast, and reduced-motion behavior.
+- Add focused tests or visual checks for the quiz, loading/results handoff, account pages, and feedback controls.
+- Keep design-system examples aligned with production components so UI regressions are easier to spot before release.
+
 ### Product Feedback Track
 
 - Add an explicit watched-movies library for signed-in users so movies marked as watched are excluded from default recommendations instead of only being inferred from recommendation feedback.
-- Introduce a stable movie identity layer for recommendation memory: prefer TMDB ids when present, and fall back to normalized title plus release year for local-only movies. Use this identity to avoid treating local and TMDB copies of the same movie as separate choices.
-- Add a small `user_movie_interactions` model as the first implementation step. Store `watched`, `liked`, `not_interested`, and `wrong_mood` per signed-in user and movie identity, with upsert semantics so repeated feedback updates the same interaction instead of creating duplicates.
-- Filter `watched` and `not_interested` movies out of default recommendations for signed-in users. Down-rank `wrong_mood` instead of permanently excluding it, and use `liked` as a positive taste signal.
-- Deduplicate account recommendation history by movie identity or clearly group repeated recommendation attempts, so the profile does not look like the system is saving the same movie as separate discoveries.
+- Use `liked` feedback as a positive taste signal in ranking. The interaction is stored today, but current ranking primarily uses negative memory for exclusion/down-ranking.
 - Consider a separate "worth rewatching" angle for watched movies so strong matches can still appear intentionally, with copy that frames them as rewatch candidates instead of new discoveries.
-- Feed watched/not-interested/liked feedback into ranking so future recommendations avoid exact repeats and make the reason for reused titles transparent.
-- Keep the first implementation intentionally small: signed-in feedback should prevent obvious repeat recommendations by default. Manual watched-list management, rewatch mode, richer preference editing, and gamified taste history can follow after the core memory behavior is stable.
+- Make the reason for reused titles transparent when feedback history intentionally allows a repeat.
+- Manual watched-list management, rewatch mode, richer preference editing, and gamified taste history can follow after the core memory behavior is stable.
 
 ## Priority Items for the Next 30 Days
 


### PR DESCRIPTION
## Summary
- add account API support for movie memory summaries and deletion
- show watched/liked/miss memory on the account page with per-movie forget controls
- update roadmap notes for recommendation memory and account improvements

## Test plan
- npm run test --workspace=apps/web -- src/lib/db/recommendations.test.ts src/app/api/account/route.test.ts src/app/api/account/movie-memory/route.test.ts
- npm run lint:check
- npm run type-check
- npm run format:check
- npm run build