### PR TITLE
Add real-data recommendation eval workflow

### DIFF
--- a/.github/workflows/recommendation-real-data-evals.yml
+++ b/.github/workflows/recommendation-real-data-evals.yml
@@ -1,0 +1,50 @@
+name: Recommendation Real-Data Evals
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 4 * * 1'
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  DATABASE_URL: postgresql://popchoice_e2e@127.0.0.1:55432/popchoice_e2e
+
+jobs:
+  recommendation-real-data-evals:
+    name: Recommendation Real-Data Evals
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare seeded eval database
+        run: npm run test:e2e:setup
+
+      - name: Run real-data recommendation evals
+        run: >
+          npm run eval:recommendations --workspace=apps/web --
+          --real-data
+          --output apps/web/test-results/recommendation-real-data-evals/report.json
+
+      - name: Stop eval database
+        if: always()
+        run: npm run test:e2e:down
+
+      - name: Upload real-data recommendation eval report
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: recommendation-real-data-eval-report
+          path: apps/web/test-results/recommendation-real-data-evals/
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -162,6 +162,14 @@ npm run eval:recommendations
 
 The command writes a JSON report to `apps/web/test-results/recommendation-evals/report.json` and checks output shape, candidate validity, safety constraints, repeat avoidance, and explanation quality. Optional live-provider runs are explicit:
 
+Real-data evals use the isolated e2e database and real catalog retrieval while keeping model output controlled:
+
+```bash
+npm run test:e2e:setup
+DATABASE_URL=postgresql://popchoice_e2e@127.0.0.1:55432/popchoice_e2e npm run eval:recommendations:real-data
+npm run test:e2e:down
+```
+
 ```bash
 npm run eval:recommendations -- --live
 ```

--- a/apps/web/e2e/available-movies.spec.ts
+++ b/apps/web/e2e/available-movies.spec.ts
@@ -16,7 +16,7 @@ test('renders seeded catalog data and filters it through the real movies API', a
   await page.goto('/available-movies');
 
   await expect(page.getByRole('heading', { name: 'Available Movies' })).toBeVisible();
-  await expect(page.getByText(/Showing 1.4 of 4 movies/)).toBeVisible();
+  await expect(page.getByText(/Showing 1.6 of 6 movies/)).toBeVisible();
   await expect(page.getByText('PopChoice E2E Space Opera')).toBeVisible();
   await expect(page.getByText('PopChoice E2E Short Comedy')).toBeVisible();
 
@@ -50,7 +50,7 @@ test('shows a useful empty state when catalog filters match nothing', async ({ p
   await page.goto('/available-movies');
 
   await expect(page.getByRole('heading', { name: 'Available Movies' })).toBeVisible();
-  await expect(page.getByText(/Showing 1.4 of 4 movies/)).toBeVisible();
+  await expect(page.getByText(/Showing 1.6 of 6 movies/)).toBeVisible();
 
   await page.getByPlaceholder('Title, actor, director, or genre').fill('No Such PopChoice Fixture');
   await page.getByRole('button', { name: 'Apply' }).click();
@@ -61,6 +61,6 @@ test('shows a useful empty state when catalog filters match nothing', async ({ p
 
   await page.locator('form').getByRole('button', { name: 'Clear' }).click();
 
-  await expect(page.getByText(/Showing 1.4 of 4 movies/)).toBeVisible();
+  await expect(page.getByText(/Showing 1.6 of 6 movies/)).toBeVisible();
   await expect(page.getByText('PopChoice E2E Space Opera')).toBeVisible();
 });

--- a/apps/web/scripts/evaluate-recommendations.ts
+++ b/apps/web/scripts/evaluate-recommendations.ts
@@ -11,7 +11,9 @@ import {
 } from '@/features/recommendation/evals/scoring';
 
 import type {
+  RecommendationEvalCheck,
   RecommendationEvalFixture,
+  RecommendationEvalResult,
   RecommendationEvalRunMode,
 } from '@/features/recommendation/evals/types';
 import type { ApiResponse } from '@/features/recommendation/types';
@@ -30,9 +32,10 @@ type EvalCliOptions = {
 };
 
 function printUsage(): void {
-  console.log(`Usage: npm run eval:recommendations -- [--live] [--output <path>]
+  console.log(`Usage: npm run eval:recommendations -- [--real-data] [--live] [--output <path>]
 
 Default mode uses deterministic mocked model responses and does not call OpenAI or TMDB.
+Use --real-data after preparing a seeded database to validate catalog retrieval and candidate availability without live AI calls.
 Use --live only for explicit manual runs against configured providers and databases.`);
 }
 
@@ -48,6 +51,10 @@ function parseCliOptions(argv: string[]): EvalCliOptions {
     }
     if (arg === '--live') {
       mode = 'live';
+      continue;
+    }
+    if (arg === '--real-data') {
+      mode = 'real-data';
       continue;
     }
     if (arg === '--output') {
@@ -67,7 +74,7 @@ async function getFixtureResponse(
   fixture: RecommendationEvalFixture,
   mode: RecommendationEvalRunMode,
 ): Promise<ApiResponse> {
-  if (mode === 'mock') {
+  if (mode === 'mock' || mode === 'real-data') {
     return fixture.mockResponse;
   }
 
@@ -87,13 +94,101 @@ async function getFixtureResponse(
   return runRecommendationPipeline(fixture.people, fixture.locale);
 }
 
+function buildEvalCheck(
+  id: string,
+  label: string,
+  passed: boolean,
+  details: string,
+): RecommendationEvalCheck {
+  return {
+    details,
+    id,
+    label,
+    maxScore: 0,
+    passed,
+    score: 0,
+  };
+}
+
+function withAdditionalChecks(
+  result: RecommendationEvalResult,
+  checks: RecommendationEvalCheck[],
+): RecommendationEvalResult {
+  const allChecks = [...result.checks, ...checks];
+
+  return {
+    ...result,
+    checks: allChecks,
+    passed: result.score >= result.minPassingScore && allChecks.every((check) => check.passed),
+  };
+}
+
+async function getRealDataChecks(
+  fixture: RecommendationEvalFixture,
+): Promise<RecommendationEvalCheck[]> {
+  if (!process.env.DATABASE_URL) {
+    throw new Error('Real-data recommendation evals require DATABASE_URL.');
+  }
+
+  const { getMoviesPage } = await import('@/features/movies/catalog');
+  const catalog = await getMoviesPage(1, 100, {});
+  const catalogTitleYears = new Set(
+    catalog.movies.map((movie) => `${movie.name.toLocaleLowerCase('en-US')}|${movie.year}`),
+  );
+  const missingCandidates = fixture.candidates.filter(
+    (movie) => !catalogTitleYears.has(`${movie.name.toLocaleLowerCase('en-US')}|${movie.year}`),
+  );
+
+  const mainTitle = fixture.expectations.allowedMainTitles[0];
+  const searchResult = mainTitle
+    ? await getMoviesPage(1, 10, { query: mainTitle })
+    : { movies: [], totalCount: 0 };
+  const searchFound = mainTitle
+    ? searchResult.movies.some((movie) => movie.name === mainTitle)
+    : false;
+
+  return [
+    buildEvalCheck(
+      'real-data-catalog-connectivity',
+      'Real-data catalog connectivity',
+      catalog.totalCount > 0,
+      catalog.totalCount > 0
+        ? `Retrieved ${catalog.totalCount} movies from the seeded catalog.`
+        : 'Seeded catalog returned no movies.',
+    ),
+    buildEvalCheck(
+      'real-data-candidate-availability',
+      'Real-data candidate availability',
+      missingCandidates.length === 0,
+      missingCandidates.length === 0
+        ? 'All fixture candidates exist in the seeded catalog.'
+        : `Missing candidates: ${missingCandidates
+            .map((movie) => `${movie.name} (${movie.year})`)
+            .join(', ')}`,
+    ),
+    buildEvalCheck(
+      'real-data-catalog-retrieval',
+      'Real-data catalog retrieval',
+      searchFound,
+      searchFound
+        ? `Catalog search retrieved expected main title "${mainTitle}".`
+        : `Catalog search did not retrieve expected main title "${mainTitle}".`,
+    ),
+  ];
+}
+
 async function main(): Promise<void> {
   const options = parseCliOptions(process.argv.slice(2));
   const results = [];
 
   for (const fixture of recommendationEvalFixtures) {
     const response = await getFixtureResponse(fixture, options.mode);
-    results.push(scoreRecommendationEvalFixture(fixture, response, options.mode));
+    const scored = scoreRecommendationEvalFixture(fixture, response, options.mode);
+    const result =
+      options.mode === 'real-data'
+        ? withAdditionalChecks(scored, await getRealDataChecks(fixture))
+        : scored;
+    results.push(result);
   }
 
   const report = buildRecommendationEvalReport(results, options.mode);

--- a/apps/web/src/features/recommendation/evals/types.ts
+++ b/apps/web/src/features/recommendation/evals/types.ts
@@ -56,7 +56,7 @@ export type RecommendationEvalResult = {
   score: number;
 };
 
-export type RecommendationEvalRunMode = 'mock' | 'live';
+export type RecommendationEvalRunMode = 'mock' | 'real-data' | 'live';
 
 export type RecommendationEvalReport = {
   generatedAt: string;

--- a/apps/web/src/features/recommendation/jobs.ts
+++ b/apps/web/src/features/recommendation/jobs.ts
@@ -75,7 +75,7 @@ function buildDeterministicE2EResult(allPeopleData: PersonFormData[]): ApiRespon
     title: 'PopChoice E2E Space Opera',
     description: `A deterministic e2e recommendation${reference}.`,
     usedBroaderSearch: false,
-    dbMovieCount: 4,
+    dbMovieCount: 6,
     similarMovies: [
       {
         id: 1,

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -5,6 +5,7 @@
 This project uses these GitHub Actions workflow files for pull request validation and security scanning:
 
 - `.github/workflows/pr.yml` – main application and workspace checks (lint, type-check, web tests, recommendation evals, Storybook tests, e2e smoke tests, build, service CI, dependency review)
+- `.github/workflows/recommendation-real-data-evals.yml` – scheduled/manual recommendation evals against a seeded database and real catalog retrieval
 - `.github/workflows/container-images.yml` – production container image builds for app and service runtimes, published to GitHub Container Registry with commit and PR provenance metadata
 - `.github/workflows/movie-discovery-ci.yml` – TypeScript compilation and tests for the `services/movie-discovery` service, triggered when files under `services/movie-discovery/` change or when `.github/workflows/movie-discovery-ci.yml` itself changes
 - `.github/workflows/codeql.yml` – CodeQL analysis for GitHub Actions and JavaScript/TypeScript on pushes, pull requests, and a weekly schedule
@@ -15,23 +16,24 @@ The PR validation workflows run automatically on pull requests targeting the `de
 
 ### Jobs
 
-| Workflow                 | Job                    | Purpose                                                                         |
-| ------------------------ | ---------------------- | ------------------------------------------------------------------------------- |
-| `pr.yml`                 | `changes`              | Classifies PR as docs-only vs code-changing                                     |
-| `pr.yml`                 | `lint`                 | ESLint code quality + Prettier formatting                                       |
-| `pr.yml`                 | `type-check`           | TypeScript type safety (`tsc --noEmit`)                                         |
-| `pr.yml`                 | `server-tests`         | Vitest server tests with coverage collection and artifact upload                |
-| `pr.yml`                 | `recommendation-evals` | Deterministic recommendation quality fixtures and scoring                       |
-| `pr.yml`                 | `storybook-tests`      | Playwright browser install + Storybook component tests                          |
-| `pr.yml`                 | `e2e-tests`            | Playwright smoke tests against isolated PostgreSQL + Redis services             |
-| `pr.yml`                 | `build`                | Next.js production build verification                                           |
-| `pr.yml`                 | `services-ci`          | Turbo test pass for `services/*`                                                |
-| `pr.yml`                 | `dependency-review`    | Blocks PRs introducing vulnerable dependencies                                  |
-| `pr.yml`                 | `pr-validation`        | Stable required check that always runs on every PR                              |
-| `container-images.yml`   | `build-images`         | Builds and publishes GHCR production images with provenance                     |
-| `container-images.yml`   | `deploy-coolify`       | Optionally triggers the Coolify deploy webhook after development images publish |
-| `movie-discovery-ci.yml` | `movie-discovery-ci`   | TypeScript compilation and tests for `services/movie-discovery`                 |
-| `codeql.yml`             | `analyze`              | CodeQL static analysis for Actions and JavaScript/TypeScript                    |
+| Workflow                             | Job                              | Purpose                                                                         |
+| ------------------------------------ | -------------------------------- | ------------------------------------------------------------------------------- |
+| `pr.yml`                             | `changes`                        | Classifies PR as docs-only vs code-changing                                     |
+| `pr.yml`                             | `lint`                           | ESLint code quality + Prettier formatting                                       |
+| `pr.yml`                             | `type-check`                     | TypeScript type safety (`tsc --noEmit`)                                         |
+| `pr.yml`                             | `server-tests`                   | Vitest server tests with coverage collection and artifact upload                |
+| `pr.yml`                             | `recommendation-evals`           | Deterministic recommendation quality fixtures and scoring                       |
+| `pr.yml`                             | `storybook-tests`                | Playwright browser install + Storybook component tests                          |
+| `pr.yml`                             | `e2e-tests`                      | Playwright smoke tests against isolated PostgreSQL + Redis services             |
+| `pr.yml`                             | `build`                          | Next.js production build verification                                           |
+| `pr.yml`                             | `services-ci`                    | Turbo test pass for `services/*`                                                |
+| `pr.yml`                             | `dependency-review`              | Blocks PRs introducing vulnerable dependencies                                  |
+| `pr.yml`                             | `pr-validation`                  | Stable required check that always runs on every PR                              |
+| `container-images.yml`               | `build-images`                   | Builds and publishes GHCR production images with provenance                     |
+| `container-images.yml`               | `deploy-coolify`                 | Optionally triggers the Coolify deploy webhook after development images publish |
+| `movie-discovery-ci.yml`             | `movie-discovery-ci`             | TypeScript compilation and tests for `services/movie-discovery`                 |
+| `codeql.yml`                         | `analyze`                        | CodeQL static analysis for Actions and JavaScript/TypeScript                    |
+| `recommendation-real-data-evals.yml` | `recommendation-real-data-evals` | Manual/scheduled seeded-database catalog retrieval evals                        |
 
 ## Workflow Features
 
@@ -57,12 +59,12 @@ The e2e coverage proves the real app can read seeded catalog data from PostgreSQ
 
 The `recommendation-evals` job runs `npm run eval:recommendations`. This is a CI-blocking deterministic suite: it uses fixture prompts, fixture memory constraints, and mocked model outputs, then writes `apps/web/test-results/recommendation-evals/report.json`. The report is uploaded as the `recommendation-eval-report` artifact.
 
-Default evals do not require `OPENAI_API_KEY`, `TMDB_API_KEY`, Redis, or PostgreSQL. Optional live-provider evals use `npm run eval:recommendations -- --live` and are intentionally manual because they can spend API credits, depend on provider availability, and may need seeded local data.
+Default evals do not require `OPENAI_API_KEY`, `TMDB_API_KEY`, Redis, or PostgreSQL. Real-data evals use `npm run eval:recommendations:real-data` after preparing the seeded e2e database; they validate catalog connectivity, candidate availability, and catalog search retrieval while keeping model output controlled. Optional live-provider evals use `npm run eval:recommendations --workspace=apps/web -- --live` and are intentionally manual because they can spend API credits, depend on provider availability, and may need seeded local data.
 
 Recommendation checks are intentionally layered:
 
 1. **Per-PR CI:** deterministic fixtures and mocked model outputs via `npm run eval:recommendations`.
-2. **Scheduled or manual real-data eval:** seeded database and real catalog retrieval, but still controlled model output by default. Use this for schema, seed/backfill, retrieval, and candidate-availability changes once the workflow exists.
+2. **Scheduled or manual real-data eval:** seeded database and real catalog retrieval, but still controlled model output by default. Use this for schema, seed/backfill, retrieval, and candidate-availability changes. The `Recommendation Real-Data Evals` workflow runs weekly and can be triggered manually.
 3. **Manual live eval:** real data plus live AI providers via `npm run eval:recommendations -- --live`. This is not a default hard gate because provider responses, rate limits, and API cost can make it noisy.
 
 Agents and reviewers should explicitly consider these layers when a PR changes recommendation prompts, embeddings, OpenAI/TMDB integration, candidate filtering/ranking, feedback signals, or catalog data feeding recommendations.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -173,10 +173,20 @@ npm run eval:recommendations -- --live
 
 Live evals require configured provider and database environment variables such as `OPENAI_API_KEY`, `DATABASE_URL`, and usually `TMDB_API_KEY`. CI blocks on the deterministic eval job; live evals are manual so normal PR checks stay cheap and predictable.
 
+Run real-data evals when checking catalog retrieval, seed/backfill, schema, or candidate-availability changes:
+
+```bash
+npm run test:e2e:setup
+DATABASE_URL=postgresql://popchoice_e2e@127.0.0.1:55432/popchoice_e2e npm run eval:recommendations:real-data
+npm run test:e2e:down
+```
+
+The real-data mode still uses controlled recommendation outputs and does not call live AI providers. It adds catalog connectivity, candidate availability, and catalog search retrieval checks to the normal eval report.
+
 Use three eval levels when changing AI-related code:
 
 1. `npm run eval:recommendations` for every PR that changes recommendation prompts, embeddings, candidate filters, ranking, feedback signals, response shape, or eval fixtures.
-2. A real-data eval for changes that affect catalog retrieval, schema, seeding/backfill, or candidate availability. This should be scheduled or manually triggered against a seeded database; it should not be a default per-PR hard gate until it is proven cheap and stable.
+2. A real-data eval for changes that affect catalog retrieval, schema, seeding/backfill, or candidate availability. This runs against a seeded database through `npm run eval:recommendations:real-data` or the scheduled/manual GitHub workflow; it is not a default per-PR hard gate.
 3. `npm run eval:recommendations -- --live` only when intentionally checking live model/provider behavior before larger recommendation changes. Live runs can spend API credits and depend on provider availability, so agents should call out whether they ran it or why they did not.
 
 ## Project Structure

--- a/docs/RECOMMENDATION-ROADMAP.md
+++ b/docs/RECOMMENDATION-ROADMAP.md
@@ -202,7 +202,7 @@ This keeps the high-risk data and orchestration work ahead of visual polish. The
 - [x] [#474](https://github.com/shchilkin/PopChoice/issues/474): add a full Playwright e2e harness with an isolated migrated test database.
 - [x] [#475](https://github.com/shchilkin/PopChoice/issues/475): add product smoke flows for auth, catalog, quiz, recommendation, and feedback.
 - [x] [#476](https://github.com/shchilkin/PopChoice/issues/476): add recommendation eval fixtures and scoring so AI behavior can be changed with more control.
-- [ ] [#490](https://github.com/shchilkin/PopChoice/issues/490): add scheduled or manually triggered real-data recommendation evals for seeded DB and catalog-retrieval changes.
+- [x] [#490](https://github.com/shchilkin/PopChoice/issues/490): add scheduled or manually triggered real-data recommendation evals for seeded DB and catalog-retrieval changes.
 - Keep live-model evals optional. The default path should be deterministic, cheap, and safe for CI.
 
 ### Stage 6: Long-term personalization

--- a/docs/ROADMAP-ARCHITECTURE.md
+++ b/docs/ROADMAP-ARCHITECTURE.md
@@ -204,7 +204,7 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 - [x] [#474](https://github.com/shchilkin/PopChoice/issues/474): add a Playwright e2e harness with an isolated migrated test database and deterministic seed fixtures.
 - [x] [#475](https://github.com/shchilkin/PopChoice/issues/475): cover auth, catalog, quiz, recommendation, and feedback smoke flows through product-level e2e tests.
 - [x] [#476](https://github.com/shchilkin/PopChoice/issues/476): add an AI recommendation eval harness with deterministic fixtures by default and optional live model/provider runs.
-- [ ] [#490](https://github.com/shchilkin/PopChoice/issues/490): add a scheduled or manually triggered real-data recommendation eval workflow with seeded database data and real catalog retrieval.
+- [x] [#490](https://github.com/shchilkin/PopChoice/issues/490): add a scheduled or manually triggered real-data recommendation eval workflow with seeded database data and real catalog retrieval.
 - Keep Storybook/component tests separate from full product e2e tests so UI component regressions and app-flow regressions fail with clear ownership.
 - Keep AI evals separate from normal e2e smoke tests because recommendation quality gates need fixture scoring, model controls, and optional API cost.
 
@@ -264,7 +264,7 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 3. [x] Start [#474](https://github.com/shchilkin/PopChoice/issues/474) so full e2e work has a real isolated DB foundation before adding many browser scenarios.
 4. [x] Add [#475](https://github.com/shchilkin/PopChoice/issues/475) auth, catalog, quiz, and recommendation smoke flows on top of the isolated e2e harness.
 5. [x] Add [#476](https://github.com/shchilkin/PopChoice/issues/476) deterministic recommendation eval fixtures and scoring.
-6. [ ] Add [#490](https://github.com/shchilkin/PopChoice/issues/490) scheduled/manual real-data recommendation evals for seeded DB and catalog-retrieval changes.
+6. [x] Add [#490](https://github.com/shchilkin/PopChoice/issues/490) scheduled/manual real-data recommendation evals for seeded DB and catalog-retrieval changes.
 7. [x] Decide the catalog metadata model in [#471](https://github.com/shchilkin/PopChoice/issues/471) before expanding #82 into actor/director/genre search.
 8. [x] Populate the catalog metadata model in [#472](https://github.com/shchilkin/PopChoice/issues/472) from TMDB backfill/discovery before expanding #82 into actor/director/genre search.
 9. [x] Expand available-movies search in [#473](https://github.com/shchilkin/PopChoice/issues/473) across title, actor/director, and genre metadata populated by #472.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "dev": "npm run dev --workspace=apps/web",
     "dev:shared": "npm run dev --workspace=packages/shared",
     "eval:recommendations": "npm run eval:recommendations --workspace=apps/web",
+    "eval:recommendations:real-data": "npm run eval:recommendations --workspace=apps/web -- --real-data",
     "fix": "npm run lint:fix && npm run format:write && npm run format:package",
     "format:check": "prettier --check .",
     "format:package": "sort-package-json",

--- a/scripts/e2e/setup-db.mjs
+++ b/scripts/e2e/setup-db.mjs
@@ -62,7 +62,9 @@ async function seedDatabase(databaseUrl) {
           ($1, $2, $3, $4, $5, $6, $7, $8, $9),
           ($10, $11, $12, $13, $14, $15, $16, $17, $18),
           ($19, $20, $21, $22, $23, $24, $25, $26, $27),
-          ($28, $29, $30, $31, $32, $33, $34, $35, $36)
+          ($28, $29, $30, $31, $32, $33, $34, $35, $36),
+          ($37, $38, $39, $40, $41, $42, $43, $44, $45),
+          ($46, $47, $48, $49, $50, $51, $52, $53, $54)
       `,
       [
         'PopChoice E2E Space Opera',
@@ -101,6 +103,24 @@ async function seedDatabase(databaseUrl) {
         900004,
         null,
         'PopChoice E2E Family Adventure',
+        'PopChoice E2E Cozy Mystery',
+        'PG',
+        'A cozy mystery fixture for recommendation eval candidate availability.',
+        108,
+        7.8,
+        2021,
+        900005,
+        null,
+        'PopChoice E2E Cozy Mystery',
+        'PopChoice E2E Ensemble Comedy',
+        'PG-13',
+        'A playful ensemble fixture for mixed group recommendation evals.',
+        115,
+        8.3,
+        2020,
+        900006,
+        null,
+        'PopChoice E2E Ensemble Comedy',
       ],
     );
 


### PR DESCRIPTION
## Summary
- add a real-data recommendation eval mode that validates seeded catalog connectivity, candidate availability, and retrieval without live AI calls
- add a manual/weekly GitHub workflow that prepares the e2e database and uploads the eval report artifact
- seed the missing eval candidates in the e2e database and update docs/roadmap for #490

## Checks
- npm run format:check
- git diff --check
- npm run lint:check
- npm run type-check
- npm run test --workspace=apps/web -- scoring.test.ts
- npm run eval:recommendations
- npm run test:e2e:setup
- DATABASE_URL=postgresql://popchoice_e2e@127.0.0.1:55432/popchoice_e2e npm run eval:recommendations:real-data
- npm run test:e2e
- pre-push: lint, server tests, production build

Closes #490