### PR TITLE
Add catalog health report

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ npm run setup:local-db       # Generate credentials, start Docker PostgreSQL
 npm run copy:env             # Sync root .env into apps/services workspaces
 npm run migrate:db           # Apply idempotent SQL migrations
 npm run populate-db          # Populate database with movie data
+npm run catalog:health       # Report catalog metadata coverage and likely duplicates
 npm run analyze-movies       # Analyze movie data for embeddings
 npm run calibrate-similarity # Calibrate vector similarity thresholds
 npm run test:services        # Run service test scripts via Turbo

--- a/docs/BOUNDARIES.md
+++ b/docs/BOUNDARIES.md
@@ -6,6 +6,8 @@ This document defines the intended ownership boundaries for PopChoice in its cur
 
 - `apps/web` owns the user-facing Next.js app, API routes, page composition, and app-specific runtime wiring.
 - `apps/bull-board` owns queue monitoring UI and operational tooling for BullMQ.
+- Future admin/backoffice screens should live in a dedicated app, not in
+  `apps/web`.
 - `services/*` own background and offline processes that can run independently from the web app.
 - `packages/shared` owns low-level shared helpers already reused across root services.
 

--- a/docs/ROADMAP-ARCHITECTURE.md
+++ b/docs/ROADMAP-ARCHITECTURE.md
@@ -157,7 +157,7 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 ### Data Quality Track
 
 - Persist TMDB backfill review cases in `tmdb_match_reviews`, then add an admin/back-office UI to resolve ambiguous matches, missing metadata, or rejected runtime/year confidence cases.
-- Track catalog health signals such as duplicate movie identities, missing posters, missing localized names/overviews, missing runtimes, and stale TMDB metadata.
+- Track catalog health signals such as duplicate movie identities, missing posters, missing localized names/overviews, missing runtimes, and stale TMDB metadata. The initial `npm run catalog:health` report covers current `movies` schema signals; admin resolution and automated refresh remain future work.
 - Periodically refresh TMDB-backed metadata for older records without destabilizing existing recommendation history.
 - Make seed, discovery, and backfill responsibilities explicit enough that data-quality fixes do not duplicate or fight each other.
 - Define migration/versioning expectations for schema changes, including production migration safety, rollback notes, and seed/backfill coordination.
@@ -221,7 +221,7 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 2. [ ] Move account/movie-memory orchestration behind a feature-owned module if the API route keeps growing.
 3. [x] Add batched movie-memory deck submission so users can review a session locally before writing interactions.
 4. [ ] Use `liked` memory as a positive recommendation signal, not only stored account history.
-5. [ ] Add catalog-health reporting for missing posters, missing localized names, duplicate identities, and stale TMDB metadata.
+5. [x] Add catalog-health reporting for missing posters, missing localized names, duplicate identities, and stale TMDB metadata.
 6. [ ] Clarify production migration/versioning expectations for schema changes, rollbacks, and preview volume recreation.
 
 ## Working Checklist

--- a/docs/ROADMAP-ARCHITECTURE.md
+++ b/docs/ROADMAP-ARCHITECTURE.md
@@ -152,12 +152,18 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 - Sanitize client-facing error responses so internal exception details, upstream payloads, and infrastructure hints stay out of API responses.
 - Validate required environment variables on application startup for web, workers, and root services so misconfigured deployments fail early.
 - Clarify idempotency and retry behavior for recommendation creation, worker retries, more-picks jobs, and failed queue recovery.
+- Add a shared operator login model for operational apps. `apps/bull-board` is
+  currently unprotected, and a future backoffice app should use the same
+  protection instead of embedding admin access in the user-facing web app.
 - Add dependency/security scanning, static security checks, and periodic security review expectations to CI or maintenance workflows.
 
 ### Data Quality Track
 
 - Persist TMDB backfill review cases in `tmdb_match_reviews`, then add an admin/back-office UI to resolve ambiguous matches, missing metadata, or rejected runtime/year confidence cases.
 - Track catalog health signals such as duplicate movie identities, missing posters, missing localized names/overviews, missing runtimes, and stale TMDB metadata. The initial `npm run catalog:health` report covers current `movies` schema signals; admin resolution and automated refresh remain future work.
+- Create a dedicated backoffice app for catalog-health reports, TMDB match
+  review queues, and later manual data repair. Do not add this UI to
+  `apps/web`; that app remains user-facing.
 - Periodically refresh TMDB-backed metadata for older records without destabilizing existing recommendation history.
 - Make seed, discovery, and backfill responsibilities explicit enough that data-quality fixes do not duplicate or fight each other.
 - Define migration/versioning expectations for schema changes, including production migration safety, rollback notes, and seed/backfill coordination.
@@ -222,7 +228,8 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 3. [x] Add batched movie-memory deck submission so users can review a session locally before writing interactions.
 4. [ ] Use `liked` memory as a positive recommendation signal, not only stored account history.
 5. [x] Add catalog-health reporting for missing posters, missing localized names, duplicate identities, and stale TMDB metadata.
-6. [ ] Clarify production migration/versioning expectations for schema changes, rollbacks, and preview volume recreation.
+6. [ ] Create a dedicated backoffice app for catalog-health and TMDB review, then add shared login protection for it and `apps/bull-board`.
+7. [ ] Clarify production migration/versioning expectations for schema changes, rollbacks, and preview volume recreation.
 
 ## Working Checklist
 

--- a/docs/SERVICES.md
+++ b/docs/SERVICES.md
@@ -241,6 +241,10 @@ Run it from the repo root:
 npm run catalog:health
 ```
 
+The current report is CLI-only. A future dedicated backoffice app should expose
+the same data in a browser without putting admin or operational UI inside the
+user-facing `apps/web` application.
+
 Useful options:
 
 | Variable                      | Default | Description                                             |

--- a/docs/SERVICES.md
+++ b/docs/SERVICES.md
@@ -6,11 +6,12 @@ This document describes the background services that populate and maintain the m
 
 ## Services Overview
 
-| Service                 | Type                  | Trigger                                           | Source        |
+| Service / Tool          | Type                  | Trigger                                           | Source        |
 | ----------------------- | --------------------- | ------------------------------------------------- | ------------- |
 | `movie-seed`            | One-shot              | Manual / CI                                       | `movies.txt`  |
 | `movie-discovery`       | Scheduled             | Cron / One-shot                                   | TMDB API      |
 | `movie-backfill`        | One-shot              | Manual                                            | TMDB API      |
+| `catalog:health`        | Read-only report      | Manual / CI                                       | PostgreSQL    |
 | BullMQ `recommendation` | Per-request           | HTTP POST to /api/recommendations                 | TMDB + OpenAI |
 | BullMQ `more-picks`     | On demand             | HTTP POST to /api/recommendations/[id]/more-picks | TMDB + OpenAI |
 | BullMQ `movie-seed`     | Triggered by pipeline | Internal recommendation/more-picks JIT seeding    | TMDB          |
@@ -194,7 +195,7 @@ npm test                 # run vitest tests
 
 ### How it works
 
-1. Queries the database for movies where `tmdb_id IS NULL` or `duration = 0`.
+1. Queries the database for movies where `tmdb_id IS NULL`, `duration = 0`, or `poster_url IS NULL`.
 2. Searches TMDB by title + year to find a conservative TMDB identity match.
 3. Records ambiguous matches and runtime mismatches in `tmdb_match_reviews`.
 4. Fetches full movie details (runtime + US certification/age_rating) from TMDB.
@@ -223,6 +224,36 @@ cd services/movie-backfill
 npm install
 npm run dev              # run backfill
 DRY_RUN=true npm run dev # dry run
+```
+
+### Catalog health report
+
+`movie-backfill` also owns a read-only catalog health report for metadata visibility. It only runs `SELECT` queries and reports:
+
+- Missing `poster_url`, `localized_name`, `tmdb_id`, runtime, age rating, and TMDB match timestamps.
+- TMDB-backed rows whose `tmdb_matched_at` is older than the stale threshold.
+- Likely duplicate identities by repeated `tmdb_id` and normalized title/year groups.
+- Sample movie rows for each issue so local or CI logs point at concrete records.
+
+Run it from the repo root:
+
+```bash
+npm run catalog:health
+```
+
+Useful options:
+
+| Variable                      | Default | Description                                             |
+| ----------------------------- | ------- | ------------------------------------------------------- |
+| `DATABASE_URL`                | —       | PostgreSQL connection string; loaded from root `.env`   |
+| `CATALOG_HEALTH_FORMAT`       | `text`  | `text` for readable logs, `json` for machine parsing    |
+| `CATALOG_HEALTH_SAMPLE_LIMIT` | `5`     | Sample rows or duplicate groups to show per issue       |
+| `CATALOG_HEALTH_STALE_DAYS`   | `180`   | Age threshold for stale TMDB metadata, in calendar days |
+
+Example:
+
+```bash
+CATALOG_HEALTH_FORMAT=json CATALOG_HEALTH_SAMPLE_LIMIT=3 npm run catalog:health
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "build": "npm run build --workspace=apps/web",
     "build:services": "turbo run build --filter=./services/*",
+    "catalog:health": "npm run catalog:health --workspace=movie-backfill",
     "cleanup:local-db": "bash scripts/cleanup-local-db.sh",
     "copy:env": "bash scripts/copy-env.sh",
     "dev": "npm run dev --workspace=apps/web",

--- a/services/movie-backfill/README.md
+++ b/services/movie-backfill/README.md
@@ -76,6 +76,9 @@ The workspace script loads `DATABASE_URL` from the repository root `.env`.
 
 The report counts missing `poster_url`, missing `localized_name`, missing `tmdb_id`, missing runtime, missing age rating, TMDB-backed rows without `tmdb_matched_at`, stale TMDB metadata, duplicate TMDB ids, and likely duplicate normalized title/year identities. It includes sample rows for each issue.
 
+Browser access should be added later through a dedicated backoffice app, not the
+user-facing web app.
+
 Options:
 
 | Variable                      | Default | Description                                          |

--- a/services/movie-backfill/README.md
+++ b/services/movie-backfill/README.md
@@ -1,10 +1,10 @@
 # movie-backfill
 
-A one-shot script that backfills missing `duration` and `age_rating` data for movies already in the database that were seeded without runtime information.
+A one-shot script that backfills missing `duration`, `age_rating`, TMDB identity, and poster metadata for movies already in the database. It also includes a read-only catalog health report for metadata coverage checks.
 
 ## What it does
 
-1. Queries the database for movies where `tmdb_id IS NULL` or `duration = 0`.
+1. Queries the database for movies where `tmdb_id IS NULL`, `duration = 0`, or `poster_url IS NULL`.
 2. For each movie, searches TMDB by title + year to find a conservative TMDB movie ID match.
 3. Writes ambiguous matches or runtime mismatches to `tmdb_match_reviews` for later manual review.
 4. Fetches full movie details (runtime + US certification/age_rating) from TMDB.
@@ -62,4 +62,30 @@ Increase batch size for faster processing (may hit TMDB rate limits):
 
 ```bash
 BATCH_SIZE=10 npx tsx src/index.ts
+```
+
+## Catalog health report
+
+Run a read-only report for catalog/data-health issues:
+
+```bash
+npm run catalog:health
+```
+
+The workspace script loads `DATABASE_URL` from the repository root `.env`.
+
+The report counts missing `poster_url`, missing `localized_name`, missing `tmdb_id`, missing runtime, missing age rating, TMDB-backed rows without `tmdb_matched_at`, stale TMDB metadata, duplicate TMDB ids, and likely duplicate normalized title/year identities. It includes sample rows for each issue.
+
+Options:
+
+| Variable                      | Default | Description                                          |
+| ----------------------------- | ------- | ---------------------------------------------------- |
+| `CATALOG_HEALTH_FORMAT`       | `text`  | Use `json` for machine-readable output               |
+| `CATALOG_HEALTH_SAMPLE_LIMIT` | `5`     | Sample rows or duplicate groups to include per issue |
+| `CATALOG_HEALTH_STALE_DAYS`   | `180`   | Stale threshold for `tmdb_matched_at`                |
+
+Example:
+
+```bash
+CATALOG_HEALTH_FORMAT=json CATALOG_HEALTH_SAMPLE_LIMIT=3 npm run catalog:health
 ```

--- a/services/movie-backfill/package.json
+++ b/services/movie-backfill/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
+    "catalog:health": "tsx --env-file=../../.env src/catalog-health-report.ts",
     "dev": "tsx src/index.ts",
     "start": "node dist/index.js",
     "test": "vitest run"

--- a/services/movie-backfill/src/catalog-health-report.ts
+++ b/services/movie-backfill/src/catalog-health-report.ts
@@ -1,0 +1,65 @@
+/**
+ * Read-only catalog health report.
+ *
+ * Environment variables:
+ *   DATABASE_URL                 - PostgreSQL connection string (required)
+ *   CATALOG_HEALTH_FORMAT        - "text" or "json" (default: "text")
+ *   CATALOG_HEALTH_SAMPLE_LIMIT  - Number of samples/groups per issue (default: 5)
+ *   CATALOG_HEALTH_STALE_DAYS    - TMDB metadata age threshold (default: 180)
+ */
+
+import { parsePositiveInt, requireEnvVars } from '@pop-choice/shared';
+
+import { formatCatalogHealthReport, getCatalogHealthReport } from './catalog-health.js';
+import { checkTableExists, closeDatabase, initDatabase } from './database.js';
+import { logger } from './logger.js';
+
+type OutputFormat = 'json' | 'text';
+
+function loadOutputFormat(): OutputFormat {
+  const raw = process.env.CATALOG_HEALTH_FORMAT ?? 'text';
+  if (raw === 'json' || raw === 'text') return raw;
+  throw new Error(`CATALOG_HEALTH_FORMAT must be "text" or "json", got: ${JSON.stringify(raw)}`);
+}
+
+async function main(): Promise<void> {
+  const env = requireEnvVars(['DATABASE_URL']);
+  const outputFormat = loadOutputFormat();
+  const sampleLimit = parsePositiveInt(
+    process.env.CATALOG_HEALTH_SAMPLE_LIMIT,
+    5,
+    'CATALOG_HEALTH_SAMPLE_LIMIT',
+  );
+  const staleAfterDays = parsePositiveInt(
+    process.env.CATALOG_HEALTH_STALE_DAYS,
+    180,
+    'CATALOG_HEALTH_STALE_DAYS',
+  );
+
+  initDatabase(env.DATABASE_URL);
+
+  try {
+    const tableExists = await checkTableExists('movies');
+    if (!tableExists) {
+      throw new Error(
+        "Cannot generate catalog health report because table 'movies' does not exist",
+      );
+    }
+
+    const report = await getCatalogHealthReport({ sampleLimit, staleAfterDays });
+    if (outputFormat === 'json') {
+      console.log(JSON.stringify(report, null, 2));
+    } else {
+      process.stdout.write(formatCatalogHealthReport(report));
+    }
+  } finally {
+    await closeDatabase();
+  }
+}
+
+main().catch((error) => {
+  logger.error('Catalog health report failed', {
+    err: error instanceof Error ? error : new Error(String(error)),
+  });
+  process.exitCode = 1;
+});

--- a/services/movie-backfill/src/catalog-health.test.ts
+++ b/services/movie-backfill/src/catalog-health.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import pg from 'pg';
+
+import {
+  formatCatalogHealthReport,
+  getCatalogHealthReport,
+  type CatalogHealthReport,
+} from './catalog-health.js';
+import { closeDatabase, initDatabase } from './database.js';
+
+vi.mock('pg', () => {
+  const mPool = {
+    query: vi.fn(),
+    end: vi.fn(),
+  };
+  return {
+    default: {
+      Pool: vi.fn(function () {
+        return mPool;
+      }),
+    },
+  };
+});
+
+describe('catalog health report', () => {
+  let poolMock: any;
+
+  beforeEach(() => {
+    initDatabase('postgres://user:pass@localhost:5432/db');
+    poolMock = new pg.Pool();
+  });
+
+  afterEach(async () => {
+    await closeDatabase();
+    vi.clearAllMocks();
+  });
+
+  it('collects read-only catalog health counts, samples, and duplicate groups', async () => {
+    poolMock.query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            total_movies: 4,
+            missing_poster_url: 1,
+            missing_localized_name: 2,
+            missing_tmdb_id: 1,
+            missing_runtime: 1,
+            missing_age_rating: 0,
+            missing_tmdb_matched_at: 1,
+            stale_tmdb_metadata: 1,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: '1',
+            name: 'Solaris',
+            year: 1972,
+            tmdb_id: 593,
+            poster_url: null,
+            localized_name: 'Solaris Localized',
+            duration: 166,
+            age_rating: 'PG',
+            tmdb_matched_at: '2026-01-01T00:00:00.000Z',
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            identity_key: '593',
+            duplicate_count: 2,
+            total_groups: 1,
+            movies: [
+              { id: '1', name: 'Solaris', year: 1972, tmdb_id: 593 },
+              { id: '4', name: 'Solaris Duplicate', year: 1972, tmdb_id: 593 },
+            ],
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            identity_key: 'solaris:1972',
+            duplicate_count: 2,
+            total_groups: 1,
+            movies: [
+              { id: '1', name: 'Solaris', year: 1972, tmdb_id: 593 },
+              { id: '2', name: 'Solaris!', year: 1972, tmdb_id: null },
+            ],
+          },
+        ],
+      });
+
+    const report = await getCatalogHealthReport({ sampleLimit: 3, staleAfterDays: 90 });
+
+    expect(report.totalMovies).toBe(4);
+    expect(report.staleAfterDays).toBe(90);
+    expect(report.issues.find((issue) => issue.key === 'missing_poster_url')).toMatchObject({
+      count: 1,
+      samples: [{ id: '1', name: 'Solaris', tmdb_id: 593 }],
+    });
+    expect(report.duplicateTmdbIds).toMatchObject({
+      totalGroups: 1,
+      groups: [{ identityKey: '593', count: 2 }],
+    });
+    expect(report.duplicateNormalizedTitleYears).toMatchObject({
+      totalGroups: 1,
+      groups: [{ identityKey: 'solaris:1972', count: 2 }],
+    });
+
+    for (const [sql] of poolMock.query.mock.calls) {
+      const normalizedSql = String(sql).trim().toLowerCase();
+      expect(normalizedSql).toMatch(/^(select|with)\b/);
+      expect(normalizedSql).not.toMatch(/\b(insert|update|delete|alter|create|drop)\b/);
+    }
+  });
+
+  it('formats text output for local and CI logs', () => {
+    const report: CatalogHealthReport = {
+      generatedAt: '2026-05-22T10:00:00.000Z',
+      staleAfterDays: 180,
+      totalMovies: 2,
+      issues: [
+        {
+          key: 'missing_poster_url',
+          label: 'Missing poster_url',
+          count: 1,
+          samples: [
+            {
+              id: '1',
+              name: 'Solaris',
+              year: 1972,
+              tmdb_id: 593,
+              poster_url: null,
+              localized_name: 'Solaris Localized',
+              duration: 166,
+              age_rating: 'PG',
+              tmdb_matched_at: null,
+            },
+          ],
+        },
+      ],
+      duplicateTmdbIds: { totalGroups: 0, groups: [] },
+      duplicateNormalizedTitleYears: {
+        totalGroups: 1,
+        groups: [
+          {
+            identityKey: 'solaris:1972',
+            count: 2,
+            movies: [
+              { id: '1', name: 'Solaris', year: 1972, tmdb_id: 593 },
+              { id: '2', name: 'Solaris!', year: 1972, tmdb_id: null },
+            ],
+          },
+        ],
+      },
+    };
+
+    expect(formatCatalogHealthReport(report)).toContain('Catalog health report');
+    expect(formatCatalogHealthReport(report)).toContain('- Missing poster_url: 1');
+    expect(formatCatalogHealthReport(report)).toContain(
+      'Duplicate normalized title/year groups: 1',
+    );
+    expect(formatCatalogHealthReport(report)).toContain('#1 Solaris (1972) tmdb:593');
+  });
+});

--- a/services/movie-backfill/src/catalog-health.ts
+++ b/services/movie-backfill/src/catalog-health.ts
@@ -1,0 +1,356 @@
+import { getPool } from '@pop-choice/shared';
+
+export interface CatalogHealthOptions {
+  sampleLimit: number;
+  staleAfterDays: number;
+}
+
+export interface CatalogMovieSample {
+  id: string;
+  name: string;
+  year: number;
+  tmdb_id: number | null;
+  poster_url: string | null;
+  localized_name: string | null;
+  duration: number;
+  age_rating: string;
+  tmdb_matched_at: string | null;
+}
+
+export interface CatalogHealthIssue {
+  key: string;
+  label: string;
+  count: number;
+  samples: CatalogMovieSample[];
+}
+
+export interface DuplicateIdentityGroup {
+  identityKey: string;
+  count: number;
+  movies: Pick<CatalogMovieSample, 'id' | 'name' | 'year' | 'tmdb_id'>[];
+}
+
+export interface DuplicateIdentityReport {
+  totalGroups: number;
+  groups: DuplicateIdentityGroup[];
+}
+
+export interface CatalogHealthReport {
+  generatedAt: string;
+  staleAfterDays: number;
+  totalMovies: number;
+  issues: CatalogHealthIssue[];
+  duplicateTmdbIds: DuplicateIdentityReport;
+  duplicateNormalizedTitleYears: DuplicateIdentityReport;
+}
+
+interface SummaryRow {
+  total_movies: number;
+  missing_poster_url: number;
+  missing_localized_name: number;
+  missing_tmdb_id: number;
+  missing_runtime: number;
+  missing_age_rating: number;
+  missing_tmdb_matched_at: number;
+  stale_tmdb_metadata: number;
+}
+
+interface IssueDefinition {
+  key: keyof Omit<SummaryRow, 'total_movies'>;
+  label: string;
+  where: string;
+}
+
+const ISSUE_DEFINITIONS: IssueDefinition[] = [
+  {
+    key: 'missing_poster_url',
+    label: 'Missing poster_url',
+    where: "poster_url IS NULL OR btrim(poster_url) = ''",
+  },
+  {
+    key: 'missing_localized_name',
+    label: 'Missing localized_name',
+    where: "localized_name IS NULL OR btrim(localized_name) = ''",
+  },
+  {
+    key: 'missing_tmdb_id',
+    label: 'Missing tmdb_id',
+    where: 'tmdb_id IS NULL',
+  },
+  {
+    key: 'missing_runtime',
+    label: 'Missing runtime',
+    where: 'duration <= 0',
+  },
+  {
+    key: 'missing_age_rating',
+    label: 'Missing age_rating',
+    where: "age_rating IS NULL OR btrim(age_rating) = ''",
+  },
+  {
+    key: 'missing_tmdb_matched_at',
+    label: 'TMDB-backed rows missing tmdb_matched_at',
+    where: 'tmdb_id IS NOT NULL AND tmdb_matched_at IS NULL',
+  },
+  {
+    key: 'stale_tmdb_metadata',
+    label: 'Stale TMDB metadata',
+    where: "tmdb_id IS NOT NULL AND tmdb_matched_at < now() - ($1::int * interval '1 day')",
+  },
+];
+
+function toNumber(value: number | string | null | undefined): number {
+  if (value === null || value === undefined) return 0;
+  return Number(value);
+}
+
+function normalizeSample(row: CatalogMovieSample): CatalogMovieSample {
+  return {
+    id: String(row.id),
+    name: row.name,
+    year: Number(row.year),
+    tmdb_id: row.tmdb_id === null ? null : Number(row.tmdb_id),
+    poster_url: row.poster_url,
+    localized_name: row.localized_name,
+    duration: Number(row.duration),
+    age_rating: row.age_rating,
+    tmdb_matched_at: row.tmdb_matched_at,
+  };
+}
+
+function parseMovies(
+  movies: string | Pick<CatalogMovieSample, 'id' | 'name' | 'year' | 'tmdb_id'>[],
+): Pick<CatalogMovieSample, 'id' | 'name' | 'year' | 'tmdb_id'>[] {
+  const parsed = (typeof movies === 'string' ? JSON.parse(movies) : movies) as Pick<
+    CatalogMovieSample,
+    'id' | 'name' | 'year' | 'tmdb_id'
+  >[];
+  return parsed.map((movie) => ({
+    id: String(movie.id),
+    name: movie.name,
+    year: Number(movie.year),
+    tmdb_id: movie.tmdb_id === null ? null : Number(movie.tmdb_id),
+  }));
+}
+
+async function getIssueSamples(
+  issue: IssueDefinition,
+  options: CatalogHealthOptions,
+): Promise<CatalogMovieSample[]> {
+  const params =
+    issue.key === 'stale_tmdb_metadata'
+      ? [options.staleAfterDays, options.sampleLimit]
+      : [options.sampleLimit];
+  const limitParam = issue.key === 'stale_tmdb_metadata' ? '$2' : '$1';
+  const result = await getPool().query<CatalogMovieSample>(
+    `SELECT id::text, name, year, tmdb_id, poster_url, localized_name, duration, age_rating, tmdb_matched_at::text
+       FROM movies
+      WHERE ${issue.where}
+      ORDER BY id
+      LIMIT ${limitParam}`,
+    params,
+  );
+
+  return result.rows.map(normalizeSample);
+}
+
+async function getSummary(staleAfterDays: number): Promise<SummaryRow> {
+  const result = await getPool().query<SummaryRow>(
+    `SELECT
+        COUNT(*)::int AS total_movies,
+        COUNT(*) FILTER (WHERE poster_url IS NULL OR btrim(poster_url) = '')::int AS missing_poster_url,
+        COUNT(*) FILTER (WHERE localized_name IS NULL OR btrim(localized_name) = '')::int AS missing_localized_name,
+        COUNT(*) FILTER (WHERE tmdb_id IS NULL)::int AS missing_tmdb_id,
+        COUNT(*) FILTER (WHERE duration <= 0)::int AS missing_runtime,
+        COUNT(*) FILTER (WHERE age_rating IS NULL OR btrim(age_rating) = '')::int AS missing_age_rating,
+        COUNT(*) FILTER (WHERE tmdb_id IS NOT NULL AND tmdb_matched_at IS NULL)::int AS missing_tmdb_matched_at,
+        COUNT(*) FILTER (
+          WHERE tmdb_id IS NOT NULL
+            AND tmdb_matched_at < now() - ($1::int * interval '1 day')
+        )::int AS stale_tmdb_metadata
+       FROM movies`,
+    [staleAfterDays],
+  );
+
+  const row = result.rows[0];
+  return {
+    total_movies: toNumber(row?.total_movies),
+    missing_poster_url: toNumber(row?.missing_poster_url),
+    missing_localized_name: toNumber(row?.missing_localized_name),
+    missing_tmdb_id: toNumber(row?.missing_tmdb_id),
+    missing_runtime: toNumber(row?.missing_runtime),
+    missing_age_rating: toNumber(row?.missing_age_rating),
+    missing_tmdb_matched_at: toNumber(row?.missing_tmdb_matched_at),
+    stale_tmdb_metadata: toNumber(row?.stale_tmdb_metadata),
+  };
+}
+
+async function getDuplicateTmdbIds(limit: number): Promise<DuplicateIdentityReport> {
+  const result = await getPool().query<{
+    identity_key: string;
+    duplicate_count: number | string;
+    total_groups: number | string;
+    movies: string | Pick<CatalogMovieSample, 'id' | 'name' | 'year' | 'tmdb_id'>[];
+  }>(
+    `WITH duplicate_groups AS (
+        SELECT
+          tmdb_id::text AS identity_key,
+          COUNT(*)::int AS duplicate_count,
+          json_agg(
+            json_build_object('id', id::text, 'name', name, 'year', year, 'tmdb_id', tmdb_id)
+            ORDER BY id
+          ) AS movies
+        FROM movies
+        WHERE tmdb_id IS NOT NULL
+        GROUP BY tmdb_id
+        HAVING COUNT(*) > 1
+      )
+      SELECT identity_key, duplicate_count, movies, COUNT(*) OVER()::int AS total_groups
+      FROM duplicate_groups
+      ORDER BY duplicate_count DESC, identity_key
+      LIMIT $1`,
+    [limit],
+  );
+
+  return {
+    totalGroups: toNumber(result.rows[0]?.total_groups),
+    groups: result.rows.map((row) => ({
+      identityKey: row.identity_key,
+      count: toNumber(row.duplicate_count),
+      movies: parseMovies(row.movies),
+    })),
+  };
+}
+
+async function getDuplicateNormalizedTitleYears(limit: number): Promise<DuplicateIdentityReport> {
+  const result = await getPool().query<{
+    identity_key: string;
+    duplicate_count: number | string;
+    total_groups: number | string;
+    movies: string | Pick<CatalogMovieSample, 'id' | 'name' | 'year' | 'tmdb_id'>[];
+  }>(
+    `WITH keyed_movies AS (
+        SELECT
+          id,
+          name,
+          year,
+          tmdb_id,
+          concat(lower(regexp_replace(btrim(name), '[^[:alnum:]]+', '', 'g')), ':', year) AS identity_key
+        FROM movies
+      ),
+      duplicate_groups AS (
+        SELECT
+          identity_key,
+          COUNT(*)::int AS duplicate_count,
+          json_agg(
+            json_build_object('id', id::text, 'name', name, 'year', year, 'tmdb_id', tmdb_id)
+            ORDER BY id
+          ) AS movies
+        FROM keyed_movies
+        WHERE identity_key <> concat(':', year)
+        GROUP BY identity_key
+        HAVING COUNT(*) > 1
+      )
+      SELECT identity_key, duplicate_count, movies, COUNT(*) OVER()::int AS total_groups
+      FROM duplicate_groups
+      ORDER BY duplicate_count DESC, identity_key
+      LIMIT $1`,
+    [limit],
+  );
+
+  return {
+    totalGroups: toNumber(result.rows[0]?.total_groups),
+    groups: result.rows.map((row) => ({
+      identityKey: row.identity_key,
+      count: toNumber(row.duplicate_count),
+      movies: parseMovies(row.movies),
+    })),
+  };
+}
+
+export async function getCatalogHealthReport(
+  options: CatalogHealthOptions,
+): Promise<CatalogHealthReport> {
+  const summary = await getSummary(options.staleAfterDays);
+  const issues = await Promise.all(
+    ISSUE_DEFINITIONS.map(async (issue) => ({
+      key: issue.key,
+      label: issue.label,
+      count: summary[issue.key],
+      samples: await getIssueSamples(issue, options),
+    })),
+  );
+
+  const [duplicateTmdbIds, duplicateNormalizedTitleYears] = await Promise.all([
+    getDuplicateTmdbIds(options.sampleLimit),
+    getDuplicateNormalizedTitleYears(options.sampleLimit),
+  ]);
+
+  return {
+    generatedAt: new Date().toISOString(),
+    staleAfterDays: options.staleAfterDays,
+    totalMovies: summary.total_movies,
+    issues,
+    duplicateTmdbIds,
+    duplicateNormalizedTitleYears,
+  };
+}
+
+function formatMovieSample(movie: CatalogMovieSample): string {
+  const tmdb = movie.tmdb_id === null ? 'tmdb:-' : `tmdb:${movie.tmdb_id}`;
+  return `#${movie.id} ${movie.name} (${movie.year}) ${tmdb}`;
+}
+
+function formatDuplicateGroup(group: DuplicateIdentityGroup): string {
+  const movies = group.movies
+    .map((movie) => {
+      const tmdb = movie.tmdb_id === null ? 'tmdb:-' : `tmdb:${movie.tmdb_id}`;
+      return `#${movie.id} ${movie.name} (${movie.year}) ${tmdb}`;
+    })
+    .join('; ');
+
+  return `  - ${group.identityKey} (${group.count}): ${movies}`;
+}
+
+function formatDuplicateReport(title: string, report: DuplicateIdentityReport): string[] {
+  const lines = [`${title}: ${report.totalGroups}`];
+  if (report.groups.length > 0) lines.push(...report.groups.map(formatDuplicateGroup));
+  return lines;
+}
+
+export function formatCatalogHealthReport(report: CatalogHealthReport): string {
+  const lines = [
+    'Catalog health report',
+    `Generated: ${report.generatedAt}`,
+    `Stale threshold: ${report.staleAfterDays} days`,
+    '',
+    `Total movies: ${report.totalMovies}`,
+    '',
+    'Issue counts',
+  ];
+
+  for (const issue of report.issues) {
+    lines.push(`- ${issue.label}: ${issue.count}`);
+  }
+
+  lines.push('', 'Likely duplicate identities');
+  lines.push(...formatDuplicateReport('Duplicate TMDB ids', report.duplicateTmdbIds));
+  lines.push(
+    ...formatDuplicateReport(
+      'Duplicate normalized title/year groups',
+      report.duplicateNormalizedTitleYears,
+    ),
+  );
+
+  lines.push('', 'Samples');
+  for (const issue of report.issues.filter((item) => item.count > 0)) {
+    lines.push(`${issue.key} (${issue.samples.length}/${issue.count})`);
+    if (issue.samples.length === 0) {
+      lines.push('  - No samples returned');
+    } else {
+      lines.push(...issue.samples.map((movie) => `  - ${formatMovieSample(movie)}`));
+    }
+  }
+
+  return `${lines.join('\n')}\n`;
+}


### PR DESCRIPTION
## Summary
- add a read-only CLI catalog health report for missing posters, localized names, TMDB ids, runtime/age-rating data, stale TMDB metadata, and duplicate identities
- expose the report through movie-backfill scripts and the root npm script
- document how to run and interpret the report
- document the follow-up: build a dedicated backoffice app for browser access and add shared operator login for it and Bull Board; keep admin UI out of the user-facing web app

## Test Plan
- npm run test --workspace=movie-backfill
- npm run build --workspace=movie-backfill
- npm run lint:check --workspace=apps/web
- npm run type-check --workspace=apps/web
- npm run build --workspace=apps/web
- pre-push hook: lint, server tests, production build

## Merge Order
Recommended first of the four follow-up PRs.