### PR TITLE
Guard recommendations with movie memory

### DIFF
--- a/apps/web/src/features/recommendation/finalRecommendation.test.ts
+++ b/apps/web/src/features/recommendation/finalRecommendation.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  findCandidateByRecommendedTitle,
+  resolveGuardedRecommendation,
+} from './finalRecommendation';
+
+import type { EnhancedMovieMatch } from './types';
+
+function movie(overrides: Partial<EnhancedMovieMatch>): EnhancedMovieMatch {
+  return {
+    id: 1,
+    name: 'Dark City',
+    age_rating: 'R',
+    description: 'A noir mystery.',
+    duration: 100,
+    score_rating: 7.6,
+    year: 1998,
+    similarity: 0.91,
+    content: 'Dark City (1998) — A noir mystery.',
+    ...overrides,
+  };
+}
+
+describe('final recommendation guard', () => {
+  it('matches a model title that includes the release year', () => {
+    const candidates = [movie({ id: 1, name: 'Dark City', year: 1998 })];
+
+    expect(findCandidateByRecommendedTitle(candidates, 'Dark City (1998)')?.name).toBe('Dark City');
+  });
+
+  it('preserves a recommendation when the title exists in the filtered candidate set', () => {
+    const candidates = [movie({ id: 1, name: 'Dark City' })];
+
+    const result = resolveGuardedRecommendation(
+      { title: 'Dark City', description: 'Perfect for the mood.' },
+      candidates,
+      'en',
+    );
+
+    expect(result.title).toBe('Dark City');
+    expect(result.description).toBe('Perfect for the mood.');
+    expect(result.replacedOutOfSetTitle).toBe(false);
+  });
+
+  it('falls back to the strongest remaining candidate when the model returns a filtered title', () => {
+    const candidates = [
+      movie({ id: 2, name: 'Paprika', similarity: 0.93, year: 2006 }),
+      movie({ id: 3, name: 'Dark City', similarity: 0.9 }),
+    ];
+
+    const result = resolveGuardedRecommendation(
+      { title: 'The Matrix', description: 'The model picked a watched movie.' },
+      candidates,
+      'en',
+    );
+
+    expect(result.title).toBe('Paprika');
+    expect(result.movie.id).toBe(2);
+    expect(result.description).toContain('movie memory');
+    expect(result.replacedOutOfSetTitle).toBe(true);
+  });
+
+  it('returns localized fallback copy', () => {
+    const candidates = [movie({ id: 2, name: 'Паприка', similarity: 0.93 })];
+
+    const result = resolveGuardedRecommendation(
+      { title: 'Матрица', description: 'The model picked a watched movie.' },
+      candidates,
+      'ru',
+    );
+
+    expect(result.description).toContain('памяти о фильмах');
+  });
+});

--- a/apps/web/src/features/recommendation/finalRecommendation.ts
+++ b/apps/web/src/features/recommendation/finalRecommendation.ts
@@ -1,0 +1,91 @@
+import { getMovieTitleKey } from '@/lib/movieIdentity';
+
+import type { EnhancedMovieMatch } from './types';
+import type { Locale } from '@/lib/locale';
+
+type RecommendationMessage = {
+  description: string;
+  title: string;
+};
+
+type CandidateMovie = Pick<EnhancedMovieMatch, 'id' | 'name' | 'year'>;
+
+type GuardedRecommendation<TMovie extends CandidateMovie> = {
+  description: string;
+  movie: TMovie;
+  replacedOutOfSetTitle: boolean;
+  requestedTitle: string;
+  title: string;
+};
+
+function getTitleKeys(title: string, year?: number): Set<string> {
+  const keys = new Set<string>();
+  const titleKey = getMovieTitleKey(title);
+  if (titleKey) keys.add(titleKey);
+
+  const withoutTrailingYear = title.replace(/\s*\(\d{4}\)\s*$/, '');
+  const withoutTrailingYearKey = getMovieTitleKey(withoutTrailingYear);
+  if (withoutTrailingYearKey) keys.add(withoutTrailingYearKey);
+
+  if (year) {
+    const withYearKey = getMovieTitleKey(`${title} (${year})`);
+    if (withYearKey) keys.add(withYearKey);
+  }
+
+  return keys;
+}
+
+export function findCandidateByRecommendedTitle<TMovie extends CandidateMovie>(
+  movies: TMovie[],
+  recommendedTitle: string,
+): TMovie | undefined {
+  const recommendedKeys = getTitleKeys(recommendedTitle);
+  if (recommendedKeys.size === 0) return undefined;
+
+  return movies.find((movie) => {
+    const movieKeys = getTitleKeys(movie.name, movie.year);
+    return Array.from(movieKeys).some((key) => recommendedKeys.has(key));
+  });
+}
+
+function buildMemoryFallbackDescription(movieTitle: string, locale: Locale): string {
+  if (locale === 'ru') {
+    return `${movieTitle} выбран из самых сильных оставшихся совпадений с учетом вашей памяти о фильмах, чтобы не повторять уже просмотренные или недавние рекомендации.`;
+  }
+
+  if (locale === 'fi') {
+    return `${movieTitle} valittiin vahvimmista jäljellä olevista osumista elokuvamuistisi perusteella, jotta emme toista jo katsottuja tai hiljattain suositeltuja elokuvia.`;
+  }
+
+  return `${movieTitle} was picked from your strongest remaining matches after applying your movie memory, so we avoid titles you have already watched or recently seen here.`;
+}
+
+export function resolveGuardedRecommendation<TMovie extends CandidateMovie>(
+  responseMessage: RecommendationMessage,
+  movies: TMovie[],
+  locale: Locale,
+): GuardedRecommendation<TMovie> {
+  const matchedMovie = findCandidateByRecommendedTitle(movies, responseMessage.title);
+  if (matchedMovie) {
+    return {
+      description: responseMessage.description,
+      movie: matchedMovie,
+      replacedOutOfSetTitle: false,
+      requestedTitle: responseMessage.title,
+      title: matchedMovie.name,
+    };
+  }
+
+  const fallbackMovie = movies[0];
+  if (!fallbackMovie) {
+    throw new Error('No recommendation candidates are available.');
+  }
+
+  return {
+    description: buildMemoryFallbackDescription(fallbackMovie.name, locale),
+    movie: fallbackMovie,
+    replacedOutOfSetTitle: true,
+    requestedTitle: responseMessage.title,
+    title: fallbackMovie.name,
+  };
+}

--- a/apps/web/src/features/recommendation/pipeline.ts
+++ b/apps/web/src/features/recommendation/pipeline.ts
@@ -9,7 +9,6 @@ import { getDbClient } from '@/clients/dbClient';
 import { getUserRecommendationFeedbackMoviePreferences } from '@/lib/db/recommendations';
 import { MOVIE_SEED_JOB_OPTIONS, seedQueue } from '@/lib/jobQueue';
 import logger from '@/lib/logger';
-import { getMovieTitleKey } from '@/lib/movieIdentity';
 
 import {
   applyFeedbackToLocalMovies,
@@ -20,6 +19,10 @@ import {
   getMentionedMovieTitleKeys,
 } from './candidateFilters';
 import { createEmbedding, refineQueryWithLLM } from './embedding';
+import {
+  findCandidateByRecommendedTitle,
+  resolveGuardedRecommendation,
+} from './finalRecommendation';
 import { SIMILARITY_THRESHOLD, shouldFallBackToTMDB } from './helpers';
 import {
   enhanceSimilarMoviesWithPosters,
@@ -48,24 +51,6 @@ class EnqueueTimeoutError extends Error {
     super(message);
     this.name = 'EnqueueTimeoutError';
   }
-}
-
-function findRecommendedMovieByTitle<TMovie extends { id: number; name: string }>(
-  movies: TMovie[],
-  recommendedTitle: string,
-): TMovie | undefined {
-  const recommendedTitleKey = getMovieTitleKey(recommendedTitle);
-  if (recommendedTitleKey) {
-    const exactMatch = movies.find((movie) => getMovieTitleKey(movie.name) === recommendedTitleKey);
-    if (exactMatch) return exactMatch;
-  }
-
-  const normalizedRecommendedTitle = recommendedTitle.toLowerCase();
-  return movies.find(
-    (movie) =>
-      movie.name.toLowerCase().includes(normalizedRecommendedTitle) ||
-      normalizedRecommendedTitle.includes(movie.name.toLowerCase()),
-  );
 }
 
 async function withTimeout<T>(
@@ -304,11 +289,43 @@ export async function runRecommendationPipeline(
   // Step 4: Get recommendation from OpenAI
   await emitStage('ai-ranking');
   const responseMessage = await getRecommendation(similarMovies, allPeopleData, locale);
-  logger.info({ recommendedTitle: responseMessage.title }, 'OpenAI recommendation received');
+  const guardedRecommendation = resolveGuardedRecommendation(
+    responseMessage,
+    similarMovies,
+    locale,
+  );
+
+  if (guardedRecommendation.replacedOutOfSetTitle) {
+    logger.warn(
+      {
+        requestedTitle: guardedRecommendation.requestedTitle,
+        fallbackTitle: guardedRecommendation.title,
+        candidateCount: similarMovies.length,
+        feedbackExcludedMovieCount: feedbackSignals.excludedMovieKeys.size,
+        feedbackExcludedTitleCount: feedbackSignals.excludedTitleKeys.size,
+      },
+      'OpenAI returned a movie outside filtered candidates; using strongest remaining candidate',
+    );
+  } else {
+    logger.info(
+      { recommendedTitle: guardedRecommendation.title },
+      'OpenAI recommendation received',
+    );
+  }
 
   // Step 5: Get localized poster + name for main recommendation
   await emitStage('posters');
-  const { posterURL } = await getMovieInfo(responseMessage.title, locale);
+  const guardedMovieTMDBId =
+    guardedRecommendation.movie.tmdbId ??
+    (Number(guardedRecommendation.movie.id) < 0
+      ? Math.abs(Number(guardedRecommendation.movie.id))
+      : undefined);
+  const { posterURL } = await getMovieInfo(
+    guardedRecommendation.title,
+    locale,
+    guardedRecommendation.movie.year,
+    guardedMovieTMDBId ?? undefined,
+  );
 
   // Step 6: Enhance similar movies with poster URLs and localized names (in batches)
   logger.info('Enhancing similar movies with posters');
@@ -324,10 +341,9 @@ export async function runRecommendationPipeline(
   );
 
   // Find the recommended movie
-  const recommendedMovie = findRecommendedMovieByTitle(
-    moviesWithDescriptions,
-    responseMessage.title,
-  );
+  const recommendedMovie =
+    moviesWithDescriptions.find((movie) => movie.id === guardedRecommendation.movie.id) ??
+    findCandidateByRecommendedTitle(moviesWithDescriptions, guardedRecommendation.title);
 
   logger.info(
     { movieCount: moviesWithDescriptions.length },
@@ -335,8 +351,8 @@ export async function runRecommendationPipeline(
   );
 
   return {
-    description: responseMessage.description,
-    title: responseMessage.title,
+    description: guardedRecommendation.description,
+    title: guardedRecommendation.title,
     posterURL: posterURL,
     movieDetails: recommendedMovie
       ? {


### PR DESCRIPTION
## Summary
- require the final AI-picked movie to come from the already filtered candidate list
- fall back to the strongest remaining candidate when OpenAI names a watched/recently excluded title
- add focused tests for title matching, fallback selection, and localized fallback copy

## Why
Movie memory was filtering candidates before ranking, but the model could still name a filtered-out movie in its final answer. This keeps the final result aligned with memory filters without changing the broader retrieval pipeline.

## Test plan
- npm run format:check
- npm run lint:check
- npm run type-check
- npm run test --workspace=apps/web -- src/features/recommendation/finalRecommendation.test.ts src/features/recommendation/candidateFilters.test.ts src/lib/db/recommendations.test.ts
- npm run build
- pre-push hook: lint, server tests, production build