### PR TITLE
[codex] Harden request limits and OpenAI timeouts

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,9 +27,9 @@ This document outlines the security measures and vulnerability management for th
   - [x] Implement session management (`pc_session` signed cookie, `/api/auth/session`, `/api/auth/logout`, and session-aware browser auth fallback)
 
 - [ ] **Request Size & Timeout Management**
-  - [ ] Set maximum request body size limits
+  - [x] Set maximum request body size limits for expensive POST routes (`readJsonBodyWithLimit()` rejects oversized JSON with 413 before validation, moderation, queue creation, TMDB fetches, or OpenAI calls)
   - [x] Configure API timeouts for TMDB (`AbortSignal.timeout()` with 504 response in `more-tmdb-picks/route.ts`)
-  - [ ] Improve OpenAI timeout handling (default client timeout is configured in `apps/web/src/clients/openaiClient.ts`, but per-call/route-specific timeouts, cancellation via `AbortSignal`, and mapping timeout failures to HTTP 504 responses are still missing)
+  - [x] Improve OpenAI timeout handling (per-call timeout options and `AbortSignal` cancellation via `apps/web/src/lib/openaiTimeout.ts`; legacy recommendation route maps upstream OpenAI timeouts to HTTP 504)
   - [ ] Implement retry logic with exponential backoff
 
 ### ⚠️ **Medium Priority Security Issues**
@@ -88,8 +88,8 @@ This document outlines the security measures and vulnerability management for th
 1. ~~Input validation on API routes~~ ✅ Done (Zod schemas + AI moderation pipeline)
 2. ~~Rate limiting implementation~~ ✅ Done
 3. ~~Remove sensitive console logs~~ ✅ Done (pino logger)
-4. Add request timeouts for OpenAI API calls
-5. Add request body size limits
+4. ~~Add request timeouts for OpenAI API calls~~ ✅ Done
+5. ~~Add request body size limits~~ ✅ Done
 
 ### Phase 2 (Short-term - Medium Issues)
 
@@ -112,16 +112,30 @@ This document outlines the security measures and vulnerability management for th
 - [x] Input validation (Zod schema + prompt injection detection + OpenAI Moderation API + LLM content judge)
 - [x] Rate limiting (Redis-backed, 10 req/min per IP; requires `REDIS_URL`)
 - [ ] Error sanitization
-- [ ] Request size limits
-- [ ] Timeout configuration (OpenAI API calls have no `AbortSignal`)
+- [x] Request size limits (16 KiB JSON body cap)
+- [x] Timeout configuration (per-call OpenAI timeout options with `AbortSignal`; OpenAI timeout failures return 504)
+
+### `/api/recommendations`
+
+- [x] Input validation (Zod schema + shared recommendation input screening)
+- [x] Rate limiting (Redis-backed, 10 req/min per IP)
+- [x] Request size limits (16 KiB JSON body cap)
+- [ ] Error sanitization
 
 ### `/api/more-tmdb-picks`
 
 - [x] Input validation (Zod schema)
 - [x] Rate limiting (Redis-backed, 10 req/min per IP)
-- [x] Timeout configuration (`AbortSignal.timeout()` with 504 response on TMDB fetch)
+- [x] Timeout configuration (`AbortSignal.timeout()` for TMDB fetches; OpenAI calls use per-call timeout options and `AbortSignal`)
 - [ ] Error sanitization
-- [ ] Request size limits
+- [x] Request size limits (16 KiB JSON body cap)
+
+### `/api/movie-posters`
+
+- [x] Input validation (Zod schema)
+- [x] Rate limiting (Redis-backed, 10 req/min per IP)
+- [x] Request size limits (32 KiB JSON body cap)
+- [ ] Error sanitization
 
 ### AI Moderation Pipeline (implemented security layer)
 

--- a/apps/web/src/app/api/more-tmdb-picks/route.test.ts
+++ b/apps/web/src/app/api/more-tmdb-picks/route.test.ts
@@ -21,8 +21,8 @@ const mockChatCompletionsCreate = vi.fn(() =>
     choices: [{ message: { content: 'An exciting action film.' } }],
   }),
 );
-vi.mock('@/clients', () => ({
-  openAIClient: {
+vi.mock('@/clients/openaiClient', () => ({
+  getOpenAIClient: () => ({
     embeddings: {
       create: (...args: Parameters<typeof mockEmbeddingsCreate>) => mockEmbeddingsCreate(...args),
     },
@@ -32,13 +32,15 @@ vi.mock('@/clients', () => ({
           mockChatCompletionsCreate(...args),
       },
     },
-  },
+  }),
 }));
 
 // Mock IMAGE_BASE_URL from the TMDB integration
 vi.mock('@/integrations/tmdb', () => ({
   IMAGE_BASE_URL: 'https://image.tmdb.org/t/p',
 }));
+
+import { RECOMMENDATION_REQUEST_BODY_LIMIT_BYTES } from '@/lib/requestBody';
 
 import { POST } from './route';
 
@@ -73,10 +75,10 @@ const mockDiscoverResponse = {
   ],
 };
 
-function makeRequest(body: unknown = validBody) {
+function makeRequest(body: unknown = validBody, headers: Record<string, string> = {}) {
   return new NextRequest('http://localhost/api/more-tmdb-picks', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'Accept-Language': 'en' },
+    headers: { 'Content-Type': 'application/json', 'Accept-Language': 'en', ...headers },
     body: JSON.stringify(body),
   });
 }
@@ -108,6 +110,22 @@ describe('POST /api/more-tmdb-picks — timeout handling', () => {
 
     expect(res.status).toBe(504);
     expect(data).toHaveProperty('error');
+  });
+
+  it('returns 413 before TMDB or OpenAI work when the request body is too large', async () => {
+    const res = await POST(
+      makeRequest({
+        ...validBody,
+        extraPayload: 'x'.repeat(RECOMMENDATION_REQUEST_BODY_LIMIT_BYTES),
+      }),
+    );
+    const data = await res.json();
+
+    expect(res.status).toBe(413);
+    expect(data).toHaveProperty('error', 'Request body too large');
+    expect(fetch).not.toHaveBeenCalled();
+    expect(mockEmbeddingsCreate).not.toHaveBeenCalled();
+    expect(mockChatCompletionsCreate).not.toHaveBeenCalled();
   });
 
   it('returns 504 when TMDB discover fetch times out via AbortError', async () => {

--- a/apps/web/src/app/api/more-tmdb-picks/route.ts
+++ b/apps/web/src/app/api/more-tmdb-picks/route.ts
@@ -3,7 +3,13 @@ import z from 'zod';
 
 import { runMorePicksPipeline } from '@/features/recommendation/morePicksPipeline';
 import { parseLocaleFromRequest } from '@/lib/locale';
+import { isOpenAITimeoutError } from '@/lib/openaiTimeout';
 import { applyRateLimit } from '@/lib/rateLimit';
+import {
+  RECOMMENDATION_REQUEST_BODY_LIMIT_BYTES,
+  readJsonBodyWithLimit,
+  requestBodyErrorResponse,
+} from '@/lib/requestBody';
 import { withAuth } from '@/lib/withAuth';
 
 const personFormDataSchema = z.object({
@@ -28,7 +34,7 @@ async function postHandler(req: NextRequest): Promise<Response> {
   const locale = parseLocaleFromRequest(req);
 
   try {
-    const body = await req.json();
+    const body = await readJsonBodyWithLimit(req, RECOMMENDATION_REQUEST_BODY_LIMIT_BYTES);
     const { quizData, page, excludeIds } = requestBodySchema.parse(body);
 
     if (!process.env.TMDB_API_KEY) {
@@ -38,6 +44,9 @@ async function postHandler(req: NextRequest): Promise<Response> {
     const movies = await runMorePicksPipeline(quizData, excludeIds, page, locale);
     return NextResponse.json({ movies });
   } catch (error) {
+    const bodyErrorResponse = requestBodyErrorResponse(error);
+    if (bodyErrorResponse) return bodyErrorResponse;
+
     if (error instanceof z.ZodError) {
       return NextResponse.json(
         { error: 'Invalid request', details: error.issues },
@@ -45,9 +54,10 @@ async function postHandler(req: NextRequest): Promise<Response> {
       );
     }
     const isTimeout =
-      error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError');
+      (error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError')) ||
+      isOpenAITimeoutError(error);
     if (isTimeout) {
-      return NextResponse.json({ error: 'TMDB request timed out' }, { status: 504 });
+      return NextResponse.json({ error: 'Upstream request timed out' }, { status: 504 });
     }
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }

--- a/apps/web/src/app/api/movie-posters/route.ts
+++ b/apps/web/src/app/api/movie-posters/route.ts
@@ -5,6 +5,11 @@ import { getMovieInfo } from '@/features/recommendation/recommendation';
 import { parseLocaleFromRequest } from '@/lib/locale';
 import logger from '@/lib/logger';
 import { applyRateLimit } from '@/lib/rateLimit';
+import {
+  POSTER_REQUEST_BODY_LIMIT_BYTES,
+  readJsonBodyWithLimit,
+  requestBodyErrorResponse,
+} from '@/lib/requestBody';
 
 const requestSchema = z.object({
   locale: z.enum(['en', 'ru', 'fi']).optional(),
@@ -36,9 +41,11 @@ export async function POST(req: NextRequest): Promise<Response> {
 
   let body: unknown;
   try {
-    body = await req.json();
-  } catch {
-    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    body = await readJsonBodyWithLimit(req, POSTER_REQUEST_BODY_LIMIT_BYTES);
+  } catch (error) {
+    const bodyErrorResponse = requestBodyErrorResponse(error);
+    if (bodyErrorResponse) return bodyErrorResponse;
+    throw error;
   }
 
   const parsed = requestSchema.safeParse(body);

--- a/apps/web/src/app/api/movie-recommendation/route.test.ts
+++ b/apps/web/src/app/api/movie-recommendation/route.test.ts
@@ -80,6 +80,7 @@ vi.mock('@/integrations/tmdb', () => ({
 }));
 
 import { resetOpenAIClient, setOpenAIClient, type OpenAIClientLike } from '@/clients/openaiClient';
+import { RECOMMENDATION_REQUEST_BODY_LIMIT_BYTES } from '@/lib/requestBody';
 
 import { MIN_HIGH_QUALITY_LOCAL, SIMILARITY_THRESHOLD, shouldFallBackToTMDB } from './helpers';
 import { POST } from './route';
@@ -113,10 +114,10 @@ const validBody = {
   tonePreference: 'serious',
 };
 
-function makeRequest(body: unknown = validBody) {
+function makeRequest(body: unknown = validBody, headers: Record<string, string> = {}) {
   return new NextRequest('http://localhost/api/movie-recommendation', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'Accept-Language': 'en' },
+    headers: { 'Content-Type': 'application/json', 'Accept-Language': 'en', ...headers },
     body: JSON.stringify(body),
   });
 }
@@ -199,6 +200,35 @@ describe('POST /api/movie-recommendation — moderation', () => {
 
     expect(response.status).toBe(400);
     expect(data).toHaveProperty('error');
+  });
+
+  it('returns 413 before moderation or OpenAI work when the request body is too large', async () => {
+    const response = await POST(
+      makeRequest({
+        ...validBody,
+        extraPayload: 'x'.repeat(RECOMMENDATION_REQUEST_BODY_LIMIT_BYTES),
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(413);
+    expect(data).toHaveProperty('error', 'Request body too large');
+    expect(mockModerateInput).not.toHaveBeenCalled();
+    expect(mockEmbeddingsCreate).not.toHaveBeenCalled();
+    expect(mockChatCompletionsCreate).not.toHaveBeenCalled();
+  });
+
+  it('returns 504 when an OpenAI timeout reaches the route', async () => {
+    const timeoutError = Object.assign(new Error('Request timed out.'), {
+      name: 'APIConnectionTimeoutError',
+    });
+    mockEmbeddingsCreate.mockRejectedValueOnce(timeoutError);
+
+    const response = await POST(makeRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(504);
+    expect(data).toHaveProperty('error', 'OpenAI request timed out');
   });
 });
 

--- a/apps/web/src/app/api/movie-recommendation/route.ts
+++ b/apps/web/src/app/api/movie-recommendation/route.ts
@@ -6,7 +6,13 @@ import { runRecommendationPipeline } from '@/features/recommendation/pipeline';
 import { apiResponseSchema, requestBodySchema } from '@/features/recommendation/types';
 import { parseLocaleFromRequest } from '@/lib/locale';
 import logger from '@/lib/logger';
+import { isOpenAITimeoutError } from '@/lib/openaiTimeout';
 import { applyRateLimit } from '@/lib/rateLimit';
+import {
+  RECOMMENDATION_REQUEST_BODY_LIMIT_BYTES,
+  readJsonBodyWithLimit,
+  requestBodyErrorResponse,
+} from '@/lib/requestBody';
 import { withAuth } from '@/lib/withAuth';
 
 // ---------------------------------------------------------------------------
@@ -19,7 +25,7 @@ async function postHandler(req: NextRequest): Promise<Response> {
     const rateLimitResponse = await applyRateLimit(req);
     if (rateLimitResponse) return rateLimitResponse;
 
-    const body = await req.json();
+    const body = await readJsonBodyWithLimit(req, RECOMMENDATION_REQUEST_BODY_LIMIT_BYTES);
 
     // Validate request body
     const validatedBody = requestBodySchema.parse(body);
@@ -48,6 +54,9 @@ async function postHandler(req: NextRequest): Promise<Response> {
 
     return NextResponse.json(apiResponseSchema.parse(response));
   } catch (error) {
+    const bodyErrorResponse = requestBodyErrorResponse(error);
+    if (bodyErrorResponse) return bodyErrorResponse;
+
     // Handle validation errors first — these are client errors (400), not server errors
     if (error instanceof z.ZodError) {
       logger.warn({ err: error, issues: error.issues }, 'Invalid request body');
@@ -61,6 +70,10 @@ async function postHandler(req: NextRequest): Promise<Response> {
     }
 
     logger.error({ err: error }, 'Error in movie recommendation API');
+
+    if (isOpenAITimeoutError(error)) {
+      return NextResponse.json({ error: 'OpenAI request timed out' }, { status: 504 });
+    }
 
     // Handle other known errors
     if (error instanceof Error) {

--- a/apps/web/src/app/api/recommendations/route.test.ts
+++ b/apps/web/src/app/api/recommendations/route.test.ts
@@ -1,0 +1,84 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { RECOMMENDATION_REQUEST_BODY_LIMIT_BYTES } from '@/lib/requestBody';
+
+vi.mock('@/lib/withAuth', () => ({
+  withAuth:
+    (handler: (req: NextRequest, clientId: string) => Promise<Response> | Response) =>
+    (req: NextRequest) =>
+      handler(req, 'test-client'),
+}));
+
+vi.mock('@/lib/rateLimit', () => ({
+  applyRateLimit: vi.fn(() => Promise.resolve(null)),
+}));
+
+const mockGetRecommendationInputBlock = vi.fn<(allPeopleData: unknown[]) => Promise<null>>(() =>
+  Promise.resolve(null),
+);
+const mockNormalizePeopleData = vi.fn<(body: unknown) => unknown[]>((body) =>
+  Array.isArray(body) ? body : [body],
+);
+
+vi.mock('@/features/recommendation/input', () => ({
+  getRecommendationInputBlock: (allPeopleData: unknown[]) =>
+    mockGetRecommendationInputBlock(allPeopleData),
+  normalizePeopleData: (body: unknown) => mockNormalizePeopleData(body),
+}));
+
+const mockCreateAndStartRecommendation = vi.fn<(...args: unknown[]) => Promise<{ slug: string }>>(
+  () => Promise.resolve({ slug: 'rec-test-slug' }),
+);
+
+vi.mock('@/features/recommendation/jobs', () => ({
+  createAndStartRecommendation: (...args: unknown[]) => mockCreateAndStartRecommendation(...args),
+}));
+
+import { POST } from './route';
+
+const validBody = {
+  favoriteMovie: 'The Matrix',
+  newVsClassic: 'new',
+  moodPreference: ['action', 'sci-fi'],
+  tonePreference: 'serious',
+};
+
+function makeRequest(body: unknown = validBody) {
+  return new NextRequest('http://localhost/api/recommendations', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Accept-Language': 'en' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/recommendations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 413 before validation or job creation when the request body is too large', async () => {
+    const response = await POST(
+      makeRequest({
+        ...validBody,
+        extraPayload: 'x'.repeat(RECOMMENDATION_REQUEST_BODY_LIMIT_BYTES),
+      }),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(413);
+    expect(data).toHaveProperty('error', 'Request body too large');
+    expect(mockNormalizePeopleData).not.toHaveBeenCalled();
+    expect(mockGetRecommendationInputBlock).not.toHaveBeenCalled();
+    expect(mockCreateAndStartRecommendation).not.toHaveBeenCalled();
+  });
+
+  it('creates a recommendation job for a valid request', async () => {
+    const response = await POST(makeRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data).toEqual({ id: 'rec-test-slug' });
+    expect(mockCreateAndStartRecommendation).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/recommendations/route.ts
+++ b/apps/web/src/app/api/recommendations/route.ts
@@ -6,6 +6,11 @@ import { requestBodySchema } from '@/features/recommendation/types';
 import { parseLocaleFromRequest } from '@/lib/locale';
 import logger from '@/lib/logger';
 import { applyRateLimit } from '@/lib/rateLimit';
+import {
+  RECOMMENDATION_REQUEST_BODY_LIMIT_BYTES,
+  readJsonBodyWithLimit,
+  requestBodyErrorResponse,
+} from '@/lib/requestBody';
 import { withAuth } from '@/lib/withAuth';
 
 // ---------------------------------------------------------------------------
@@ -17,9 +22,11 @@ async function postHandler(req: NextRequest, clientId: string): Promise<Response
 
   let body: unknown;
   try {
-    body = await req.json();
-  } catch {
-    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    body = await readJsonBodyWithLimit(req, RECOMMENDATION_REQUEST_BODY_LIMIT_BYTES);
+  } catch (error) {
+    const bodyErrorResponse = requestBodyErrorResponse(error);
+    if (bodyErrorResponse) return bodyErrorResponse;
+    throw error;
   }
 
   // Validate request body

--- a/apps/web/src/features/recommendation/embedding.ts
+++ b/apps/web/src/features/recommendation/embedding.ts
@@ -1,6 +1,7 @@
 import { getOpenAIClient } from '@/clients/openaiClient';
 import logger from '@/lib/logger';
 import { MODELS } from '@/lib/models';
+import { OPENAI_TIMEOUTS_MS, openAIRequestOptions } from '@/lib/openaiTimeout';
 
 import type { PersonFormData } from './types';
 
@@ -96,15 +97,18 @@ export async function refineQueryWithLLM(allPeopleData: PersonFormData[]): Promi
   const rawText = whyTexts.join(' ');
 
   try {
-    const response = await getOpenAIClient().chat.completions.create({
-      model: MODELS.MINI,
-      messages: [
-        { role: 'system', content: QUERY_ENRICHMENT_SYSTEM_PROMPT },
-        { role: 'user', content: rawText },
-      ],
-      max_completion_tokens: 200,
-      temperature: 0,
-    });
+    const response = await getOpenAIClient().chat.completions.create(
+      {
+        model: MODELS.MINI,
+        messages: [
+          { role: 'system', content: QUERY_ENRICHMENT_SYSTEM_PROMPT },
+          { role: 'user', content: rawText },
+        ],
+        max_completion_tokens: 200,
+        temperature: 0,
+      },
+      openAIRequestOptions(OPENAI_TIMEOUTS_MS.queryEnrichment),
+    );
 
     const refinedTags = response.choices[0]?.message?.content?.trim();
 
@@ -149,10 +153,13 @@ export async function createEmbedding(
       ? buildEmbeddingInputWithRefinedTags(allPeopleData, refinedQueryTags)
       : combineAllPeopleDataToString(allPeopleData);
 
-    const embeddingResponse = await getOpenAIClient().embeddings.create({
-      model: MODELS.EMBEDDING,
-      input: embeddingInput,
-    });
+    const embeddingResponse = await getOpenAIClient().embeddings.create(
+      {
+        model: MODELS.EMBEDDING,
+        input: embeddingInput,
+      },
+      openAIRequestOptions(OPENAI_TIMEOUTS_MS.embedding),
+    );
     if (!embeddingResponse?.data?.[0]?.embedding) {
       throw new Error('No embedding returned from OpenAI.');
     }

--- a/apps/web/src/features/recommendation/morePicksPipeline.ts
+++ b/apps/web/src/features/recommendation/morePicksPipeline.ts
@@ -12,6 +12,7 @@ import { MOVIE_SEED_JOB_OPTIONS, seedQueue } from '@/lib/jobQueue';
 import { LOCALE_LANGUAGE, LOCALE_TO_TMDB_LANG } from '@/lib/locale';
 import logger from '@/lib/logger';
 import { MODELS } from '@/lib/models';
+import { OPENAI_TIMEOUTS_MS, openAIRequestOptions } from '@/lib/openaiTimeout';
 import {
   GENRE_LABEL_TO_TMDB_ID,
   cosineSimilarity,
@@ -270,8 +271,14 @@ export async function runMorePicksPipeline(
   const similarityMap = new Map<number, number>();
   try {
     const [queryEmbedRes, movieEmbedRes] = await Promise.all([
-      getOpenAIClient().embeddings.create({ model: MODELS.EMBEDDING, input: queryText }),
-      getOpenAIClient().embeddings.create({ model: MODELS.EMBEDDING, input: candidateTexts }),
+      getOpenAIClient().embeddings.create(
+        { model: MODELS.EMBEDDING, input: queryText },
+        openAIRequestOptions(OPENAI_TIMEOUTS_MS.embedding),
+      ),
+      getOpenAIClient().embeddings.create(
+        { model: MODELS.EMBEDDING, input: candidateTexts },
+        openAIRequestOptions(OPENAI_TIMEOUTS_MS.embedding),
+      ),
     ]);
     const queryEmbedding = queryEmbedRes.data[0]?.embedding;
     if (queryEmbedding && queryEmbedding.length > 0) {
@@ -341,17 +348,20 @@ Respond in ${language} only.`;
         // AI-generated description in the target language
         let aiDescription = localizedOverview;
         try {
-          const descriptionResponse = await getOpenAIClient().chat.completions.create({
-            model: MODELS.MINI,
-            messages: [
-              { role: 'system', content: descriptionSystemPrompt },
-              {
-                role: 'user',
-                content: `Movie: ${localizedTitle} (${year})\nRating: ${score}/10\nPlot: ${localizedOverview}`,
-              },
-            ],
-            max_completion_tokens: 150,
-          });
+          const descriptionResponse = await getOpenAIClient().chat.completions.create(
+            {
+              model: MODELS.MINI,
+              messages: [
+                { role: 'system', content: descriptionSystemPrompt },
+                {
+                  role: 'user',
+                  content: `Movie: ${localizedTitle} (${year})\nRating: ${score}/10\nPlot: ${localizedOverview}`,
+                },
+              ],
+              max_completion_tokens: 150,
+            },
+            openAIRequestOptions(OPENAI_TIMEOUTS_MS.description),
+          );
           aiDescription = descriptionResponse.choices[0]?.message?.content?.trim() || aiDescription;
         } catch (err) {
           logger.warn(

--- a/apps/web/src/features/recommendation/recommendation.ts
+++ b/apps/web/src/features/recommendation/recommendation.ts
@@ -4,6 +4,7 @@ import { MovieService } from '@/integrations/tmdb';
 import { LOCALE_LANGUAGE, LOCALE_TO_TMDB_LANG, type Locale } from '@/lib/locale';
 import logger from '@/lib/logger';
 import { MODELS } from '@/lib/models';
+import { OPENAI_TIMEOUTS_MS, openAIRequestOptions } from '@/lib/openaiTimeout';
 
 import { LOCAL_VECTOR_MATCH_THRESHOLD, MAX_TOTAL_MOVIES } from './config';
 import { combineAllPeopleDataToString } from './embedding';
@@ -112,17 +113,20 @@ export async function getRecommendation(
     const moviesContext = similarMovies.map((movie) => movie.content).join('\n\n');
     const userPreferencesContext = combineAllPeopleDataToString(userPreferences);
 
-    const recommendation = await getOpenAIClient().chat.completions.create({
-      model: MODELS.RECOMMENDATION,
-      messages: [
-        { role: 'system', content: buildPrompt(locale) },
-        {
-          role: 'user',
-          content: `Available movie context:\n${moviesContext}\n\nViewer preferences:\n${userPreferencesContext}`,
-        },
-      ],
-      response_format: recommendationResponseFormat,
-    });
+    const recommendation = await getOpenAIClient().chat.completions.create(
+      {
+        model: MODELS.RECOMMENDATION,
+        messages: [
+          { role: 'system', content: buildPrompt(locale) },
+          {
+            role: 'user',
+            content: `Available movie context:\n${moviesContext}\n\nViewer preferences:\n${userPreferencesContext}`,
+          },
+        ],
+        response_format: recommendationResponseFormat,
+      },
+      openAIRequestOptions(OPENAI_TIMEOUTS_MS.recommendation),
+    );
     if (!recommendation.choices[0].message.content) {
       throw new Error('No output text from OpenAI.');
     }
@@ -193,14 +197,17 @@ Plot: ${movie.description}
 
 Remember: respond in ${language} only.`;
 
-          const descriptionResponse = await getOpenAIClient().chat.completions.create({
-            model: MODELS.MINI,
-            messages: [
-              { role: 'system', content: descriptionPrompt },
-              { role: 'user', content: movieContext },
-            ],
-            max_completion_tokens: 150,
-          });
+          const descriptionResponse = await getOpenAIClient().chat.completions.create(
+            {
+              model: MODELS.MINI,
+              messages: [
+                { role: 'system', content: descriptionPrompt },
+                { role: 'user', content: movieContext },
+              ],
+              max_completion_tokens: 150,
+            },
+            openAIRequestOptions(OPENAI_TIMEOUTS_MS.description),
+          );
 
           const aiDescription =
             descriptionResponse.choices[0]?.message?.content?.trim() || movie.description;

--- a/apps/web/src/features/recommendation/tmdb.ts
+++ b/apps/web/src/features/recommendation/tmdb.ts
@@ -5,6 +5,7 @@ import { getOpenAIClient } from '@/clients/openaiClient';
 import { IMAGE_BASE_URL } from '@/integrations/tmdb';
 import logger from '@/lib/logger';
 import { MODELS } from '@/lib/models';
+import { OPENAI_TIMEOUTS_MS, openAIRequestOptions } from '@/lib/openaiTimeout';
 import {
   GENRE_LABEL_TO_TMDB_ID,
   cosineSimilarity,
@@ -216,10 +217,13 @@ export async function scoreAndConvertTMDBMovies(
 
   let rawEmbeddings: number[][] = [];
   try {
-    const response = await getOpenAIClient().embeddings.create({
-      model: MODELS.EMBEDDING,
-      input: texts,
-    });
+    const response = await getOpenAIClient().embeddings.create(
+      {
+        model: MODELS.EMBEDDING,
+        input: texts,
+      },
+      openAIRequestOptions(OPENAI_TIMEOUTS_MS.embedding),
+    );
     rawEmbeddings = response.data.map((d) => d.embedding);
   } catch (error) {
     logger.warn(
@@ -383,10 +387,13 @@ export async function seedMovies(
           `Description: ${movie.overview || ''}`,
         ].join('\n');
 
-        const embeddingResponse = await getOpenAIClient().embeddings.create({
-          model: MODELS.EMBEDDING,
-          input: embeddingText,
-        });
+        const embeddingResponse = await getOpenAIClient().embeddings.create(
+          {
+            model: MODELS.EMBEDDING,
+            input: embeddingText,
+          },
+          openAIRequestOptions(OPENAI_TIMEOUTS_MS.embedding),
+        );
         embedding = embeddingResponse.data[0]?.embedding;
       }
       if (!embedding) continue;

--- a/apps/web/src/lib/openaiTimeout.ts
+++ b/apps/web/src/lib/openaiTimeout.ts
@@ -1,0 +1,69 @@
+import type OpenAI from 'openai';
+
+export const OPENAI_TIMEOUTS_MS = {
+  moderation: 10_000,
+  judge: 15_000,
+  queryEnrichment: 15_000,
+  embedding: 10_000,
+  recommendation: 30_000,
+  description: 20_000,
+} as const;
+
+export function openAIRequestOptions(timeoutMs: number): OpenAI.RequestOptions {
+  return {
+    signal: AbortSignal.timeout(timeoutMs),
+    timeout: timeoutMs,
+  };
+}
+
+export function isOpenAITimeoutError(error: unknown): boolean {
+  const seen = new Set<unknown>();
+
+  function visit(value: unknown): boolean {
+    if (!value || seen.has(value)) return false;
+    seen.add(value);
+
+    if (value instanceof Error) {
+      if (
+        value.name === 'AbortError' ||
+        value.name === 'TimeoutError' ||
+        value.name === 'APIConnectionTimeoutError'
+      ) {
+        return true;
+      }
+
+      const message = value.message.toLowerCase();
+      if (
+        message.includes('timed out') ||
+        message.includes('timeout') ||
+        message.includes('aborted')
+      ) {
+        return true;
+      }
+
+      return visit(value.cause);
+    }
+
+    if (typeof value === 'object') {
+      const maybeError = value as { name?: unknown; message?: unknown; cause?: unknown };
+      if (
+        maybeError.name === 'AbortError' ||
+        maybeError.name === 'TimeoutError' ||
+        maybeError.name === 'APIConnectionTimeoutError'
+      ) {
+        return true;
+      }
+      if (
+        typeof maybeError.message === 'string' &&
+        /timed out|timeout|aborted/i.test(maybeError.message)
+      ) {
+        return true;
+      }
+      return visit(maybeError.cause);
+    }
+
+    return false;
+  }
+
+  return visit(error);
+}

--- a/apps/web/src/lib/requestBody.ts
+++ b/apps/web/src/lib/requestBody.ts
@@ -1,0 +1,61 @@
+import { NextResponse, type NextRequest } from 'next/server';
+
+export const RECOMMENDATION_REQUEST_BODY_LIMIT_BYTES = 16 * 1024;
+export const POSTER_REQUEST_BODY_LIMIT_BYTES = 32 * 1024;
+
+export class RequestBodyTooLargeError extends Error {
+  constructor(readonly limitBytes: number) {
+    super(`Request body exceeds ${limitBytes} bytes`);
+    this.name = 'RequestBodyTooLargeError';
+  }
+}
+
+export class InvalidRequestBodyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidRequestBodyError';
+  }
+}
+
+function parseContentLength(headerValue: string | null): number | null {
+  if (headerValue === null) return null;
+  if (!/^\d+$/.test(headerValue.trim())) {
+    throw new InvalidRequestBodyError('Invalid Content-Length header');
+  }
+  return Number.parseInt(headerValue, 10);
+}
+
+function byteLength(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+export async function readJsonBodyWithLimit(
+  req: NextRequest,
+  limitBytes: number,
+): Promise<unknown> {
+  const contentLength = parseContentLength(req.headers.get('content-length'));
+  if (contentLength !== null && contentLength > limitBytes) {
+    throw new RequestBodyTooLargeError(limitBytes);
+  }
+
+  const rawBody = await req.text();
+  if (byteLength(rawBody) > limitBytes) {
+    throw new RequestBodyTooLargeError(limitBytes);
+  }
+
+  try {
+    return JSON.parse(rawBody) as unknown;
+  } catch {
+    throw new InvalidRequestBodyError('Invalid JSON body');
+  }
+}
+
+export function requestBodyErrorResponse(error: unknown): NextResponse | null {
+  if (error instanceof RequestBodyTooLargeError) {
+    return NextResponse.json({ error: 'Request body too large' }, { status: 413 });
+  }
+  if (error instanceof InvalidRequestBodyError) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+  return null;
+}

--- a/apps/web/src/utils/ai/embeddings.ts
+++ b/apps/web/src/utils/ai/embeddings.ts
@@ -1,4 +1,5 @@
 import { getOpenAIClient } from '@/clients/openaiClient';
+import { OPENAI_TIMEOUTS_MS, openAIRequestOptions } from '@/lib/openaiTimeout';
 
 import type { ChunkWithEmbedding, EmbeddableChunk } from '../types';
 
@@ -17,10 +18,13 @@ export async function createEmbeddingsForChunks<T extends EmbeddableChunk>(
 ): Promise<ChunkWithEmbedding<T>[]> {
   return Promise.all(
     chunks.map(async (chunk) => {
-      const embeddingResponse = await getOpenAIClient().embeddings.create({
-        model,
-        input: chunk.pageContent,
-      });
+      const embeddingResponse = await getOpenAIClient().embeddings.create(
+        {
+          model,
+          input: chunk.pageContent,
+        },
+        openAIRequestOptions(OPENAI_TIMEOUTS_MS.embedding),
+      );
 
       return {
         ...chunk,

--- a/apps/web/src/utils/ai/moderation.test.ts
+++ b/apps/web/src/utils/ai/moderation.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { OPENAI_TIMEOUTS_MS } from '@/lib/openaiTimeout';
 
 const mockModerationsCreate = vi.fn();
 const mockChatCompletionsParse = vi.fn();
@@ -18,6 +20,10 @@ vi.mock('@/clients/openaiClient', () => ({
 
 const { moderateInput, checkForPromptInjection, judgeForMoviePlatform, ALWAYS_BLOCK_CATEGORIES } =
   await import('./moderation');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 function makeModerationResponse(flagged: boolean, categories: Record<string, boolean> = {}) {
   return {
@@ -60,10 +66,16 @@ describe('moderateInput', () => {
     const result = await moderateInput('The Dark Knight');
 
     expect(result).toEqual({ flagged: false });
-    expect(mockModerationsCreate).toHaveBeenCalledWith({
-      model: 'omni-moderation-latest',
-      input: 'The Dark Knight',
-    });
+    expect(mockModerationsCreate).toHaveBeenCalledWith(
+      {
+        model: 'omni-moderation-latest',
+        input: 'The Dark Knight',
+      },
+      expect.objectContaining({
+        signal: expect.any(Object),
+        timeout: OPENAI_TIMEOUTS_MS.moderation,
+      }),
+    );
   });
 
   it('returns flagged: true with ALL categories including violence (no filtering)', async () => {
@@ -101,10 +113,16 @@ describe('moderateInput', () => {
     const result = await moderateInput(['action', 'comedy', 'light']);
 
     expect(result).toEqual({ flagged: false });
-    expect(mockModerationsCreate).toHaveBeenCalledWith({
-      model: 'omni-moderation-latest',
-      input: ['action', 'comedy', 'light'],
-    });
+    expect(mockModerationsCreate).toHaveBeenCalledWith(
+      {
+        model: 'omni-moderation-latest',
+        input: ['action', 'comedy', 'light'],
+      },
+      expect.objectContaining({
+        signal: expect.any(Object),
+        timeout: OPENAI_TIMEOUTS_MS.moderation,
+      }),
+    );
   });
 
   it('deduplicates flagged categories across multiple results', async () => {
@@ -262,7 +280,8 @@ describe('judgeForMoviePlatform', () => {
 
     await judgeForMoviePlatform(killBillInputs, ['violence']);
 
-    expect(mockChatCompletionsParse).toHaveBeenCalledWith(
+    const [payload, options] = mockChatCompletionsParse.mock.calls[0];
+    expect(payload).toEqual(
       expect.objectContaining({
         model: 'gpt-5.4-mini',
         max_completion_tokens: 50,
@@ -274,11 +293,18 @@ describe('judgeForMoviePlatform', () => {
             role: 'user',
             content: expect.stringContaining('Kill Bill'),
           }),
-          expect.objectContaining({
-            role: 'user',
-            content: expect.stringContaining('violence'),
-          }),
         ]),
+      }),
+    );
+    expect(payload.messages.find((message: { role: string }) => message.role === 'user')).toEqual(
+      expect.objectContaining({
+        content: expect.stringContaining('violence'),
+      }),
+    );
+    expect(options).toEqual(
+      expect.objectContaining({
+        signal: expect.any(Object),
+        timeout: OPENAI_TIMEOUTS_MS.judge,
       }),
     );
   });

--- a/apps/web/src/utils/ai/moderation.ts
+++ b/apps/web/src/utils/ai/moderation.ts
@@ -2,7 +2,9 @@ import { zodResponseFormat } from 'openai/helpers/zod';
 import z from 'zod';
 
 import { getOpenAIClient } from '@/clients/openaiClient';
+import logger from '@/lib/logger';
 import { MODELS } from '@/lib/models';
+import { OPENAI_TIMEOUTS_MS, openAIRequestOptions } from '@/lib/openaiTimeout';
 
 export type ModerationResult = { flagged: false } | { flagged: true; categories: string[] };
 
@@ -44,10 +46,13 @@ export function checkForPromptInjection(text: string): boolean {
  * @returns A ModerationResult with all flagged categories.
  */
 export async function moderateInput(input: string | string[]): Promise<ModerationResult> {
-  const response = await getOpenAIClient().moderations.create({
-    model: 'omni-moderation-latest',
-    input,
-  });
+  const response = await getOpenAIClient().moderations.create(
+    {
+      model: 'omni-moderation-latest',
+      input,
+    },
+    openAIRequestOptions(OPENAI_TIMEOUTS_MS.moderation),
+  );
 
   const flaggedCategories: string[] = [];
 
@@ -125,24 +130,27 @@ export async function judgeForMoviePlatform(
   const inputSummary = labeledInputs.map(({ field, value }) => `${field}: "${value}"`).join('\n');
 
   try {
-    const response = await getOpenAIClient().chat.completions.parse({
-      model: MODELS.MINI,
-      messages: [
-        { role: 'system', content: JUDGE_SYSTEM_PROMPT },
-        {
-          role: 'user',
-          content: `Moderation flagged: ${flaggedCategories.join(', ')}\n\nUser inputs:\n${inputSummary}`,
-        },
-      ],
-      response_format: zodResponseFormat(judgeResponseSchema, 'judgeResult'),
-      max_completion_tokens: 50,
-    });
+    const response = await getOpenAIClient().chat.completions.parse(
+      {
+        model: MODELS.MINI,
+        messages: [
+          { role: 'system', content: JUDGE_SYSTEM_PROMPT },
+          {
+            role: 'user',
+            content: `Moderation flagged: ${flaggedCategories.join(', ')}\n\nUser inputs:\n${inputSummary}`,
+          },
+        ],
+        response_format: zodResponseFormat(judgeResponseSchema, 'judgeResult'),
+        max_completion_tokens: 50,
+      },
+      openAIRequestOptions(OPENAI_TIMEOUTS_MS.judge),
+    );
 
     const parsed = response.choices[0].message.parsed;
     return { suitable: parsed?.suitable === true };
   } catch (err) {
     // Fail-safe: if the judge call fails for any reason (e.g. invalid model name), block the request.
-    console.error('[judgeForMoviePlatform] judge call failed, blocking as fail-safe:', err);
+    logger.error({ err }, 'judgeForMoviePlatform: judge call failed, blocking as fail-safe');
     return { suitable: false };
   }
 }

--- a/docs/ROADMAP-ARCHITECTURE.md
+++ b/docs/ROADMAP-ARCHITECTURE.md
@@ -61,6 +61,8 @@ The main remaining risks are:
 - [x] Movie-memory candidate cards keep session state locally, submit completed choices in one batched request, and flush pending choices on page hide or unmount.
 - [x] The account movie-memory view supports large histories with paginated loading, virtualized rendering, total counts, and poster-aware fallbacks.
 - [x] The available-movies catalog now supports exact-title escape-hatch search with optional year-range filters across the API and page UI.
+- [x] Expensive recommendation/poster POST routes now reject oversized JSON bodies before validation, moderation, queue creation, TMDB fetches, or OpenAI work.
+- [x] OpenAI calls now use per-call timeout options and `AbortSignal` cancellation, with legacy recommendation requests mapping upstream OpenAI timeouts to HTTP 504.
 - [x] `tmdb_match_reviews` persists ambiguous TMDB/local matches and runtime mismatches for later manual review.
 - [x] PR CI has a consolidated `services-ci` pass for service workspaces and CodeQL runs for Actions and JavaScript/TypeScript.
 
@@ -151,8 +153,8 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 
 ### Security and Reliability Track
 
-- Add per-call OpenAI timeout handling with cancellation where supported, and map upstream timeout failures to clear 504-style API responses.
-- Add request body size limits for externally facing routes before expensive parsing, moderation, embedding, or recommendation work begins.
+- [x] Add per-call OpenAI timeout handling with cancellation where supported, and map upstream timeout failures to clear 504-style API responses.
+- [x] Add request body size limits for externally facing routes before expensive parsing, moderation, embedding, or recommendation work begins.
 - Add retry/backoff and circuit-breaker behavior for expensive external dependencies where retrying is safe.
 - Sanitize client-facing error responses so internal exception details, upstream payloads, and infrastructure hints stay out of API responses.
 - Validate required environment variables on application startup for web, workers, and root services so misconfigured deployments fail early.


### PR DESCRIPTION
## Summary

- Add shared JSON body-size guards and apply them before expensive parsing/work in recommendation, async recommendation creation, more-picks, and poster POST routes.
- Add per-call OpenAI timeout options with `AbortSignal` across moderation, embeddings, recommendation selection, query enrichment, and AI descriptions.
- Map OpenAI timeout failures in the legacy recommendation route to HTTP 504 and update security/roadmap docs.

## Validation

- `npm run test`
- `npm run type-check`
- `npm run lint:check`
- `npm run build`
- pre-push checks: lint, server tests, production build
