### PR TITLE
Extract movie memory feature service

### DIFF
--- a/apps/web/src/app/api/account/movie-memory/route.ts
+++ b/apps/web/src/app/api/account/movie-memory/route.ts
@@ -1,28 +1,23 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { z } from 'zod';
 
-import { IMAGE_BASE_URL, MovieService } from '@/integrations/tmdb';
+import {
+  CANDIDATE_LIMIT,
+  addMovieMemoryBatchForUser,
+  addMovieMemoryBatchSchema,
+  addMovieMemoryItemForUser,
+  addMovieMemorySchema,
+  deleteMovieMemoryForUser,
+  deleteMovieMemorySchema,
+  getMovieMemoryPageForUser,
+  listMovieMemorySchema,
+  loadMovieMemoryCandidatesForUser,
+  parseMovieMemoryLocale,
+  searchMovieMemoryCatalog,
+  searchMovieMemorySchema,
+} from '@/features/movie-memory/service';
 import { getSessionFromRequest } from '@/lib/auth/session';
-import {
-  addUserMovieMemoryBatchFromCatalog,
-  addUserMovieMemoryFromExternalMovie,
-  addUserMovieMemoryFromCatalog,
-  deleteUserMovieMemory,
-  getMovieMemoryCandidateStatsForUser,
-  getMovieMemoryCandidatesForUser,
-  getUserMovieMemoryPage,
-  getUserMovieMemorySummaries,
-  searchMovieCatalogForMemory,
-  type UserMovieMemorySummary,
-} from '@/lib/db/recommendations';
-import {
-  LOCALE_TO_TMDB_LANG,
-  parseLocale,
-  parseLocaleFromRequest,
-  type Locale,
-} from '@/lib/locale';
+import { parseLocaleFromRequest, type Locale } from '@/lib/locale';
 import logger from '@/lib/logger';
-import { getMovieIdentityKey, getYearFromReleaseDate } from '@/lib/movieIdentity';
 import { applyRateLimit } from '@/lib/rateLimit';
 import { isSameOriginBrowserRequest } from '@/lib/withAuth';
 
@@ -31,68 +26,7 @@ const privateResponseHeaders = {
   Vary: 'Cookie',
 };
 
-const deleteMovieMemorySchema = z
-  .object({
-    movieKey: z.string().min(1).max(160),
-  })
-  .strict();
-const searchMovieMemorySchema = z
-  .object({
-    query: z.string().trim().min(2).max(80),
-  })
-  .strict();
-const listMovieMemorySchema = z
-  .object({
-    offset: z.coerce.number().int().min(0).optional().default(0),
-    limit: z.coerce.number().int().min(1).max(100).optional().default(50),
-  })
-  .strict();
-const movieMemoryIdSchema = z.coerce
-  .number()
-  .int()
-  .refine((value) => value !== 0, 'Movie id is required');
-const addMovieMemorySchema = z
-  .object({
-    movieId: movieMemoryIdSchema,
-    kind: z.enum(['watched', 'not_seen']).optional().default('watched'),
-    locale: z.enum(['en', 'ru', 'fi']).optional(),
-  })
-  .strict();
-const addMovieMemoryBatchSchema = z
-  .object({
-    locale: z.enum(['en', 'ru', 'fi']).optional(),
-    items: z
-      .array(
-        z
-          .object({
-            movieId: movieMemoryIdSchema,
-            kind: z.enum(['watched', 'not_seen']).optional().default('watched'),
-          })
-          .strict(),
-      )
-      .min(1)
-      .max(50),
-  })
-  .strict();
 const CSRF_COOKIE = '__csrf';
-const CANDIDATE_LIMIT = 20;
-const TMDB_DISCOVER_FETCH_TIMEOUT_MS = 8_000;
-const TMDB_DISCOVER_MAX_PAGES = 3;
-const movieService = new MovieService();
-
-const tmdbCandidateSchema = z.object({
-  id: z.number(),
-  title: z.string(),
-  original_title: z.string().optional().nullable(),
-  release_date: z.string().optional().nullable(),
-  poster_path: z.string().nullable(),
-  overview: z.string().optional().nullable(),
-  vote_average: z.number().optional(),
-});
-
-const tmdbDiscoverResponseSchema = z.object({
-  results: z.array(tmdbCandidateSchema).optional(),
-});
 
 function elapsedMs(startedAt: number): number {
   return Date.now() - startedAt;
@@ -112,179 +46,7 @@ function hasValidCsrf(req: NextRequest): boolean {
 
 function parseRequestedLocale(req: NextRequest): Locale {
   const localeParam = req.nextUrl.searchParams.get('locale');
-  return localeParam ? parseLocale(localeParam) : parseLocaleFromRequest(req);
-}
-
-function getPosterURL(posterPath: string | null | undefined): string | null {
-  return posterPath ? `${IMAGE_BASE_URL}/w500${posterPath}` : null;
-}
-
-function buildMemoryExclusionSet(items: UserMovieMemorySummary[]): Set<string> {
-  const excluded = new Set<string>();
-  for (const item of items) {
-    excluded.add(item.movieKey);
-    const derivedKey = getMovieIdentityKey({
-      tmdbId: item.tmdbId,
-      title: item.movieName,
-      year: item.movieYear,
-    });
-    if (derivedKey) excluded.add(derivedKey);
-  }
-
-  return excluded;
-}
-
-async function getTMDBMovieMemoryCandidatesForUser(
-  userId: string,
-  limit: number,
-  locale: Locale,
-): Promise<Awaited<ReturnType<typeof getMovieMemoryCandidatesForUser>>> {
-  const tmdbApiKey = process.env.TMDB_API_KEY;
-  if (!tmdbApiKey) return [];
-
-  const memoryItems = await getUserMovieMemorySummaries(userId, 100);
-  const excluded = buildMemoryExclusionSet(memoryItems);
-  const candidates: Awaited<ReturnType<typeof getMovieMemoryCandidatesForUser>> = [];
-  const seenCandidateKeys = new Set<string>();
-  const tmdbLanguage = LOCALE_TO_TMDB_LANG[locale] ?? 'en-US';
-
-  for (let page = 1; page <= TMDB_DISCOVER_MAX_PAGES && candidates.length < limit; page++) {
-    const url = new URL('https://api.themoviedb.org/3/discover/movie');
-    url.searchParams.set('include_adult', 'false');
-    url.searchParams.set('language', tmdbLanguage);
-    url.searchParams.set('page', String(page));
-    url.searchParams.set('sort_by', 'vote_average.desc');
-    url.searchParams.set('vote_count.gte', '1000');
-
-    const parsed = await fetch(url.toString(), {
-      headers: { Authorization: `Bearer ${tmdbApiKey}`, Accept: 'application/json' },
-      signal: AbortSignal.timeout(TMDB_DISCOVER_FETCH_TIMEOUT_MS),
-    })
-      .then(async (response) => {
-        if (!response.ok) {
-          logger.warn({ status: response.status, page }, 'Movie memory TMDB fallback failed');
-          return null;
-        }
-
-        const responseBody = tmdbDiscoverResponseSchema.safeParse(await response.json());
-        if (!responseBody.success) {
-          logger.warn(
-            { err: responseBody.error, page },
-            'Movie memory TMDB fallback response invalid',
-          );
-          return null;
-        }
-
-        return responseBody.data;
-      })
-      .catch((err: unknown) => {
-        logger.warn({ err, page }, 'Movie memory TMDB fallback failed');
-        return null;
-      });
-    if (!parsed) {
-      break;
-    }
-
-    for (const movie of parsed.results ?? []) {
-      const movieYear = getYearFromReleaseDate(movie.release_date);
-      const canonicalTitle = movie.original_title?.trim() || movie.title;
-      const localizedTitle =
-        locale !== 'en' && movie.title.trim() && movie.title.trim() !== canonicalTitle
-          ? movie.title
-          : null;
-      const movieKey = getMovieIdentityKey({
-        tmdbId: movie.id,
-        title: canonicalTitle,
-        year: movieYear,
-      });
-      if (!movieKey || excluded.has(movieKey) || seenCandidateKeys.has(movieKey)) continue;
-
-      seenCandidateKeys.add(movieKey);
-      candidates.push({
-        id: -movie.id,
-        tmdbId: movie.id,
-        movieName: canonicalTitle,
-        movieYear,
-        posterURL: getPosterURL(movie.poster_path),
-        localizedName: localizedTitle,
-        duration: null,
-        description: locale === 'en' ? movie.overview || null : null,
-        localizedOverview: locale === 'en' ? null : movie.overview || null,
-      });
-
-      if (candidates.length >= limit) break;
-    }
-  }
-
-  return candidates;
-}
-
-async function addUserMovieMemoryFromTMDB(
-  userId: string,
-  transientMovieId: number,
-  kind: 'watched' | 'not_seen',
-  locale: Locale,
-) {
-  const tmdbId = Math.abs(transientMovieId);
-  const movie = await movieService.getMovieById(tmdbId);
-  if (!movie) return null;
-
-  const localized =
-    locale === 'en'
-      ? undefined
-      : await movieService.getLocalizedMovieInfo(tmdbId, LOCALE_TO_TMDB_LANG[locale]);
-
-  const localizedName =
-    localized?.title && localized.title.trim() !== movie.title.trim() ? localized.title : null;
-  const posterURL =
-    movieService.getPosterURL(localized?.poster_path ?? movie.poster_path, 'w500') ?? null;
-
-  return addUserMovieMemoryFromExternalMovie(
-    userId,
-    {
-      tmdbId: movie.id,
-      movieName: movie.title,
-      movieYear: getYearFromReleaseDate(movie.release_date),
-      posterURL,
-      localizedName,
-    },
-    kind,
-  );
-}
-
-async function addUserMovieMemoryItem(
-  userId: string,
-  movieId: number,
-  kind: 'watched' | 'not_seen',
-  locale: Locale,
-) {
-  if (movieId < 0) {
-    return addUserMovieMemoryFromTMDB(userId, movieId, kind, locale);
-  }
-
-  return addUserMovieMemoryFromCatalog(userId, movieId, kind);
-}
-
-async function addUserMovieMemoryBatch(
-  userId: string,
-  items: Array<{ movieId: number; kind?: 'watched' | 'not_seen' }>,
-  locale: Locale,
-) {
-  const localItems = items.filter((item) => item.movieId > 0);
-  const tmdbItems = items.filter((item) => item.movieId < 0);
-  const saved = await addUserMovieMemoryBatchFromCatalog(userId, localItems);
-
-  for (const item of tmdbItems) {
-    const result = await addUserMovieMemoryFromTMDB(
-      userId,
-      item.movieId,
-      item.kind ?? 'watched',
-      locale,
-    );
-    if (result) saved.push(result);
-  }
-
-  return saved;
+  return parseMovieMemoryLocale(localeParam, parseLocaleFromRequest(req));
 }
 
 export async function GET(req: NextRequest): Promise<Response> {
@@ -324,28 +86,11 @@ export async function GET(req: NextRequest): Promise<Response> {
   if (isCandidatesRequest) {
     try {
       const locale = parseRequestedLocale(req);
-      let movies = await getMovieMemoryCandidatesForUser(session.sub, CANDIDATE_LIMIT);
-      let emptyStats: Awaited<ReturnType<typeof getMovieMemoryCandidateStatsForUser>> | undefined;
-      let source: 'catalog' | 'tmdb' = 'catalog';
-      if (movies.length === 0) {
-        try {
-          emptyStats = await getMovieMemoryCandidateStatsForUser(session.sub);
-        } catch (statsErr) {
-          logger.warn(
-            { err: statsErr, userId: session.sub, requestKind },
-            'Failed to collect empty movie memory candidate stats',
-          );
-        }
-        try {
-          movies = await getTMDBMovieMemoryCandidatesForUser(session.sub, CANDIDATE_LIMIT, locale);
-          if (movies.length > 0) source = 'tmdb';
-        } catch (tmdbErr) {
-          logger.warn(
-            { err: tmdbErr, userId: session.sub, requestKind, locale },
-            'Movie memory TMDB fallback failed',
-          );
-        }
-      }
+      const { movies, source, emptyStats } = await loadMovieMemoryCandidatesForUser(
+        session.sub,
+        locale,
+        { logContext: { requestKind } },
+      );
       logger.info(
         {
           userId: session.sub,
@@ -384,7 +129,7 @@ export async function GET(req: NextRequest): Promise<Response> {
     }
 
     try {
-      const page = await getUserMovieMemoryPage(session.sub, parsed.data);
+      const page = await getMovieMemoryPageForUser(session.sub, parsed.data);
       logger.info(
         {
           userId: session.sub,
@@ -432,7 +177,7 @@ export async function GET(req: NextRequest): Promise<Response> {
   }
 
   try {
-    const movies = await searchMovieCatalogForMemory(parsed.data.query);
+    const movies = await searchMovieMemoryCatalog(parsed.data.query);
     logger.info(
       {
         userId: session.sub,
@@ -494,7 +239,7 @@ export async function POST(req: NextRequest): Promise<Response> {
   if (parsedBatch.success) {
     const locale = parsedBatch.data.locale ?? parseLocaleFromRequest(req);
     try {
-      const items = await addUserMovieMemoryBatch(session.sub, parsedBatch.data.items, locale);
+      const items = await addMovieMemoryBatchForUser(session.sub, parsedBatch.data.items, locale);
       logger.info(
         {
           userId: session.sub,
@@ -534,7 +279,7 @@ export async function POST(req: NextRequest): Promise<Response> {
 
   const locale = parsed.data.locale ?? parseLocaleFromRequest(req);
   try {
-    const item = await addUserMovieMemoryItem(
+    const item = await addMovieMemoryItemForUser(
       session.sub,
       parsed.data.movieId,
       parsed.data.kind,
@@ -600,7 +345,7 @@ export async function DELETE(req: NextRequest): Promise<Response> {
   }
 
   try {
-    const deleted = await deleteUserMovieMemory(session.sub, parsed.data.movieKey);
+    const deleted = await deleteMovieMemoryForUser(session.sub, parsed.data.movieKey);
     if (!deleted) {
       return movieMemoryJson({ error: 'Movie memory item not found' }, 404);
     }

--- a/apps/web/src/features/movie-memory/service.test.ts
+++ b/apps/web/src/features/movie-memory/service.test.ts
@@ -1,0 +1,256 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockAddUserMovieMemoryBatchFromCatalog,
+  mockAddUserMovieMemoryFromExternalMovie,
+  mockAddUserMovieMemoryFromCatalog,
+  mockDeleteUserMovieMemory,
+  mockGetMovieMemoryCandidateStatsForUser,
+  mockGetMovieMemoryCandidatesForUser,
+  mockGetLocalizedMovieInfo,
+  mockGetMovieById,
+  mockGetPosterURL,
+  mockGetUserMovieMemoryPage,
+  mockGetUserMovieMemorySummaries,
+  mockLoggerWarn,
+  mockSearchMovieCatalogForMemory,
+} = vi.hoisted(() => ({
+  mockAddUserMovieMemoryBatchFromCatalog: vi.fn(),
+  mockAddUserMovieMemoryFromExternalMovie: vi.fn(),
+  mockAddUserMovieMemoryFromCatalog: vi.fn(),
+  mockDeleteUserMovieMemory: vi.fn(),
+  mockGetMovieMemoryCandidateStatsForUser: vi.fn(),
+  mockGetMovieMemoryCandidatesForUser: vi.fn(),
+  mockGetLocalizedMovieInfo: vi.fn(),
+  mockGetMovieById: vi.fn(),
+  mockGetPosterURL: vi.fn((path: string | null) =>
+    path ? `https://image.tmdb.org/t/p/w500${path}` : undefined,
+  ),
+  mockGetUserMovieMemoryPage: vi.fn(),
+  mockGetUserMovieMemorySummaries: vi.fn(),
+  mockLoggerWarn: vi.fn(),
+  mockSearchMovieCatalogForMemory: vi.fn(),
+}));
+
+vi.mock('@/lib/db/recommendations', () => ({
+  addUserMovieMemoryBatchFromCatalog: mockAddUserMovieMemoryBatchFromCatalog,
+  addUserMovieMemoryFromExternalMovie: mockAddUserMovieMemoryFromExternalMovie,
+  addUserMovieMemoryFromCatalog: mockAddUserMovieMemoryFromCatalog,
+  deleteUserMovieMemory: mockDeleteUserMovieMemory,
+  getMovieMemoryCandidateStatsForUser: mockGetMovieMemoryCandidateStatsForUser,
+  getMovieMemoryCandidatesForUser: mockGetMovieMemoryCandidatesForUser,
+  getUserMovieMemoryPage: mockGetUserMovieMemoryPage,
+  getUserMovieMemorySummaries: mockGetUserMovieMemorySummaries,
+  searchMovieCatalogForMemory: mockSearchMovieCatalogForMemory,
+}));
+
+vi.mock('@/integrations/tmdb', () => ({
+  IMAGE_BASE_URL: 'https://image.tmdb.org/t/p',
+  MovieService: vi.fn(function () {
+    return {
+      getLocalizedMovieInfo: mockGetLocalizedMovieInfo,
+      getMovieById: mockGetMovieById,
+      getPosterURL: mockGetPosterURL,
+    };
+  }),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  default: { error: vi.fn(), warn: mockLoggerWarn, info: vi.fn(), debug: vi.fn() },
+}));
+
+import { addMovieMemoryBatchForUser, loadMovieMemoryCandidatesForUser } from './service';
+
+describe('movie memory feature service', () => {
+  beforeEach(() => {
+    mockAddUserMovieMemoryBatchFromCatalog.mockReset();
+    mockAddUserMovieMemoryFromExternalMovie.mockReset();
+    mockAddUserMovieMemoryFromCatalog.mockReset();
+    mockDeleteUserMovieMemory.mockReset();
+    mockGetMovieMemoryCandidateStatsForUser.mockReset();
+    mockGetMovieMemoryCandidatesForUser.mockReset();
+    mockGetLocalizedMovieInfo.mockReset();
+    mockGetMovieById.mockReset();
+    mockGetPosterURL.mockClear();
+    mockGetUserMovieMemoryPage.mockReset();
+    mockGetUserMovieMemorySummaries.mockReset();
+    mockLoggerWarn.mockReset();
+    mockSearchMovieCatalogForMemory.mockReset();
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it('returns catalog candidates without collecting empty-catalog diagnostics', async () => {
+    mockGetMovieMemoryCandidatesForUser.mockResolvedValueOnce([
+      {
+        id: 129,
+        tmdbId: 129,
+        movieName: 'Spirited Away',
+        movieYear: 2001,
+        posterURL: 'https://example.com/poster.jpg',
+        localizedName: null,
+        duration: 125,
+        description: 'A girl enters the spirit world.',
+        localizedOverview: null,
+      },
+    ]);
+
+    const result = await loadMovieMemoryCandidatesForUser('42', 'en');
+
+    expect(result).toEqual({
+      source: 'catalog',
+      emptyStats: undefined,
+      movies: [
+        {
+          id: 129,
+          tmdbId: 129,
+          movieName: 'Spirited Away',
+          movieYear: 2001,
+          posterURL: 'https://example.com/poster.jpg',
+          localizedName: null,
+          duration: 125,
+          description: 'A girl enters the spirit world.',
+          localizedOverview: null,
+        },
+      ],
+    });
+    expect(mockGetMovieMemoryCandidateStatsForUser).not.toHaveBeenCalled();
+    expect(mockGetUserMovieMemorySummaries).not.toHaveBeenCalled();
+  });
+
+  it('falls back to localized TMDB candidates while excluding existing memory', async () => {
+    vi.stubEnv('TMDB_API_KEY', 'tmdb-key');
+    mockGetMovieMemoryCandidatesForUser.mockResolvedValueOnce([]);
+    mockGetMovieMemoryCandidateStatsForUser.mockResolvedValueOnce({
+      catalogCount: 0,
+      memoryCount: 1,
+      availableCatalogCount: 0,
+    });
+    mockGetUserMovieMemorySummaries.mockResolvedValueOnce([
+      {
+        movieKey: 'tmdb:550',
+        tmdbId: 550,
+        movieName: 'Fight Club',
+        movieYear: 1999,
+        posterURL: null,
+        localizedName: null,
+        kind: 'watched',
+        updatedAt: '2026-05-20T12:00:00.000Z',
+      },
+    ]);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValueOnce(
+        Response.json({
+          results: [
+            {
+              id: 550,
+              title: 'Бойцовский клуб',
+              original_title: 'Fight Club',
+              release_date: '1999-10-15',
+              poster_path: '/fight.jpg',
+              overview: 'Офисный работник встречает торговца мылом.',
+            },
+            {
+              id: 27205,
+              title: 'Начало',
+              original_title: 'Inception',
+              release_date: '2010-07-15',
+              poster_path: '/inception.jpg',
+              overview: 'Вор крадет секреты через сны.',
+            },
+          ],
+        }),
+      ),
+    );
+
+    const result = await loadMovieMemoryCandidatesForUser('42', 'ru', { limit: 1 });
+
+    expect(result).toEqual({
+      source: 'tmdb',
+      emptyStats: { catalogCount: 0, memoryCount: 1, availableCatalogCount: 0 },
+      movies: [
+        {
+          id: -27205,
+          tmdbId: 27205,
+          movieName: 'Inception',
+          movieYear: 2010,
+          posterURL: 'https://image.tmdb.org/t/p/w500/inception.jpg',
+          localizedName: 'Начало',
+          duration: null,
+          description: null,
+          localizedOverview: 'Вор крадет секреты через сны.',
+        },
+      ],
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('language=ru-RU'),
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer tmdb-key', Accept: 'application/json' },
+      }),
+    );
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+  });
+
+  it('splits batch saves between local catalog rows and transient TMDB rows', async () => {
+    mockAddUserMovieMemoryBatchFromCatalog.mockResolvedValueOnce([
+      {
+        movieKey: 'tmdb:129',
+        tmdbId: 129,
+        movieName: 'Spirited Away',
+        movieYear: 2001,
+        posterURL: null,
+        localizedName: null,
+        kind: 'watched',
+        updatedAt: '2026-05-20T12:00:00.000Z',
+      },
+    ]);
+    mockGetMovieById.mockResolvedValueOnce({
+      id: 550,
+      title: 'Fight Club',
+      release_date: '1999-10-15',
+      poster_path: '/fight.jpg',
+    });
+    mockGetLocalizedMovieInfo.mockResolvedValueOnce({
+      title: 'Бойцовский клуб',
+      poster_path: '/fight-ru.jpg',
+    });
+    mockAddUserMovieMemoryFromExternalMovie.mockResolvedValueOnce({
+      movieKey: 'tmdb:550',
+      tmdbId: 550,
+      movieName: 'Fight Club',
+      movieYear: 1999,
+      posterURL: 'https://image.tmdb.org/t/p/w500/fight-ru.jpg',
+      localizedName: 'Бойцовский клуб',
+      kind: 'not_seen',
+      updatedAt: '2026-05-20T12:00:00.000Z',
+    });
+
+    const result = await addMovieMemoryBatchForUser(
+      '42',
+      [
+        { movieId: 129, kind: 'watched' },
+        { movieId: -550, kind: 'not_seen' },
+      ],
+      'ru',
+    );
+
+    expect(result).toHaveLength(2);
+    expect(mockAddUserMovieMemoryBatchFromCatalog).toHaveBeenCalledWith('42', [
+      { movieId: 129, kind: 'watched' },
+    ]);
+    expect(mockGetMovieById).toHaveBeenCalledWith(550);
+    expect(mockGetLocalizedMovieInfo).toHaveBeenCalledWith(550, 'ru-RU');
+    expect(mockAddUserMovieMemoryFromExternalMovie).toHaveBeenCalledWith(
+      '42',
+      {
+        tmdbId: 550,
+        movieName: 'Fight Club',
+        movieYear: 1999,
+        posterURL: 'https://image.tmdb.org/t/p/w500/fight-ru.jpg',
+        localizedName: 'Бойцовский клуб',
+      },
+      'not_seen',
+    );
+  });
+});

--- a/apps/web/src/features/movie-memory/service.ts
+++ b/apps/web/src/features/movie-memory/service.ts
@@ -1,0 +1,333 @@
+import { z } from 'zod';
+
+import { IMAGE_BASE_URL, MovieService } from '@/integrations/tmdb';
+import {
+  addUserMovieMemoryBatchFromCatalog,
+  addUserMovieMemoryFromExternalMovie,
+  addUserMovieMemoryFromCatalog,
+  deleteUserMovieMemory,
+  getMovieMemoryCandidateStatsForUser,
+  getMovieMemoryCandidatesForUser,
+  getUserMovieMemoryPage,
+  getUserMovieMemorySummaries,
+  searchMovieCatalogForMemory,
+  type MovieMemoryCandidateStats,
+  type MovieMemoryCatalogSearchResult,
+  type UserMovieInteractionKind,
+  type UserMovieMemoryPage,
+  type UserMovieMemorySummary,
+} from '@/lib/db/recommendations';
+import { LOCALE_TO_TMDB_LANG, parseLocale, type Locale } from '@/lib/locale';
+import logger from '@/lib/logger';
+import { getMovieIdentityKey, getYearFromReleaseDate } from '@/lib/movieIdentity';
+
+export const CANDIDATE_LIMIT = 20;
+
+const TMDB_DISCOVER_FETCH_TIMEOUT_MS = 8_000;
+const TMDB_DISCOVER_MAX_PAGES = 3;
+const movieService = new MovieService();
+
+export type MovieMemoryInteractionKind = Extract<UserMovieInteractionKind, 'watched' | 'not_seen'>;
+export type MovieMemoryCandidate = MovieMemoryCatalogSearchResult;
+export type MovieMemoryCandidateSource = 'catalog' | 'tmdb';
+
+export const deleteMovieMemorySchema = z
+  .object({
+    movieKey: z.string().min(1).max(160),
+  })
+  .strict();
+
+export const searchMovieMemorySchema = z
+  .object({
+    query: z.string().trim().min(2).max(80),
+  })
+  .strict();
+
+export const listMovieMemorySchema = z
+  .object({
+    offset: z.coerce.number().int().min(0).optional().default(0),
+    limit: z.coerce.number().int().min(1).max(100).optional().default(50),
+  })
+  .strict();
+
+const movieMemoryIdSchema = z.coerce
+  .number()
+  .int()
+  .refine((value) => value !== 0, 'Movie id is required');
+
+export const addMovieMemorySchema = z
+  .object({
+    movieId: movieMemoryIdSchema,
+    kind: z.enum(['watched', 'not_seen']).optional().default('watched'),
+    locale: z.enum(['en', 'ru', 'fi']).optional(),
+  })
+  .strict();
+
+export const addMovieMemoryBatchSchema = z
+  .object({
+    locale: z.enum(['en', 'ru', 'fi']).optional(),
+    items: z
+      .array(
+        z
+          .object({
+            movieId: movieMemoryIdSchema,
+            kind: z.enum(['watched', 'not_seen']).optional().default('watched'),
+          })
+          .strict(),
+      )
+      .min(1)
+      .max(50),
+  })
+  .strict();
+
+const tmdbCandidateSchema = z.object({
+  id: z.number(),
+  title: z.string(),
+  original_title: z.string().optional().nullable(),
+  release_date: z.string().optional().nullable(),
+  poster_path: z.string().nullable(),
+  overview: z.string().optional().nullable(),
+  vote_average: z.number().optional(),
+});
+
+const tmdbDiscoverResponseSchema = z.object({
+  results: z.array(tmdbCandidateSchema).optional(),
+});
+
+type MovieMemoryLogContext = Record<string, unknown>;
+
+export interface MovieMemoryCandidateResult {
+  movies: MovieMemoryCandidate[];
+  source: MovieMemoryCandidateSource;
+  emptyStats?: MovieMemoryCandidateStats;
+}
+
+export function parseMovieMemoryLocale(
+  requestedLocale: string | null | undefined,
+  fallbackLocale: Locale,
+): Locale {
+  return requestedLocale ? parseLocale(requestedLocale) : fallbackLocale;
+}
+
+function getPosterURL(posterPath: string | null | undefined): string | null {
+  return posterPath ? `${IMAGE_BASE_URL}/w500${posterPath}` : null;
+}
+
+function buildMemoryExclusionSet(items: UserMovieMemorySummary[]): Set<string> {
+  const excluded = new Set<string>();
+  for (const item of items) {
+    excluded.add(item.movieKey);
+    const derivedKey = getMovieIdentityKey({
+      tmdbId: item.tmdbId,
+      title: item.movieName,
+      year: item.movieYear,
+    });
+    if (derivedKey) excluded.add(derivedKey);
+  }
+
+  return excluded;
+}
+
+async function getTMDBMovieMemoryCandidatesForUser(
+  userId: string,
+  limit: number,
+  locale: Locale,
+): Promise<MovieMemoryCandidate[]> {
+  const tmdbApiKey = process.env.TMDB_API_KEY;
+  if (!tmdbApiKey) return [];
+
+  const memoryItems = await getUserMovieMemorySummaries(userId, 100);
+  const excluded = buildMemoryExclusionSet(memoryItems);
+  const candidates: MovieMemoryCandidate[] = [];
+  const seenCandidateKeys = new Set<string>();
+  const tmdbLanguage = LOCALE_TO_TMDB_LANG[locale] ?? 'en-US';
+
+  for (let page = 1; page <= TMDB_DISCOVER_MAX_PAGES && candidates.length < limit; page++) {
+    const url = new URL('https://api.themoviedb.org/3/discover/movie');
+    url.searchParams.set('include_adult', 'false');
+    url.searchParams.set('language', tmdbLanguage);
+    url.searchParams.set('page', String(page));
+    url.searchParams.set('sort_by', 'vote_average.desc');
+    url.searchParams.set('vote_count.gte', '1000');
+
+    const parsed = await fetch(url.toString(), {
+      headers: { Authorization: `Bearer ${tmdbApiKey}`, Accept: 'application/json' },
+      signal: AbortSignal.timeout(TMDB_DISCOVER_FETCH_TIMEOUT_MS),
+    })
+      .then(async (response) => {
+        if (!response.ok) {
+          logger.warn({ status: response.status, page }, 'Movie memory TMDB fallback failed');
+          return null;
+        }
+
+        const responseBody = tmdbDiscoverResponseSchema.safeParse(await response.json());
+        if (!responseBody.success) {
+          logger.warn(
+            { err: responseBody.error, page },
+            'Movie memory TMDB fallback response invalid',
+          );
+          return null;
+        }
+
+        return responseBody.data;
+      })
+      .catch((err: unknown) => {
+        logger.warn({ err, page }, 'Movie memory TMDB fallback failed');
+        return null;
+      });
+    if (!parsed) {
+      break;
+    }
+
+    for (const movie of parsed.results ?? []) {
+      const movieYear = getYearFromReleaseDate(movie.release_date);
+      const canonicalTitle = movie.original_title?.trim() || movie.title;
+      const localizedTitle =
+        locale !== 'en' && movie.title.trim() && movie.title.trim() !== canonicalTitle
+          ? movie.title
+          : null;
+      const movieKey = getMovieIdentityKey({
+        tmdbId: movie.id,
+        title: canonicalTitle,
+        year: movieYear,
+      });
+      if (!movieKey || excluded.has(movieKey) || seenCandidateKeys.has(movieKey)) continue;
+
+      seenCandidateKeys.add(movieKey);
+      candidates.push({
+        id: -movie.id,
+        tmdbId: movie.id,
+        movieName: canonicalTitle,
+        movieYear,
+        posterURL: getPosterURL(movie.poster_path),
+        localizedName: localizedTitle,
+        duration: null,
+        description: locale === 'en' ? movie.overview || null : null,
+        localizedOverview: locale === 'en' ? null : movie.overview || null,
+      });
+
+      if (candidates.length >= limit) break;
+    }
+  }
+
+  return candidates;
+}
+
+export async function loadMovieMemoryCandidatesForUser(
+  userId: string,
+  locale: Locale,
+  {
+    limit = CANDIDATE_LIMIT,
+    logContext = {},
+  }: { limit?: number; logContext?: MovieMemoryLogContext } = {},
+): Promise<MovieMemoryCandidateResult> {
+  let movies = await getMovieMemoryCandidatesForUser(userId, limit);
+  let emptyStats: MovieMemoryCandidateStats | undefined;
+  let source: MovieMemoryCandidateSource = 'catalog';
+
+  if (movies.length === 0) {
+    try {
+      emptyStats = await getMovieMemoryCandidateStatsForUser(userId);
+    } catch (statsErr) {
+      logger.warn(
+        { err: statsErr, userId, ...logContext },
+        'Failed to collect empty movie memory candidate stats',
+      );
+    }
+
+    try {
+      movies = await getTMDBMovieMemoryCandidatesForUser(userId, limit, locale);
+      if (movies.length > 0) source = 'tmdb';
+    } catch (tmdbErr) {
+      logger.warn(
+        { err: tmdbErr, userId, locale, ...logContext },
+        'Movie memory TMDB fallback failed',
+      );
+    }
+  }
+
+  return { movies, source, emptyStats };
+}
+
+async function addUserMovieMemoryFromTMDB(
+  userId: string,
+  transientMovieId: number,
+  kind: MovieMemoryInteractionKind,
+  locale: Locale,
+): Promise<UserMovieMemorySummary | null> {
+  const tmdbId = Math.abs(transientMovieId);
+  const movie = await movieService.getMovieById(tmdbId);
+  if (!movie) return null;
+
+  const localized =
+    locale === 'en'
+      ? undefined
+      : await movieService.getLocalizedMovieInfo(tmdbId, LOCALE_TO_TMDB_LANG[locale]);
+
+  const localizedName =
+    localized?.title && localized.title.trim() !== movie.title.trim() ? localized.title : null;
+  const posterURL =
+    movieService.getPosterURL(localized?.poster_path ?? movie.poster_path, 'w500') ?? null;
+
+  return addUserMovieMemoryFromExternalMovie(
+    userId,
+    {
+      tmdbId: movie.id,
+      movieName: movie.title,
+      movieYear: getYearFromReleaseDate(movie.release_date),
+      posterURL,
+      localizedName,
+    },
+    kind,
+  );
+}
+
+export async function addMovieMemoryItemForUser(
+  userId: string,
+  movieId: number,
+  kind: MovieMemoryInteractionKind,
+  locale: Locale,
+): Promise<UserMovieMemorySummary | null> {
+  if (movieId < 0) {
+    return addUserMovieMemoryFromTMDB(userId, movieId, kind, locale);
+  }
+
+  return addUserMovieMemoryFromCatalog(userId, movieId, kind);
+}
+
+export async function addMovieMemoryBatchForUser(
+  userId: string,
+  items: Array<{ movieId: number; kind?: MovieMemoryInteractionKind }>,
+  locale: Locale,
+): Promise<UserMovieMemorySummary[]> {
+  const localItems = items.filter((item) => item.movieId > 0);
+  const tmdbItems = items.filter((item) => item.movieId < 0);
+  const saved = await addUserMovieMemoryBatchFromCatalog(userId, localItems);
+
+  for (const item of tmdbItems) {
+    const result = await addUserMovieMemoryFromTMDB(
+      userId,
+      item.movieId,
+      item.kind ?? 'watched',
+      locale,
+    );
+    if (result) saved.push(result);
+  }
+
+  return saved;
+}
+
+export function getMovieMemoryPageForUser(
+  userId: string,
+  pagination: { offset: number; limit: number },
+): Promise<UserMovieMemoryPage> {
+  return getUserMovieMemoryPage(userId, pagination);
+}
+
+export function searchMovieMemoryCatalog(query: string): Promise<MovieMemoryCandidate[]> {
+  return searchMovieCatalogForMemory(query);
+}
+
+export function deleteMovieMemoryForUser(userId: string, movieKey: string): Promise<boolean> {
+  return deleteUserMovieMemory(userId, movieKey);
+}

--- a/docs/ROADMAP-ARCHITECTURE.md
+++ b/docs/ROADMAP-ARCHITECTURE.md
@@ -57,6 +57,7 @@ The main remaining risks are:
 - [x] New users are signed in automatically after registration when the session secret is configured.
 - [x] Password reset request and confirmation routes exist, with Resend delivery in production and non-production reset URL exposure for local testing.
 - [x] A dedicated `/account/movie-memory` experience exists with candidate cards and catalog search backed by `/api/account/movie-memory`.
+- [x] Account movie-memory API orchestration now lives behind a feature-owned service module instead of the route handler.
 - [x] Movie-memory candidate cards keep session state locally, submit completed choices in one batched request, and flush pending choices on page hide or unmount.
 - [x] The account movie-memory view supports large histories with paginated loading, virtualized rendering, total counts, and poster-aware fallbacks.
 - [x] `tmdb_match_reviews` persists ambiguous TMDB/local matches and runtime mismatches for later manual review.
@@ -67,7 +68,6 @@ The main remaining risks are:
 - The quiz-to-results handoff still relies on route-local state and a short-lived browser handoff marker to avoid visual flashes. A follow-up PR should simplify this architecture so the quiz route never needs to reset itself while it is still responsible for rendering the submit handoff.
 - The current quiz is still a first-generation guided flow. It should evolve toward a signal-based recommendation model with a shorter "tonight" quiz, a swipe-based mode for movie-heavy users, and a TMDB-first catalog strategy. See [RECOMMENDATION-ROADMAP.md](./RECOMMENDATION-ROADMAP.md).
 - Route-local compatibility re-export files still exist under `src/app/api/movie-recommendation`; future recommendation changes should continue moving real logic into `src/features/recommendation`.
-- Account movie-memory behavior has grown enough that a feature-owned orchestration module would make future changes easier to review and test.
 - Account settings/profile/provider identity remain intentionally thin.
 
 Reference: use [BOUNDARIES.md](./BOUNDARIES.md) as the current ownership baseline.
@@ -114,7 +114,7 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 - Centralize configuration and constants to reduce manual synchronization.
 - Prefer extracting recommendation flows out of `src/app/api` into clearer domain-owned modules.
 - Refactor the quiz submission lifecycle so recommendation creation is modeled explicitly instead of coordinated through route-local `useEffect`, refs, and navigation timing.
-- Move growing account/movie-memory behavior behind a feature-owned module once the route logic expands beyond simple session, validation, and repository calls.
+- Keep account/movie-memory orchestration behind feature-owned modules as the API surface grows beyond the current service extraction.
 
 ### Phase 3: Extract intentional packages from the existing layout
 
@@ -228,7 +228,7 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 ## Priority Items for the Next 30 Days
 
 1. [ ] Refactor the quiz submit/results handoff so navigation state is explicit and the quiz page does not need short-lived reset guards.
-2. [ ] Move account/movie-memory orchestration behind a feature-owned module if the API route keeps growing.
+2. [x] Move account/movie-memory orchestration behind a feature-owned module if the API route keeps growing.
 3. [x] Add batched movie-memory deck submission so users can review a session locally before writing interactions.
 4. [x] Use `liked` memory as a positive recommendation signal, not only stored account history.
 5. [x] Add catalog-health reporting for missing posters, missing localized names, duplicate identities, and stale TMDB metadata.


### PR DESCRIPTION
## Summary
- extract account movie-memory server orchestration into a feature-owned service module
- keep the API route focused on session, rate limiting, CSRF, parsing, logging, and response mapping
- add focused service tests while preserving existing API behavior

## Test Plan
- npm run test:server --workspace=apps/web -- src/features/movie-memory/service.test.ts src/app/api/account/movie-memory/route.test.ts
- npm run type-check
- npm run lint:check
- pre-push hook: lint, server tests, production build

## Merge Order
Recommended after #453, #454, and #455, since this is a structural cleanup on top of the movie-memory work.