### PR TITLE
Allow manual Coolify deploy workflow

### DIFF
--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -166,7 +166,7 @@ jobs:
 
   deploy-coolify:
     name: Trigger Coolify deploy
-    if: github.event_name == 'push' && github.ref_name == 'development'
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref_name == 'development'
     needs: build-images
     runs-on: ubuntu-latest
     env:

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -114,9 +114,11 @@ that exact release bundle. Every PopChoice service must use the same
 `IMAGE_TAG`; mixing `web`, `workers`, `bull-board`, and service images from
 different commits is not a supported deployment shape.
 
-Set the repository secret `COOLIFY_DEPLOY_WEBHOOK` to enable automatic redeploys
-after pushes to `development`. When the secret is absent, images are still
-published, but deployment remains manual.
+Set the repository secret `COOLIFY_DEPLOY_WEBHOOK` to enable redeploys after
+pushes to `development`. The same deploy step also runs for manual
+`workflow_dispatch` runs on `development`, which is useful for smoke-testing the
+image build and Coolify webhook path without merging another code change. When
+the secret is absent, images are still published, but deployment remains manual.
 
 For provenance in `/api/build`, pass these non-secret runtime variables to the
 deployed web container when using a prebuilt image:

--- a/docs/COOLIFY.md
+++ b/docs/COOLIFY.md
@@ -252,6 +252,11 @@ after the full image matrix succeeds does the workflow call the deploy webhook.
 Coolify then pulls the already-built `development` images and restarts the
 stack.
 
+To smoke-test the same path without a new merge, manually run the
+`Container Images` workflow on the `development` branch. Manual runs rebuild and
+republish the same image set, then call the Coolify deploy webhook after the
+matrix succeeds.
+
 For stricter release promotion, keep automatic deployment disabled, copy the
 `sha-<12-char-github-sha>` tag from the workflow run, set `IMAGE_TAG` to that
 exact tag in Coolify, and redeploy manually. That gives better rollback and


### PR DESCRIPTION
## Summary
- allow the Container Images deploy job to run for manual workflow_dispatch runs on development
- document manual smoke deploys through GitHub Actions and Coolify webhook

## Validation
- npx prettier --check .github/workflows/container-images.yml docs/CI-CD.md docs/COOLIFY.md
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/container-images.yml"); puts "workflow yaml ok"'
- pre-push: lint, server tests, production build