### PR TITLE
Fix own recommendation rating ownership

### DIFF
--- a/apps/web/src/lib/db/recommendations.test.ts
+++ b/apps/web/src/lib/db/recommendations.test.ts
@@ -807,6 +807,31 @@ describe('getRecommendationWithMovies', () => {
     expect(result?.isSharedResult).toBe(false);
   });
 
+  it('treats numeric database user ids as owned by the matching signed-in viewer', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'rec-id',
+            status: 'completed',
+            stage: 'complete',
+            error: null,
+            used_broader_search: false,
+            db_movie_count: 12,
+            quiz_data: null,
+            more_picks_status: null,
+            user_id: 42,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const result = await getRecommendationWithMovies('slug-123', '42');
+
+    expect(result?.viewerCanRate).toBe(true);
+    expect(result?.isSharedResult).toBe(false);
+  });
+
   it('returns redacted group metadata instead of raw quiz data', async () => {
     mockQuery
       .mockResolvedValueOnce({

--- a/apps/web/src/lib/db/recommendations.ts
+++ b/apps/web/src/lib/db/recommendations.ts
@@ -538,8 +538,14 @@ export async function getRecommendationWithMovies(
 
   const rec = recResult.rows[0];
   if (!rec) return null;
-  const viewerCanRate = Boolean(viewerUserId && rec.user_id && rec.user_id === viewerUserId);
-  const isSharedResult = Boolean(rec.user_id && rec.user_id !== viewerUserId);
+  const ownerUserId = rec.user_id === null ? null : String(rec.user_id);
+  const normalizedViewerUserId = viewerUserId === undefined ? null : String(viewerUserId);
+  const viewerCanRate = Boolean(
+    normalizedViewerUserId && ownerUserId && ownerUserId === normalizedViewerUserId,
+  );
+  const isSharedResult = Boolean(
+    ownerUserId && (!normalizedViewerUserId || ownerUserId !== normalizedViewerUserId),
+  );
   const peopleCount = getQuizPeopleCount(rec.quiz_data);
   const hasActorSignal = hasFavoriteActorSignal(rec.quiz_data);
   const groupInsights = buildGroupResultInsights(rec.quiz_data);


### PR DESCRIPTION
## Summary
- normalize recommendation owner/viewer ids before deciding whether a result is shared
- restore rating controls for signed-in users viewing their own recommendations
- add a regression test for numeric DB user ids

## Test Plan
- npm run test:server --workspace=apps/web -- src/lib/db/recommendations.test.ts
- npm run lint:check --workspace=apps/web
- npm run type-check --workspace=apps/web
- pre-push: lint, server tests, production build