### PR TITLE
deps(deps): bump nanoid to 5.1.11

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -38,7 +38,7 @@
     "ioredis": "^5.10.1",
     "lucide-react": "^1.16.0",
     "motion": "^12.39.0",
-    "nanoid": "^3.3.11",
+    "nanoid": "^5.1.11",
     "next": "^16.2.6",
     "next-themes": "^0.4.6",
     "openai": "^6.38.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "ioredis": "^5.10.1",
         "lucide-react": "^1.16.0",
         "motion": "^12.39.0",
-        "nanoid": "^3.3.11",
+        "nanoid": "^5.1.11",
         "next": "^16.2.6",
         "next-themes": "^0.4.6",
         "openai": "^6.38.0",
@@ -197,6 +197,24 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/web/node_modules/nanoid": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
+      "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
       }
     },
     "apps/web/node_modules/tinyrainbow": {


### PR DESCRIPTION
Supersedes #383.

The original Dependabot branch is now conflicted after the lockfile refreshes from the recent dependency PRs, so this replacement keeps the same nanoid 5.1.11 upgrade on top of current development with an npm 11.12.1-generated lockfile.

Local verification:
- npx npm@11.12.1 ci
- npm run lint:check
- npm run type-check
- npm run test
- pre-push hook: lint, server tests, production build