### PR TITLE
Link roadmap work to GitHub issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,12 @@ When code changes affect setup, scripts, architecture, services, CI, or deployme
 - Update `docs/ROADMAP-ARCHITECTURE.md` when work completes or new known follow-ups appear.
 - Keep service READMEs aligned with their actual scripts and environment variables.
 
+When adding new roadmap work:
+
+- Create a GitHub issue for each actionable new ticket before or alongside adding it to roadmap docs.
+- If the work is broad, keep the original issue as an epic/umbrella and create focused implementation issues underneath it.
+- Prefer roadmap entries that link to concrete issues; avoid long-lived untracked bullets unless they are intentionally exploratory notes.
+
 ## Gotchas
 
 - Next.js uses `apps/web/src/proxy.ts` for the CSRF cookie path. Older docs or comments may still say middleware.

--- a/docs/MAINTAINABILITY-CHECKLIST.md
+++ b/docs/MAINTAINABILITY-CHECKLIST.md
@@ -7,6 +7,7 @@ Use this checklist for lightweight, periodic maintainability reviews of PopChoic
 - Review this checklist during larger feature PRs, refactors, or monthly maintenance.
 - Prefer small, scoped fixes instead of broad cleanup PRs.
 - Link related docs (`README.md`, `docs/DEVELOPMENT.md`, `docs/CI-CD.md`, `docs/SERVICES.md`) when checking items.
+- Create GitHub issues for new actionable roadmap tickets. If an item is too large for one PR, make it an epic/umbrella and split focused child issues before implementation.
 
 ## Checklist
 
@@ -79,7 +80,7 @@ Use this checklist for lightweight, periodic maintainability reviews of PopChoic
 
 ## PopChoice priority next steps (highest impact)
 
-- [ ] Refactor the quiz submit/results handoff so navigation state is explicit.
+- [x] Refactor the quiz submit/results handoff so navigation state is explicit.
 - [ ] Keep API route handlers thin and move growing account/movie-memory logic into `src/features` when needed.
 - [ ] Use positive `liked` memory as a ranking signal, not only stored history.
 - [ ] Add catalog-health reporting for missing posters, localized metadata, duplicate identities, and stale TMDB data.

--- a/docs/RECOMMENDATION-ROADMAP.md
+++ b/docs/RECOMMENDATION-ROADMAP.md
@@ -12,6 +12,12 @@ The guiding shift is:
 
 This should be done in stages. A full rewrite is not the goal.
 
+## Backlog Hygiene
+
+- Create a GitHub issue for each actionable roadmap ticket before or alongside adding it here.
+- If the work is too large for one PR, keep the original issue as an epic/umbrella and split focused implementation issues underneath it.
+- Prefer linked roadmap entries so completed work can be checked off without losing context.
+
 ## Current Quiz Flow
 
 The current quiz captures:
@@ -179,7 +185,7 @@ This keeps the high-risk data and orchestration work ahead of visual polish. The
 - Move candidate sourcing toward TMDB discover/search as the broad first pass.
 - Use local embeddings as enrichment and reranking, not as the complete universe of possible movies.
 - Add JIT embedding/enrichment for strong TMDB candidates.
-- Move TMDB discovery and backfill into rate-limited BullMQ catalog workers before increasing catalog expansion volume:
+- Move TMDB discovery and backfill into rate-limited BullMQ catalog workers in [#492](https://github.com/shchilkin/PopChoice/issues/492) before increasing catalog expansion volume:
   - Add a dedicated catalog-maintenance queue for discovery pages, movie detail enrichment, metadata refresh, and per-movie backfill jobs.
   - Enforce one shared TMDB request budget across discovery, backfill, and worker-driven enrichment, with configurable concurrency and `429` backoff.
   - Use deterministic `jobId` values such as `tmdb-details:{tmdbId}:{language}` and `backfill:{movieId}` so retries and duplicate triggers do not fan out duplicate TMDB calls.
@@ -189,7 +195,7 @@ This keeps the high-risk data and orchestration work ahead of visual polish. The
   - [x] [#472](https://github.com/shchilkin/PopChoice/issues/472) TMDB backfill and refresh for that metadata.
   - [x] [#473](https://github.com/shchilkin/PopChoice/issues/473) available-movies partial `ILIKE` search over titles, actors, directors, and genres, combined with exact/ranged catalog filters.
 - Track TMDB API failures, timeout behavior, and fallback quality.
-- Keep an admin/back-office backlog for ambiguous title matches and catalog-health issues.
+- Keep [#493](https://github.com/shchilkin/PopChoice/issues/493) as the epic for admin/back-office review of ambiguous title matches and catalog-health issues.
 
 ### Stage 5.5: Deterministic e2e and eval foundations
 
@@ -210,8 +216,8 @@ This keeps the high-risk data and orchestration work ahead of visual polish. The
 
 Good next PRs, in order:
 
-1. Refactor the quiz submit/results handoff so navigation state is explicit and the quiz page does not need short-lived reset guards.
-2. Move TMDB discovery/backfill/enrichment into a shared rate-limited BullMQ catalog worker before scaling catalog volume.
+1. [x] [#484](https://github.com/shchilkin/PopChoice/issues/484): refactor the quiz submit/results handoff so navigation state is explicit and the quiz page does not need short-lived reset guards.
+2. [#492](https://github.com/shchilkin/PopChoice/issues/492): move TMDB discovery/backfill/enrichment into a shared rate-limited BullMQ catalog worker before scaling catalog volume.
 3. Replace the current quiz copy and options with a more "tonight" oriented flow while preserving existing API shape.
 4. Add a small taste-swipe prototype behind a feature flag or alternate quiz entry path.
 5. Add TMDB-backed candidate-card sourcing for swipe mode.

--- a/docs/ROADMAP-ARCHITECTURE.md
+++ b/docs/ROADMAP-ARCHITECTURE.md
@@ -69,12 +69,18 @@ The main remaining risks are:
 
 ### Issues Still Present
 
-- The quiz-to-results handoff still relies on route-local state and a short-lived browser handoff marker to avoid visual flashes. A follow-up PR should simplify this architecture so the quiz route never needs to reset itself while it is still responsible for rendering the submit handoff.
 - The current quiz is still a first-generation guided flow. It should evolve toward a signal-based recommendation model with a shorter "tonight" quiz, a swipe-based mode for movie-heavy users, and a TMDB-first catalog strategy. See [RECOMMENDATION-ROADMAP.md](./RECOMMENDATION-ROADMAP.md).
 - Route-local compatibility re-export files still exist under `src/app/api/movie-recommendation`; future recommendation changes should continue moving real logic into `src/features/recommendation`.
 - Account settings/profile/provider identity remain intentionally thin.
 
 Reference: use [BOUNDARIES.md](./BOUNDARIES.md) as the current ownership baseline.
+
+### Backlog Hygiene
+
+- Create a GitHub issue for every actionable roadmap ticket before or alongside adding it to this document.
+- If a roadmap item is too large for one PR, keep the original issue as an epic/umbrella and create focused child issues for implementation-sized work.
+- Link roadmap items to concrete issues whenever possible so completed work can be checked off and future agents do not have to rediscover context.
+- Keep unlinked bullets for direction-setting only; convert them into issues once they become actionable.
 
 ## Target Direction
 
@@ -169,14 +175,14 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 
 - [x] [#471](https://github.com/shchilkin/PopChoice/issues/471): add a catalog metadata model for cast, directors, genres, and keywords before expanding search beyond title/year.
 - [x] [#472](https://github.com/shchilkin/PopChoice/issues/472): extend TMDB backfill/discovery to populate people, genre, and keyword metadata, with catalog-health visibility for missing coverage.
-- Persist TMDB backfill review cases in `tmdb_match_reviews`, then add an admin/back-office UI to resolve ambiguous matches, missing metadata, or rejected runtime/year confidence cases.
+- Persist TMDB backfill review cases in `tmdb_match_reviews`, then add an admin/back-office UI to resolve ambiguous matches, missing metadata, or rejected runtime/year confidence cases under [#493](https://github.com/shchilkin/PopChoice/issues/493).
 - Track catalog health signals such as duplicate movie identities, missing posters, missing localized names/overviews, missing runtimes, stale TMDB metadata, and missing cast/director/genre/keyword coverage. Admin resolution and automated refresh remain future work.
 - Create a dedicated backoffice app for catalog-health reports, TMDB match
   review queues, and later manual data repair. Do not add this UI to
-  `apps/web`; that app remains user-facing.
+  `apps/web`; that app remains user-facing. Track the epic in [#493](https://github.com/shchilkin/PopChoice/issues/493) and split child issues before broad implementation starts.
 - Periodically refresh TMDB-backed metadata for older records without destabilizing existing recommendation history.
 - Make seed, discovery, and backfill responsibilities explicit enough that data-quality fixes do not duplicate or fight each other.
-- Define migration/versioning expectations for schema changes, including production migration safety, rollback notes, and seed/backfill coordination.
+- Define migration/versioning expectations for schema changes in [#494](https://github.com/shchilkin/PopChoice/issues/494), including production migration safety, rollback notes, and seed/backfill coordination.
 
 ### Account Platform Track
 
@@ -220,8 +226,8 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 - Keep the local `movies` table as a cache/index of known titles, embeddings, localized names, poster URLs, and TMDB ids rather than the full source of truth.
 - Backfill TMDB ids for existing local movies using exact title/year matches first, then persist ambiguous or low-confidence matches for manual review.
 - Add cast, director, genre, and keyword metadata as first-class catalog data before implementing actor/director/genre search.
-- Move TMDB discovery, backfill, and metadata refresh into shared rate-limited BullMQ catalog workers before growing catalog volume. The worker should enforce one configurable TMDB request budget across all catalog-maintenance jobs, honor `429` with backoff, dedupe jobs by stable `tmdbId`/`movieId` keys, and expose queue depth/failures in Bull Board.
-- Add a back-office review queue for ambiguous TMDB matches, missing posters, duplicate identities, and metadata conflicts before applying risky automatic merges.
+- Move TMDB discovery, backfill, and metadata refresh into shared rate-limited BullMQ catalog workers in [#492](https://github.com/shchilkin/PopChoice/issues/492) before growing catalog volume. The worker should enforce one configurable TMDB request budget across all catalog-maintenance jobs, honor `429` with backoff, dedupe jobs by stable `tmdbId`/`movieId` keys, and expose queue depth/failures in Bull Board.
+- Add a back-office review queue for ambiguous TMDB matches, missing posters, duplicate identities, and metadata conflicts in [#493](https://github.com/shchilkin/PopChoice/issues/493) before applying risky automatic merges.
 - Prefer TMDB ids for all cross-feature identity checks. Fall back to normalized title plus year only when TMDB identity is unavailable.
 - Design future discovery flows around dynamic TMDB candidate sets: "I have watched many films" deck mode, quiz-assisted mode, and later a preference/taste-training mode.
 
@@ -254,7 +260,7 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 ## Priority Items for the Next 30 Days
 
 1. [x] Complete [#81](https://github.com/shchilkin/PopChoice/issues/81) with available-movies runtime, score, and age-rating filters on the existing catalog fields.
-2. [ ] Refactor the quiz submit/results handoff so navigation state is explicit and the quiz page does not need short-lived reset guards.
+2. [x] Refactor the quiz submit/results handoff in [#484](https://github.com/shchilkin/PopChoice/issues/484) so navigation state is explicit and the quiz page does not need short-lived reset guards.
 3. [x] Start [#474](https://github.com/shchilkin/PopChoice/issues/474) so full e2e work has a real isolated DB foundation before adding many browser scenarios.
 4. [x] Add [#475](https://github.com/shchilkin/PopChoice/issues/475) auth, catalog, quiz, and recommendation smoke flows on top of the isolated e2e harness.
 5. [x] Add [#476](https://github.com/shchilkin/PopChoice/issues/476) deterministic recommendation eval fixtures and scoring.
@@ -262,9 +268,9 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 7. [x] Decide the catalog metadata model in [#471](https://github.com/shchilkin/PopChoice/issues/471) before expanding #82 into actor/director/genre search.
 8. [x] Populate the catalog metadata model in [#472](https://github.com/shchilkin/PopChoice/issues/472) from TMDB backfill/discovery before expanding #82 into actor/director/genre search.
 9. [x] Expand available-movies search in [#473](https://github.com/shchilkin/PopChoice/issues/473) across title, actor/director, and genre metadata populated by #472.
-10. [ ] Move TMDB discovery/backfill/metadata refresh into shared rate-limited BullMQ catalog workers before increasing catalog expansion volume.
-11. [ ] Create a dedicated backoffice app for catalog-health and TMDB review, then add shared login protection for it and `apps/bull-board`.
-12. [ ] Clarify production migration/versioning expectations for schema changes, rollbacks, and preview volume recreation.
+10. [ ] Move TMDB discovery/backfill/metadata refresh into shared rate-limited BullMQ catalog workers in [#492](https://github.com/shchilkin/PopChoice/issues/492) before increasing catalog expansion volume.
+11. [ ] Plan and split the [#493](https://github.com/shchilkin/PopChoice/issues/493) backoffice/catalog-health epic, including shared login protection for it and `apps/bull-board`.
+12. [ ] Clarify production migration/versioning expectations in [#494](https://github.com/shchilkin/PopChoice/issues/494) for schema changes, rollbacks, and preview volume recreation.
 
 ## Working Checklist
 


### PR DESCRIPTION
## Summary

- add issue hygiene guidance to AGENTS and roadmap docs
- link new roadmap work to #492, #493, and #494
- mark the completed #484 quiz handoff cleanup as done
- clarify that broad roadmap work should be tracked as an epic/umbrella with focused child issues

## Issues created

- #492 Move TMDB catalog maintenance into rate-limited BullMQ workers
- #493 [Epic] Backoffice and catalog-health review app
- #494 Clarify production migration and schema versioning workflow

## Checks

- npm run format:check
- git diff --check
- pre-commit type-check
- pre-push lint, server tests, production build
