### PR TITLE
Add self-hosted observability foundation

### DIFF
--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -1,0 +1,83 @@
+name: popchoice-observability
+
+services:
+  observability-uptime-kuma:
+    image: louislam/uptime-kuma:1.23.16
+    container_name: popchoice-observability-uptime-kuma
+    restart: unless-stopped
+    ports:
+      - '127.0.0.1:3002:3001'
+    volumes:
+      - uptime-kuma-data:/app/data
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'node -e "fetch(''http://127.0.0.1:3001'').then(r=>process.exit(r.status<500?0:1)).catch(()=>process.exit(1))"',
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+
+  observability-loki:
+    image: grafana/loki:3.5.7
+    container_name: popchoice-observability-loki
+    restart: unless-stopped
+    command: ['-config.file=/etc/loki/loki.yaml']
+    ports:
+      - '127.0.0.1:3100:3100'
+    volumes:
+      - ./observability/loki/loki.yaml:/etc/loki/loki.yaml:ro
+      - lokidata:/loki
+    healthcheck:
+      test:
+        ['CMD-SHELL', 'wget --no-verbose --tries=1 --spider http://127.0.0.1:3100/ready || exit 1']
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  observability-alloy:
+    image: grafana/alloy:v1.11.3
+    container_name: popchoice-observability-alloy
+    restart: unless-stopped
+    command:
+      [
+        'run',
+        '--server.http.listen-addr=0.0.0.0:12345',
+        '--storage.path=/var/lib/alloy/data',
+        '/etc/alloy/config.alloy',
+      ]
+    ports:
+      - '127.0.0.1:12345:12345'
+    volumes:
+      - ./observability/alloy/config.alloy:/etc/alloy/config.alloy:ro
+      - alloydata:/var/lib/alloy/data
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    depends_on:
+      observability-loki:
+        condition: service_healthy
+
+  observability-grafana:
+    image: grafana/grafana:12.3.0
+    container_name: popchoice-observability-grafana
+    restart: unless-stopped
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?Set GRAFANA_ADMIN_PASSWORD before starting observability}
+      GF_USERS_ALLOW_SIGN_UP: 'false'
+      GF_AUTH_ANONYMOUS_ENABLED: 'false'
+    ports:
+      - '127.0.0.1:3001:3000'
+    volumes:
+      - grafanadata:/var/lib/grafana
+      - ./observability/grafana/provisioning:/etc/grafana/provisioning:ro
+    depends_on:
+      observability-loki:
+        condition: service_healthy
+
+volumes:
+  alloydata:
+  grafanadata:
+  lokidata:
+  uptime-kuma-data:

--- a/docs/COOLIFY.md
+++ b/docs/COOLIFY.md
@@ -238,6 +238,19 @@ Run this checklist after production deploys and after any infrastructure change:
 - Worker logs show Redis readiness and recommendation job completion.
 - The latest PostgreSQL backup exists in the configured backup destination.
 
+## Optional observability stack
+
+For searchable Docker/Coolify logs, run the separate Loki, Alloy, and Grafana
+stack documented in [OBSERVABILITY-LOGS.md](./OBSERVABILITY-LOGS.md). Keep it as
+a separate Coolify Docker Compose resource so PopChoice containers do not depend
+on Loki availability at runtime.
+
+For external uptime and cheap synthetic monitoring, run Uptime Kuma as a
+separate observability stack and configure the monitors in
+[Uptime Kuma Monitoring](./OBSERVABILITY-UPTIME.md). Keep those checks
+read-only by default so production monitoring does not spend AI-provider
+credits.
+
 ## Automatic redeploys
 
 For a simple continuous deployment path:

--- a/docs/OBSERVABILITY-LOGS.md
+++ b/docs/OBSERVABILITY-LOGS.md
@@ -1,0 +1,223 @@
+# Observability Logs
+
+PopChoice can run a small self-hosted log stack for production or preview VPS
+debugging: Grafana Loki stores logs, Grafana Alloy tails Docker containers, and
+Grafana provides search through the provisioned Loki data source.
+
+This stack is intentionally separate from the PopChoice app stack. Web,
+workers, Bull Board, PostgreSQL, Redis, and one-shot service containers keep
+writing to stdout/stderr; Alloy reads Docker logs and pushes them to Loki. If
+Loki, Alloy, or Grafana are down, PopChoice keeps running and Docker still keeps
+its local container logs.
+
+## Files
+
+- `docker-compose.observability.yml` starts Loki, Alloy, Grafana, and the
+  Uptime Kuma service documented separately in
+  [OBSERVABILITY-UPTIME.md](./OBSERVABILITY-UPTIME.md).
+- `observability/loki/loki.yaml` configures single-binary Loki with filesystem
+  TSDB storage and seven-day retention.
+- `observability/alloy/config.alloy` discovers Docker containers, parses Docker
+  log envelopes, extracts Pino JSON fields, and ships logs to Loki.
+- `observability/grafana/provisioning/datasources/loki.yaml` provisions the
+  local Loki data source.
+
+## Local or VPS start
+
+From the repo root:
+
+```bash
+export GRAFANA_ADMIN_PASSWORD='replace-with-a-long-password'
+docker compose -f docker-compose.observability.yml up -d
+```
+
+Grafana listens on `127.0.0.1:3001` by default. On a VPS, either expose it
+through Coolify with authentication enabled or reach it over an SSH tunnel:
+
+```bash
+ssh -L 3001:127.0.0.1:3001 your-vps
+```
+
+Then open `http://127.0.0.1:3001`, choose the `Loki` data source in Explore, and
+query recent logs.
+
+Alloy also exposes its debugging UI on `127.0.0.1:12345`. Use it only from the
+host or an SSH tunnel because the container mounts the Docker socket read-only.
+
+## Coolify deployment shape
+
+Keep this as a separate Docker Compose resource from `coolify.compose.yml` so
+log storage can restart, resize, or be removed without redeploying PopChoice.
+Use `docker-compose.observability.yml` as the compose file path and set
+`GRAFANA_ADMIN_PASSWORD` in the observability resource.
+
+The stack collects every Docker container visible through
+`/var/run/docker.sock`, including PopChoice containers and infrastructure
+containers where Docker exposes metadata. Do not add Loki as a runtime
+dependency to `web`, `workers`, or service containers.
+
+## Labels and structured fields
+
+Alloy stores these low-cardinality labels:
+
+| Label             | Source                         | Use                                                    |
+| ----------------- | ------------------------------ | ------------------------------------------------------ |
+| `stack`           | Static `popchoice` label       | Narrow queries to this log stack                       |
+| `service`         | Docker Compose service label   | Search `web`, `workers`, `bull-board`, `db`, `redis`   |
+| `container`       | Docker container name          | Inspect one concrete container                         |
+| `compose_project` | Docker Compose project label   | Separate preview, local, and production compose stacks |
+| `level`           | Pino JSON `level` when present | Filter application log severity                        |
+
+Alloy attaches these Pino fields as Loki structured metadata instead of labels:
+`requestId`, `reqId`, `recommendationId`, `recommendationSlug`, `queue`,
+`queueName`, `jobId`, `jobName`, `stage`, `userId`, `err`, and `msg`.
+
+The identifier fields are intentionally not indexed as labels because request,
+recommendation, job, and user ids are high-cardinality. Loki can still filter
+structured metadata after selecting a small enough stream and time window.
+
+Pino levels are numeric by default:
+
+| Pino level | Meaning |
+| ---------- | ------- |
+| `10`       | trace   |
+| `20`       | debug   |
+| `30`       | info    |
+| `40`       | warn    |
+| `50`       | error   |
+| `60`       | fatal   |
+
+## Query examples
+
+Start broad, then add structured metadata filters. Keep the time picker narrow
+for identifier searches.
+
+Recent web logs:
+
+```logql
+{stack="popchoice", service="web"}
+```
+
+Application errors across web and workers:
+
+```logql
+{stack="popchoice", level=~"50|60"}
+```
+
+Warnings and errors for workers:
+
+```logql
+{stack="popchoice", service="workers", level=~"40|50|60"}
+```
+
+One request id, supporting both common field names:
+
+```logql
+{stack="popchoice", service="web"} | requestId="req_123"
+```
+
+```logql
+{stack="popchoice", service="web"} | reqId="req_123"
+```
+
+One recommendation flow across API and workers:
+
+```logql
+{stack="popchoice", service=~"web|workers"} | recommendationId="rec_123"
+```
+
+Recommendation stage updates or failures:
+
+```logql
+{stack="popchoice", service=~"web|workers"} | recommendationId="rec_123" | stage="descriptions"
+```
+
+One BullMQ job id:
+
+```logql
+{stack="popchoice", service="workers"} | jobId="tmdb-seed:550:en-US"
+```
+
+Queue-related worker logs, depending on which field exists in the log line:
+
+```logql
+{stack="popchoice", service="workers"} | queue="recommendation"
+```
+
+```logql
+{stack="popchoice", service="workers"} | queueName="catalog-maintenance"
+```
+
+Catalog maintenance job completions and failures:
+
+```logql
+{stack="popchoice", service="workers"} | jobName="seed-tmdb-movie"
+```
+
+Plain text fallback for infrastructure logs or older unstructured lines:
+
+```logql
+{stack="popchoice", service=~"db|redis|bull-board"} |= "error"
+```
+
+Parse original JSON at query time when a field was not promoted by Alloy:
+
+```logql
+{stack="popchoice", service="web"} | json | userId="user_123"
+```
+
+## Incident shortcuts
+
+Recommendation is stuck:
+
+1. Search by `recommendationId` across `web` and `workers`.
+2. Check worker `level=~"40|50|60"` in the same time window.
+3. Search for `jobId` if the enqueue or worker log includes one.
+4. Check `redis` logs for connectivity errors and `db` logs for migrations or
+   connection saturation.
+
+Worker or queue failures:
+
+1. Start with `{stack="popchoice", service="workers", level=~"40|50|60"}`.
+2. Filter by `jobName`, `queue`, `queueName`, or `jobId` when available.
+3. Use Bull Board for retry state after Loki identifies the failing job.
+
+Provider or catalog issues:
+
+1. Search workers for `TMDB`, `OpenAI`, `timeout`, or `429`.
+2. Check `catalog-maintenance` job names and `jobId` values.
+3. Compare with `db` and `redis` logs before assuming a provider outage.
+
+## Retention and disk pressure
+
+The default Loki retention is `168h` (seven days). This is a conservative small
+VPS default: useful for post-incident review without silently growing forever.
+Loki retention is enforced by the compactor, and the config also limits query
+lookback to the same seven-day window.
+
+Tradeoffs:
+
+- Shorter retention, such as `72h`, is safer on a 40 GB VPS or noisy preview
+  host.
+- Longer retention, such as `336h`, is useful for low-volume production but can
+  crowd PostgreSQL backups, Docker layers, and Coolify data.
+- Filesystem Loki does not delete based on free disk percentage. It deletes by
+  retention age, so host disk alerts and backups still matter.
+- Keep identifiers as structured metadata, not labels, to avoid large indexes.
+- Avoid `LOG_LEVEL=debug` in production unless investigating a short-lived
+  incident.
+
+If disk pressure appears, first reduce `limits_config.retention_period` and
+`max_query_lookback` in `observability/loki/loki.yaml`, restart Loki, and give
+the compactor time to delete old chunks. If the host is already critically full,
+stop the observability stack before trimming Docker images or volumes so
+PopChoice storage and backups are not competing with new log writes.
+
+## Security notes
+
+- The compose file binds Grafana, Loki, and Alloy to `127.0.0.1` for local use.
+  Put Grafana behind Coolify auth, a VPN, or an SSH tunnel before exposing it.
+- Alloy mounts `/var/run/docker.sock` read-only, but Docker socket access is
+  still sensitive. Do not publish the Alloy UI publicly.
+- Loki runs without tenant auth because it is private to the compose network.
+  Put an authenticating reverse proxy in front of it if it ever leaves the host.

--- a/docs/OBSERVABILITY-UPTIME.md
+++ b/docs/OBSERVABILITY-UPTIME.md
@@ -1,0 +1,151 @@
+# Uptime Kuma Monitoring
+
+Issue [#502](https://github.com/shchilkin/PopChoice/issues/502) starts the
+self-hosted observability stack with an external view of PopChoice production
+reachability. This page is intentionally limited to Uptime Kuma uptime and
+cheap synthetic checks. Logs, metrics, traces, and dashboards are tracked in
+separate observability issues.
+
+## Stack
+
+Run Uptime Kuma outside the PopChoice application Compose stack so app deploys,
+database migrations, and worker restarts cannot take the monitor down with the
+service it is watching.
+
+```bash
+docker compose -f docker-compose.observability.yml up -d
+```
+
+The local Compose file exposes Kuma on `http://127.0.0.1:3002` and stores all
+monitor state in the named `uptime-kuma-data` volume. On a VPS, put this service
+behind Coolify, Caddy, nginx, or a private network such as Tailscale. Do not
+publish the Kuma UI directly without authentication and TLS.
+
+Recommended VPS shape:
+
+- One small Uptime Kuma service from `docker-compose.observability.yml`.
+- A persistent volume mounted at `/app/data`.
+- A private or protected public URL such as `https://uptime.example.com`.
+- Backups enabled for the Kuma volume before monitors become the source of
+  truth.
+
+## Production Monitors
+
+Create these monitors manually in Kuma. Keep names stable so alert history stays
+readable.
+
+| Name                          | Type            | Target                                              | Interval | Success criteria                   | Purpose                                                                                                                  |
+| ----------------------------- | --------------- | --------------------------------------------------- | -------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `popchoice-prod-health`       | HTTP(s)         | `https://pop-choice.shchilkin.dev/api/health`       | 60s      | HTTP `200`                         | Catches app, PostgreSQL, or Redis outages because `/api/health` fails closed when required dependencies are unavailable. |
+| `popchoice-prod-build`        | HTTP(s) Keyword | `https://pop-choice.shchilkin.dev/api/build`        | 5m       | HTTP `200` and keyword `version`   | Confirms the deployed app is serving build metadata for release/debug visibility.                                        |
+| `popchoice-prod-homepage`     | HTTP(s) Keyword | `https://pop-choice.shchilkin.dev/`                 | 5m       | HTTP `200` and keyword `PopChoice` | Cheap browserless smoke check for the public app shell.                                                                  |
+| `popchoice-prod-catalog-page` | HTTP(s)         | `https://pop-choice.shchilkin.dev/available-movies` | 10m      | HTTP `200`                         | Cheap smoke check for a catalog-backed page without invoking recommendations or external AI providers.                   |
+
+Use retries before alerting to reduce noise from transient network blips. A good
+starting point is 2 retries, 20s retry interval, and a 20s request timeout.
+
+## Synthetic Smoke Strategy
+
+The default synthetic checks must not spend OpenAI or TMDB credits. Keep the
+always-on Kuma checks to read-only routes:
+
+- `/api/health` for app, PostgreSQL, and Redis readiness.
+- `/api/build` for deploy provenance.
+- `/` for the public shell.
+- `/available-movies` for a cheap catalog-backed page load.
+
+Do not make an always-on production monitor POST to
+`/api/movie-recommendation`, `/api/recommendations`, or
+`/api/recommendations/[id]/more-picks`. Those paths can call embeddings,
+chat completions, TMDB, Redis workers, or recommendation persistence depending
+on environment and request shape.
+
+For deeper recommendation smoke coverage, use one of these explicitly separated
+paths:
+
+- Run the existing Playwright e2e smoke suite in CI or after deploy with
+  `E2E_DETERMINISTIC_RECOMMENDATIONS=1`. That validates the browser, API,
+  database, results, feedback, and movie-memory flow without live AI calls.
+- Add a staging-only deterministic endpoint or staging deployment later, then
+  point a Kuma monitor at staging rather than production.
+- Run live-provider recommendation checks manually when you intentionally want
+  to spend API credits and inspect model/provider behavior.
+
+If a future synthetic job posts to a PopChoice API, give it a dedicated API key,
+rate-limit it tightly, and document whether it is deterministic, staging-only,
+or allowed to call live providers.
+
+## Notifications
+
+Configure at least one low-friction notification channel in Kuma before relying
+on the monitor:
+
+- Telegram: bot token plus chat ID for fast personal alerts.
+- Slack: incoming webhook URL for a project or ops channel.
+- Email/SMTP: host, port, username, password, `from`, and recipient address.
+
+Suggested alert behavior:
+
+- Alert when `popchoice-prod-health` is down after retries. Treat this as
+  production-impacting because it covers the app and required dependencies.
+- Alert when `popchoice-prod-build` is down for deploy visibility loss, but use
+  a lower urgency than `/api/health`.
+- Alert on homepage or catalog-page failures after retries. These usually mean
+  routing, certificate, rendering, or application availability problems.
+- Send recovery notifications so incident timelines include both outage and
+  restoration times.
+
+Keep secrets only in Kuma's notification settings or the host secret manager.
+Do not commit bot tokens, webhook URLs, SMTP passwords, or destination IDs.
+
+## Backup and Restore
+
+Kuma stores monitors, notification settings, status pages, and history under
+`/app/data`. In this repository's Compose file, that path is backed by the
+`uptime-kuma-data` Docker volume.
+
+Back up before changing monitor definitions and on a regular VPS backup
+schedule:
+
+```bash
+docker run --rm \
+  -v popchoice-observability_uptime-kuma-data:/data:ro \
+  -v "$PWD/backups":/backup \
+  alpine \
+  tar czf /backup/uptime-kuma-$(date +%Y%m%d-%H%M%S).tgz -C /data .
+```
+
+Restore into a stopped Kuma service:
+
+```bash
+docker compose -f docker-compose.observability.yml down
+docker run --rm \
+  -v popchoice-observability_uptime-kuma-data:/data \
+  -v "$PWD/backups":/backup \
+  alpine \
+  sh -c 'rm -rf /data/* && tar xzf /backup/uptime-kuma-YYYYMMDD-HHMMSS.tgz -C /data'
+docker compose -f docker-compose.observability.yml up -d
+```
+
+The exact volume name can vary by Compose project name. Check it with:
+
+```bash
+docker volume ls | grep uptime-kuma
+```
+
+Kuma also has an in-app export/import path for monitor definitions. Use it for
+quick edits, but keep volume backups as the recovery source because notification
+settings and history live in the data directory.
+
+## Operational Checks
+
+After the monitor stack starts:
+
+1. Open the Kuma UI and create the admin account.
+2. Add the production monitors from this document.
+3. Configure at least one notification channel.
+4. Use Kuma's test notification button.
+5. Temporarily pause any monitor you are intentionally breaking during deploy
+   work, and add a note to the incident timeline if an alert fires.
+6. Export monitor definitions after the first working setup and after major
+   changes.

--- a/docs/ROADMAP-ARCHITECTURE.md
+++ b/docs/ROADMAP-ARCHITECTURE.md
@@ -151,8 +151,8 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 ### Operational Observability Track
 
 - [ ] Build the self-hosted observability stack under [#498](https://github.com/shchilkin/PopChoice/issues/498). This is intentionally a learning track: SaaS tools would be simpler, but self-hosting teaches uptime checks, log shipping, metrics, traces, alerts, retention, and backups.
-- [ ] Add Uptime Kuma health and synthetic monitoring in [#502](https://github.com/shchilkin/PopChoice/issues/502) for `/api/health`, build metadata, and cheap smoke checks before deeper instrumentation.
-- [ ] Add Grafana Loki log aggregation in [#499](https://github.com/shchilkin/PopChoice/issues/499) so Coolify/Docker logs are searchable by service, level, request id, recommendation id, queue, job id, and stage.
+- [x] Add Uptime Kuma health and synthetic monitoring in [#502](https://github.com/shchilkin/PopChoice/issues/502) for `/api/health`, build metadata, and cheap smoke checks before deeper instrumentation. See [Uptime Kuma Monitoring](./OBSERVABILITY-UPTIME.md).
+- [x] Add Grafana Loki log aggregation in [#499](https://github.com/shchilkin/PopChoice/issues/499) so Coolify/Docker logs are searchable by service, level, request id, recommendation id, queue, job id, and stage. See [Observability Logs](./OBSERVABILITY-LOGS.md).
 - [ ] Add Prometheus metrics and Grafana dashboards in [#501](https://github.com/shchilkin/PopChoice/issues/501) for container health, Postgres, Redis, BullMQ queues, recommendation latency, provider timeouts, and failed jobs.
 - [ ] Add OpenTelemetry traces with Tempo in [#500](https://github.com/shchilkin/PopChoice/issues/500) once the low-noise uptime/logs/metrics foundation exists.
 - [ ] Add alert routing, retention, backups, and incident runbooks in [#503](https://github.com/shchilkin/PopChoice/issues/503) so the monitoring stack stays useful and recoverable.

--- a/observability/alloy/config.alloy
+++ b/observability/alloy/config.alloy
@@ -1,0 +1,85 @@
+discovery.docker "containers" {
+  host             = "unix:///var/run/docker.sock"
+  refresh_interval = "10s"
+}
+
+discovery.relabel "containers" {
+  targets = discovery.docker.containers.targets
+
+  rule {
+    source_labels = ["__meta_docker_container_name"]
+    regex         = "/(.*)"
+    target_label  = "container"
+  }
+
+  rule {
+    source_labels = ["__meta_docker_container_label_com_docker_compose_service"]
+    target_label  = "service"
+  }
+
+  rule {
+    source_labels = ["__meta_docker_container_label_com_docker_compose_project"]
+    target_label  = "compose_project"
+  }
+
+}
+
+loki.source.docker "containers" {
+  host       = "unix:///var/run/docker.sock"
+  targets    = discovery.relabel.containers.output
+  labels     = { stack = "popchoice" }
+  forward_to = [loki.process.popchoice.receiver]
+}
+
+loki.process "popchoice" {
+  stage.docker {}
+
+  stage.json {
+    expressions = {
+      level              = "level",
+      msg                = "msg",
+      requestId          = "requestId",
+      reqId              = "reqId",
+      recommendationId   = "recommendationId",
+      recommendationSlug = "recommendationSlug",
+      queue              = "queue",
+      queueName          = "queueName",
+      jobId              = "jobId",
+      jobName            = "jobName",
+      stage              = "stage",
+      userId             = "userId",
+      err                = "err.message",
+    }
+  }
+
+  stage.labels {
+    values = {
+      level = "",
+    }
+  }
+
+  stage.structured_metadata {
+    values = {
+      requestId          = "",
+      reqId              = "",
+      recommendationId   = "",
+      recommendationSlug = "",
+      queue              = "",
+      queueName          = "",
+      jobId              = "",
+      jobName            = "",
+      stage              = "",
+      userId             = "",
+      err                = "",
+      msg                = "",
+    }
+  }
+
+  forward_to = [loki.write.local.receiver]
+}
+
+loki.write "local" {
+  endpoint {
+    url = "http://observability-loki:3100/loki/api/v1/push"
+  }
+}

--- a/observability/grafana/provisioning/datasources/loki.yaml
+++ b/observability/grafana/provisioning/datasources/loki.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://observability-loki:3100
+    isDefault: true
+    editable: true

--- a/observability/loki/loki.yaml
+++ b/observability/loki/loki.yaml
@@ -1,0 +1,61 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  log_level: info
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  tsdb_shipper:
+    active_index_directory: /loki/tsdb-index
+    cache_location: /loki/tsdb-cache
+    cache_ttl: 24h
+
+compactor:
+  working_directory: /loki/compactor
+  compaction_interval: 10m
+  retention_enabled: true
+  retention_delete_delay: 2h
+  delete_request_store: filesystem
+
+limits_config:
+  allow_structured_metadata: true
+  discover_log_levels: true
+  retention_period: 168h
+  max_query_lookback: 168h
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+  ingestion_rate_mb: 4
+  ingestion_burst_size_mb: 8
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+analytics:
+  reporting_enabled: false


### PR DESCRIPTION
## Summary
- add a separate self-hosted observability compose stack with Uptime Kuma, Loki, Alloy, and Grafana
- document Uptime Kuma production health/synthetic checks that avoid AI-provider spend
- document Loki log aggregation, structured Pino metadata, query examples, retention, and incident shortcuts
- mark #502 and #499 complete in the architecture roadmap

## Issues
Closes #502
Closes #499
Part of #498

## Verification
- npm run format:check
- npx prettier --check docker-compose.observability.yml docs/OBSERVABILITY-UPTIME.md docs/OBSERVABILITY-LOGS.md docs/COOLIFY.md docs/ROADMAP-ARCHITECTURE.md observability/loki/loki.yaml observability/grafana/provisioning/datasources/loki.yaml
- GRAFANA_ADMIN_PASSWORD=example docker compose -f docker-compose.observability.yml config
- docker manifest inspect grafana/loki:3.5.7
- docker manifest inspect grafana/alloy:v1.11.3
- docker manifest inspect grafana/grafana:12.3.0
- docker manifest inspect louislam/uptime-kuma:1.23.16
- pre-push hook: lint, server tests, production build