### PR TITLE
[codex] Address available movies review comments

### DIFF
--- a/apps/web/src/app/api/movies/route.test.ts
+++ b/apps/web/src/app/api/movies/route.test.ts
@@ -78,6 +78,22 @@ describe('Movies API Route', () => {
     expect(data).toHaveProperty('error');
   });
 
+  it('should return error for non-numeric pagination parameters', async () => {
+    const invalidPageRequest = new NextRequest('http://localhost:3000/api/movies?page=abc');
+    const invalidPageResponse = await GET(invalidPageRequest);
+    const invalidPageData = await invalidPageResponse.json();
+
+    expect(invalidPageResponse.status).toBe(400);
+    expect(invalidPageData).toHaveProperty('error');
+
+    const invalidPageSizeRequest = new NextRequest('http://localhost:3000/api/movies?pageSize=abc');
+    const invalidPageSizeResponse = await GET(invalidPageSizeRequest);
+    const invalidPageSizeData = await invalidPageSizeResponse.json();
+
+    expect(invalidPageSizeResponse.status).toBe(400);
+    expect(invalidPageSizeData).toHaveProperty('error');
+  });
+
   it('should handle custom page and pageSize parameters', async () => {
     const request = new NextRequest('http://localhost:3000/api/movies?page=2&pageSize=25');
     const response = await GET(request);

--- a/apps/web/src/app/api/movies/route.ts
+++ b/apps/web/src/app/api/movies/route.ts
@@ -7,6 +7,13 @@ import { withAuth } from '@/lib/withAuth';
 const MIN_MOVIE_YEAR = 1878;
 const MAX_MOVIE_YEAR = 2100;
 
+function parseRequiredPositiveInteger(value: string | null, fallback: number): number {
+  if (value == null || value.trim() === '') return fallback;
+  if (!/^\d+$/.test(value.trim())) return Number.NaN;
+  const parsed = Number.parseInt(value.trim(), 10);
+  return Number.isSafeInteger(parsed) ? parsed : Number.NaN;
+}
+
 function parseOptionalYear(value: string | null): number | undefined {
   if (value == null || value.trim() === '') return undefined;
   if (!/^\d{1,4}$/.test(value.trim())) return Number.NaN;
@@ -17,14 +24,20 @@ function parseOptionalYear(value: string | null): number | undefined {
 async function getHandler(request: NextRequest): Promise<NextResponse> {
   try {
     const { searchParams } = new URL(request.url);
-    const page = parseInt(searchParams.get('page') || '1', 10);
-    const pageSize = parseInt(searchParams.get('pageSize') || '50', 10);
+    const page = parseRequiredPositiveInteger(searchParams.get('page'), 1);
+    const pageSize = parseRequiredPositiveInteger(searchParams.get('pageSize'), 50);
     const query = (searchParams.get('query') ?? searchParams.get('title') ?? '').trim();
     const yearFrom = parseOptionalYear(searchParams.get('yearFrom'));
     const yearTo = parseOptionalYear(searchParams.get('yearTo'));
 
     // Validate page and pageSize
-    if (page < 1 || pageSize < 1 || pageSize > 100) {
+    if (
+      !Number.isInteger(page) ||
+      !Number.isInteger(pageSize) ||
+      page < 1 ||
+      pageSize < 1 ||
+      pageSize > 100
+    ) {
       return NextResponse.json({ error: 'Invalid page or pageSize parameters' }, { status: 400 });
     }
 

--- a/apps/web/src/app/available-movies/page.tsx
+++ b/apps/web/src/app/available-movies/page.tsx
@@ -1,14 +1,13 @@
 'use client';
 
 import { ChevronLeft, ChevronRight, Search, X } from 'lucide-react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, type FormEvent } from 'react';
 
 import { MoviesTable, MoviesTableSkeleton } from '@/components';
 import { useLanguage } from '@/i18n';
 import { getCsrfToken } from '@/lib/csrfClient';
 
 import type { Movie, MoviesResponse } from '@/features/movies/catalog';
-import type { FormEvent } from 'react';
 
 interface MovieFilters {
   query: string;


### PR DESCRIPTION
## Summary
- combine the duplicate React import in the available movies page
- reject non-numeric page and pageSize query params in /api/movies
- add regression coverage for page=abc and pageSize=abc

## Context
Follow-up for Copilot review comments on #461:
- https://github.com/shchilkin/PopChoice/pull/461#discussion_r3291092395
- https://github.com/shchilkin/PopChoice/pull/461#discussion_r3291092425

## Validation
- npm run test --workspace=apps/web -- src/app/api/movies/route.test.ts
- npm run type-check
- npm run lint:check
- pre-push checks: lint, server tests, production build