### PR TITLE
Add self-hosted observability roadmap

### DIFF
--- a/docs/ROADMAP-ARCHITECTURE.md
+++ b/docs/ROADMAP-ARCHITECTURE.md
@@ -150,6 +150,12 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 
 ### Operational Observability Track
 
+- [ ] Build the self-hosted observability stack under [#498](https://github.com/shchilkin/PopChoice/issues/498). This is intentionally a learning track: SaaS tools would be simpler, but self-hosting teaches uptime checks, log shipping, metrics, traces, alerts, retention, and backups.
+- [ ] Add Uptime Kuma health and synthetic monitoring in [#502](https://github.com/shchilkin/PopChoice/issues/502) for `/api/health`, build metadata, and cheap smoke checks before deeper instrumentation.
+- [ ] Add Grafana Loki log aggregation in [#499](https://github.com/shchilkin/PopChoice/issues/499) so Coolify/Docker logs are searchable by service, level, request id, recommendation id, queue, job id, and stage.
+- [ ] Add Prometheus metrics and Grafana dashboards in [#501](https://github.com/shchilkin/PopChoice/issues/501) for container health, Postgres, Redis, BullMQ queues, recommendation latency, provider timeouts, and failed jobs.
+- [ ] Add OpenTelemetry traces with Tempo in [#500](https://github.com/shchilkin/PopChoice/issues/500) once the low-noise uptime/logs/metrics foundation exists.
+- [ ] Add alert routing, retention, backups, and incident runbooks in [#503](https://github.com/shchilkin/PopChoice/issues/503) so the monitoring stack stays useful and recoverable.
 - Enable Coolify notifications for failed deploys, failed backups, server disk/resource warnings, and unhealthy or restarting containers where supported.
 - Add external uptime monitoring for `https://pop-choice.shchilkin.dev/api/health`, then consider a deeper synthetic recommendation smoke check.
 - Add application error tracking for frontend, API routes, and workers so browser errors, API exceptions, and background job failures are visible outside Coolify logs.
@@ -271,6 +277,7 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 10. [x] Move TMDB discovery/backfill/metadata refresh into shared rate-limited BullMQ catalog workers in [#492](https://github.com/shchilkin/PopChoice/issues/492) before increasing catalog expansion volume.
 11. [ ] Plan and split the [#493](https://github.com/shchilkin/PopChoice/issues/493) backoffice/catalog-health epic, including shared login protection for it and `apps/bull-board`.
 12. [ ] Clarify production migration/versioning expectations in [#494](https://github.com/shchilkin/PopChoice/issues/494) for schema changes, rollbacks, and preview volume recreation.
+13. [ ] Start the self-hosted observability epic in [#498](https://github.com/shchilkin/PopChoice/issues/498), beginning with Uptime Kuma in [#502](https://github.com/shchilkin/PopChoice/issues/502) and log aggregation in [#499](https://github.com/shchilkin/PopChoice/issues/499).
 
 ## Working Checklist
 


### PR DESCRIPTION
## Summary
- add a self-hosted observability epic and child issue links to the architecture roadmap
- document the suggested implementation order: Uptime Kuma, Loki logs, Prometheus/Grafana metrics, alerts/runbooks, then OpenTelemetry/Tempo traces

## Issues
- #498
- #499
- #500
- #501
- #502
- #503

## Verification
- npm run format:check
- pre-push hook: lint, server tests, production build