### PR TITLE
Document rate-limited TMDB catalog workers

### DIFF
--- a/docs/RECOMMENDATION-ROADMAP.md
+++ b/docs/RECOMMENDATION-ROADMAP.md
@@ -179,6 +179,11 @@ This keeps the high-risk data and orchestration work ahead of visual polish. The
 - Move candidate sourcing toward TMDB discover/search as the broad first pass.
 - Use local embeddings as enrichment and reranking, not as the complete universe of possible movies.
 - Add JIT embedding/enrichment for strong TMDB candidates.
+- Move TMDB discovery and backfill into rate-limited BullMQ catalog workers before increasing catalog expansion volume:
+  - Add a dedicated catalog-maintenance queue for discovery pages, movie detail enrichment, metadata refresh, and per-movie backfill jobs.
+  - Enforce one shared TMDB request budget across discovery, backfill, and worker-driven enrichment, with configurable concurrency and `429` backoff.
+  - Use deterministic `jobId` values such as `tmdb-details:{tmdbId}:{language}` and `backfill:{movieId}` so retries and duplicate triggers do not fan out duplicate TMDB calls.
+  - Keep the existing one-shot services as enqueue/maintenance entrypoints while workers own API pacing, retries, observability, and Bull Board visibility.
 - Add catalog metadata prerequisites for richer search:
   - [x] [#471](https://github.com/shchilkin/PopChoice/issues/471) schema/model for cast, directors, genres, and keywords.
   - [x] [#472](https://github.com/shchilkin/PopChoice/issues/472) TMDB backfill and refresh for that metadata.
@@ -205,11 +210,12 @@ This keeps the high-risk data and orchestration work ahead of visual polish. The
 Good next PRs, in order:
 
 1. Refactor the quiz submit/results handoff so navigation state is explicit and the quiz page does not need short-lived reset guards.
-2. Replace the current quiz copy and options with a more "tonight" oriented flow while preserving existing API shape.
-3. Add a small taste-swipe prototype behind a feature flag or alternate quiz entry path.
-4. Add TMDB-backed candidate-card sourcing for swipe mode.
-5. Add a `TasteSignal` domain model and adapters from quiz answers and swipe reactions.
-6. Add manual-review logging for ambiguous TMDB/local identity matches.
+2. Move TMDB discovery/backfill/enrichment into a shared rate-limited BullMQ catalog worker before scaling catalog volume.
+3. Replace the current quiz copy and options with a more "tonight" oriented flow while preserving existing API shape.
+4. Add a small taste-swipe prototype behind a feature flag or alternate quiz entry path.
+5. Add TMDB-backed candidate-card sourcing for swipe mode.
+6. Add a `TasteSignal` domain model and adapters from quiz answers and swipe reactions.
+7. Add manual-review logging for ambiguous TMDB/local identity matches.
 
 ## Non-Goals For Now
 

--- a/docs/ROADMAP-ARCHITECTURE.md
+++ b/docs/ROADMAP-ARCHITECTURE.md
@@ -219,6 +219,7 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 - Keep the local `movies` table as a cache/index of known titles, embeddings, localized names, poster URLs, and TMDB ids rather than the full source of truth.
 - Backfill TMDB ids for existing local movies using exact title/year matches first, then persist ambiguous or low-confidence matches for manual review.
 - Add cast, director, genre, and keyword metadata as first-class catalog data before implementing actor/director/genre search.
+- Move TMDB discovery, backfill, and metadata refresh into shared rate-limited BullMQ catalog workers before growing catalog volume. The worker should enforce one configurable TMDB request budget across all catalog-maintenance jobs, honor `429` with backoff, dedupe jobs by stable `tmdbId`/`movieId` keys, and expose queue depth/failures in Bull Board.
 - Add a back-office review queue for ambiguous TMDB matches, missing posters, duplicate identities, and metadata conflicts before applying risky automatic merges.
 - Prefer TMDB ids for all cross-feature identity checks. Fall back to normalized title plus year only when TMDB identity is unavailable.
 - Design future discovery flows around dynamic TMDB candidate sets: "I have watched many films" deck mode, quiz-assisted mode, and later a preference/taste-training mode.
@@ -259,8 +260,9 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 6. [x] Decide the catalog metadata model in [#471](https://github.com/shchilkin/PopChoice/issues/471) before expanding #82 into actor/director/genre search.
 7. [x] Populate the catalog metadata model in [#472](https://github.com/shchilkin/PopChoice/issues/472) from TMDB backfill/discovery before expanding #82 into actor/director/genre search.
 8. [x] Expand available-movies search in [#473](https://github.com/shchilkin/PopChoice/issues/473) across title, actor/director, and genre metadata populated by #472.
-9. [ ] Create a dedicated backoffice app for catalog-health and TMDB review, then add shared login protection for it and `apps/bull-board`.
-10. [ ] Clarify production migration/versioning expectations for schema changes, rollbacks, and preview volume recreation.
+9. [ ] Move TMDB discovery/backfill/metadata refresh into shared rate-limited BullMQ catalog workers before increasing catalog expansion volume.
+10. [ ] Create a dedicated backoffice app for catalog-health and TMDB review, then add shared login protection for it and `apps/bull-board`.
+11. [ ] Clarify production migration/versioning expectations for schema changes, rollbacks, and preview volume recreation.
 
 ## Working Checklist
 


### PR DESCRIPTION
## Summary
- add rate-limited BullMQ catalog workers as a Stage 5 roadmap feature
- move the worker migration into near-term PR candidates before scaling catalog volume
- mirror the architecture roadmap priority item with shared TMDB request budgeting, 429 backoff, job dedupe, and Bull Board visibility

## Tests
- npm run format:check
- git diff --check
- pre-push hook: lint, server tests, build