### PR TITLE
Authenticate Coolify deploy webhook

### DIFF
--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -73,7 +73,7 @@ jobs:
             if [[ -n "${PR_NUMBER}" ]]; then
               echo "${image_repository}:pr-${PR_NUMBER}"
             fi
-            if [[ "${GITHUB_REF_NAME}" == "development" && "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            if [[ "${GITHUB_REF_NAME}" == "development" && ( "${GITHUB_EVENT_NAME}" == "push" || "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ) ]]; then
               echo "${image_repository}:development"
             fi
             echo "EOF"
@@ -171,17 +171,20 @@ jobs:
     runs-on: ubuntu-latest
     env:
       COOLIFY_DEPLOY_WEBHOOK: ${{ secrets.COOLIFY_DEPLOY_WEBHOOK }}
+      COOLIFY_TOKEN: ${{ secrets.COOLIFY_TOKEN }}
     steps:
-      - name: Trigger Coolify deploy webhook
-        if: env.COOLIFY_DEPLOY_WEBHOOK != ''
-        env:
-          COMMIT_SHA: ${{ github.sha }}
-          REF_NAME: ${{ github.ref_name }}
+      - name: Validate Coolify deploy secrets
+        if: env.COOLIFY_DEPLOY_WEBHOOK != '' && env.COOLIFY_TOKEN == ''
         run: |
-          short_sha="${COMMIT_SHA::12}"
-          curl -fsS -X POST "${COOLIFY_DEPLOY_WEBHOOK}" \
-            -H "Content-Type: application/json" \
-            --data "{\"ref\":\"${REF_NAME}\",\"sha\":\"${COMMIT_SHA}\",\"imageTag\":\"sha-${short_sha}\"}"
+          echo "COOLIFY_DEPLOY_WEBHOOK is configured but COOLIFY_TOKEN is missing."
+          echo "Create a Coolify API token with deploy permission and save it as the COOLIFY_TOKEN repository secret."
+          exit 1
+
+      - name: Trigger Coolify deploy webhook
+        if: env.COOLIFY_DEPLOY_WEBHOOK != '' && env.COOLIFY_TOKEN != ''
+        run: |
+          curl -fsS --request GET "${COOLIFY_DEPLOY_WEBHOOK}" \
+            -H "Authorization: Bearer ${COOLIFY_TOKEN}"
 
       - name: Skip deploy when webhook is not configured
         if: env.COOLIFY_DEPLOY_WEBHOOK == ''

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -114,11 +114,17 @@ that exact release bundle. Every PopChoice service must use the same
 `IMAGE_TAG`; mixing `web`, `workers`, `bull-board`, and service images from
 different commits is not a supported deployment shape.
 
-Set the repository secret `COOLIFY_DEPLOY_WEBHOOK` to enable redeploys after
-pushes to `development`. The same deploy step also runs for manual
-`workflow_dispatch` runs on `development`, which is useful for smoke-testing the
-image build and Coolify webhook path without merging another code change. When
-the secret is absent, images are still published, but deployment remains manual.
+Set the repository secrets `COOLIFY_DEPLOY_WEBHOOK` and `COOLIFY_TOKEN` to
+enable redeploys after pushes to `development`. `COOLIFY_TOKEN` must be a
+Coolify API token with deploy permission because the deploy webhook is
+authenticated with `Authorization: Bearer <token>`. The same deploy step also
+runs for manual `workflow_dispatch` runs on `development`, which is useful for
+smoke-testing the image build and Coolify webhook path without merging another
+code change. Manual `development` runs publish the `development` image tag
+before the webhook is called, so Coolify pulls the images from that workflow
+run. When the webhook secret is absent, images are still published, but
+deployment remains manual. When the webhook is present but the token is missing,
+the deploy job fails to make the misconfiguration visible.
 
 For provenance in `/api/build`, pass these non-secret runtime variables to the
 deployed web container when using a prebuilt image:

--- a/docs/COOLIFY.md
+++ b/docs/COOLIFY.md
@@ -245,17 +245,20 @@ For a simple continuous deployment path:
 1. Set `IMAGE_TAG=development` on the Coolify Compose resource.
 2. Add the repository secret `COOLIFY_DEPLOY_WEBHOOK` with the production
    Coolify deploy webhook URL.
-3. Merge to `development`.
+3. Add the repository secret `COOLIFY_TOKEN` with a Coolify API token that has
+   deploy permission.
+4. Merge to `development`.
 
 GitHub Actions builds and publishes every PopChoice runtime image first. Only
 after the full image matrix succeeds does the workflow call the deploy webhook.
-Coolify then pulls the already-built `development` images and restarts the
-stack.
+The webhook call is an authenticated `GET` request using
+`Authorization: Bearer ${COOLIFY_TOKEN}`. Coolify then pulls the already-built
+`development` images and restarts the stack.
 
 To smoke-test the same path without a new merge, manually run the
 `Container Images` workflow on the `development` branch. Manual runs rebuild and
-republish the same image set, then call the Coolify deploy webhook after the
-matrix succeeds.
+republish the same image set, update the `development` image tag, then call the
+Coolify deploy webhook after the matrix succeeds.
 
 For stricter release promotion, keep automatic deployment disabled, copy the
 `sha-<12-char-github-sha>` tag from the workflow run, set `IMAGE_TAG` to that


### PR DESCRIPTION
## Summary
- call the Coolify deploy webhook as authenticated GET with COOLIFY_TOKEN
- fail fast when COOLIFY_DEPLOY_WEBHOOK is set without COOLIFY_TOKEN
- document the required token secret for automatic/manual deploys

## Validation
- npx prettier --check .github/workflows/container-images.yml docs/CI-CD.md docs/COOLIFY.md
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/container-images.yml"); puts "workflow yaml ok"'
- pre-push: lint, server tests, production build