### PR TITLE
Expand available movies metadata search

### DIFF
--- a/apps/web/e2e/available-movies.spec.ts
+++ b/apps/web/e2e/available-movies.spec.ts
@@ -31,13 +31,28 @@ test('renders seeded catalog data and filters it through the real movies API', a
   await expect(page.getByText('8.7')).toBeVisible();
 });
 
+test('searches seeded actor, director, and genre metadata through the real movies API', async ({
+  request,
+}) => {
+  for (const query of ['Astra Fixture', 'Moonlit Director', 'Nebula Noir']) {
+    const response = await request.get(`/api/movies?query=${encodeURIComponent(query)}`);
+    expect(response.ok()).toBe(true);
+
+    const body = await response.json();
+    expect(body.totalCount).toBe(1);
+    expect(body.movies).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'PopChoice E2E Space Opera' })]),
+    );
+  }
+});
+
 test('shows a useful empty state when catalog filters match nothing', async ({ page }) => {
   await page.goto('/available-movies');
 
   await expect(page.getByRole('heading', { name: 'Available Movies' })).toBeVisible();
   await expect(page.getByText(/Showing 1.4 of 4 movies/)).toBeVisible();
 
-  await page.getByPlaceholder('Movie title').fill('No Such PopChoice Fixture');
+  await page.getByPlaceholder('Title, actor, director, or genre').fill('No Such PopChoice Fixture');
   await page.getByRole('button', { name: 'Apply' }).click();
 
   await expect(page.getByText('No movies found')).toBeVisible();

--- a/apps/web/src/clients/dbClient.ts
+++ b/apps/web/src/clients/dbClient.ts
@@ -38,6 +38,12 @@ export interface QueryResult<T = unknown> {
   count?: number | null;
 }
 
+/** Minimal raw SQL result shape used by pg-backed feature queries. */
+export interface RawQueryResult<T = unknown> {
+  rows: T[];
+  rowCount?: number | null;
+}
+
 /** Terminal query step – awaitable for a result. */
 export interface QueryTerminal<T = unknown> extends PromiseLike<QueryResult<T>> {
   order: (column: string, options?: { ascending?: boolean }) => PromiseLike<QueryResult<T>>;
@@ -114,6 +120,15 @@ export interface DbClient {
 
   /** Return a chainable query builder for the given table. */
   from: <T = unknown>(table: string) => TableRef<T>;
+
+  /**
+   * Run a parameterized SQL query when a feature needs joins or EXISTS clauses
+   * beyond the chainable query-builder surface.
+   */
+  query?: <T = unknown>(
+    text: string,
+    values?: readonly unknown[],
+  ) => PromiseLike<RawQueryResult<T>>;
 
   /** Call a stored procedure / RPC function. */
   rpc: (

--- a/apps/web/src/clients/pgClient.ts
+++ b/apps/web/src/clients/pgClient.ts
@@ -528,6 +528,14 @@ export function createPgDbClient(): DbClient {
   return {
     isConfigured: () => Boolean(process.env.DATABASE_URL),
 
+    query: async <T = unknown>(
+      text: string,
+      values: readonly unknown[] = [],
+    ): Promise<{ rows: T[]; rowCount: number | null }> => {
+      const result = await getPool().query(text, [...values]);
+      return { rows: result.rows as T[], rowCount: result.rowCount };
+    },
+
     from: <T = unknown>(table: string): TableRef<T> => {
       assertSafeIdentifier(table, 'table name');
 

--- a/apps/web/src/features/movies/catalog.test.ts
+++ b/apps/web/src/features/movies/catalog.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { resetDbClient, setDbClient } from '@/clients/dbClient';
+
+import { getMoviesPage } from './catalog';
+
+import type { DbClient } from '@/clients/dbClient';
+
+function createSqlClient(query: NonNullable<DbClient['query']>): DbClient {
+  return {
+    isConfigured: () => true,
+    from: vi.fn(() => {
+      throw new Error('query-builder fallback should not be used');
+    }),
+    query,
+    rpc: vi.fn(),
+  };
+}
+
+describe('movies catalog', () => {
+  afterEach(() => {
+    resetDbClient();
+  });
+
+  it('searches titles, people, and genres while preserving filters and pagination', async () => {
+    const queryMock = vi.fn();
+    const query: NonNullable<DbClient['query']> = async <T = unknown>(
+      sql: string,
+      values?: readonly unknown[],
+    ) => {
+      queryMock(sql, values);
+      if (sql.includes('COUNT(*)')) {
+        return { rows: [{ count: 2 }] as T[], rowCount: 1 };
+      }
+
+      expect(values).toEqual(['%Nolan%', 2000, 2020, 121, 8, ['PG-13'], 10, 10]);
+      return {
+        rows: [
+          {
+            id: 7,
+            name: 'Inception',
+            age_rating: 'PG-13',
+            duration: 148,
+            score_rating: 8.8,
+            year: 2010,
+          },
+        ] as T[],
+        rowCount: 1,
+      };
+    };
+    setDbClient(createSqlClient(query));
+
+    const result = await getMoviesPage(2, 10, {
+      query: 'Nolan',
+      yearFrom: 2000,
+      yearTo: 2020,
+      duration: 'over-120',
+      minScore: 8,
+      ageRatings: ['PG-13'],
+    });
+    const [countSql, countValues] = queryMock.mock.calls[0] ?? [];
+    const [dataSql] = queryMock.mock.calls[1] ?? [];
+
+    expect(result).toMatchObject({
+      totalCount: 2,
+      page: 2,
+      pageSize: 10,
+      totalPages: 1,
+      movies: [{ name: 'Inception' }],
+    });
+    expect(countValues).toEqual(['%Nolan%', 2000, 2020, 121, 8, ['PG-13']]);
+    expect(countSql).toContain('movies.name ILIKE $1');
+    expect(countSql).toContain('catalog_people.name ILIKE $1');
+    expect(countSql).toContain('catalog_genres.name ILIKE $1');
+    expect(countSql).toContain('movie_people.movie_id = movies.id');
+    expect(countSql).toContain('movie_genres.movie_id = movies.id');
+    expect(dataSql).toContain('LIMIT $7');
+    expect(dataSql).toContain('OFFSET $8');
+  });
+
+  it('escapes wildcard characters in metadata search terms', async () => {
+    const query: NonNullable<DbClient['query']> = async <T = unknown>(
+      sql: string,
+      values?: readonly unknown[],
+    ) => {
+      if (sql.includes('COUNT(*)')) {
+        expect(values).toEqual(['%100\\% fun\\_%']);
+        return { rows: [{ count: '0' }] as T[], rowCount: 1 };
+      }
+
+      expect(values).toEqual(['%100\\% fun\\_%', 5, 0]);
+      return { rows: [], rowCount: 0 };
+    };
+    setDbClient(createSqlClient(query));
+
+    const result = await getMoviesPage(1, 5, { query: '100% fun_' });
+
+    expect(result.movies).toEqual([]);
+    expect(result.totalCount).toBe(0);
+  });
+});

--- a/apps/web/src/features/movies/catalog.ts
+++ b/apps/web/src/features/movies/catalog.ts
@@ -1,6 +1,6 @@
 import { getDbClient } from '@/clients/dbClient';
 
-import type { QueryFilter, QuerySelect } from '@/clients/dbClient';
+import type { DbClient, QueryFilter, QuerySelect } from '@/clients/dbClient';
 
 export interface Movie {
   id: number;
@@ -28,6 +28,10 @@ export interface MoviesPageFilters {
   duration?: MovieDurationFilter;
   minScore?: number;
   ageRatings?: string[];
+}
+
+interface CountRow {
+  count: number | string;
 }
 
 function escapeLikePattern(value: string): string {
@@ -72,6 +76,115 @@ function applyMovieFilters<T extends Movie>(
   return query;
 }
 
+function addSqlParam(values: unknown[], value: unknown): string {
+  values.push(value);
+  return `$${values.length}`;
+}
+
+function buildMoviesWhereSql(filters: MoviesPageFilters): { whereSql: string; values: unknown[] } {
+  const clauses: string[] = [];
+  const values: unknown[] = [];
+  const searchQuery = normalizeQuery(filters.query);
+
+  if (searchQuery) {
+    const patternParam = addSqlParam(values, `%${escapeLikePattern(searchQuery)}%`);
+    clauses.push(`(
+      movies.name ILIKE ${patternParam} ESCAPE '\\'
+      OR EXISTS (
+        SELECT 1
+        FROM movie_people
+        JOIN catalog_people ON catalog_people.id = movie_people.person_id
+        WHERE movie_people.movie_id = movies.id
+          AND catalog_people.name ILIKE ${patternParam} ESCAPE '\\'
+      )
+      OR EXISTS (
+        SELECT 1
+        FROM movie_genres
+        JOIN catalog_genres ON catalog_genres.id = movie_genres.genre_id
+        WHERE movie_genres.movie_id = movies.id
+          AND catalog_genres.name ILIKE ${patternParam} ESCAPE '\\'
+      )
+    )`);
+  }
+  if (typeof filters.yearFrom === 'number') {
+    clauses.push(`movies.year >= ${addSqlParam(values, filters.yearFrom)}`);
+  }
+  if (typeof filters.yearTo === 'number') {
+    clauses.push(`movies.year <= ${addSqlParam(values, filters.yearTo)}`);
+  }
+  if (filters.duration === 'under-90') {
+    clauses.push(`movies.duration <= ${addSqlParam(values, 89)}`);
+  } else if (filters.duration === '90-120') {
+    clauses.push(
+      `movies.duration BETWEEN ${addSqlParam(values, 90)} AND ${addSqlParam(values, 120)}`,
+    );
+  } else if (filters.duration === 'over-120') {
+    clauses.push(`movies.duration >= ${addSqlParam(values, 121)}`);
+  }
+  if (typeof filters.minScore === 'number') {
+    clauses.push(`movies.score_rating >= ${addSqlParam(values, filters.minScore)}`);
+  }
+  if (filters.ageRatings && filters.ageRatings.length > 0) {
+    clauses.push(`movies.age_rating = ANY(${addSqlParam(values, filters.ageRatings)}::text[])`);
+  }
+
+  return {
+    whereSql: clauses.length > 0 ? `WHERE ${clauses.join('\n  AND ')}` : '',
+    values,
+  };
+}
+
+function parseCount(value: CountRow['count'] | undefined): number {
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+async function getMoviesPageFromSql(
+  db: DbClient & Required<Pick<DbClient, 'query'>>,
+  page: number,
+  pageSize: number,
+  filters: MoviesPageFilters,
+): Promise<MoviesResponse> {
+  const offset = (page - 1) * pageSize;
+  const { whereSql, values } = buildMoviesWhereSql(filters);
+  const countResult = await db.query<CountRow>(
+    `
+      SELECT COUNT(*)::int AS count
+      FROM movies
+      ${whereSql}
+    `,
+    values,
+  );
+  const totalCount = parseCount(countResult.rows[0]?.count);
+  const limitParam = `$${values.length + 1}`;
+  const offsetParam = `$${values.length + 2}`;
+  const moviesResult = await db.query<Movie>(
+    `
+      SELECT id, name, age_rating, duration, score_rating, year
+      FROM movies
+      ${whereSql}
+      ORDER BY id ASC
+      LIMIT ${limitParam}
+      OFFSET ${offsetParam}
+    `,
+    [...values, pageSize, offset],
+  );
+
+  return {
+    movies: moviesResult.rows,
+    totalCount,
+    page,
+    pageSize,
+    totalPages: Math.ceil(totalCount / pageSize),
+  };
+}
+
 function filterMockMovies(movies: Movie[], filters: MoviesPageFilters): Movie[] {
   const titleQuery = normalizeQuery(filters.query)?.toLocaleLowerCase();
   return movies.filter((movie) => {
@@ -113,6 +226,15 @@ export async function getMoviesPage(
 
   if (!db.isConfigured()) {
     return buildMoviesResponse(filterMockMovies(generateMockMovies(), filters), page, pageSize);
+  }
+
+  if (db.query) {
+    return getMoviesPageFromSql(
+      db as DbClient & Required<Pick<DbClient, 'query'>>,
+      page,
+      pageSize,
+      filters,
+    );
   }
 
   const offset = (page - 1) * pageSize;

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -604,7 +604,7 @@ export const en = {
     emptyCatalogBody:
       'Seed the catalog and this table will fill with ratings, runtimes, and scores.',
     searchLabel: 'Search',
-    searchPlaceholder: 'Movie title',
+    searchPlaceholder: 'Title, actor, director, or genre',
     yearFrom: 'Year from',
     yearTo: 'Year to',
     durationFilter: 'Runtime',

--- a/apps/web/src/i18n/locales/fi.ts
+++ b/apps/web/src/i18n/locales/fi.ts
@@ -605,7 +605,7 @@ export const fi: Translations = {
     emptyCatalogTitle: 'Katalogissa ei ole vielä elokuvia',
     emptyCatalogBody: 'Kun katalogi on täytetty, tässä näkyvät ikärajat, kestot ja pisteet.',
     searchLabel: 'Haku',
-    searchPlaceholder: 'Elokuvan nimi',
+    searchPlaceholder: 'Nimi, näyttelijä, ohjaaja tai genre',
     yearFrom: 'Vuodesta',
     yearTo: 'Vuoteen',
     durationFilter: 'Kesto',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -604,7 +604,7 @@ export const ru: Translations = {
     emptyCatalogBody:
       'После наполнения каталога здесь появятся фильмы, рейтинги, длительность и оценки.',
     searchLabel: 'Поиск',
-    searchPlaceholder: 'Название фильма',
+    searchPlaceholder: 'Название, актер, режиссер или жанр',
     yearFrom: 'Год с',
     yearTo: 'Год до',
     durationFilter: 'Длительность',

--- a/docs/RECOMMENDATION-ROADMAP.md
+++ b/docs/RECOMMENDATION-ROADMAP.md
@@ -182,7 +182,7 @@ This keeps the high-risk data and orchestration work ahead of visual polish. The
 - Add catalog metadata prerequisites for richer search:
   - [x] [#471](https://github.com/shchilkin/PopChoice/issues/471) schema/model for cast, directors, genres, and keywords.
   - [x] [#472](https://github.com/shchilkin/PopChoice/issues/472) TMDB backfill and refresh for that metadata.
-  - [#473](https://github.com/shchilkin/PopChoice/issues/473) available-movies search over actors, directors, and genres.
+  - [x] [#473](https://github.com/shchilkin/PopChoice/issues/473) available-movies partial `ILIKE` search over titles, actors, directors, and genres, combined with exact/ranged catalog filters.
 - Track TMDB API failures, timeout behavior, and fallback quality.
 - Keep an admin/back-office backlog for ambiguous title matches and catalog-health issues.
 
@@ -204,13 +204,12 @@ This keeps the high-risk data and orchestration work ahead of visual polish. The
 
 Good next PRs, in order:
 
-1. Implement [#473](https://github.com/shchilkin/PopChoice/issues/473) so available-movies can search over actors, directors, and genres now populated by #472.
-2. Refactor the quiz submit/results handoff so navigation state is explicit and the quiz page does not need short-lived reset guards.
-3. Replace the current quiz copy and options with a more "tonight" oriented flow while preserving existing API shape.
-4. Add a small taste-swipe prototype behind a feature flag or alternate quiz entry path.
-5. Add TMDB-backed candidate-card sourcing for swipe mode.
-6. Add a `TasteSignal` domain model and adapters from quiz answers and swipe reactions.
-7. Add manual-review logging for ambiguous TMDB/local identity matches.
+1. Refactor the quiz submit/results handoff so navigation state is explicit and the quiz page does not need short-lived reset guards.
+2. Replace the current quiz copy and options with a more "tonight" oriented flow while preserving existing API shape.
+3. Add a small taste-swipe prototype behind a feature flag or alternate quiz entry path.
+4. Add TMDB-backed candidate-card sourcing for swipe mode.
+5. Add a `TasteSignal` domain model and adapters from quiz answers and swipe reactions.
+6. Add manual-review logging for ambiguous TMDB/local identity matches.
 
 ## Non-Goals For Now
 

--- a/docs/ROADMAP-ARCHITECTURE.md
+++ b/docs/ROADMAP-ARCHITECTURE.md
@@ -258,8 +258,9 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 5. [x] Add [#476](https://github.com/shchilkin/PopChoice/issues/476) deterministic recommendation eval fixtures and scoring.
 6. [x] Decide the catalog metadata model in [#471](https://github.com/shchilkin/PopChoice/issues/471) before expanding #82 into actor/director/genre search.
 7. [x] Populate the catalog metadata model in [#472](https://github.com/shchilkin/PopChoice/issues/472) from TMDB backfill/discovery before expanding #82 into actor/director/genre search.
-8. [ ] Create a dedicated backoffice app for catalog-health and TMDB review, then add shared login protection for it and `apps/bull-board`.
-9. [ ] Clarify production migration/versioning expectations for schema changes, rollbacks, and preview volume recreation.
+8. [x] Expand available-movies search in [#473](https://github.com/shchilkin/PopChoice/issues/473) across title, actor/director, and genre metadata populated by #472.
+9. [ ] Create a dedicated backoffice app for catalog-health and TMDB review, then add shared login protection for it and `apps/bull-board`.
+10. [ ] Clarify production migration/versioning expectations for schema changes, rollbacks, and preview volume recreation.
 
 ## Working Checklist
 

--- a/scripts/e2e/setup-db.mjs
+++ b/scripts/e2e/setup-db.mjs
@@ -43,6 +43,12 @@ async function seedDatabase(databaseUrl) {
         recommendation_movies,
         recommendations,
         tmdb_match_reviews,
+        movie_keywords,
+        movie_genres,
+        movie_people,
+        catalog_keywords,
+        catalog_genres,
+        catalog_people,
         movies,
         users
       RESTART IDENTITY CASCADE
@@ -97,6 +103,56 @@ async function seedDatabase(databaseUrl) {
         'PopChoice E2E Family Adventure',
       ],
     );
+
+    await client.query(
+      `
+        INSERT INTO catalog_people (tmdb_id, name)
+        VALUES
+          ($1, $2),
+          ($3, $4)
+      `,
+      [910001, 'Astra Fixture', 910002, 'Moonlit Director'],
+    );
+
+    await client.query(
+      `
+        INSERT INTO catalog_genres (tmdb_id, name)
+        VALUES
+          ($1, $2),
+          ($3, $4)
+      `,
+      [920001, 'Nebula Noir', 920002, 'Fixture Comedy'],
+    );
+
+    await client.query(`
+      INSERT INTO movie_people
+        (movie_id, person_id, role, character_name, billing_order)
+      SELECT 1, id, 'cast', 'Captain Test', 0
+      FROM catalog_people
+      WHERE name = 'Astra Fixture'
+    `);
+
+    await client.query(`
+      INSERT INTO movie_people
+        (movie_id, person_id, role, job, department)
+      SELECT 1, id, 'director', 'Director', 'Directing'
+      FROM catalog_people
+      WHERE name = 'Moonlit Director'
+    `);
+
+    await client.query(`
+      INSERT INTO movie_genres (movie_id, genre_id, source)
+      SELECT 1, id, 'manual'
+      FROM catalog_genres
+      WHERE name = 'Nebula Noir'
+    `);
+
+    await client.query(`
+      INSERT INTO movie_genres (movie_id, genre_id, source)
+      SELECT 2, id, 'manual'
+      FROM catalog_genres
+      WHERE name = 'Fixture Comedy'
+    `);
 
     await client.query('COMMIT');
     console.log('[e2e:db] Seeded deterministic movie fixtures.');


### PR DESCRIPTION
## Summary
- expand /api/movies search to match title, catalog people, and catalog genres with parameterized SQL while keeping existing filters and pagination
- update available-movies search copy in supported locales
- seed e2e catalog metadata and cover actor, director, and genre search through the real movies API
- mark #473 complete in the roadmap docs

Closes #473

## Tests
- npm run format:check
- npm run test --workspace=apps/web -- src/features/movies/catalog.test.ts src/app/api/movies/route.test.ts
- npm run type-check --workspace=apps/web
- npm run lint:check
- npm run test
- npm run build
- npm run test:e2e
- pre-push hook: lint, server tests, build, storybook tests