### PR TITLE
Make quiz results handoff explicit

### DIFF
--- a/apps/web/src/app/quiz/page.tsx
+++ b/apps/web/src/app/quiz/page.tsx
@@ -39,12 +39,12 @@ export default function QuizPage() {
 
 function QuizPageContent() {
   const searchParams = useSearchParams();
-  const restartToken = searchParams.get('restart');
+  const quizSessionKey = searchParams.get('session') ?? searchParams.get('restart') ?? 'active';
 
-  return <QuizSession key={restartToken ?? 'active'} restartToken={restartToken} />;
+  return <QuizSession key={quizSessionKey} />;
 }
 
-function QuizSession({ restartToken }: { restartToken: string | null }) {
+function QuizSession() {
   const [state, send] = useMachine(quizMachine);
   const router = useRouter();
   const { t } = useLanguage();
@@ -67,11 +67,6 @@ function QuizSession({ restartToken }: { restartToken: string | null }) {
       : null;
   const currentStepIdx = questionsStep ? STEP_KEYS.indexOf(questionsStep) : -1;
   const isLastStep = questionsStep === 'favoriteActor';
-
-  useEffect(() => {
-    if (!restartToken) return;
-    router.replace('/quiz', { scroll: false });
-  }, [restartToken, router]);
 
   // Trigger submit side-effect when machine reaches the final state
   useEffect(() => {

--- a/apps/web/src/lib/quizNavigation.test.ts
+++ b/apps/web/src/lib/quizNavigation.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { createFreshQuizHref } from './quizNavigation';
+
+describe('quiz navigation', () => {
+  it('creates explicit fresh quiz session URLs', () => {
+    const href = createFreshQuizHref();
+    const url = new URL(href, 'https://popchoice.test');
+
+    expect(url.pathname).toBe('/quiz');
+    expect(url.searchParams.has('restart')).toBe(false);
+    expect(url.searchParams.get('session')).toMatch(/^[a-z0-9]+-[a-z0-9]{6}$/);
+  });
+});

--- a/apps/web/src/lib/quizNavigation.ts
+++ b/apps/web/src/lib/quizNavigation.ts
@@ -1,6 +1,6 @@
 export function createFreshQuizHref(): string {
   const token = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
-  return `/quiz?restart=${token}`;
+  return `/quiz?session=${token}`;
 }
 
 export function navigateToFreshQuiz(): void {

--- a/docs/RECOMMENDATION-ROADMAP.md
+++ b/docs/RECOMMENDATION-ROADMAP.md
@@ -196,6 +196,7 @@ This keeps the high-risk data and orchestration work ahead of visual polish. The
 - [x] [#474](https://github.com/shchilkin/PopChoice/issues/474): add a full Playwright e2e harness with an isolated migrated test database.
 - [x] [#475](https://github.com/shchilkin/PopChoice/issues/475): add product smoke flows for auth, catalog, quiz, recommendation, and feedback.
 - [x] [#476](https://github.com/shchilkin/PopChoice/issues/476): add recommendation eval fixtures and scoring so AI behavior can be changed with more control.
+- [ ] [#490](https://github.com/shchilkin/PopChoice/issues/490): add scheduled or manually triggered real-data recommendation evals for seeded DB and catalog-retrieval changes.
 - Keep live-model evals optional. The default path should be deterministic, cheap, and safe for CI.
 
 ### Stage 6: Long-term personalization

--- a/docs/ROADMAP-ARCHITECTURE.md
+++ b/docs/ROADMAP-ARCHITECTURE.md
@@ -198,6 +198,7 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 - [x] [#474](https://github.com/shchilkin/PopChoice/issues/474): add a Playwright e2e harness with an isolated migrated test database and deterministic seed fixtures.
 - [x] [#475](https://github.com/shchilkin/PopChoice/issues/475): cover auth, catalog, quiz, recommendation, and feedback smoke flows through product-level e2e tests.
 - [x] [#476](https://github.com/shchilkin/PopChoice/issues/476): add an AI recommendation eval harness with deterministic fixtures by default and optional live model/provider runs.
+- [ ] [#490](https://github.com/shchilkin/PopChoice/issues/490): add a scheduled or manually triggered real-data recommendation eval workflow with seeded database data and real catalog retrieval.
 - Keep Storybook/component tests separate from full product e2e tests so UI component regressions and app-flow regressions fail with clear ownership.
 - Keep AI evals separate from normal e2e smoke tests because recommendation quality gates need fixture scoring, model controls, and optional API cost.
 
@@ -257,12 +258,13 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 3. [x] Start [#474](https://github.com/shchilkin/PopChoice/issues/474) so full e2e work has a real isolated DB foundation before adding many browser scenarios.
 4. [x] Add [#475](https://github.com/shchilkin/PopChoice/issues/475) auth, catalog, quiz, and recommendation smoke flows on top of the isolated e2e harness.
 5. [x] Add [#476](https://github.com/shchilkin/PopChoice/issues/476) deterministic recommendation eval fixtures and scoring.
-6. [x] Decide the catalog metadata model in [#471](https://github.com/shchilkin/PopChoice/issues/471) before expanding #82 into actor/director/genre search.
-7. [x] Populate the catalog metadata model in [#472](https://github.com/shchilkin/PopChoice/issues/472) from TMDB backfill/discovery before expanding #82 into actor/director/genre search.
-8. [x] Expand available-movies search in [#473](https://github.com/shchilkin/PopChoice/issues/473) across title, actor/director, and genre metadata populated by #472.
-9. [ ] Move TMDB discovery/backfill/metadata refresh into shared rate-limited BullMQ catalog workers before increasing catalog expansion volume.
-10. [ ] Create a dedicated backoffice app for catalog-health and TMDB review, then add shared login protection for it and `apps/bull-board`.
-11. [ ] Clarify production migration/versioning expectations for schema changes, rollbacks, and preview volume recreation.
+6. [ ] Add [#490](https://github.com/shchilkin/PopChoice/issues/490) scheduled/manual real-data recommendation evals for seeded DB and catalog-retrieval changes.
+7. [x] Decide the catalog metadata model in [#471](https://github.com/shchilkin/PopChoice/issues/471) before expanding #82 into actor/director/genre search.
+8. [x] Populate the catalog metadata model in [#472](https://github.com/shchilkin/PopChoice/issues/472) from TMDB backfill/discovery before expanding #82 into actor/director/genre search.
+9. [x] Expand available-movies search in [#473](https://github.com/shchilkin/PopChoice/issues/473) across title, actor/director, and genre metadata populated by #472.
+10. [ ] Move TMDB discovery/backfill/metadata refresh into shared rate-limited BullMQ catalog workers before increasing catalog expansion volume.
+11. [ ] Create a dedicated backoffice app for catalog-health and TMDB review, then add shared login protection for it and `apps/bull-board`.
+12. [ ] Clarify production migration/versioning expectations for schema changes, rollbacks, and preview volume recreation.
 
 ## Working Checklist
 


### PR DESCRIPTION
## Summary

- replace fresh quiz restart URLs with explicit quiz session URLs
- remove the quiz page effect that immediately scrubbed reset tokens from the route
- keep legacy restart query support as a remount key fallback
- add a focused quiz navigation helper test
- add #490 real-data recommendation eval workflow to the roadmap

Closes #484

## Checks

- npm run test --workspace=apps/web -- quiz.machine.test.ts quizNavigation.test.ts
- npm run lint:check --workspace=apps/web
- npm run type-check
- npm run format:check
- npm run test:e2e
- npm run test:e2e:down
- git push pre-push checks: lint, server tests, production build
