### PR TITLE
Bound catalog health sample queries

### DIFF
--- a/services/movie-backfill/src/catalog-health.test.ts
+++ b/services/movie-backfill/src/catalog-health.test.ts
@@ -71,7 +71,6 @@ describe('catalog health report', () => {
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({
         rows: [
           {
@@ -116,11 +115,48 @@ describe('catalog health report', () => {
       groups: [{ identityKey: 'solaris:1972', count: 2 }],
     });
 
+    expect(poolMock.query).toHaveBeenCalledTimes(9);
+    const duplicateTmdbSql = String(poolMock.query.mock.calls[7]?.[0]);
+    expect(duplicateTmdbSql).toContain('ROW_NUMBER() OVER (PARTITION BY tmdb_id ORDER BY id)');
+    expect(duplicateTmdbSql).toContain('sample_rank <= $1');
+    const duplicateTitleYearSql = String(poolMock.query.mock.calls[8]?.[0]);
+    expect(duplicateTitleYearSql).toContain(
+      'ROW_NUMBER() OVER (PARTITION BY identity_key ORDER BY id)',
+    );
+    expect(duplicateTitleYearSql).toContain('sample_rank <= $1');
+
     for (const [sql] of poolMock.query.mock.calls) {
       const normalizedSql = String(sql).trim().toLowerCase();
       expect(normalizedSql).toMatch(/^(select|with)\b/);
       expect(normalizedSql).not.toMatch(/\b(insert|update|delete|alter|create|drop)\b/);
     }
+  });
+
+  it('skips sample queries for issues with zero rows', async () => {
+    poolMock.query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            total_movies: 4,
+            missing_poster_url: 0,
+            missing_localized_name: 0,
+            missing_tmdb_id: 0,
+            missing_runtime: 0,
+            missing_age_rating: 0,
+            missing_tmdb_matched_at: 0,
+            stale_tmdb_metadata: 0,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const report = await getCatalogHealthReport({ sampleLimit: 3, staleAfterDays: 90 });
+
+    expect(report.issues.every((issue) => issue.samples.length === 0)).toBe(true);
+    expect(poolMock.query).toHaveBeenCalledTimes(3);
+    const sqlStatements = poolMock.query.mock.calls.slice(1).map(([sql]) => String(sql));
+    expect(sqlStatements.join('\n')).not.toContain('WHERE poster_url IS NULL');
   });
 
   it('formats text output for local and CI logs', () => {

--- a/services/movie-backfill/src/catalog-health.ts
+++ b/services/movie-backfill/src/catalog-health.ts
@@ -192,18 +192,30 @@ async function getDuplicateTmdbIds(limit: number): Promise<DuplicateIdentityRepo
     total_groups: number | string;
     movies: string | Pick<CatalogMovieSample, 'id' | 'name' | 'year' | 'tmdb_id'>[];
   }>(
-    `WITH duplicate_groups AS (
+    `WITH ranked_movies AS (
         SELECT
+          id,
+          name,
+          year,
+          tmdb_id,
           tmdb_id::text AS identity_key,
-          COUNT(*)::int AS duplicate_count,
+          COUNT(*) OVER (PARTITION BY tmdb_id)::int AS duplicate_count,
+          ROW_NUMBER() OVER (PARTITION BY tmdb_id ORDER BY id)::int AS sample_rank
+        FROM movies
+        WHERE tmdb_id IS NOT NULL
+      ),
+      duplicate_groups AS (
+        SELECT
+          identity_key,
+          MAX(duplicate_count)::int AS duplicate_count,
           json_agg(
             json_build_object('id', id::text, 'name', name, 'year', year, 'tmdb_id', tmdb_id)
             ORDER BY id
           ) AS movies
-        FROM movies
-        WHERE tmdb_id IS NOT NULL
-        GROUP BY tmdb_id
-        HAVING COUNT(*) > 1
+        FROM ranked_movies
+        WHERE duplicate_count > 1
+          AND sample_rank <= $1
+        GROUP BY identity_key
       )
       SELECT identity_key, duplicate_count, movies, COUNT(*) OVER()::int AS total_groups
       FROM duplicate_groups
@@ -241,15 +253,22 @@ async function getDuplicateNormalizedTitleYears(limit: number): Promise<Duplicat
       duplicate_groups AS (
         SELECT
           identity_key,
-          COUNT(*)::int AS duplicate_count,
+          MAX(duplicate_count)::int AS duplicate_count,
           json_agg(
             json_build_object('id', id::text, 'name', name, 'year', year, 'tmdb_id', tmdb_id)
             ORDER BY id
           ) AS movies
-        FROM keyed_movies
-        WHERE identity_key <> concat(':', year)
+        FROM (
+          SELECT
+            *,
+            COUNT(*) OVER (PARTITION BY identity_key)::int AS duplicate_count,
+            ROW_NUMBER() OVER (PARTITION BY identity_key ORDER BY id)::int AS sample_rank
+          FROM keyed_movies
+          WHERE identity_key <> concat(':', year)
+        ) ranked_movies
+        WHERE duplicate_count > 1
+          AND sample_rank <= $1
         GROUP BY identity_key
-        HAVING COUNT(*) > 1
       )
       SELECT identity_key, duplicate_count, movies, COUNT(*) OVER()::int AS total_groups
       FROM duplicate_groups
@@ -273,12 +292,15 @@ export async function getCatalogHealthReport(
 ): Promise<CatalogHealthReport> {
   const summary = await getSummary(options.staleAfterDays);
   const issues = await Promise.all(
-    ISSUE_DEFINITIONS.map(async (issue) => ({
-      key: issue.key,
-      label: issue.label,
-      count: summary[issue.key],
-      samples: await getIssueSamples(issue, options),
-    })),
+    ISSUE_DEFINITIONS.map(async (issue) => {
+      const count = summary[issue.key];
+      return {
+        key: issue.key,
+        label: issue.label,
+        count,
+        samples: count > 0 ? await getIssueSamples(issue, options) : [],
+      };
+    }),
   );
 
   const [duplicateTmdbIds, duplicateNormalizedTitleYears] = await Promise.all([


### PR DESCRIPTION
## Summary
- skip per-issue sample queries when the catalog health summary count is zero
- bound duplicate-identity movie samples per group using the same sample limit as the report
- add tests covering zero-count issue behavior and duplicate query sample bounds

## Test Plan
- npm run test --workspace=movie-backfill
- npm run build --workspace=movie-backfill
- pre-push hook: lint, server tests, production build

Follow-up for Copilot review comments on #453.