### PR TITLE
Document AI eval policy

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -56,8 +56,15 @@ PopChoice is a Next.js application focused on movie recommendations, leveraging 
 
 ## CI/CD
 
-- PR workflow runs lint, format, type-check, server tests, Storybook tests (conditional on Playwright), and build on pull requests targeting the `development` branch. See `.github/workflows/pr.yml`.
+- PR workflow runs lint, format, type-check, server tests, deterministic recommendation evals, Storybook tests, e2e smoke tests, and build on pull requests targeting the `development` branch. See `.github/workflows/pr.yml`.
 - Build may fail in CI due to network issues with external fonts but works locally and in production.
+
+## AI Evaluation Expectations
+
+- Browser e2e uses deterministic recommendation fixtures and does not validate live model quality.
+- Run `npm run eval:recommendations` for changes to recommendation prompts, embeddings, OpenAI/TMDB integration, candidate filtering/ranking, feedback signals, response shape, or eval fixtures.
+- Consider whether a manual/scheduled real-data eval is needed for schema, seed/backfill, catalog retrieval, or candidate-availability changes.
+- Do not run or require live-provider evals by default. `npm run eval:recommendations -- --live` is manual because it can spend API credits and depend on provider availability.
 
 ## Example: Adding a New Movie API Integration
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,14 @@ See `docs/BOUNDARIES.md` for the canonical boundary rules.
 - User movie memory is exposed through `/account/movie-memory` and `/api/account/movie-memory`.
 - Movie identity should prefer TMDB ids and fall back to normalized title plus year via `apps/web/src/lib/movieIdentity.ts`.
 
+## AI and Recommendation Evaluation
+
+- Product e2e tests do not call live AI providers. `E2E_DETERMINISTIC_RECOMMENDATIONS=1` verifies the real browser/API/DB/results/feedback flow with deterministic recommendation fixtures, not model quality.
+- `npm run eval:recommendations` is the default AI regression gate. It is deterministic, CI-blocking, and does not require OpenAI, TMDB, Redis, or PostgreSQL.
+- If changes touch recommendation prompts, OpenAI/TMDB integration, embeddings, candidate filtering/ranking, movie-memory feedback, recommendation result shape, or eval fixtures, run `npm run eval:recommendations` and report the result. If you cannot run it, explain why.
+- If changes affect real catalog retrieval, schema, seed/backfill data, or candidate availability, also consider whether a real-data eval is needed. Real-data evals should be scheduled/manual, may require a seeded DB, and should be documented as follow-up when not run.
+- Live provider evals (`npm run eval:recommendations -- --live`) are manual because they can spend API credits and be flaky. Do not make them a default CI gate or run them unless the user explicitly wants live-provider validation and the required env is configured.
+
 ## Database and Migrations
 
 - Keep `db/init/*.sql`, `db/createDB.sql`, and service/app schema helpers in sync when adding schema.

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -59,6 +59,14 @@ The `recommendation-evals` job runs `npm run eval:recommendations`. This is a CI
 
 Default evals do not require `OPENAI_API_KEY`, `TMDB_API_KEY`, Redis, or PostgreSQL. Optional live-provider evals use `npm run eval:recommendations -- --live` and are intentionally manual because they can spend API credits, depend on provider availability, and may need seeded local data.
 
+Recommendation checks are intentionally layered:
+
+1. **Per-PR CI:** deterministic fixtures and mocked model outputs via `npm run eval:recommendations`.
+2. **Scheduled or manual real-data eval:** seeded database and real catalog retrieval, but still controlled model output by default. Use this for schema, seed/backfill, retrieval, and candidate-availability changes once the workflow exists.
+3. **Manual live eval:** real data plus live AI providers via `npm run eval:recommendations -- --live`. This is not a default hard gate because provider responses, rate limits, and API cost can make it noisy.
+
+Agents and reviewers should explicitly consider these layers when a PR changes recommendation prompts, embeddings, OpenAI/TMDB integration, candidate filtering/ranking, feedback signals, or catalog data feeding recommendations.
+
 ### Code Coverage
 
 Server tests run with `--coverage` via `@vitest/coverage-v8`. Coverage reports (HTML, JSON, LCOV) are uploaded as a GitHub Actions artifact named `coverage-report` and retained for 30 days. Coverage is configured in `vitest.config.ts`.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -173,6 +173,12 @@ npm run eval:recommendations -- --live
 
 Live evals require configured provider and database environment variables such as `OPENAI_API_KEY`, `DATABASE_URL`, and usually `TMDB_API_KEY`. CI blocks on the deterministic eval job; live evals are manual so normal PR checks stay cheap and predictable.
 
+Use three eval levels when changing AI-related code:
+
+1. `npm run eval:recommendations` for every PR that changes recommendation prompts, embeddings, candidate filters, ranking, feedback signals, response shape, or eval fixtures.
+2. A real-data eval for changes that affect catalog retrieval, schema, seeding/backfill, or candidate availability. This should be scheduled or manually triggered against a seeded database; it should not be a default per-PR hard gate until it is proven cheap and stable.
+3. `npm run eval:recommendations -- --live` only when intentionally checking live model/provider behavior before larger recommendation changes. Live runs can spend API credits and depend on provider availability, so agents should call out whether they ran it or why they did not.
+
 ## Project Structure
 
 ```text


### PR DESCRIPTION
## Summary
- document the deterministic recommendation eval expectations for AI/recommendation changes
- clarify when agents should consider real-data or live eval follow-ups
- mirror the policy in project and Copilot agent instructions

## Checks
- npm run format:check
- pre-push: lint, server tests, build