### PR TITLE
Track TMDB backfill review cases

### DIFF
--- a/db/createDB.sql
+++ b/db/createDB.sql
@@ -37,6 +37,31 @@ CREATE UNIQUE INDEX IF NOT EXISTS movies_tmdb_id_unique
   ON movies (tmdb_id)
   WHERE tmdb_id IS NOT NULL;
 
+CREATE TABLE IF NOT EXISTS tmdb_match_reviews (
+  id bigserial PRIMARY KEY,
+  movie_id bigint NOT NULL REFERENCES movies(id) ON DELETE CASCADE,
+  movie_name text NOT NULL,
+  movie_year int NOT NULL,
+  reason text NOT NULL,
+  status text NOT NULL DEFAULT 'open',
+  candidates jsonb NOT NULL DEFAULT '[]'::jsonb,
+  notes text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT tmdb_match_reviews_reason_check CHECK (
+    reason IN ('ambiguous_match', 'runtime_mismatch')
+  ),
+  CONSTRAINT tmdb_match_reviews_status_check CHECK (
+    status IN ('open', 'resolved', 'ignored')
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tmdb_match_reviews_movie_reason
+  ON tmdb_match_reviews (movie_id, reason);
+
+CREATE INDEX IF NOT EXISTS idx_tmdb_match_reviews_status_updated_at
+  ON tmdb_match_reviews (status, updated_at DESC);
+
 CREATE TABLE IF NOT EXISTS users (
   id bigserial PRIMARY KEY,
   email text NOT NULL,

--- a/db/init/01_schema.sql
+++ b/db/init/01_schema.sql
@@ -42,6 +42,31 @@ CREATE UNIQUE INDEX IF NOT EXISTS movies_tmdb_id_unique
   ON movies (tmdb_id)
   WHERE tmdb_id IS NOT NULL;
 
+CREATE TABLE IF NOT EXISTS tmdb_match_reviews (
+  id bigserial PRIMARY KEY,
+  movie_id bigint NOT NULL REFERENCES movies(id) ON DELETE CASCADE,
+  movie_name text NOT NULL,
+  movie_year int NOT NULL,
+  reason text NOT NULL,
+  status text NOT NULL DEFAULT 'open',
+  candidates jsonb NOT NULL DEFAULT '[]'::jsonb,
+  notes text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT tmdb_match_reviews_reason_check CHECK (
+    reason IN ('ambiguous_match', 'runtime_mismatch')
+  ),
+  CONSTRAINT tmdb_match_reviews_status_check CHECK (
+    status IN ('open', 'resolved', 'ignored')
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tmdb_match_reviews_movie_reason
+  ON tmdb_match_reviews (movie_id, reason);
+
+CREATE INDEX IF NOT EXISTS idx_tmdb_match_reviews_status_updated_at
+  ON tmdb_match_reviews (status, updated_at DESC);
+
 CREATE TABLE IF NOT EXISTS users (
   id bigserial PRIMARY KEY,
   email text NOT NULL,

--- a/docs/ROADMAP-ARCHITECTURE.md
+++ b/docs/ROADMAP-ARCHITECTURE.md
@@ -135,7 +135,7 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 
 ### Data Quality Track
 
-- Add a lightweight review path for TMDB backfill cases that are ambiguous, missing metadata, or rejected because runtime/year confidence is too low.
+- Persist TMDB backfill review cases in `tmdb_match_reviews`, then add an admin/back-office UI to resolve ambiguous matches, missing metadata, or rejected runtime/year confidence cases.
 - Track catalog health signals such as duplicate movie identities, missing posters, missing localized names/overviews, missing runtimes, and stale TMDB metadata.
 - Periodically refresh TMDB-backed metadata for older records without destabilizing existing recommendation history.
 - Make seed, discovery, and backfill responsibilities explicit enough that data-quality fixes do not duplicate or fight each other.

--- a/packages/shared/src/db.ts
+++ b/packages/shared/src/db.ts
@@ -149,6 +149,33 @@ export async function ensureSchema(): Promise<void> {
   `);
 
   await getPool().query(`
+    CREATE TABLE IF NOT EXISTS tmdb_match_reviews (
+      id bigserial PRIMARY KEY,
+      movie_id bigint NOT NULL REFERENCES movies(id) ON DELETE CASCADE,
+      movie_name text NOT NULL,
+      movie_year int NOT NULL,
+      reason text NOT NULL,
+      status text NOT NULL DEFAULT 'open',
+      candidates jsonb NOT NULL DEFAULT '[]'::jsonb,
+      notes text,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now(),
+      CONSTRAINT tmdb_match_reviews_reason_check CHECK (
+        reason IN ('ambiguous_match', 'runtime_mismatch')
+      ),
+      CONSTRAINT tmdb_match_reviews_status_check CHECK (
+        status IN ('open', 'resolved', 'ignored')
+      )
+    );
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_tmdb_match_reviews_movie_reason
+      ON tmdb_match_reviews (movie_id, reason);
+
+    CREATE INDEX IF NOT EXISTS idx_tmdb_match_reviews_status_updated_at
+      ON tmdb_match_reviews (status, updated_at DESC);
+  `);
+
+  await getPool().query(`
     DROP FUNCTION IF EXISTS match_movies(vector, float, int);
 
     CREATE OR REPLACE FUNCTION match_movies (

--- a/services/movie-backfill/README.md
+++ b/services/movie-backfill/README.md
@@ -4,13 +4,16 @@ A one-shot script that backfills missing `duration` and `age_rating` data for mo
 
 ## What it does
 
-1. Queries the database for all movies where `duration = 0` (missing runtime).
-2. For each movie, searches TMDB by title + year to find the TMDB movie ID.
-3. Fetches full movie details (runtime + US certification/age_rating) from TMDB.
-4. Re-generates the embedding for each movie (since the embedding text includes duration and age_rating).
-5. Updates the database row with the new `duration`, `age_rating`, and `embedding`.
+1. Queries the database for movies where `tmdb_id IS NULL` or `duration = 0`.
+2. For each movie, searches TMDB by title + year to find a conservative TMDB movie ID match.
+3. Writes ambiguous matches or runtime mismatches to `tmdb_match_reviews` for later manual review.
+4. Fetches full movie details (runtime + US certification/age_rating) from TMDB.
+5. Re-generates the embedding for each movie (since the embedding text includes duration and age_rating).
+6. Updates the database row with the new `tmdb_id`, `duration`, `age_rating`, match confidence, and `embedding`.
 
 Movies for which TMDB returns no runtime are skipped (logged as warnings) so the script never replaces a `0` with another `0`.
+
+Ambiguous TMDB matches are intentionally not auto-applied. They are recorded in `tmdb_match_reviews` with candidate IDs, confidence scores, and a reason (`ambiguous_match` or `runtime_mismatch`) so a future admin/back-office view can resolve them safely.
 
 ## Environment Variables
 

--- a/services/movie-backfill/src/database.test.ts
+++ b/services/movie-backfill/src/database.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import pg from 'pg';
-import { initDatabase, checkTableExists, closeDatabase } from './database.js';
+import {
+  checkTableExists,
+  closeDatabase,
+  ensureTMDBMatchReviewSchema,
+  initDatabase,
+  recordTMDBMatchReview,
+} from './database.js';
 
 vi.mock('pg', () => {
   const mPool = {
@@ -52,6 +58,69 @@ describe('database', () => {
         ['non_existent_table'],
       );
       expect(result).toBe(false);
+    });
+  });
+
+  describe('ensureTMDBMatchReviewSchema', () => {
+    it('creates the TMDB match review table and indexes', async () => {
+      poolMock.query.mockResolvedValueOnce({ rows: [] });
+
+      await ensureTMDBMatchReviewSchema();
+
+      expect(poolMock.query).toHaveBeenCalledTimes(1);
+      const [sql] = poolMock.query.mock.calls[0];
+      expect(sql).toContain('CREATE TABLE IF NOT EXISTS tmdb_match_reviews');
+      expect(sql).toContain('idx_tmdb_match_reviews_movie_reason');
+      expect(sql).toContain('idx_tmdb_match_reviews_status_updated_at');
+    });
+  });
+
+  describe('recordTMDBMatchReview', () => {
+    it('upserts an open review for ambiguous TMDB matches', async () => {
+      poolMock.query.mockResolvedValueOnce({ rows: [] });
+
+      await recordTMDBMatchReview({
+        movie: {
+          id: '42',
+          name: 'Solaris',
+          year: 1972,
+          duration: 166,
+          score_rating: 8.1,
+          description: 'A psychologist is sent to a space station.',
+        },
+        reason: 'ambiguous_match',
+        candidates: [
+          {
+            id: 593,
+            title: 'Solaris',
+            originalTitle: 'Solaris',
+            releaseYear: 1972,
+            confidence: 1,
+          },
+        ],
+        notes: 'TMDB returned multiple candidates.',
+      });
+
+      expect(poolMock.query).toHaveBeenCalledTimes(1);
+      const [sql, params] = poolMock.query.mock.calls[0];
+      expect(sql).toContain('INSERT INTO tmdb_match_reviews');
+      expect(sql).toContain('ON CONFLICT (movie_id, reason) DO UPDATE');
+      expect(params).toEqual([
+        '42',
+        'Solaris',
+        1972,
+        'ambiguous_match',
+        JSON.stringify([
+          {
+            id: 593,
+            title: 'Solaris',
+            originalTitle: 'Solaris',
+            releaseYear: 1972,
+            confidence: 1,
+          },
+        ]),
+        'TMDB returned multiple candidates.',
+      ]);
     });
   });
 });

--- a/services/movie-backfill/src/database.ts
+++ b/services/movie-backfill/src/database.ts
@@ -1,5 +1,7 @@
 import { checkTableExists, closeDatabase, getPool, initDatabase, logger } from '@pop-choice/shared';
 
+import type { TMDBSearchCandidate } from './tmdb.js';
+
 export { initDatabase, closeDatabase, checkTableExists };
 
 export interface IncompleteMovie {
@@ -9,6 +11,44 @@ export interface IncompleteMovie {
   duration: number;
   score_rating: number;
   description: string;
+}
+
+export type TMDBMatchReviewReason = 'ambiguous_match' | 'runtime_mismatch';
+
+export interface RecordTMDBMatchReviewInput {
+  movie: IncompleteMovie;
+  reason: TMDBMatchReviewReason;
+  candidates: TMDBSearchCandidate[];
+  notes?: string;
+}
+
+export async function ensureTMDBMatchReviewSchema(): Promise<void> {
+  await getPool().query(`
+    CREATE TABLE IF NOT EXISTS tmdb_match_reviews (
+      id bigserial PRIMARY KEY,
+      movie_id bigint NOT NULL REFERENCES movies(id) ON DELETE CASCADE,
+      movie_name text NOT NULL,
+      movie_year int NOT NULL,
+      reason text NOT NULL,
+      status text NOT NULL DEFAULT 'open',
+      candidates jsonb NOT NULL DEFAULT '[]'::jsonb,
+      notes text,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now(),
+      CONSTRAINT tmdb_match_reviews_reason_check CHECK (
+        reason IN ('ambiguous_match', 'runtime_mismatch')
+      ),
+      CONSTRAINT tmdb_match_reviews_status_check CHECK (
+        status IN ('open', 'resolved', 'ignored')
+      )
+    );
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_tmdb_match_reviews_movie_reason
+      ON tmdb_match_reviews (movie_id, reason);
+
+    CREATE INDEX IF NOT EXISTS idx_tmdb_match_reviews_status_updated_at
+      ON tmdb_match_reviews (status, updated_at DESC);
+  `);
 }
 
 export async function getIncompleteMovies(limit: number): Promise<IncompleteMovie[]> {
@@ -57,4 +97,31 @@ export async function updateMovie(
     [duration, ageRating, tmdbId, matchConfidence, JSON.stringify(embedding), id],
   );
   logger.debug('Movie updated in database', { id, duration, ageRating, tmdbId, matchConfidence });
+}
+
+export async function recordTMDBMatchReview(input: RecordTMDBMatchReviewInput): Promise<void> {
+  const { movie, reason, candidates, notes } = input;
+
+  await getPool().query(
+    `INSERT INTO tmdb_match_reviews (
+       movie_id, movie_name, movie_year, reason, status, candidates, notes, updated_at
+     )
+     VALUES ($1, $2, $3, $4, 'open', $5::jsonb, $6, now())
+     ON CONFLICT (movie_id, reason) DO UPDATE
+       SET movie_name = EXCLUDED.movie_name,
+           movie_year = EXCLUDED.movie_year,
+           status = 'open',
+           candidates = EXCLUDED.candidates,
+           notes = EXCLUDED.notes,
+           updated_at = now()`,
+    [movie.id, movie.name, movie.year, reason, JSON.stringify(candidates), notes ?? null],
+  );
+
+  logger.debug('TMDB match review recorded', {
+    id: movie.id,
+    name: movie.name,
+    year: movie.year,
+    reason,
+    candidateCount: candidates.length,
+  });
 }

--- a/services/movie-backfill/src/index.ts
+++ b/services/movie-backfill/src/index.ts
@@ -18,10 +18,13 @@ import { loadConfig } from './config.js';
 import {
   checkTableExists,
   closeDatabase,
+  ensureTMDBMatchReviewSchema,
   getIncompleteMovies,
   initDatabase,
+  recordTMDBMatchReview,
   updateMovie,
   type IncompleteMovie,
+  type RecordTMDBMatchReviewInput,
 } from './database.js';
 import { createEmbeddings } from './embeddings.js';
 import { logger } from './logger.js';
@@ -47,6 +50,24 @@ function isRuntimeCompatible(existingRuntime: number, tmdbRuntime: number): bool
   return Math.abs(existingRuntime - tmdbRuntime) <= 20;
 }
 
+async function maybeRecordTMDBMatchReview(
+  config: ReturnType<typeof loadConfig>,
+  input: RecordTMDBMatchReviewInput,
+): Promise<void> {
+  if (config.dryRun) {
+    logger.info('DRY RUN: would record TMDB match review', {
+      id: input.movie.id,
+      name: input.movie.name,
+      year: input.movie.year,
+      reason: input.reason,
+      candidateCount: input.candidates.length,
+    });
+    return;
+  }
+
+  await recordTMDBMatchReview(input);
+}
+
 async function main(): Promise<void> {
   const config = loadConfig();
 
@@ -69,6 +90,8 @@ async function main(): Promise<void> {
       logger.info("Table 'movies' does not exist — skipping backfill");
       return;
     }
+
+    await ensureTMDBMatchReviewSchema();
 
     const movies = await getIncompleteMovies(config.maxMovies);
     logger.info('Fetched movies needing TMDB identity or metadata backfill', {
@@ -103,6 +126,12 @@ async function main(): Promise<void> {
                 name: movie.name,
                 year: movie.year,
                 candidates: match.candidates,
+              });
+              await maybeRecordTMDBMatchReview(config, {
+                movie,
+                reason: 'ambiguous_match',
+                candidates: match.candidates,
+                notes: 'TMDB returned multiple high-confidence title/year candidates.',
               });
               totalSkipped++;
               return;
@@ -154,6 +183,12 @@ async function main(): Promise<void> {
                 tmdbRuntime: runtime,
                 matchConfidence: match.confidence,
                 candidates: match.candidates,
+              });
+              await maybeRecordTMDBMatchReview(config, {
+                movie,
+                reason: 'runtime_mismatch',
+                candidates: match.candidates,
+                notes: `Existing runtime ${movie.duration} min did not match TMDB runtime ${runtime} min for candidate ${match.tmdbId}.`,
               });
               totalSkipped++;
               return;


### PR DESCRIPTION
## Summary
- add tmdb_match_reviews schema to capture ambiguous and runtime-mismatch TMDB backfill cases
- persist review rows from the movie-backfill service instead of only logging skipped matches
- document the backfill review flow and roadmap/admin-panel follow-up

## Tests
- npm run test --workspace=services/movie-backfill
- npm run type-check
- npm run lint:check
- npm run format:check
- npm run build
- npm run test
- pre-push checks