### PR TITLE
Boost recommendations from liked movie memory

### DIFF
--- a/apps/web/src/features/recommendation/candidateFilters.test.ts
+++ b/apps/web/src/features/recommendation/candidateFilters.test.ts
@@ -153,6 +153,50 @@ describe('candidateFilters', () => {
     expect(result.find((candidate) => candidate.name === 'Arrival')?.similarity).toBeCloseTo(0.83);
   });
 
+  it('boosts liked memory enough to affect local recommendation ordering', () => {
+    const signals = getFeedbackCandidateSignals([
+      { kind: 'liked', movieName: 'Past Lives', movieYear: 2023 },
+    ]);
+    const steadyMatch = { ...movie('After Yang'), similarity: 0.8 };
+    const likedMatch = { ...movie('Past Lives'), similarity: 0.77 };
+
+    const result = applyFeedbackToLocalMovies([steadyMatch, likedMatch], signals);
+
+    expect(result.map((candidate) => candidate.name)).toEqual(['Past Lives', 'After Yang']);
+    expect(result[0]?.similarity).toBeCloseTo(0.81);
+  });
+
+  it('keeps watched exclusions ahead of liked boosts so watched movies do not repeat', () => {
+    const signals = getFeedbackCandidateSignals([
+      { kind: 'liked', movieName: 'Past Lives', movieYear: 2023 },
+      { kind: 'watched', movieName: 'Past Lives', movieYear: 2023 },
+    ]);
+
+    expect(
+      applyFeedbackToLocalMovies(
+        [
+          { ...movie('Past Lives'), similarity: 0.77 },
+          { ...movie('After Yang'), similarity: 0.76 },
+        ],
+        signals,
+      ).map((candidate) => candidate.name),
+    ).toEqual(['After Yang']);
+  });
+
+  it('keeps wrong-mood down-ranking intact when a title also has liked memory', () => {
+    const signals = getFeedbackCandidateSignals([
+      { kind: 'liked', movieName: 'Arrival', movieYear: 2016 },
+      { kind: 'wrong_mood', movieName: 'Arrival', movieYear: 2016 },
+    ]);
+    const arrival = { ...movie('Arrival'), similarity: 0.91 };
+    const afterYang = { ...movie('After Yang'), similarity: 0.84 };
+
+    const result = applyFeedbackToLocalMovies([arrival, afterYang], signals);
+
+    expect(result.map((candidate) => candidate.name)).toEqual(['After Yang', 'Arrival']);
+    expect(result.find((candidate) => candidate.name === 'Arrival')?.similarity).toBeCloseTo(0.83);
+  });
+
   it('filters TMDB candidates by durable movie identity when available', () => {
     const signals = getFeedbackCandidateSignals([
       {

--- a/apps/web/src/features/recommendation/candidateFilters.ts
+++ b/apps/web/src/features/recommendation/candidateFilters.ts
@@ -21,9 +21,12 @@ export type FeedbackCandidateSignals = {
   excludedTitleKeys: Set<string>;
   downrankMovieKeys: Set<string>;
   downrankTitleKeys: Set<string>;
+  boostMovieKeys: Set<string>;
+  boostTitleKeys: Set<string>;
 };
 
 const FEEDBACK_DOWNRANK_AMOUNT = 0.08;
+const LIKED_MEMORY_BOOST_AMOUNT = 0.04;
 
 export function getMentionedMovieTitleKeys(allPeopleData: PersonFormData[]): Set<string> {
   return new Set(
@@ -62,6 +65,8 @@ export function getFeedbackCandidateSignals(
   const excludedTitleKeys = new Set<string>();
   const downrankMovieKeys = new Set<string>();
   const downrankTitleKeys = new Set<string>();
+  const boostMovieKeys = new Set<string>();
+  const boostTitleKeys = new Set<string>();
 
   for (const preference of preferences) {
     const movieKey =
@@ -89,9 +94,21 @@ export function getFeedbackCandidateSignals(
       if (movieKey) downrankMovieKeys.add(movieKey);
       if (titleKey) downrankTitleKeys.add(titleKey);
     }
+
+    if (preference.kind === 'liked') {
+      if (movieKey) boostMovieKeys.add(movieKey);
+      if (titleKey) boostTitleKeys.add(titleKey);
+    }
   }
 
-  return { excludedMovieKeys, excludedTitleKeys, downrankMovieKeys, downrankTitleKeys };
+  return {
+    excludedMovieKeys,
+    excludedTitleKeys,
+    downrankMovieKeys,
+    downrankTitleKeys,
+    boostMovieKeys,
+    boostTitleKeys,
+  };
 }
 
 function getLocalMovieIdentityKey(movie: EnhancedMovieMatch): string | null {
@@ -130,6 +147,18 @@ function isFeedbackDownrankedLocalMovie(
   );
 }
 
+function isFeedbackBoostedLocalMovie(
+  movie: EnhancedMovieMatch,
+  signals: FeedbackCandidateSignals,
+): boolean {
+  const movieKey = getLocalMovieIdentityKey(movie);
+  const titleKey = getMovieTitleKey(movie.name);
+  return Boolean(
+    (movieKey && signals.boostMovieKeys.has(movieKey)) ||
+    (titleKey && signals.boostTitleKeys.has(titleKey)),
+  );
+}
+
 function isFeedbackExcludedTMDBMovie(
   movie: TMDBDiscoverMovie,
   signals: FeedbackCandidateSignals,
@@ -150,7 +179,9 @@ export function applyFeedbackToLocalMovies(
     signals.excludedMovieKeys.size === 0 &&
     signals.excludedTitleKeys.size === 0 &&
     signals.downrankMovieKeys.size === 0 &&
-    signals.downrankTitleKeys.size === 0
+    signals.downrankTitleKeys.size === 0 &&
+    signals.boostMovieKeys.size === 0 &&
+    signals.boostTitleKeys.size === 0
   ) {
     return movies;
   }
@@ -158,11 +189,22 @@ export function applyFeedbackToLocalMovies(
   return movies
     .filter((movie) => !isFeedbackExcludedLocalMovie(movie, signals))
     .map((movie) => {
-      if (!isFeedbackDownrankedLocalMovie(movie, signals)) return movie;
+      const isDownranked = isFeedbackDownrankedLocalMovie(movie, signals);
+      const isBoosted = !isDownranked && isFeedbackBoostedLocalMovie(movie, signals);
+
+      if (!isDownranked && !isBoosted) return movie;
 
       return {
         ...movie,
-        similarity: Math.max(0, movie.similarity - FEEDBACK_DOWNRANK_AMOUNT),
+        similarity: Math.min(
+          1,
+          Math.max(
+            0,
+            movie.similarity -
+              (isDownranked ? FEEDBACK_DOWNRANK_AMOUNT : 0) +
+              (isBoosted ? LIKED_MEMORY_BOOST_AMOUNT : 0),
+          ),
+        ),
       };
     })
     .sort((a, b) => b.similarity - a.similarity);

--- a/apps/web/src/lib/db/recommendations.test.ts
+++ b/apps/web/src/lib/db/recommendations.test.ts
@@ -279,6 +279,13 @@ describe('getUserRecommendationFeedbackMoviePreferences', () => {
             movie_name: 'Arrival',
             movie_year: 2016,
           },
+          {
+            kind: 'liked',
+            movie_key: 'tmdb:496243',
+            tmdb_id: 496243,
+            movie_name: 'Parasite',
+            movie_year: 2019,
+          },
         ],
       })
       .mockResolvedValueOnce({
@@ -314,6 +321,13 @@ describe('getUserRecommendationFeedbackMoviePreferences', () => {
         movieYear: 2016,
       },
       {
+        kind: 'liked',
+        movieKey: 'tmdb:496243',
+        tmdbId: 496243,
+        movieName: 'Parasite',
+        movieYear: 2019,
+      },
+      {
         kind: 'recently_recommended',
         movieKey: 'tmdb:129',
         tmdbId: 129,
@@ -330,7 +344,7 @@ describe('getUserRecommendationFeedbackMoviePreferences', () => {
     ]);
     const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
     expect(sql).toContain('user_movie_interactions');
-    expect(sql).toContain("kind IN ('watched', 'not_interested', 'wrong_mood')");
+    expect(sql).toContain("kind IN ('watched', 'liked', 'not_interested', 'wrong_mood')");
     const [recentSql, recentParams] = mockQuery.mock.calls[1] as [string, unknown[]];
     const recentWindowIndex = recentSql.indexOf('WITH recent_recommendations AS');
     const recentWindowLimitIndex = recentSql.indexOf('LIMIT $2');

--- a/apps/web/src/lib/db/recommendations.ts
+++ b/apps/web/src/lib/db/recommendations.ts
@@ -328,7 +328,7 @@ export async function getUserRecommendationFeedbackMoviePreferences(
        movie_year
      FROM user_movie_interactions
      WHERE user_id = $1
-       AND kind IN ('watched', 'not_interested', 'wrong_mood')
+       AND kind IN ('watched', 'liked', 'not_interested', 'wrong_mood')
      ORDER BY updated_at DESC
      LIMIT $2`,
     [userId, limit],

--- a/docs/RECOMMENDATION-ROADMAP.md
+++ b/docs/RECOMMENDATION-ROADMAP.md
@@ -31,7 +31,7 @@ This creates a usable first recommendation, but the data is coarse. It asks user
 - The favorite movie prompt is high friction and can over-anchor the result toward movies the user already watched.
 - Mood options are partly genre labels, which makes them too broad for accurate ranking.
 - The quiz does not capture enough negative intent, such as "not slow", "not horror", "not long", "not subtitles", or "not something obvious".
-- The app has started storing movie memory, but watched/liked/not-interested signals are still not a first-class input model for recommendations.
+- The app has started using signed-in movie memory for exclusions, down-ranking, and exact liked-candidate boosts, but watched/liked/not-interested signals are still not unified behind a first-class recommendation signal model.
 - Group mode currently collects individual preferences, but the recommendation model should eventually optimize for overlap and compromise explicitly.
 - The embedded/local movie catalog is too small to produce consistently satisfying real-world results.
 

--- a/docs/ROADMAP-ARCHITECTURE.md
+++ b/docs/ROADMAP-ARCHITECTURE.md
@@ -51,6 +51,7 @@ The main remaining risks are:
 - [x] Recommendation feedback is captured from the results page and stored separately from generated recommendation payloads.
 - [x] Signed-in feedback is persisted into `user_movie_interactions` with upsert semantics for `watched`, `liked`, `not_interested`, and `wrong_mood`.
 - [x] Feedback-derived recommendation memory now filters watched/not-interested movies and down-ranks wrong-mood movies for signed-in users.
+- [x] Liked movie memory now applies a conservative positive ranking boost for matching signed-in recommendation candidates.
 - [x] Account recommendation history is deduplicated by movie identity so repeated recommendation attempts do not appear as separate discoveries.
 - [x] Result pages expose a share action that creates/copies a stable recommendation URL.
 - [x] New users are signed in automatically after registration when the session secret is configured.
@@ -67,7 +68,6 @@ The main remaining risks are:
 - The current quiz is still a first-generation guided flow. It should evolve toward a signal-based recommendation model with a shorter "tonight" quiz, a swipe-based mode for movie-heavy users, and a TMDB-first catalog strategy. See [RECOMMENDATION-ROADMAP.md](./RECOMMENDATION-ROADMAP.md).
 - Route-local compatibility re-export files still exist under `src/app/api/movie-recommendation`; future recommendation changes should continue moving real logic into `src/features/recommendation`.
 - Account movie-memory behavior has grown enough that a feature-owned orchestration module would make future changes easier to review and test.
-- `liked` feedback is stored as durable memory, but ranking still primarily uses negative memory for exclusion/down-ranking rather than treating likes as a positive taste signal.
 - Account settings/profile/provider identity remain intentionally thin.
 
 Reference: use [BOUNDARIES.md](./BOUNDARIES.md) as the current ownership baseline.
@@ -190,7 +190,7 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 ### Product Feedback Track
 
 - Expand the explicit movie-memory experience so watched/not-seen setup feels complete for users with large histories.
-- Use `liked` feedback as a positive taste signal in ranking. The interaction is stored today, but current ranking primarily uses negative memory for exclusion/down-ranking.
+- Expand `liked` feedback beyond exact candidate boosts into a richer positive taste signal once the canonical signal model exists.
 - Consider a separate "worth rewatching" angle for watched movies so strong matches can still appear intentionally, with copy that frames them as rewatch candidates instead of new discoveries.
 - Make the reason for reused titles transparent when feedback history intentionally allows a repeat.
 - Manual watched-list management, rewatch mode, richer preference editing, and gamified taste history can follow after the core memory behavior is stable.
@@ -230,7 +230,7 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 1. [ ] Refactor the quiz submit/results handoff so navigation state is explicit and the quiz page does not need short-lived reset guards.
 2. [ ] Move account/movie-memory orchestration behind a feature-owned module if the API route keeps growing.
 3. [x] Add batched movie-memory deck submission so users can review a session locally before writing interactions.
-4. [ ] Use `liked` memory as a positive recommendation signal, not only stored account history.
+4. [x] Use `liked` memory as a positive recommendation signal, not only stored account history.
 5. [x] Add catalog-health reporting for missing posters, missing localized names, duplicate identities, and stale TMDB metadata.
 6. [ ] Create a dedicated backoffice app for catalog-health and TMDB review, then add shared login protection for it and `apps/bull-board`.
 7. [ ] Clarify production migration/versioning expectations for schema changes, rollbacks, and preview volume recreation.
@@ -250,7 +250,7 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 - [x] Recommendation pipeline ownership is no longer tied to `src/app/api/movie-recommendation`.
 - [x] Queueing, DB writes, and response mapping are separated cleanly from recommendation decision logic.
 - [x] Similarity thresholds and related calibration docs point to the same source of truth.
-- [ ] Positive user memory (`liked`) influences ranking.
+- [x] Positive user memory (`liked`) influences ranking.
 - [ ] Quiz submit handoff no longer depends on route-local reset timing.
 
 ### Documentation Alignment


### PR DESCRIPTION
## Summary
- load liked interactions into signed-in recommendation memory
- apply a conservative capped positive boost for liked movie identities
- keep watched/not-interested exclusions and wrong-mood down-ranking ahead of the boost

## Test Plan
- npm run test --workspace=apps/web -- --run src/features/recommendation/candidateFilters.test.ts src/lib/db/recommendations.test.ts
- npm run type-check
- npm run lint:check
- pre-push hook: lint, server tests, production build

## Merge Order
Recommended after #453 and #454. The boost is exact identity/title based; embedding-neighbor taste expansion is intentionally left for later.