### PR TITLE
Add catalog metadata schema

### DIFF
--- a/db/createDB.sql
+++ b/db/createDB.sql
@@ -35,6 +35,12 @@ ALTER TABLE movies
   ADD COLUMN IF NOT EXISTS tmdb_matched_at timestamptz;
 
 ALTER TABLE movies
+  ADD COLUMN IF NOT EXISTS tmdb_metadata jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+ALTER TABLE movies
+  ADD COLUMN IF NOT EXISTS tmdb_metadata_refreshed_at timestamptz;
+
+ALTER TABLE movies
   DROP CONSTRAINT IF EXISTS movies_tmdb_match_source_check;
 
 ALTER TABLE movies
@@ -44,6 +50,104 @@ ALTER TABLE movies
 CREATE UNIQUE INDEX IF NOT EXISTS movies_tmdb_id_unique
   ON movies (tmdb_id)
   WHERE tmdb_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS catalog_people (
+  id bigserial PRIMARY KEY,
+  tmdb_id bigint,
+  name text NOT NULL,
+  profile_path text,
+  popularity float,
+  raw_metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS catalog_people_tmdb_id_unique
+  ON catalog_people (tmdb_id)
+  WHERE tmdb_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_catalog_people_name_lower
+  ON catalog_people (lower(name));
+
+CREATE TABLE IF NOT EXISTS catalog_genres (
+  id bigserial PRIMARY KEY,
+  tmdb_id int,
+  name text NOT NULL,
+  raw_metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS catalog_genres_tmdb_id_unique
+  ON catalog_genres (tmdb_id)
+  WHERE tmdb_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_catalog_genres_name_lower
+  ON catalog_genres (lower(name));
+
+CREATE TABLE IF NOT EXISTS catalog_keywords (
+  id bigserial PRIMARY KEY,
+  tmdb_id bigint,
+  name text NOT NULL,
+  raw_metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS catalog_keywords_tmdb_id_unique
+  ON catalog_keywords (tmdb_id)
+  WHERE tmdb_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_catalog_keywords_name_lower
+  ON catalog_keywords (lower(name));
+
+CREATE TABLE IF NOT EXISTS movie_people (
+  id bigserial PRIMARY KEY,
+  movie_id bigint NOT NULL REFERENCES movies(id) ON DELETE CASCADE,
+  person_id bigint NOT NULL REFERENCES catalog_people(id) ON DELETE CASCADE,
+  tmdb_credit_id text,
+  role text NOT NULL,
+  character_name text,
+  job text,
+  department text,
+  billing_order int,
+  raw_metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT movie_people_role_check CHECK (role IN ('cast', 'director'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS movie_people_tmdb_credit_unique
+  ON movie_people (movie_id, tmdb_credit_id)
+  WHERE tmdb_credit_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_movie_people_movie_role_order
+  ON movie_people (movie_id, role, billing_order NULLS LAST);
+
+CREATE INDEX IF NOT EXISTS idx_movie_people_person_role
+  ON movie_people (person_id, role);
+
+CREATE TABLE IF NOT EXISTS movie_genres (
+  movie_id bigint NOT NULL REFERENCES movies(id) ON DELETE CASCADE,
+  genre_id bigint NOT NULL REFERENCES catalog_genres(id) ON DELETE CASCADE,
+  source text NOT NULL DEFAULT 'tmdb',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (movie_id, genre_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_movie_genres_genre_id
+  ON movie_genres (genre_id);
+
+CREATE TABLE IF NOT EXISTS movie_keywords (
+  movie_id bigint NOT NULL REFERENCES movies(id) ON DELETE CASCADE,
+  keyword_id bigint NOT NULL REFERENCES catalog_keywords(id) ON DELETE CASCADE,
+  source text NOT NULL DEFAULT 'tmdb',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (movie_id, keyword_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_movie_keywords_keyword_id
+  ON movie_keywords (keyword_id);
 
 CREATE TABLE IF NOT EXISTS tmdb_match_reviews (
   id bigserial PRIMARY KEY,

--- a/db/init/01_schema.sql
+++ b/db/init/01_schema.sql
@@ -40,6 +40,12 @@ ALTER TABLE movies
   ADD COLUMN IF NOT EXISTS tmdb_matched_at timestamptz;
 
 ALTER TABLE movies
+  ADD COLUMN IF NOT EXISTS tmdb_metadata jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+ALTER TABLE movies
+  ADD COLUMN IF NOT EXISTS tmdb_metadata_refreshed_at timestamptz;
+
+ALTER TABLE movies
   DROP CONSTRAINT IF EXISTS movies_tmdb_match_source_check;
 
 ALTER TABLE movies
@@ -49,6 +55,104 @@ ALTER TABLE movies
 CREATE UNIQUE INDEX IF NOT EXISTS movies_tmdb_id_unique
   ON movies (tmdb_id)
   WHERE tmdb_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS catalog_people (
+  id bigserial PRIMARY KEY,
+  tmdb_id bigint,
+  name text NOT NULL,
+  profile_path text,
+  popularity float,
+  raw_metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS catalog_people_tmdb_id_unique
+  ON catalog_people (tmdb_id)
+  WHERE tmdb_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_catalog_people_name_lower
+  ON catalog_people (lower(name));
+
+CREATE TABLE IF NOT EXISTS catalog_genres (
+  id bigserial PRIMARY KEY,
+  tmdb_id int,
+  name text NOT NULL,
+  raw_metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS catalog_genres_tmdb_id_unique
+  ON catalog_genres (tmdb_id)
+  WHERE tmdb_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_catalog_genres_name_lower
+  ON catalog_genres (lower(name));
+
+CREATE TABLE IF NOT EXISTS catalog_keywords (
+  id bigserial PRIMARY KEY,
+  tmdb_id bigint,
+  name text NOT NULL,
+  raw_metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS catalog_keywords_tmdb_id_unique
+  ON catalog_keywords (tmdb_id)
+  WHERE tmdb_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_catalog_keywords_name_lower
+  ON catalog_keywords (lower(name));
+
+CREATE TABLE IF NOT EXISTS movie_people (
+  id bigserial PRIMARY KEY,
+  movie_id bigint NOT NULL REFERENCES movies(id) ON DELETE CASCADE,
+  person_id bigint NOT NULL REFERENCES catalog_people(id) ON DELETE CASCADE,
+  tmdb_credit_id text,
+  role text NOT NULL,
+  character_name text,
+  job text,
+  department text,
+  billing_order int,
+  raw_metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT movie_people_role_check CHECK (role IN ('cast', 'director'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS movie_people_tmdb_credit_unique
+  ON movie_people (movie_id, tmdb_credit_id)
+  WHERE tmdb_credit_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_movie_people_movie_role_order
+  ON movie_people (movie_id, role, billing_order NULLS LAST);
+
+CREATE INDEX IF NOT EXISTS idx_movie_people_person_role
+  ON movie_people (person_id, role);
+
+CREATE TABLE IF NOT EXISTS movie_genres (
+  movie_id bigint NOT NULL REFERENCES movies(id) ON DELETE CASCADE,
+  genre_id bigint NOT NULL REFERENCES catalog_genres(id) ON DELETE CASCADE,
+  source text NOT NULL DEFAULT 'tmdb',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (movie_id, genre_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_movie_genres_genre_id
+  ON movie_genres (genre_id);
+
+CREATE TABLE IF NOT EXISTS movie_keywords (
+  movie_id bigint NOT NULL REFERENCES movies(id) ON DELETE CASCADE,
+  keyword_id bigint NOT NULL REFERENCES catalog_keywords(id) ON DELETE CASCADE,
+  source text NOT NULL DEFAULT 'tmdb',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (movie_id, keyword_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_movie_keywords_keyword_id
+  ON movie_keywords (keyword_id);
 
 CREATE TABLE IF NOT EXISTS tmdb_match_reviews (
   id bigserial PRIMARY KEY,

--- a/docs/RECOMMENDATION-ROADMAP.md
+++ b/docs/RECOMMENDATION-ROADMAP.md
@@ -180,7 +180,7 @@ This keeps the high-risk data and orchestration work ahead of visual polish. The
 - Use local embeddings as enrichment and reranking, not as the complete universe of possible movies.
 - Add JIT embedding/enrichment for strong TMDB candidates.
 - Add catalog metadata prerequisites for richer search:
-  - [#471](https://github.com/shchilkin/PopChoice/issues/471) schema/model for cast, directors, genres, and keywords.
+  - [x] [#471](https://github.com/shchilkin/PopChoice/issues/471) schema/model for cast, directors, genres, and keywords.
   - [#472](https://github.com/shchilkin/PopChoice/issues/472) TMDB backfill and refresh for that metadata.
   - [#473](https://github.com/shchilkin/PopChoice/issues/473) available-movies search over actors, directors, and genres.
 - Track TMDB API failures, timeout behavior, and fallback quality.
@@ -204,7 +204,7 @@ This keeps the high-risk data and orchestration work ahead of visual polish. The
 
 Good next PRs, in order:
 
-1. Decide [#471](https://github.com/shchilkin/PopChoice/issues/471) before expanding #82 into actor/director/genre search.
+1. Implement [#472](https://github.com/shchilkin/PopChoice/issues/472) so TMDB backfill/discovery populates the catalog metadata model from #471.
 2. Refactor the quiz submit/results handoff so navigation state is explicit and the quiz page does not need short-lived reset guards.
 3. Replace the current quiz copy and options with a more "tonight" oriented flow while preserving existing API shape.
 4. Add a small taste-swipe prototype behind a feature flag or alternate quiz entry path.

--- a/docs/ROADMAP-ARCHITECTURE.md
+++ b/docs/ROADMAP-ARCHITECTURE.md
@@ -167,7 +167,7 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 
 ### Data Quality Track
 
-- [#471](https://github.com/shchilkin/PopChoice/issues/471): add a catalog metadata model for cast, directors, genres, and keywords before expanding search beyond title/year.
+- [x] [#471](https://github.com/shchilkin/PopChoice/issues/471): add a catalog metadata model for cast, directors, genres, and keywords before expanding search beyond title/year.
 - [#472](https://github.com/shchilkin/PopChoice/issues/472): extend TMDB backfill/discovery to populate people and genre metadata, with catalog-health visibility for missing coverage.
 - Persist TMDB backfill review cases in `tmdb_match_reviews`, then add an admin/back-office UI to resolve ambiguous matches, missing metadata, or rejected runtime/year confidence cases.
 - Track catalog health signals such as duplicate movie identities, missing posters, missing localized names/overviews, missing runtimes, and stale TMDB metadata. The initial `npm run catalog:health` report covers current `movies` schema signals; admin resolution and automated refresh remain future work.
@@ -256,7 +256,7 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 3. [x] Start [#474](https://github.com/shchilkin/PopChoice/issues/474) so full e2e work has a real isolated DB foundation before adding many browser scenarios.
 4. [x] Add [#475](https://github.com/shchilkin/PopChoice/issues/475) auth, catalog, quiz, and recommendation smoke flows on top of the isolated e2e harness.
 5. [x] Add [#476](https://github.com/shchilkin/PopChoice/issues/476) deterministic recommendation eval fixtures and scoring.
-6. [ ] Decide the catalog metadata model in [#471](https://github.com/shchilkin/PopChoice/issues/471) before expanding #82 into actor/director/genre search.
+6. [x] Decide the catalog metadata model in [#471](https://github.com/shchilkin/PopChoice/issues/471) before expanding #82 into actor/director/genre search.
 7. [ ] Create a dedicated backoffice app for catalog-health and TMDB review, then add shared login protection for it and `apps/bull-board`.
 8. [ ] Clarify production migration/versioning expectations for schema changes, rollbacks, and preview volume recreation.
 

--- a/docs/SERVICES.md
+++ b/docs/SERVICES.md
@@ -401,7 +401,8 @@ To add or edit calibration queries, modify the `QUERIES` array in `scripts/calib
 The app and root services share the same PostgreSQL schema through `db/init/*.sql` and service-level `ensureSchema()` helpers:
 
 - **Extension:** `pgvector` (vector similarity search)
-- **Table:** `movies` — stores name, year, age_rating, description, duration, score_rating, TMDB identity/metadata, poster/localized fields, and a 3072-dimension embedding vector
+- **Table:** `movies` — stores name, year, age_rating, description, duration, score_rating, TMDB identity, lightweight TMDB metadata snapshots, poster/localized fields, and a 3072-dimension embedding vector
+- **Tables:** `catalog_people`, `catalog_genres`, `catalog_keywords`, `movie_people`, `movie_genres`, and `movie_keywords` — store normalized cast, director, genre, and keyword metadata for future backfill and search. These tables are intentionally allowed to be empty while TMDB metadata backfill is incomplete.
 - **Table:** `tmdb_match_reviews` — stores ambiguous TMDB/local match cases for later manual review
 - **Table:** `users` and `password_reset_tokens` — support email/password auth and reset flow
 - **Tables:** `recommendations`, `recommendation_movies`, `recommendation_feedback`, and `user_movie_interactions` — support persisted async recommendations, feedback, sharing, account history, and movie memory

--- a/packages/shared/src/db.ts
+++ b/packages/shared/src/db.ts
@@ -16,7 +16,48 @@ export interface MovieRecord {
   tmdb_id?: number | null;
   tmdb_match_confidence?: number | null;
   tmdb_match_source?: 'tmdb_discovery' | 'backfill_auto' | 'manual' | null;
+  tmdb_metadata?: Record<string, unknown> | null;
+  tmdb_metadata_refreshed_at?: string | Date | null;
   embedding: number[];
+}
+
+export type CatalogMetadataSource = 'tmdb' | 'manual';
+export type MoviePersonRole = 'cast' | 'director';
+
+export interface CatalogPersonRecord {
+  id: string;
+  tmdb_id: number | null;
+  name: string;
+  profile_path: string | null;
+  popularity: number | null;
+  raw_metadata: Record<string, unknown>;
+}
+
+export interface CatalogGenreRecord {
+  id: string;
+  tmdb_id: number | null;
+  name: string;
+  raw_metadata: Record<string, unknown>;
+}
+
+export interface CatalogKeywordRecord {
+  id: string;
+  tmdb_id: number | null;
+  name: string;
+  raw_metadata: Record<string, unknown>;
+}
+
+export interface MoviePersonCreditRecord {
+  id: string;
+  movie_id: string;
+  person_id: string;
+  tmdb_credit_id: string | null;
+  role: MoviePersonRole;
+  character_name: string | null;
+  job: string | null;
+  department: string | null;
+  billing_order: number | null;
+  raw_metadata: Record<string, unknown>;
 }
 
 let pool: InstanceType<typeof Pool> | null = null;
@@ -147,6 +188,12 @@ export async function ensureSchema(): Promise<void> {
       ADD COLUMN IF NOT EXISTS tmdb_matched_at timestamptz;
 
     ALTER TABLE movies
+      ADD COLUMN IF NOT EXISTS tmdb_metadata jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+    ALTER TABLE movies
+      ADD COLUMN IF NOT EXISTS tmdb_metadata_refreshed_at timestamptz;
+
+    ALTER TABLE movies
       DROP CONSTRAINT IF EXISTS movies_tmdb_match_source_check;
 
     ALTER TABLE movies
@@ -157,6 +204,8 @@ export async function ensureSchema(): Promise<void> {
       ON movies (tmdb_id)
       WHERE tmdb_id IS NOT NULL;
   `);
+
+  await ensureCatalogMetadataSchema();
 
   await getPool().query(`
     CREATE TABLE IF NOT EXISTS tmdb_match_reviews (
@@ -235,6 +284,108 @@ export async function ensureSchema(): Promise<void> {
   `);
 
   logger.info('Schema ensured');
+}
+
+export async function ensureCatalogMetadataSchema(): Promise<void> {
+  await getPool().query(`
+    CREATE TABLE IF NOT EXISTS catalog_people (
+      id bigserial PRIMARY KEY,
+      tmdb_id bigint,
+      name text NOT NULL,
+      profile_path text,
+      popularity float,
+      raw_metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    );
+
+    CREATE UNIQUE INDEX IF NOT EXISTS catalog_people_tmdb_id_unique
+      ON catalog_people (tmdb_id)
+      WHERE tmdb_id IS NOT NULL;
+
+    CREATE INDEX IF NOT EXISTS idx_catalog_people_name_lower
+      ON catalog_people (lower(name));
+
+    CREATE TABLE IF NOT EXISTS catalog_genres (
+      id bigserial PRIMARY KEY,
+      tmdb_id int,
+      name text NOT NULL,
+      raw_metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    );
+
+    CREATE UNIQUE INDEX IF NOT EXISTS catalog_genres_tmdb_id_unique
+      ON catalog_genres (tmdb_id)
+      WHERE tmdb_id IS NOT NULL;
+
+    CREATE INDEX IF NOT EXISTS idx_catalog_genres_name_lower
+      ON catalog_genres (lower(name));
+
+    CREATE TABLE IF NOT EXISTS catalog_keywords (
+      id bigserial PRIMARY KEY,
+      tmdb_id bigint,
+      name text NOT NULL,
+      raw_metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    );
+
+    CREATE UNIQUE INDEX IF NOT EXISTS catalog_keywords_tmdb_id_unique
+      ON catalog_keywords (tmdb_id)
+      WHERE tmdb_id IS NOT NULL;
+
+    CREATE INDEX IF NOT EXISTS idx_catalog_keywords_name_lower
+      ON catalog_keywords (lower(name));
+
+    CREATE TABLE IF NOT EXISTS movie_people (
+      id bigserial PRIMARY KEY,
+      movie_id bigint NOT NULL REFERENCES movies(id) ON DELETE CASCADE,
+      person_id bigint NOT NULL REFERENCES catalog_people(id) ON DELETE CASCADE,
+      tmdb_credit_id text,
+      role text NOT NULL,
+      character_name text,
+      job text,
+      department text,
+      billing_order int,
+      raw_metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now(),
+      CONSTRAINT movie_people_role_check CHECK (role IN ('cast', 'director'))
+    );
+
+    CREATE UNIQUE INDEX IF NOT EXISTS movie_people_tmdb_credit_unique
+      ON movie_people (movie_id, tmdb_credit_id)
+      WHERE tmdb_credit_id IS NOT NULL;
+
+    CREATE INDEX IF NOT EXISTS idx_movie_people_movie_role_order
+      ON movie_people (movie_id, role, billing_order NULLS LAST);
+
+    CREATE INDEX IF NOT EXISTS idx_movie_people_person_role
+      ON movie_people (person_id, role);
+
+    CREATE TABLE IF NOT EXISTS movie_genres (
+      movie_id bigint NOT NULL REFERENCES movies(id) ON DELETE CASCADE,
+      genre_id bigint NOT NULL REFERENCES catalog_genres(id) ON DELETE CASCADE,
+      source text NOT NULL DEFAULT 'tmdb',
+      created_at timestamptz NOT NULL DEFAULT now(),
+      PRIMARY KEY (movie_id, genre_id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_movie_genres_genre_id
+      ON movie_genres (genre_id);
+
+    CREATE TABLE IF NOT EXISTS movie_keywords (
+      movie_id bigint NOT NULL REFERENCES movies(id) ON DELETE CASCADE,
+      keyword_id bigint NOT NULL REFERENCES catalog_keywords(id) ON DELETE CASCADE,
+      source text NOT NULL DEFAULT 'tmdb',
+      created_at timestamptz NOT NULL DEFAULT now(),
+      PRIMARY KEY (movie_id, keyword_id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_movie_keywords_keyword_id
+      ON movie_keywords (keyword_id);
+  `);
 }
 
 export async function getMovieCount(): Promise<number> {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,11 +5,20 @@ export {
   getPool,
   checkTableExists,
   filterNewMovies,
+  ensureCatalogMetadataSchema,
   ensureSchema,
   getMovieCount,
   insertMovies,
 } from './db.js';
-export type { MovieRecord } from './db.js';
+export type {
+  CatalogGenreRecord,
+  CatalogKeywordRecord,
+  CatalogMetadataSource,
+  CatalogPersonRecord,
+  MoviePersonCreditRecord,
+  MoviePersonRole,
+  MovieRecord,
+} from './db.js';
 export { createEmbeddings } from './embeddings.js';
 export {
   parsePositiveInt,

--- a/services/movie-backfill/src/database.test.ts
+++ b/services/movie-backfill/src/database.test.ts
@@ -3,6 +3,7 @@ import pg from 'pg';
 import {
   checkTableExists,
   closeDatabase,
+  ensureCatalogMetadataSchema,
   ensureTMDBMatchReviewSchema,
   getIncompleteMovies,
   initDatabase,
@@ -74,6 +75,25 @@ describe('database', () => {
       expect(sql).toContain('CREATE TABLE IF NOT EXISTS tmdb_match_reviews');
       expect(sql).toContain('idx_tmdb_match_reviews_movie_reason');
       expect(sql).toContain('idx_tmdb_match_reviews_status_updated_at');
+    });
+  });
+
+  describe('ensureCatalogMetadataSchema', () => {
+    it('creates the normalized catalog metadata tables and indexes', async () => {
+      poolMock.query.mockResolvedValueOnce({ rows: [] });
+
+      await ensureCatalogMetadataSchema();
+
+      expect(poolMock.query).toHaveBeenCalledTimes(1);
+      const [sql] = poolMock.query.mock.calls[0];
+      expect(sql).toContain('CREATE TABLE IF NOT EXISTS catalog_people');
+      expect(sql).toContain('CREATE TABLE IF NOT EXISTS catalog_genres');
+      expect(sql).toContain('CREATE TABLE IF NOT EXISTS catalog_keywords');
+      expect(sql).toContain('CREATE TABLE IF NOT EXISTS movie_people');
+      expect(sql).toContain('CREATE TABLE IF NOT EXISTS movie_genres');
+      expect(sql).toContain('CREATE TABLE IF NOT EXISTS movie_keywords');
+      expect(sql).toContain('catalog_people_tmdb_id_unique');
+      expect(sql).toContain('idx_movie_people_movie_role_order');
     });
   });
 

--- a/services/movie-backfill/src/database.ts
+++ b/services/movie-backfill/src/database.ts
@@ -1,8 +1,15 @@
-import { checkTableExists, closeDatabase, getPool, initDatabase, logger } from '@pop-choice/shared';
+import {
+  checkTableExists,
+  closeDatabase,
+  ensureCatalogMetadataSchema,
+  getPool,
+  initDatabase,
+  logger,
+} from '@pop-choice/shared';
 
 import type { TMDBSearchCandidate } from './tmdb.js';
 
-export { initDatabase, closeDatabase, checkTableExists };
+export { initDatabase, closeDatabase, checkTableExists, ensureCatalogMetadataSchema };
 
 export interface IncompleteMovie {
   id: string;


### PR DESCRIPTION
## Summary
- add the #471 catalog metadata model for people, genres, keywords, and movie joins
- add lightweight TMDB metadata snapshot columns to movies for partial/raw metadata while backfill is incomplete
- expose shared catalog metadata types and schema helper for services
- document the schema decision and update roadmap next steps toward #472

Closes #471

## Checks
- npm run format:check
- npm run type-check
- npm run build:services
- npm run test --workspace=services/movie-backfill -- database.test.ts
- npm run test:services
- npm run test:e2e:setup
- docker exec popchoice-e2e-db ... verified catalog metadata tables exist
- npm run test:e2e:run
- npm run eval:recommendations
- npm run lint:check
- npm run build
- pre-push: lint, server tests, build