### PR TITLE
Fix catalog metadata schema contracts

### DIFF
--- a/db/createDB.sql
+++ b/db/createDB.sql
@@ -53,7 +53,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS movies_tmdb_id_unique
 
 CREATE TABLE IF NOT EXISTS catalog_people (
   id bigserial PRIMARY KEY,
-  tmdb_id bigint,
+  tmdb_id int,
   name text NOT NULL,
   profile_path text,
   popularity float,
@@ -61,6 +61,9 @@ CREATE TABLE IF NOT EXISTS catalog_people (
   created_at timestamptz NOT NULL DEFAULT now(),
   updated_at timestamptz NOT NULL DEFAULT now()
 );
+
+ALTER TABLE catalog_people
+  ALTER COLUMN tmdb_id TYPE int USING tmdb_id::int;
 
 CREATE UNIQUE INDEX IF NOT EXISTS catalog_people_tmdb_id_unique
   ON catalog_people (tmdb_id)
@@ -87,12 +90,15 @@ CREATE INDEX IF NOT EXISTS idx_catalog_genres_name_lower
 
 CREATE TABLE IF NOT EXISTS catalog_keywords (
   id bigserial PRIMARY KEY,
-  tmdb_id bigint,
+  tmdb_id int,
   name text NOT NULL,
   raw_metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
   created_at timestamptz NOT NULL DEFAULT now(),
   updated_at timestamptz NOT NULL DEFAULT now()
 );
+
+ALTER TABLE catalog_keywords
+  ALTER COLUMN tmdb_id TYPE int USING tmdb_id::int;
 
 CREATE UNIQUE INDEX IF NOT EXISTS catalog_keywords_tmdb_id_unique
   ON catalog_keywords (tmdb_id)
@@ -132,8 +138,15 @@ CREATE TABLE IF NOT EXISTS movie_genres (
   genre_id bigint NOT NULL REFERENCES catalog_genres(id) ON DELETE CASCADE,
   source text NOT NULL DEFAULT 'tmdb',
   created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT movie_genres_source_check CHECK (source IN ('tmdb', 'manual')),
   PRIMARY KEY (movie_id, genre_id)
 );
+
+ALTER TABLE movie_genres
+  DROP CONSTRAINT IF EXISTS movie_genres_source_check;
+
+ALTER TABLE movie_genres
+  ADD CONSTRAINT movie_genres_source_check CHECK (source IN ('tmdb', 'manual'));
 
 CREATE INDEX IF NOT EXISTS idx_movie_genres_genre_id
   ON movie_genres (genre_id);
@@ -143,8 +156,15 @@ CREATE TABLE IF NOT EXISTS movie_keywords (
   keyword_id bigint NOT NULL REFERENCES catalog_keywords(id) ON DELETE CASCADE,
   source text NOT NULL DEFAULT 'tmdb',
   created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT movie_keywords_source_check CHECK (source IN ('tmdb', 'manual')),
   PRIMARY KEY (movie_id, keyword_id)
 );
+
+ALTER TABLE movie_keywords
+  DROP CONSTRAINT IF EXISTS movie_keywords_source_check;
+
+ALTER TABLE movie_keywords
+  ADD CONSTRAINT movie_keywords_source_check CHECK (source IN ('tmdb', 'manual'));
 
 CREATE INDEX IF NOT EXISTS idx_movie_keywords_keyword_id
   ON movie_keywords (keyword_id);

--- a/db/init/01_schema.sql
+++ b/db/init/01_schema.sql
@@ -58,7 +58,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS movies_tmdb_id_unique
 
 CREATE TABLE IF NOT EXISTS catalog_people (
   id bigserial PRIMARY KEY,
-  tmdb_id bigint,
+  tmdb_id int,
   name text NOT NULL,
   profile_path text,
   popularity float,
@@ -66,6 +66,9 @@ CREATE TABLE IF NOT EXISTS catalog_people (
   created_at timestamptz NOT NULL DEFAULT now(),
   updated_at timestamptz NOT NULL DEFAULT now()
 );
+
+ALTER TABLE catalog_people
+  ALTER COLUMN tmdb_id TYPE int USING tmdb_id::int;
 
 CREATE UNIQUE INDEX IF NOT EXISTS catalog_people_tmdb_id_unique
   ON catalog_people (tmdb_id)
@@ -92,12 +95,15 @@ CREATE INDEX IF NOT EXISTS idx_catalog_genres_name_lower
 
 CREATE TABLE IF NOT EXISTS catalog_keywords (
   id bigserial PRIMARY KEY,
-  tmdb_id bigint,
+  tmdb_id int,
   name text NOT NULL,
   raw_metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
   created_at timestamptz NOT NULL DEFAULT now(),
   updated_at timestamptz NOT NULL DEFAULT now()
 );
+
+ALTER TABLE catalog_keywords
+  ALTER COLUMN tmdb_id TYPE int USING tmdb_id::int;
 
 CREATE UNIQUE INDEX IF NOT EXISTS catalog_keywords_tmdb_id_unique
   ON catalog_keywords (tmdb_id)
@@ -137,8 +143,15 @@ CREATE TABLE IF NOT EXISTS movie_genres (
   genre_id bigint NOT NULL REFERENCES catalog_genres(id) ON DELETE CASCADE,
   source text NOT NULL DEFAULT 'tmdb',
   created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT movie_genres_source_check CHECK (source IN ('tmdb', 'manual')),
   PRIMARY KEY (movie_id, genre_id)
 );
+
+ALTER TABLE movie_genres
+  DROP CONSTRAINT IF EXISTS movie_genres_source_check;
+
+ALTER TABLE movie_genres
+  ADD CONSTRAINT movie_genres_source_check CHECK (source IN ('tmdb', 'manual'));
 
 CREATE INDEX IF NOT EXISTS idx_movie_genres_genre_id
   ON movie_genres (genre_id);
@@ -148,8 +161,15 @@ CREATE TABLE IF NOT EXISTS movie_keywords (
   keyword_id bigint NOT NULL REFERENCES catalog_keywords(id) ON DELETE CASCADE,
   source text NOT NULL DEFAULT 'tmdb',
   created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT movie_keywords_source_check CHECK (source IN ('tmdb', 'manual')),
   PRIMARY KEY (movie_id, keyword_id)
 );
+
+ALTER TABLE movie_keywords
+  DROP CONSTRAINT IF EXISTS movie_keywords_source_check;
+
+ALTER TABLE movie_keywords
+  ADD CONSTRAINT movie_keywords_source_check CHECK (source IN ('tmdb', 'manual'));
 
 CREATE INDEX IF NOT EXISTS idx_movie_keywords_keyword_id
   ON movie_keywords (keyword_id);

--- a/packages/shared/src/db.ts
+++ b/packages/shared/src/db.ts
@@ -16,7 +16,7 @@ export interface MovieRecord {
   tmdb_id?: number | null;
   tmdb_match_confidence?: number | null;
   tmdb_match_source?: 'tmdb_discovery' | 'backfill_auto' | 'manual' | null;
-  tmdb_metadata?: Record<string, unknown> | null;
+  tmdb_metadata?: Record<string, unknown>;
   tmdb_metadata_refreshed_at?: string | Date | null;
   embedding: number[];
 }
@@ -290,7 +290,7 @@ export async function ensureCatalogMetadataSchema(): Promise<void> {
   await getPool().query(`
     CREATE TABLE IF NOT EXISTS catalog_people (
       id bigserial PRIMARY KEY,
-      tmdb_id bigint,
+      tmdb_id int,
       name text NOT NULL,
       profile_path text,
       popularity float,
@@ -298,6 +298,9 @@ export async function ensureCatalogMetadataSchema(): Promise<void> {
       created_at timestamptz NOT NULL DEFAULT now(),
       updated_at timestamptz NOT NULL DEFAULT now()
     );
+
+    ALTER TABLE catalog_people
+      ALTER COLUMN tmdb_id TYPE int USING tmdb_id::int;
 
     CREATE UNIQUE INDEX IF NOT EXISTS catalog_people_tmdb_id_unique
       ON catalog_people (tmdb_id)
@@ -324,12 +327,15 @@ export async function ensureCatalogMetadataSchema(): Promise<void> {
 
     CREATE TABLE IF NOT EXISTS catalog_keywords (
       id bigserial PRIMARY KEY,
-      tmdb_id bigint,
+      tmdb_id int,
       name text NOT NULL,
       raw_metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
       created_at timestamptz NOT NULL DEFAULT now(),
       updated_at timestamptz NOT NULL DEFAULT now()
     );
+
+    ALTER TABLE catalog_keywords
+      ALTER COLUMN tmdb_id TYPE int USING tmdb_id::int;
 
     CREATE UNIQUE INDEX IF NOT EXISTS catalog_keywords_tmdb_id_unique
       ON catalog_keywords (tmdb_id)
@@ -369,8 +375,15 @@ export async function ensureCatalogMetadataSchema(): Promise<void> {
       genre_id bigint NOT NULL REFERENCES catalog_genres(id) ON DELETE CASCADE,
       source text NOT NULL DEFAULT 'tmdb',
       created_at timestamptz NOT NULL DEFAULT now(),
+      CONSTRAINT movie_genres_source_check CHECK (source IN ('tmdb', 'manual')),
       PRIMARY KEY (movie_id, genre_id)
     );
+
+    ALTER TABLE movie_genres
+      DROP CONSTRAINT IF EXISTS movie_genres_source_check;
+
+    ALTER TABLE movie_genres
+      ADD CONSTRAINT movie_genres_source_check CHECK (source IN ('tmdb', 'manual'));
 
     CREATE INDEX IF NOT EXISTS idx_movie_genres_genre_id
       ON movie_genres (genre_id);
@@ -380,8 +393,15 @@ export async function ensureCatalogMetadataSchema(): Promise<void> {
       keyword_id bigint NOT NULL REFERENCES catalog_keywords(id) ON DELETE CASCADE,
       source text NOT NULL DEFAULT 'tmdb',
       created_at timestamptz NOT NULL DEFAULT now(),
+      CONSTRAINT movie_keywords_source_check CHECK (source IN ('tmdb', 'manual')),
       PRIMARY KEY (movie_id, keyword_id)
     );
+
+    ALTER TABLE movie_keywords
+      DROP CONSTRAINT IF EXISTS movie_keywords_source_check;
+
+    ALTER TABLE movie_keywords
+      ADD CONSTRAINT movie_keywords_source_check CHECK (source IN ('tmdb', 'manual'));
 
     CREATE INDEX IF NOT EXISTS idx_movie_keywords_keyword_id
       ON movie_keywords (keyword_id);

--- a/services/movie-backfill/src/database.test.ts
+++ b/services/movie-backfill/src/database.test.ts
@@ -92,8 +92,11 @@ describe('database', () => {
       expect(sql).toContain('CREATE TABLE IF NOT EXISTS movie_people');
       expect(sql).toContain('CREATE TABLE IF NOT EXISTS movie_genres');
       expect(sql).toContain('CREATE TABLE IF NOT EXISTS movie_keywords');
+      expect(sql).toContain('ALTER COLUMN tmdb_id TYPE int');
       expect(sql).toContain('catalog_people_tmdb_id_unique');
       expect(sql).toContain('idx_movie_people_movie_role_order');
+      expect(sql).toContain('movie_genres_source_check');
+      expect(sql).toContain('movie_keywords_source_check');
     });
   });
 


### PR DESCRIPTION
Follow-up to review comments on #485.\n\n## Summary\n- Align movie tmdb_metadata TS type with the NOT NULL JSONB schema.\n- Use integer TMDB ids for catalog people/keywords so pg returns numbers instead of int8 strings.\n- Add source CHECK constraints for movie_genres and movie_keywords, including idempotent migration steps for existing tables.\n\n## Validation\n- npm run format:check\n- npm run type-check\n- npm run build --workspace=packages/shared\n- npm run test --workspace=services/movie-backfill -- database.test.ts\n- npm run test:e2e:setup\n- docker exec popchoice-e2e-db psql ... verified integer tmdb_id columns and source constraints\n- npm run test:e2e:run\n- npm run lint:check\n- npm run build\n- npm run eval:recommendations\n- pre-push: lint, 701 server tests, production build