### PR TITLE
Add product e2e smoke flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ The e2e suite uses its own Docker compose file, ports, and disposable database s
 npm run test:e2e
 ```
 
-This command resets `docker-compose.e2e.yml`, applies `db/init` migrations, seeds deterministic movie fixtures, starts the Next.js app on `http://127.0.0.1:3100`, and runs Playwright. Stop and remove the e2e services with:
+This command resets `docker-compose.e2e.yml`, applies `db/init` migrations, seeds deterministic movie fixtures, starts the Next.js app on `http://127.0.0.1:3100`, and runs Playwright. The smoke suite covers health checks, catalog filtering and empty states, registration/login/logout/session behavior, quiz submission, deterministic result rendering, feedback, and movie-memory persistence. Stop and remove the e2e services with:
 
 ```bash
 npm run test:e2e:down

--- a/apps/web/e2e/auth.spec.ts
+++ b/apps/web/e2e/auth.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from 'playwright/test';
+
+import { readSession, registerUser, uniqueEmail } from './helpers';
+
+test('registers, persists a session, logs out, and logs back in', async ({ page }, testInfo) => {
+  const email = uniqueEmail(testInfo.title);
+  const password = 'E2E-password-475!';
+
+  await registerUser(page, email, password);
+  await expect.poll(() => readSession(page)).toMatchObject({ authenticated: true });
+  await expect(page.getByRole('link', { name: 'Account' })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Log out' }).click();
+  await expect.poll(() => readSession(page)).toMatchObject({ authenticated: false });
+  await expect(page.getByRole('link', { name: 'Log in' })).toBeVisible();
+
+  await page.goto('/login');
+  await page.getByLabel('Email address').fill(email);
+  await page.getByLabel('Password').fill(password);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  await expect(page.getByRole('heading', { name: 'Signed in!' })).toBeVisible();
+  await expect.poll(() => readSession(page)).toMatchObject({ authenticated: true });
+  await expect(page.getByRole('link', { name: 'Account' })).toBeVisible();
+});

--- a/apps/web/e2e/available-movies.spec.ts
+++ b/apps/web/e2e/available-movies.spec.ts
@@ -30,3 +30,22 @@ test('renders seeded catalog data and filters it through the real movies API', a
   await expect(page.getByRole('img', { name: 'Age rating: PG-13' })).toBeVisible();
   await expect(page.getByText('8.7')).toBeVisible();
 });
+
+test('shows a useful empty state when catalog filters match nothing', async ({ page }) => {
+  await page.goto('/available-movies');
+
+  await expect(page.getByRole('heading', { name: 'Available Movies' })).toBeVisible();
+  await expect(page.getByText(/Showing 1.4 of 4 movies/)).toBeVisible();
+
+  await page.getByPlaceholder('Movie title').fill('No Such PopChoice Fixture');
+  await page.getByRole('button', { name: 'Apply' }).click();
+
+  await expect(page.getByText('No movies found')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'No matches for this search' })).toBeVisible();
+  await expect(page.getByText('PopChoice E2E Space Opera')).toHaveCount(0);
+
+  await page.locator('form').getByRole('button', { name: 'Clear' }).click();
+
+  await expect(page.getByText(/Showing 1.4 of 4 movies/)).toBeVisible();
+  await expect(page.getByText('PopChoice E2E Space Opera')).toBeVisible();
+});

--- a/apps/web/e2e/helpers.ts
+++ b/apps/web/e2e/helpers.ts
@@ -1,0 +1,33 @@
+import { expect } from 'playwright/test';
+
+import type { Page } from 'playwright/test';
+
+export function uniqueEmail(testTitle: string): string {
+  const slug = testTitle
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+  return `e2e-${slug}-${Date.now()}@example.com`;
+}
+
+export async function registerUser(page: Page, email: string, password: string): Promise<void> {
+  await page.goto('/register');
+  await page.getByLabel('Email address').fill(email);
+  await page.getByLabel('Password', { exact: true }).fill(password);
+  await page.getByLabel('Confirm password').fill(password);
+  await page.getByRole('button', { name: 'Create account' }).click();
+  await expect(page.getByRole('heading', { name: 'Account created!' })).toBeVisible();
+}
+
+export async function readSession(page: Page): Promise<{
+  authenticated?: boolean;
+  userId?: string;
+}> {
+  return page.evaluate(async () => {
+    const response = await fetch('/api/auth/session', {
+      cache: 'no-store',
+      credentials: 'same-origin',
+    });
+    return response.json() as Promise<{ authenticated?: boolean; userId?: string }>;
+  });
+}

--- a/apps/web/e2e/recommendation.spec.ts
+++ b/apps/web/e2e/recommendation.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from 'playwright/test';
+
+import { readSession, registerUser, uniqueEmail } from './helpers';
+
+import type { Page } from 'playwright/test';
+
+async function readMovieMemory(page: Page) {
+  return page.evaluate(async () => {
+    const response = await fetch('/api/account/movie-memory?mode=list&limit=10', {
+      cache: 'no-store',
+      credentials: 'same-origin',
+    });
+    return response.json() as Promise<{
+      movieMemory?: Array<{ kind: string; movieName: string; movieYear: number | null }>;
+      total?: number;
+    }>;
+  });
+}
+
+test('submits the solo quiz, renders deterministic results, and records feedback', async ({
+  page,
+}, testInfo) => {
+  const email = uniqueEmail(testInfo.title);
+  const password = 'E2E-password-475!';
+
+  await registerUser(page, email, password);
+  await expect.poll(() => readSession(page)).toMatchObject({ authenticated: true });
+
+  await page.goto('/quiz');
+  await page.getByRole('button', { name: /Just me/ }).click();
+
+  await page.getByRole('button', { name: 'The Matrix' }).click();
+  await page.getByRole('button', { name: 'Continue' }).click();
+
+  await page.getByRole('button', { name: /Open field/ }).click();
+  await page.getByRole('button', { name: 'Continue' }).click();
+
+  await page.getByRole('button', { name: /Sci-Fi/ }).click();
+  await page.getByRole('button', { name: 'Continue' }).click();
+
+  await page.getByRole('button', { name: /Balanced/ }).click();
+  await page.getByRole('button', { name: 'Continue' }).click();
+
+  await page.getByPlaceholder(/Tom Hanks/).fill('Cillian Murphy');
+  await page.getByRole('button', { name: /Find My Movie/ }).click();
+
+  await expect(page).toHaveURL(/\/results\/[A-Za-z0-9_-]+/);
+  await expect(page.getByRole('heading', { name: 'We found your perfect film' })).toBeVisible();
+  await expect(page.locator('span').filter({ hasText: /^Top Pick$/ })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'PopChoice E2E Space Opera' })).toBeVisible();
+  await expect(page.getByText(/deterministic top pick/i)).toBeVisible();
+  await expect(page.getByText('Was this useful?')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Good pick' }).click();
+
+  await expect(page.getByText('Thanks — saved for future tuning.')).toBeVisible();
+  await expect
+    .poll(() => readMovieMemory(page))
+    .toMatchObject({
+      movieMemory: [
+        {
+          kind: 'liked',
+          movieName: 'PopChoice E2E Space Opera',
+          movieYear: 2024,
+        },
+      ],
+    });
+});

--- a/apps/web/playwright.e2e.config.ts
+++ b/apps/web/playwright.e2e.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
     env: {
       AUTH_SESSION_SECRET: 'e2e-auth-session-secret',
       DATABASE_URL: databaseUrl,
+      E2E_DETERMINISTIC_RECOMMENDATIONS: '1',
       NEXT_PUBLIC_BASE_URL: baseURL,
       REDIS_URL: redisUrl,
       RESEND_API_KEY: '',

--- a/apps/web/src/app/api/recommendations/route.test.ts
+++ b/apps/web/src/app/api/recommendations/route.test.ts
@@ -30,9 +30,11 @@ vi.mock('@/features/recommendation/input', () => ({
 const mockCreateAndStartRecommendation = vi.fn<(...args: unknown[]) => Promise<{ slug: string }>>(
   () => Promise.resolve({ slug: 'rec-test-slug' }),
 );
+const mockUsesDeterministicE2ERecommendations = vi.fn(() => false);
 
 vi.mock('@/features/recommendation/jobs', () => ({
   createAndStartRecommendation: (...args: unknown[]) => mockCreateAndStartRecommendation(...args),
+  usesDeterministicE2ERecommendations: () => mockUsesDeterministicE2ERecommendations(),
 }));
 
 import { POST } from './route';
@@ -55,6 +57,7 @@ function makeRequest(body: unknown = validBody) {
 describe('POST /api/recommendations', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUsesDeterministicE2ERecommendations.mockReturnValue(false);
   });
 
   it('returns 413 before validation or job creation when the request body is too large', async () => {
@@ -79,6 +82,17 @@ describe('POST /api/recommendations', () => {
 
     expect(response.status).toBe(201);
     expect(data).toEqual({ id: 'rec-test-slug' });
+    expect(mockGetRecommendationInputBlock).toHaveBeenCalled();
+    expect(mockCreateAndStartRecommendation).toHaveBeenCalled();
+  });
+
+  it('skips AI moderation when deterministic e2e recommendations are enabled', async () => {
+    mockUsesDeterministicE2ERecommendations.mockReturnValue(true);
+
+    const response = await POST(makeRequest());
+
+    expect(response.status).toBe(201);
+    expect(mockGetRecommendationInputBlock).not.toHaveBeenCalled();
     expect(mockCreateAndStartRecommendation).toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/recommendations/route.ts
+++ b/apps/web/src/app/api/recommendations/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { getRecommendationInputBlock, normalizePeopleData } from '@/features/recommendation/input';
-import { createAndStartRecommendation } from '@/features/recommendation/jobs';
+import {
+  createAndStartRecommendation,
+  usesDeterministicE2ERecommendations,
+} from '@/features/recommendation/jobs';
 import { requestBodySchema } from '@/features/recommendation/types';
 import { parseLocaleFromRequest } from '@/lib/locale';
 import logger from '@/lib/logger';
@@ -50,9 +53,11 @@ async function postHandler(req: NextRequest, clientId: string): Promise<Response
     'Creating recommendation via /api/recommendations',
   );
 
-  const inputBlock = await getRecommendationInputBlock(allPeopleData);
-  if (inputBlock) {
-    return NextResponse.json(inputBlock, { status: 422 });
+  if (!usesDeterministicE2ERecommendations()) {
+    const inputBlock = await getRecommendationInputBlock(allPeopleData);
+    if (inputBlock) {
+      return NextResponse.json(inputBlock, { status: 422 });
+    }
   }
 
   try {

--- a/apps/web/src/features/recommendation/jobs.ts
+++ b/apps/web/src/features/recommendation/jobs.ts
@@ -10,7 +10,7 @@ import {
 } from './persistence';
 import { runRecommendationPipeline } from './pipeline';
 
-import type { PersonFormData, RecommendationRequestBody } from './types';
+import type { ApiResponse, PersonFormData, RecommendationRequestBody } from './types';
 import type { Locale } from '@/lib/locale';
 
 export async function createAndStartRecommendation(
@@ -24,6 +24,11 @@ export async function createAndStartRecommendation(
   const recommendationSlug = created.slug;
 
   logger.info({ recommendationId, recommendationSlug }, 'Recommendation row created');
+
+  if (usesDeterministicE2ERecommendations()) {
+    await completeDeterministicE2ERecommendation(recommendationId, allPeopleData);
+    return created;
+  }
 
   if (recommendationQueue) {
     try {
@@ -46,6 +51,74 @@ export async function createAndStartRecommendation(
   }
 
   return created;
+}
+
+export function usesDeterministicE2ERecommendations(): boolean {
+  return process.env.E2E_DETERMINISTIC_RECOMMENDATIONS === '1';
+}
+
+async function completeDeterministicE2ERecommendation(
+  recommendationId: string,
+  allPeopleData: PersonFormData[],
+): Promise<void> {
+  logger.info({ recommendationId }, 'Completing recommendation with deterministic e2e fixture');
+  await markRecommendationProcessing(recommendationId);
+  await markRecommendationStage(recommendationId, 'complete');
+  await completeRecommendationRecord(recommendationId, buildDeterministicE2EResult(allPeopleData));
+}
+
+function buildDeterministicE2EResult(allPeopleData: PersonFormData[]): ApiResponse {
+  const primary = allPeopleData[0];
+  const reference = primary?.favoriteMovie ? ` after your ${primary.favoriteMovie} cue` : '';
+
+  return {
+    title: 'PopChoice E2E Space Opera',
+    description: `A deterministic e2e recommendation${reference}.`,
+    usedBroaderSearch: false,
+    dbMovieCount: 4,
+    similarMovies: [
+      {
+        id: 1,
+        tmdbId: 900001,
+        name: 'PopChoice E2E Space Opera',
+        year: 2024,
+        similarity: 0.98,
+        age_rating: 'PG-13',
+        duration: 142,
+        score_rating: 8.7,
+        aiDescription:
+          'A deterministic top pick for proving quiz submission, result rendering, and feedback.',
+        localizedName: 'PopChoice E2E Space Opera',
+        isMainRecommendation: true,
+      },
+      {
+        id: 4,
+        tmdbId: 900004,
+        name: 'PopChoice E2E Family Adventure',
+        year: 2018,
+        similarity: 0.84,
+        age_rating: 'G',
+        duration: 101,
+        score_rating: 8.1,
+        aiDescription: 'A friendly alternate pick from the seeded e2e catalog.',
+        localizedName: 'PopChoice E2E Family Adventure',
+        isMainRecommendation: false,
+      },
+      {
+        id: 3,
+        tmdbId: 900003,
+        name: 'PopChoice E2E Classic Drama',
+        year: 1998,
+        similarity: 0.79,
+        age_rating: 'R',
+        duration: 126,
+        score_rating: 9.1,
+        aiDescription: 'A stronger dramatic alternate for the seeded e2e catalog.',
+        localizedName: 'PopChoice E2E Classic Drama',
+        isMainRecommendation: false,
+      },
+    ],
+  };
 }
 
 async function processInlineRecommendation(

--- a/apps/web/src/lib/withAuth.test.ts
+++ b/apps/web/src/lib/withAuth.test.ts
@@ -73,6 +73,31 @@ describe('withAuth', () => {
     await expect(response.json()).resolves.toEqual({ clientId: 'user:42' });
   });
 
+  it('preserves browser session identity before using the dev auth bypass', async () => {
+    vi.stubEnv('VALID_API_KEYS', '');
+    const sessionToken = createSessionToken('42');
+    expect(sessionToken).toBeTruthy();
+
+    const handler = vi.fn(async (_req: NextRequest, clientId: string) =>
+      NextResponse.json({ clientId }),
+    );
+    const wrapped = withAuth(handler);
+
+    const response = await wrapped(
+      new NextRequest('http://localhost/api/recommendations/test/feedback', {
+        headers: {
+          Origin: 'http://localhost',
+          'X-CSRF-Token': 'csrf-token',
+          Cookie: `__csrf=csrf-token; ${SESSION_COOKIE}=${sessionToken}`,
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(handler).toHaveBeenCalledWith(expect.any(NextRequest), 'user:42');
+    await expect(response.json()).resolves.toEqual({ clientId: 'user:42' });
+  });
+
   it('rejects cross-origin CSRF fallback when API key is missing', async () => {
     const handler = vi.fn(async () => NextResponse.json({ ok: true }));
     const wrapped = withAuth(handler);

--- a/apps/web/src/lib/withAuth.ts
+++ b/apps/web/src/lib/withAuth.ts
@@ -49,11 +49,9 @@ export function withAuth(handler: RouteHandler) {
     const hasApiKeyCredential = Boolean(
       req.headers.get('authorization') || req.headers.get('x-api-key'),
     );
-    const shouldUseDevAuthBypass =
-      process.env.NODE_ENV !== 'production' && !process.env.VALID_API_KEYS;
 
     // 2. Prefer API key auth for external/service callers when a key is actually supplied.
-    if (hasApiKeyCredential || shouldUseDevAuthBypass) {
+    if (hasApiKeyCredential) {
       const clientId = await validateApiKey(req);
       if (clientId !== null) {
         return handler(req, clientId);
@@ -75,6 +73,17 @@ export function withAuth(handler: RouteHandler) {
     if (csrfHeader || csrfCookie) {
       logger.warn('Auth failed: cross-origin CSRF fallback attempt');
       return NextResponse.json({ error: 'Unauthorized: invalid CSRF token.' }, { status: 401 });
+    }
+
+    const shouldUseDevAuthBypass =
+      process.env.NODE_ENV !== 'production' && !process.env.VALID_API_KEYS;
+
+    // 4. Development-only unauthenticated API fallback when no credentials were supplied.
+    if (shouldUseDevAuthBypass) {
+      const clientId = await validateApiKey(req);
+      if (clientId !== null) {
+        return handler(req, clientId);
+      }
     }
 
     return NextResponse.json(

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -50,7 +50,7 @@ The `storybook-tests` job caches Playwright browser binaries in `~/.cache/ms-pla
 
 The `e2e-tests` job runs `npm run test:e2e`. That command starts the isolated `docker-compose.e2e.yml` services, applies the same `db/init` migrations used by production/local setup, seeds deterministic movie fixtures, starts Next.js on port `3100`, and runs Playwright. The job always runs `npm run test:e2e:down` afterwards so the disposable database volume is removed.
 
-The first e2e coverage proves the real app can read seeded catalog data from PostgreSQL and that `/api/health` can reach both PostgreSQL and Redis. Broader auth, quiz, recommendation, and AI-eval coverage is tracked separately from this foundation.
+The e2e coverage proves the real app can read seeded catalog data from PostgreSQL, that `/api/health` can reach both PostgreSQL and Redis, and that auth/session, catalog empty states, quiz submission, deterministic result rendering, feedback, and movie-memory persistence work through the browser. AI-eval coverage is tracked separately so model quality gates can use fixture scoring and optional live-provider runs.
 
 ### Code Coverage
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -139,6 +139,7 @@ The command prepares an isolated environment:
 - `docker-compose.e2e.yml` starts PostgreSQL with pgvector on `127.0.0.1:55432` and Redis on `127.0.0.1:56379`.
 - `scripts/e2e/setup-db.mjs` resets the e2e compose project, applies every `db/init/*.sql` migration through `apps/web/scripts/migrate-db.js`, and seeds deterministic movie fixtures.
 - `apps/web/playwright.e2e.config.ts` starts the app on `http://127.0.0.1:3100` with `DATABASE_URL` and `REDIS_URL` pointed at the isolated services.
+- `E2E_DETERMINISTIC_RECOMMENDATIONS=1` makes quiz submissions complete from seeded fixtures instead of calling live OpenAI/TMDB services or requiring a worker process.
 
 Stop and remove the e2e services with:
 
@@ -146,7 +147,7 @@ Stop and remove the e2e services with:
 npm run test:e2e:down
 ```
 
-The first smoke coverage intentionally focuses on `/api/health` and the Available Movies page. Auth, quiz, recommendation polling, and AI-response evals are planned as follow-up e2e/eval issues.
+The smoke coverage proves `/api/health`, Available Movies filtering and empty states, auth/session flows, solo quiz submission, result rendering, recommendation feedback, and movie-memory persistence. AI-response evals remain separate so they can add fixture scoring and optional live-model runs without slowing normal e2e.
 
 ## Project Structure
 

--- a/docs/RECOMMENDATION-ROADMAP.md
+++ b/docs/RECOMMENDATION-ROADMAP.md
@@ -189,7 +189,7 @@ This keeps the high-risk data and orchestration work ahead of visual polish. The
 ### Stage 5.5: Deterministic e2e and eval foundations
 
 - [x] [#474](https://github.com/shchilkin/PopChoice/issues/474): add a full Playwright e2e harness with an isolated migrated test database.
-- [#475](https://github.com/shchilkin/PopChoice/issues/475): add product smoke flows for auth, catalog, quiz, recommendation, and feedback.
+- [x] [#475](https://github.com/shchilkin/PopChoice/issues/475): add product smoke flows for auth, catalog, quiz, recommendation, and feedback.
 - [#476](https://github.com/shchilkin/PopChoice/issues/476): add recommendation eval fixtures and scoring so AI behavior can be changed with more control.
 - Keep live-model evals optional. The default path should be deterministic, cheap, and safe for CI.
 
@@ -204,7 +204,7 @@ This keeps the high-risk data and orchestration work ahead of visual polish. The
 
 Good next PRs, in order:
 
-1. Add [#475](https://github.com/shchilkin/PopChoice/issues/475) product smoke flows for auth, catalog, quiz, recommendation, and feedback on top of the e2e foundation.
+1. Add [#476](https://github.com/shchilkin/PopChoice/issues/476) recommendation eval fixtures and scoring on top of the deterministic test foundation.
 2. Decide [#471](https://github.com/shchilkin/PopChoice/issues/471) before expanding #82 into actor/director/genre search.
 3. Refactor the quiz submit/results handoff so navigation state is explicit and the quiz page does not need short-lived reset guards.
 4. Replace the current quiz copy and options with a more "tonight" oriented flow while preserving existing API shape.

--- a/docs/ROADMAP-ARCHITECTURE.md
+++ b/docs/ROADMAP-ARCHITECTURE.md
@@ -196,7 +196,7 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 ### Testing and Evaluation Track
 
 - [x] [#474](https://github.com/shchilkin/PopChoice/issues/474): add a Playwright e2e harness with an isolated migrated test database and deterministic seed fixtures.
-- [#475](https://github.com/shchilkin/PopChoice/issues/475): cover auth, catalog, quiz, recommendation, and feedback smoke flows through product-level e2e tests.
+- [x] [#475](https://github.com/shchilkin/PopChoice/issues/475): cover auth, catalog, quiz, recommendation, and feedback smoke flows through product-level e2e tests.
 - [#476](https://github.com/shchilkin/PopChoice/issues/476): add an AI recommendation eval harness with deterministic fixtures by default and optional live model/provider runs.
 - Keep Storybook/component tests separate from full product e2e tests so UI component regressions and app-flow regressions fail with clear ownership.
 - Keep AI evals separate from normal e2e smoke tests because recommendation quality gates need fixture scoring, model controls, and optional API cost.
@@ -254,10 +254,11 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 1. [x] Complete [#81](https://github.com/shchilkin/PopChoice/issues/81) with available-movies runtime, score, and age-rating filters on the existing catalog fields.
 2. [ ] Refactor the quiz submit/results handoff so navigation state is explicit and the quiz page does not need short-lived reset guards.
 3. [x] Start [#474](https://github.com/shchilkin/PopChoice/issues/474) so full e2e work has a real isolated DB foundation before adding many browser scenarios.
-4. [ ] Add [#475](https://github.com/shchilkin/PopChoice/issues/475) auth, catalog, quiz, and recommendation smoke flows on top of the isolated e2e harness.
-5. [ ] Decide the catalog metadata model in [#471](https://github.com/shchilkin/PopChoice/issues/471) before expanding #82 into actor/director/genre search.
-6. [ ] Create a dedicated backoffice app for catalog-health and TMDB review, then add shared login protection for it and `apps/bull-board`.
-7. [ ] Clarify production migration/versioning expectations for schema changes, rollbacks, and preview volume recreation.
+4. [x] Add [#475](https://github.com/shchilkin/PopChoice/issues/475) auth, catalog, quiz, and recommendation smoke flows on top of the isolated e2e harness.
+5. [ ] Add [#476](https://github.com/shchilkin/PopChoice/issues/476) deterministic recommendation eval fixtures and scoring.
+6. [ ] Decide the catalog metadata model in [#471](https://github.com/shchilkin/PopChoice/issues/471) before expanding #82 into actor/director/genre search.
+7. [ ] Create a dedicated backoffice app for catalog-health and TMDB review, then add shared login protection for it and `apps/bull-board`.
+8. [ ] Clarify production migration/versioning expectations for schema changes, rollbacks, and preview volume recreation.
 
 ## Working Checklist
 


### PR DESCRIPTION
## Summary
- add auth/register-login-logout/session e2e coverage and shared helpers
- extend catalog e2e coverage with seeded empty-state/search behavior
- add deterministic recommendation e2e mode covering quiz -> results -> feedback -> movie memory without OpenAI/TMDB
- fix browser-session auth attribution before dev auth bypass and document the expanded smoke suite

## Verification
- npm run type-check
- npm run lint:check
- npm run test:server -- src/lib/withAuth.test.ts (from apps/web)
- npm run test:e2e
- npm run test:server
- npm run build

Closes #475