### PR TITLE
Add Prometheus metrics and dashboard

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -48,6 +48,7 @@
     "openai": "^6.38.0",
     "pg": "^8.21.0",
     "pino": "^10.3.1",
+    "prom-client": "^15.1.3",
     "react": "^19.2.6",
     "react-canvas-confetti": "^2.0.7",
     "react-dom": "^19.2.6",

--- a/apps/web/src/app/api/health/route.ts
+++ b/apps/web/src/app/api/health/route.ts
@@ -4,6 +4,7 @@ import { createClient } from 'redis';
 
 import { getBuildInfo } from '@/lib/buildInfo';
 import logger from '@/lib/logger';
+import { recordDependencyHealth } from '@/lib/metrics';
 
 const { Pool } = pg;
 const CHECK_TIMEOUT_MS = 2_000;
@@ -121,6 +122,9 @@ async function checkRedis(): Promise<CheckStatus> {
 
 async function getHealthResponse(): Promise<CachedHealthResponse> {
   const [postgres, redis] = await Promise.all([checkPostgres(), checkRedis()]);
+  recordDependencyHealth('postgres', postgres === 'ok');
+  recordDependencyHealth('redis', redis === 'ok');
+
   const status: CheckStatus = postgres === 'ok' && redis === 'ok' ? 'ok' : 'error';
   const buildInfo = getBuildInfo();
   const body: HealthResponse = {

--- a/apps/web/src/app/api/metrics/route.test.ts
+++ b/apps/web/src/app/api/metrics/route.test.ts
@@ -1,0 +1,65 @@
+import { NextRequest } from 'next/server';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/server', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('next/server')>();
+  return {
+    ...actual,
+    connection: vi.fn(),
+  };
+});
+
+vi.mock('@/lib/jobQueue', () => ({
+  CATALOG_MAINTENANCE_QUEUE_NAME: 'catalog-maintenance',
+  MORE_PICKS_QUEUE_NAME: 'more-picks',
+  MOVIE_SEED_QUEUE_NAME: 'movie-seed',
+  RECOMMENDATION_QUEUE_NAME: 'recommendation',
+  catalogMaintenanceQueue: null,
+  morePicksQueue: null,
+  recommendationQueue: null,
+  seedQueue: null,
+}));
+
+const { GET } = await import('./route');
+
+function request(headers?: HeadersInit): NextRequest {
+  return new NextRequest('http://localhost/api/metrics', { headers });
+}
+
+describe('GET /api/metrics', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('is available in development without a bearer token', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+
+    const response = await GET(request());
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(body).toContain('popchoice_recommendations_total');
+    expect(body).toContain('popchoice_queue_depth');
+  });
+
+  it('is disabled by default in production', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+
+    const response = await GET(request());
+
+    expect(response.status).toBe(404);
+  });
+
+  it('requires the configured bearer token when enabled in production', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('METRICS_ENABLED', 'true');
+    vi.stubEnv('METRICS_BEARER_TOKEN', 'secret-token');
+
+    const rejected = await GET(request({ authorization: 'Bearer wrong-token' }));
+    const accepted = await GET(request({ authorization: 'Bearer secret-token' }));
+
+    expect(rejected.status).toBe(401);
+    expect(accepted.status).toBe(200);
+  });
+});

--- a/apps/web/src/app/api/metrics/route.ts
+++ b/apps/web/src/app/api/metrics/route.ts
@@ -1,0 +1,44 @@
+import { connection, NextRequest } from 'next/server';
+
+import {
+  CATALOG_MAINTENANCE_QUEUE_NAME,
+  MORE_PICKS_QUEUE_NAME,
+  MOVIE_SEED_QUEUE_NAME,
+  RECOMMENDATION_QUEUE_NAME,
+  catalogMaintenanceQueue,
+  morePicksQueue,
+  recommendationQueue,
+  seedQueue,
+} from '@/lib/jobQueue';
+import {
+  areMetricsEnabled,
+  collectMetrics,
+  isMetricsRequestAuthorized,
+  metricsContentType,
+} from '@/lib/metrics';
+
+export async function GET(req: NextRequest): Promise<Response> {
+  await connection();
+
+  if (!areMetricsEnabled()) {
+    return new Response('Metrics are disabled.\n', { status: 404 });
+  }
+
+  if (!isMetricsRequestAuthorized(req.headers.get('authorization'))) {
+    return new Response('Unauthorized.\n', { status: 401 });
+  }
+
+  const body = await collectMetrics([
+    { name: MOVIE_SEED_QUEUE_NAME, queue: seedQueue },
+    { name: RECOMMENDATION_QUEUE_NAME, queue: recommendationQueue },
+    { name: MORE_PICKS_QUEUE_NAME, queue: morePicksQueue },
+    { name: CATALOG_MAINTENANCE_QUEUE_NAME, queue: catalogMaintenanceQueue },
+  ]);
+
+  return new Response(body, {
+    headers: {
+      'Cache-Control': 'no-store',
+      'Content-Type': metricsContentType(),
+    },
+  });
+}

--- a/apps/web/src/app/api/movie-recommendation/route.ts
+++ b/apps/web/src/app/api/movie-recommendation/route.ts
@@ -6,6 +6,7 @@ import { runRecommendationPipeline } from '@/features/recommendation/pipeline';
 import { apiResponseSchema, requestBodySchema } from '@/features/recommendation/types';
 import { parseLocaleFromRequest } from '@/lib/locale';
 import logger from '@/lib/logger';
+import { recordRecommendationCompletion } from '@/lib/metrics';
 import { isOpenAITimeoutError } from '@/lib/openaiTimeout';
 import { applyRateLimit } from '@/lib/rateLimit';
 import {
@@ -23,7 +24,14 @@ async function postHandler(req: NextRequest): Promise<Response> {
 
   try {
     const rateLimitResponse = await applyRateLimit(req);
-    if (rateLimitResponse) return rateLimitResponse;
+    if (rateLimitResponse) {
+      recordRecommendationCompletion({
+        mode: 'legacy_sync',
+        status: 'failure',
+        durationMs: Date.now() - startTime,
+      });
+      return rateLimitResponse;
+    }
 
     const body = await readJsonBodyWithLimit(req, RECOMMENDATION_REQUEST_BODY_LIMIT_BYTES);
 
@@ -40,6 +48,11 @@ async function postHandler(req: NextRequest): Promise<Response> {
 
     const inputBlock = await getRecommendationInputBlock(allPeopleData);
     if (inputBlock) {
+      recordRecommendationCompletion({
+        mode: 'legacy_sync',
+        status: 'failure',
+        durationMs: Date.now() - startTime,
+      });
       return NextResponse.json(inputBlock, { status: 422 });
     }
 
@@ -51,9 +64,20 @@ async function postHandler(req: NextRequest): Promise<Response> {
       { durationMs: duration, movieCount: response.similarMovies?.length ?? 0 },
       'Recommendation request completed',
     );
+    recordRecommendationCompletion({
+      mode: 'legacy_sync',
+      status: 'success',
+      durationMs: duration,
+    });
 
     return NextResponse.json(apiResponseSchema.parse(response));
   } catch (error) {
+    recordRecommendationCompletion({
+      mode: 'legacy_sync',
+      status: 'failure',
+      durationMs: Date.now() - startTime,
+    });
+
     const bodyErrorResponse = requestBodyErrorResponse(error);
     if (bodyErrorResponse) return bodyErrorResponse;
 

--- a/apps/web/src/features/catalogMaintenance/tmdb.ts
+++ b/apps/web/src/features/catalogMaintenance/tmdb.ts
@@ -1,6 +1,7 @@
 import z from 'zod';
 
 import logger from '@/lib/logger';
+import { recordTMDBProviderError } from '@/lib/metrics';
 
 import type { TMDBCatalogCandidate, TMDBDiscoverySource } from '@/lib/jobQueue';
 
@@ -156,6 +157,7 @@ export async function fetchMovieDetails(
     });
 
     if (!response.ok) {
+      recordTMDBProviderError('catalog_details', 'http_error');
       logger.warn(
         { movieId, status: response.status, statusText: response.statusText },
         'TMDB movie details fetch failed',
@@ -166,6 +168,12 @@ export async function fetchMovieDetails(
     return (await response.json()) as TMDBMovieDetails;
   } catch (error) {
     if (error instanceof TMDBRateLimitError) throw error;
+    recordTMDBProviderError(
+      'catalog_details',
+      error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError')
+        ? 'timeout'
+        : 'error',
+    );
     logger.warn({ err: error, movieId }, 'TMDB movie details fetch failed');
     return null;
   }
@@ -229,11 +237,13 @@ export async function fetchTMDBSourcePage(input: {
   });
 
   if (!response.ok) {
+    recordTMDBProviderError('catalog_discover', 'http_error');
     throw new Error(`TMDB source page API error: ${response.status} ${response.statusText}`);
   }
 
   const parsed = tmdbListResponseSchema.safeParse(await response.json());
   if (!parsed.success) {
+    recordTMDBProviderError('catalog_discover', 'invalid_response');
     logger.warn(
       { source: input.source, page: input.page, zodError: parsed.error },
       'TMDB source page response validation failed',
@@ -295,11 +305,13 @@ async function tmdbSearch(
 
   const response = await tmdbGet(apiKey, '/search/movie', params);
   if (!response.ok) {
+    recordTMDBProviderError('catalog_details', 'http_error');
     throw new Error(`TMDB search API error: ${response.status} ${response.statusText}`);
   }
 
   const parsed = tmdbSearchResponseSchema.safeParse(await response.json());
   if (!parsed.success) {
+    recordTMDBProviderError('catalog_details', 'invalid_response');
     logger.warn({ title, year, zodError: parsed.error }, 'TMDB search response validation failed');
     return [];
   }

--- a/apps/web/src/features/recommendation/embedding.ts
+++ b/apps/web/src/features/recommendation/embedding.ts
@@ -1,5 +1,6 @@
 import { getOpenAIClient } from '@/clients/openaiClient';
 import logger from '@/lib/logger';
+import { recordOpenAIProviderError } from '@/lib/metrics';
 import { MODELS } from '@/lib/models';
 import { OPENAI_TIMEOUTS_MS, openAIRequestOptions } from '@/lib/openaiTimeout';
 
@@ -127,6 +128,7 @@ export async function refineQueryWithLLM(allPeopleData: PersonFormData[]): Promi
 
     return refinedTags;
   } catch (error) {
+    recordOpenAIProviderError('query_enrichment', error);
     const err =
       error instanceof Error
         ? { name: error.name, message: error.message }
@@ -165,6 +167,7 @@ export async function createEmbedding(
     }
     return embeddingResponse.data[0].embedding;
   } catch (error) {
+    recordOpenAIProviderError('embedding', error);
     throw new Error(`Failed to create embedding: ${error}`);
   }
 }

--- a/apps/web/src/features/recommendation/jobs.ts
+++ b/apps/web/src/features/recommendation/jobs.ts
@@ -1,5 +1,6 @@
 import { RECOMMENDATION_JOB_OPTIONS, recommendationQueue } from '@/lib/jobQueue';
 import logger from '@/lib/logger';
+import { recordRecommendationCompletion } from '@/lib/metrics';
 
 import {
   completeRecommendationRecord,
@@ -62,9 +63,15 @@ async function completeDeterministicE2ERecommendation(
   allPeopleData: PersonFormData[],
 ): Promise<void> {
   logger.info({ recommendationId }, 'Completing recommendation with deterministic e2e fixture');
+  const startTime = Date.now();
   await markRecommendationProcessing(recommendationId);
   await markRecommendationStage(recommendationId, 'complete');
   await completeRecommendationRecord(recommendationId, buildDeterministicE2EResult(allPeopleData));
+  recordRecommendationCompletion({
+    mode: 'deterministic_e2e',
+    status: 'success',
+    durationMs: Date.now() - startTime,
+  });
 }
 
 function buildDeterministicE2EResult(allPeopleData: PersonFormData[]): ApiResponse {
@@ -127,6 +134,7 @@ async function processInlineRecommendation(
   locale: Locale,
   userId?: string,
 ): Promise<void> {
+  const startTime = Date.now();
   try {
     await markRecommendationProcessing(recommendationId);
     const result = await runRecommendationPipeline(allPeopleData, locale, {
@@ -135,8 +143,18 @@ async function processInlineRecommendation(
     });
 
     await completeRecommendationRecord(recommendationId, result);
+    recordRecommendationCompletion({
+      mode: 'async_inline',
+      status: 'success',
+      durationMs: Date.now() - startTime,
+    });
     logger.info({ recommendationId }, 'Inline recommendation processing completed');
   } catch (err) {
+    recordRecommendationCompletion({
+      mode: 'async_inline',
+      status: 'failure',
+      durationMs: Date.now() - startTime,
+    });
     const message = err instanceof Error ? err.message : String(err);
     logger.error({ err, recommendationId }, 'Inline recommendation processing failed');
     await failRecommendationRecord(recommendationId, message).catch((dbErr) => {

--- a/apps/web/src/features/recommendation/recommendation.ts
+++ b/apps/web/src/features/recommendation/recommendation.ts
@@ -3,6 +3,7 @@ import { getOpenAIClient } from '@/clients/openaiClient';
 import { MovieService } from '@/integrations/tmdb';
 import { LOCALE_LANGUAGE, LOCALE_TO_TMDB_LANG, type Locale } from '@/lib/locale';
 import logger from '@/lib/logger';
+import { recordOpenAIProviderError } from '@/lib/metrics';
 import { MODELS } from '@/lib/models';
 import { OPENAI_TIMEOUTS_MS, openAIRequestOptions } from '@/lib/openaiTimeout';
 
@@ -134,6 +135,7 @@ export async function getRecommendation(
       JSON.parse(recommendation.choices[0].message.content),
     );
   } catch (error) {
+    recordOpenAIProviderError('ranking', error);
     throw new Error(`Failed to get recommendation from OpenAI: ${error}`);
   }
 }
@@ -214,6 +216,7 @@ Remember: respond in ${language} only.`;
 
           return { ...movie, aiDescription };
         } catch (error) {
+          recordOpenAIProviderError('description', error);
           const isRateLimit =
             typeof error === 'object' &&
             error !== null &&

--- a/apps/web/src/features/recommendation/tmdb.ts
+++ b/apps/web/src/features/recommendation/tmdb.ts
@@ -4,6 +4,7 @@ import { getDbClient } from '@/clients/dbClient';
 import { getOpenAIClient } from '@/clients/openaiClient';
 import { IMAGE_BASE_URL } from '@/integrations/tmdb';
 import logger from '@/lib/logger';
+import { recordOpenAIProviderError, recordTMDBProviderError } from '@/lib/metrics';
 import { MODELS } from '@/lib/models';
 import { OPENAI_TIMEOUTS_MS, openAIRequestOptions } from '@/lib/openaiTimeout';
 import {
@@ -169,21 +170,25 @@ export async function fetchTMDBDiscoverMovies(
     });
 
     if (!response.ok) {
+      recordTMDBProviderError('movie_discover', 'http_error');
       logger.warn({ status: response.status }, 'TMDB discover request failed');
       return [];
     }
 
     const parsedResponse = tmdbDiscoverResponseSchema.safeParse(await response.json());
     if (!parsedResponse.success) {
+      recordTMDBProviderError('movie_discover', 'invalid_response');
       logger.warn({ zodError: parsedResponse.error }, 'TMDB discover response validation failed');
       return [];
     }
     return (parsedResponse.data.results ?? []).slice(0, MAX_TOTAL_MOVIES);
   } catch (error) {
     if (error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError')) {
+      recordTMDBProviderError('movie_discover', 'timeout');
       logger.warn({ timeoutMs: TMDB_DISCOVER_FETCH_TIMEOUT_MS }, 'TMDB discover request timed out');
       return [];
     }
+    recordTMDBProviderError('movie_discover', 'error');
     logger.warn({ err: error }, 'Error fetching movies from TMDB discover');
     return [];
   }
@@ -226,6 +231,7 @@ export async function scoreAndConvertTMDBMovies(
     );
     rawEmbeddings = response.data.map((d) => d.embedding);
   } catch (error) {
+    recordOpenAIProviderError('similarity_embedding', error);
     logger.warn(
       { err: error },
       'Failed to embed TMDB movies for similarity scoring — using fallback score',

--- a/apps/web/src/lib/metrics.ts
+++ b/apps/web/src/lib/metrics.ts
@@ -1,0 +1,240 @@
+import { Counter, Gauge, Histogram, Registry, collectDefaultMetrics } from 'prom-client';
+
+import { isOpenAITimeoutError } from '@/lib/openaiTimeout';
+
+import type { Queue } from 'bullmq';
+
+type RecommendationMode = 'legacy_sync' | 'async_worker' | 'async_inline' | 'deterministic_e2e';
+type RecommendationStatus = 'success' | 'failure';
+type Provider = 'openai' | 'tmdb';
+type ProviderOperation =
+  | 'catalog_discover'
+  | 'catalog_details'
+  | 'description'
+  | 'embedding'
+  | 'movie_discover'
+  | 'query_enrichment'
+  | 'ranking'
+  | 'similarity_embedding';
+type ProviderReason = 'error' | 'http_error' | 'invalid_response' | 'rate_limited' | 'timeout';
+type QueueEvent = 'completed' | 'failed';
+type Dependency = 'postgres' | 'redis';
+
+type QueueMetricSource = {
+  name: string;
+  queue: Queue | null;
+};
+
+type MetricsState = {
+  registry: Registry;
+  recommendationTotal: Counter<'mode' | 'status'>;
+  recommendationDuration: Histogram<'mode' | 'status'>;
+  providerErrorsTotal: Counter<'provider' | 'operation' | 'reason'>;
+  queueJobsTotal: Counter<'queue' | 'job' | 'event' | 'final'>;
+  queueDepth: Gauge<'queue' | 'status'>;
+  queueScrapeErrorsTotal: Counter<'queue'>;
+  dependencyHealth: Gauge<'dependency'>;
+  dependencyHealthFailuresTotal: Counter<'dependency'>;
+};
+
+const GLOBAL_METRICS_KEY = Symbol.for('popchoice.metrics');
+
+function createMetricsState(): MetricsState {
+  const registry = new Registry();
+  registry.setDefaultLabels({ app: 'popchoice' });
+
+  collectDefaultMetrics({
+    prefix: 'popchoice_',
+    register: registry,
+  });
+
+  const recommendationTotal = new Counter({
+    name: 'popchoice_recommendations_total',
+    help: 'Total completed PopChoice recommendation attempts.',
+    labelNames: ['mode', 'status'],
+    registers: [registry],
+  });
+
+  const recommendationDuration = new Histogram({
+    name: 'popchoice_recommendation_duration_seconds',
+    help: 'Recommendation processing duration in seconds.',
+    labelNames: ['mode', 'status'],
+    buckets: [0.5, 1, 2, 5, 10, 20, 30, 60, 90, 120],
+    registers: [registry],
+  });
+
+  const providerErrorsTotal = new Counter({
+    name: 'popchoice_provider_errors_total',
+    help: 'Upstream OpenAI and TMDB degradation events observed by the app.',
+    labelNames: ['provider', 'operation', 'reason'],
+    registers: [registry],
+  });
+
+  const queueJobsTotal = new Counter({
+    name: 'popchoice_queue_jobs_total',
+    help: 'BullMQ worker job completion and failure events.',
+    labelNames: ['queue', 'job', 'event', 'final'],
+    registers: [registry],
+  });
+
+  const queueDepth = new Gauge({
+    name: 'popchoice_queue_depth',
+    help: 'BullMQ queue job counts by queue and status, collected at scrape time.',
+    labelNames: ['queue', 'status'],
+    registers: [registry],
+  });
+
+  const queueScrapeErrorsTotal = new Counter({
+    name: 'popchoice_queue_scrape_errors_total',
+    help: 'Failures while collecting BullMQ queue counts for metrics.',
+    labelNames: ['queue'],
+    registers: [registry],
+  });
+
+  const dependencyHealth = new Gauge({
+    name: 'popchoice_dependency_health',
+    help: 'Dependency health from app health checks. 1 means healthy, 0 means unhealthy.',
+    labelNames: ['dependency'],
+    registers: [registry],
+  });
+
+  const dependencyHealthFailuresTotal = new Counter({
+    name: 'popchoice_dependency_health_failures_total',
+    help: 'Dependency health check failures observed by the app.',
+    labelNames: ['dependency'],
+    registers: [registry],
+  });
+
+  return {
+    registry,
+    recommendationTotal,
+    recommendationDuration,
+    providerErrorsTotal,
+    queueJobsTotal,
+    queueDepth,
+    queueScrapeErrorsTotal,
+    dependencyHealth,
+    dependencyHealthFailuresTotal,
+  };
+}
+
+function getMetricsState(): MetricsState {
+  const globalWithMetrics = globalThis as typeof globalThis & {
+    [GLOBAL_METRICS_KEY]?: MetricsState;
+  };
+
+  globalWithMetrics[GLOBAL_METRICS_KEY] ??= createMetricsState();
+  return globalWithMetrics[GLOBAL_METRICS_KEY];
+}
+
+export function metricsContentType(): string {
+  return getMetricsState().registry.contentType;
+}
+
+export function areMetricsEnabled(): boolean {
+  const configured = process.env.METRICS_ENABLED?.trim().toLowerCase();
+  if (configured) return configured === '1' || configured === 'true' || configured === 'yes';
+
+  return process.env.NODE_ENV !== 'production';
+}
+
+export function isMetricsRequestAuthorized(authorizationHeader: string | null): boolean {
+  const token = process.env.METRICS_BEARER_TOKEN;
+  if (!token) return process.env.NODE_ENV !== 'production';
+
+  return authorizationHeader === `Bearer ${token}`;
+}
+
+export function recordRecommendationCompletion(input: {
+  mode: RecommendationMode;
+  status: RecommendationStatus;
+  durationMs: number;
+}): void {
+  const metrics = getMetricsState();
+  const labels = { mode: input.mode, status: input.status };
+  metrics.recommendationTotal.inc(labels);
+  metrics.recommendationDuration.observe(labels, Math.max(0, input.durationMs) / 1000);
+}
+
+export function recordOpenAIProviderError(
+  operation: Extract<
+    ProviderOperation,
+    'description' | 'embedding' | 'query_enrichment' | 'ranking' | 'similarity_embedding'
+  >,
+  error: unknown,
+): void {
+  recordProviderError({
+    provider: 'openai',
+    operation,
+    reason: isOpenAITimeoutError(error) ? 'timeout' : 'error',
+  });
+}
+
+export function recordTMDBProviderError(
+  operation: Extract<ProviderOperation, 'catalog_discover' | 'catalog_details' | 'movie_discover'>,
+  reason: ProviderReason,
+): void {
+  recordProviderError({
+    provider: 'tmdb',
+    operation,
+    reason,
+  });
+}
+
+export function recordProviderError(input: {
+  provider: Provider;
+  operation: ProviderOperation;
+  reason: ProviderReason;
+}): void {
+  getMetricsState().providerErrorsTotal.inc(input);
+}
+
+export function recordQueueJobEvent(input: {
+  queue: string;
+  job: string;
+  event: QueueEvent;
+  final: boolean;
+}): void {
+  getMetricsState().queueJobsTotal.inc({
+    queue: input.queue,
+    job: input.job,
+    event: input.event,
+    final: input.final ? 'true' : 'false',
+  });
+}
+
+export function recordDependencyHealth(dependency: Dependency, isHealthy: boolean): void {
+  const metrics = getMetricsState();
+  metrics.dependencyHealth.set({ dependency }, isHealthy ? 1 : 0);
+  if (!isHealthy) metrics.dependencyHealthFailuresTotal.inc({ dependency });
+}
+
+export async function collectMetrics(queueSources: QueueMetricSource[] = []): Promise<string> {
+  await updateQueueMetrics(queueSources);
+  return getMetricsState().registry.metrics();
+}
+
+async function updateQueueMetrics(queueSources: QueueMetricSource[]): Promise<void> {
+  const metrics = getMetricsState();
+  const statuses = ['waiting', 'active', 'delayed', 'completed', 'failed', 'paused'] as const;
+
+  await Promise.all(
+    queueSources.map(async ({ name, queue }) => {
+      if (!queue) {
+        for (const status of statuses) {
+          metrics.queueDepth.set({ queue: name, status }, 0);
+        }
+        return;
+      }
+
+      try {
+        const counts = await queue.getJobCounts(...statuses);
+        for (const status of statuses) {
+          metrics.queueDepth.set({ queue: name, status }, counts[status] ?? 0);
+        }
+      } catch {
+        metrics.queueScrapeErrorsTotal.inc({ queue: name });
+      }
+    }),
+  );
+}

--- a/apps/web/src/lib/workers/catalogMaintenanceWorker.ts
+++ b/apps/web/src/lib/workers/catalogMaintenanceWorker.ts
@@ -26,6 +26,7 @@ import {
   createBullMQConnection,
 } from '@/lib/jobQueue';
 import logger from '@/lib/logger';
+import { recordQueueJobEvent, recordTMDBProviderError } from '@/lib/metrics';
 
 import type {
   CatalogBackfillMovieJobData,
@@ -101,6 +102,16 @@ async function handleRateLimit(
   logger.warn({ jobId: job.id, delayMs }, 'TMDB returned 429; pausing catalog queue');
   await worker.rateLimit(delayMs);
   throw Worker.RateLimitError();
+}
+
+function catalogTMDBOperationForJob(jobName: CatalogMaintenanceJobName) {
+  return jobName === CATALOG_MAINTENANCE_JOB_NAMES.discoverTMDBSourcePage
+    ? 'catalog_discover'
+    : 'catalog_details';
+}
+
+function isTimeoutError(error: unknown): boolean {
+  return error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError');
 }
 
 async function findExistingMovieId(input: {
@@ -404,7 +415,11 @@ export function createCatalogMaintenanceWorker(): CatalogWorker | null {
         throw new Error(`Unsupported catalog maintenance job: ${job.name}`);
       } catch (error) {
         if (error instanceof TMDBRateLimitError) {
+          recordTMDBProviderError(catalogTMDBOperationForJob(job.name), 'rate_limited');
           await handleRateLimit(job, worker, error);
+        }
+        if (isTimeoutError(error)) {
+          recordTMDBProviderError(catalogTMDBOperationForJob(job.name), 'timeout');
         }
         throw error;
       }
@@ -423,11 +438,23 @@ export function createCatalogMaintenanceWorker(): CatalogWorker | null {
   );
 
   worker.on('completed', (job) => {
+    recordQueueJobEvent({
+      queue: CATALOG_MAINTENANCE_QUEUE_NAME,
+      job: job.name,
+      event: 'completed',
+      final: true,
+    });
     logger.info({ jobId: job.id, jobName: job.name }, 'Catalog maintenance job completed');
   });
 
   worker.on('failed', (job, err) => {
     const attemptsMade = job?.attemptsMade ?? 0;
+    recordQueueJobEvent({
+      queue: CATALOG_MAINTENANCE_QUEUE_NAME,
+      job: job?.name ?? 'unknown',
+      event: 'failed',
+      final: attemptsMade >= MAX_CATALOG_ATTEMPTS,
+    });
     logger.error(
       {
         err,

--- a/apps/web/src/lib/workers/metricsServer.ts
+++ b/apps/web/src/lib/workers/metricsServer.ts
@@ -1,0 +1,83 @@
+import { createServer } from 'node:http';
+
+import {
+  CATALOG_MAINTENANCE_QUEUE_NAME,
+  MORE_PICKS_QUEUE_NAME,
+  MOVIE_SEED_QUEUE_NAME,
+  RECOMMENDATION_QUEUE_NAME,
+  catalogMaintenanceQueue,
+  morePicksQueue,
+  recommendationQueue,
+  seedQueue,
+} from '@/lib/jobQueue';
+import logger from '@/lib/logger';
+import {
+  areMetricsEnabled,
+  collectMetrics,
+  isMetricsRequestAuthorized,
+  metricsContentType,
+} from '@/lib/metrics';
+
+import type { Server } from 'node:http';
+
+const DEFAULT_WORKER_METRICS_PORT = 9464;
+
+function parsePort(value: string | undefined): number {
+  if (!value) return DEFAULT_WORKER_METRICS_PORT;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 && parsed < 65536
+    ? parsed
+    : DEFAULT_WORKER_METRICS_PORT;
+}
+
+export function startWorkerMetricsServer(): Server | null {
+  if (!areMetricsEnabled()) return null;
+
+  const port = parsePort(process.env.WORKER_METRICS_PORT);
+  const server = createServer((req, res) => {
+    void (async () => {
+      if (req.url !== '/metrics') {
+        res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+        res.end('Not found.\n');
+        return;
+      }
+
+      const authorization = Array.isArray(req.headers.authorization)
+        ? req.headers.authorization[0]
+        : req.headers.authorization;
+
+      if (!isMetricsRequestAuthorized(authorization ?? null)) {
+        res.writeHead(401, { 'Content-Type': 'text/plain; charset=utf-8' });
+        res.end('Unauthorized.\n');
+        return;
+      }
+
+      const body = await collectMetrics([
+        { name: MOVIE_SEED_QUEUE_NAME, queue: seedQueue },
+        { name: RECOMMENDATION_QUEUE_NAME, queue: recommendationQueue },
+        { name: MORE_PICKS_QUEUE_NAME, queue: morePicksQueue },
+        { name: CATALOG_MAINTENANCE_QUEUE_NAME, queue: catalogMaintenanceQueue },
+      ]);
+
+      res.writeHead(200, {
+        'Cache-Control': 'no-store',
+        'Content-Type': metricsContentType(),
+      });
+      res.end(body);
+    })().catch((err) => {
+      logger.error({ err }, 'Worker metrics scrape failed');
+      res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end('Metrics scrape failed.\n');
+    });
+  });
+
+  server.listen(port, '0.0.0.0', () => {
+    logger.info({ port }, 'Worker metrics server listening');
+  });
+
+  server.on('error', (err) => {
+    logger.error({ err, port }, 'Worker metrics server failed');
+  });
+
+  return server;
+}

--- a/apps/web/src/lib/workers/morePicksWorker.ts
+++ b/apps/web/src/lib/workers/morePicksWorker.ts
@@ -7,6 +7,7 @@ import {
   createBullMQConnection,
 } from '@/lib/jobQueue';
 import logger from '@/lib/logger';
+import { recordQueueJobEvent } from '@/lib/metrics';
 
 import type { MorePicksJobData } from '@/lib/jobQueue';
 
@@ -30,16 +31,29 @@ export function createMorePicksWorker(): Worker<MorePicksJobData> | null {
   );
 
   worker.on('completed', (job) => {
+    recordQueueJobEvent({
+      queue: MORE_PICKS_QUEUE_NAME,
+      job: job.name,
+      event: 'completed',
+      final: true,
+    });
     logger.info({ jobId: job.id, slug: job.data.slug }, 'More-picks job completed successfully');
   });
 
   worker.on('failed', (job, err) => {
+    const attemptsMade = job?.attemptsMade ?? 0;
+    recordQueueJobEvent({
+      queue: MORE_PICKS_QUEUE_NAME,
+      job: job?.name ?? 'unknown',
+      event: 'failed',
+      final: attemptsMade >= MAX_ATTEMPTS,
+    });
     logger.error(
       {
         err,
         jobId: job?.id,
         slug: job?.data?.slug,
-        attemptsMade: job?.attemptsMade ?? 0,
+        attemptsMade,
         maxAttempts: MAX_ATTEMPTS,
       },
       'More-picks job failed',

--- a/apps/web/src/lib/workers/movieSeedWorker.ts
+++ b/apps/web/src/lib/workers/movieSeedWorker.ts
@@ -7,6 +7,7 @@ import {
   createBullMQConnection,
 } from '@/lib/jobQueue';
 import logger from '@/lib/logger';
+import { recordQueueJobEvent } from '@/lib/metrics';
 
 import type { MovieSeedJobData } from '@/lib/jobQueue';
 
@@ -30,6 +31,12 @@ export function createMovieSeedWorker(): Worker<MovieSeedJobData> | null {
   );
 
   worker.on('completed', (job) => {
+    recordQueueJobEvent({
+      queue: MOVIE_SEED_QUEUE_NAME,
+      job: job.name,
+      event: 'completed',
+      final: true,
+    });
     logger.info(
       { jobId: job.id, queuedMovies: job.data.tmdbMovies.length },
       'Movie seeding job completed',
@@ -38,6 +45,12 @@ export function createMovieSeedWorker(): Worker<MovieSeedJobData> | null {
 
   worker.on('failed', (job, err) => {
     const attemptsMade = job?.attemptsMade ?? 0;
+    recordQueueJobEvent({
+      queue: MOVIE_SEED_QUEUE_NAME,
+      job: job?.name ?? 'unknown',
+      event: 'failed',
+      final: attemptsMade >= MAX_MOVIE_SEED_ATTEMPTS,
+    });
     logger.error(
       {
         err,

--- a/apps/web/src/lib/workers/recommendationWorker.ts
+++ b/apps/web/src/lib/workers/recommendationWorker.ts
@@ -13,6 +13,7 @@ import {
   createBullMQConnection,
 } from '@/lib/jobQueue';
 import logger from '@/lib/logger';
+import { recordQueueJobEvent, recordRecommendationCompletion } from '@/lib/metrics';
 
 import type { RecommendationJobData } from '@/lib/jobQueue';
 
@@ -28,6 +29,7 @@ export function createRecommendationWorker(): Worker<RecommendationJobData> | nu
   const worker = new Worker<RecommendationJobData>(
     RECOMMENDATION_QUEUE_NAME,
     async (job) => {
+      const startTime = Date.now();
       const { recommendationId, quizData, locale, userId } = job.data;
 
       logger.info({ recommendationId, jobId: job.id }, 'Recommendation job started');
@@ -50,7 +52,17 @@ export function createRecommendationWorker(): Worker<RecommendationJobData> | nu
           { recommendationId, jobId: job.id, movieCount },
           'Recommendation job completed',
         );
+        recordRecommendationCompletion({
+          mode: 'async_worker',
+          status: 'success',
+          durationMs: Date.now() - startTime,
+        });
       } catch (err) {
+        recordRecommendationCompletion({
+          mode: 'async_worker',
+          status: 'failure',
+          durationMs: Date.now() - startTime,
+        });
         const message = err instanceof Error ? err.message : String(err);
         logger.error({ err, recommendationId, jobId: job.id }, 'Recommendation job failed');
 
@@ -67,6 +79,12 @@ export function createRecommendationWorker(): Worker<RecommendationJobData> | nu
   );
 
   worker.on('completed', (job) => {
+    recordQueueJobEvent({
+      queue: RECOMMENDATION_QUEUE_NAME,
+      job: job.name,
+      event: 'completed',
+      final: true,
+    });
     logger.info(
       { jobId: job.id, recommendationId: job.data.recommendationId },
       'Recommendation job completed successfully',
@@ -75,6 +93,12 @@ export function createRecommendationWorker(): Worker<RecommendationJobData> | nu
 
   worker.on('failed', (job, err) => {
     const attemptsMade = job?.attemptsMade ?? 0;
+    recordQueueJobEvent({
+      queue: RECOMMENDATION_QUEUE_NAME,
+      job: job?.name ?? 'unknown',
+      event: 'failed',
+      final: attemptsMade >= MAX_RECOMMENDATION_ATTEMPTS,
+    });
     logger.error(
       {
         err,

--- a/apps/web/src/lib/workers/startWorkers.ts
+++ b/apps/web/src/lib/workers/startWorkers.ts
@@ -2,6 +2,7 @@ import { closeBullMQQueues } from '@/lib/jobQueue';
 import logger from '@/lib/logger';
 
 import { createCatalogMaintenanceWorker } from './catalogMaintenanceWorker';
+import { startWorkerMetricsServer } from './metricsServer';
 import { createMorePicksWorker } from './morePicksWorker';
 import { createMovieSeedWorker } from './movieSeedWorker';
 import { createRecommendationWorker } from './recommendationWorker';
@@ -10,6 +11,7 @@ const catalogMaintenanceWorker = createCatalogMaintenanceWorker();
 const movieSeedWorker = createMovieSeedWorker();
 const recommendationWorker = createRecommendationWorker();
 const morePicksWorker = createMorePicksWorker();
+const metricsServer = startWorkerMetricsServer();
 
 if (!catalogMaintenanceWorker && !movieSeedWorker && !recommendationWorker) {
   // Both core workers failed — REDIS_URL is likely unset or Redis is unreachable.
@@ -42,6 +44,16 @@ const shutdown = async (signal: NodeJS.Signals) => {
       movieSeedWorker?.close(),
       recommendationWorker?.close(),
       morePicksWorker?.close(),
+      new Promise<void>((resolve, reject) => {
+        if (!metricsServer) {
+          resolve();
+          return;
+        }
+        metricsServer.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      }),
     ]);
     await closeBullMQQueues();
     logger.info('Workers closed gracefully');

--- a/coolify.compose.yml
+++ b/coolify.compose.yml
@@ -19,6 +19,8 @@ x-app-env: &app-env
   TMDB_API_KEY: ${TMDB_API_KEY:-}
   NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:?Set NEXT_PUBLIC_BASE_URL to the public app URL in Coolify}
   LOG_LEVEL: ${LOG_LEVEL:-info}
+  METRICS_ENABLED: ${METRICS_ENABLED:-false}
+  METRICS_BEARER_TOKEN: ${METRICS_BEARER_TOKEN:-}
   API_KEY_HMAC_SECRET: ${API_KEY_HMAC_SECRET:-}
   AUTH_SESSION_SECRET: ${AUTH_SESSION_SECRET:?Set AUTH_SESSION_SECRET in Coolify}
   VALID_API_KEYS: ${VALID_API_KEYS:-}
@@ -105,11 +107,14 @@ services:
     environment:
       <<: *app-env
       NODE_OPTIONS: --require /app/apps/web/scripts/coolify-runtime-env.cjs
+      WORKER_METRICS_PORT: 9464
     depends_on:
       db:
         condition: service_healthy
       redis:
         condition: service_healthy
+    expose:
+      - '9464'
     healthcheck:
       test:
         [

--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -1,6 +1,92 @@
 name: popchoice-observability
 
 services:
+  observability-prometheus:
+    image: prom/prometheus:v3.7.3
+    container_name: popchoice-observability-prometheus
+    restart: unless-stopped
+    command:
+      [
+        '--config.file=/etc/prometheus/prometheus.yml',
+        '--config.expand-env',
+        '--storage.tsdb.path=/prometheus',
+        '--storage.tsdb.retention.time=15d',
+        '--web.enable-lifecycle',
+      ]
+    environment:
+      METRICS_BEARER_TOKEN: ${METRICS_BEARER_TOKEN:-}
+      POPCHOICE_WEB_METRICS_TARGET: ${POPCHOICE_WEB_METRICS_TARGET:-web:3000}
+      POPCHOICE_WORKERS_METRICS_TARGET: ${POPCHOICE_WORKERS_METRICS_TARGET:-workers:9464}
+    ports:
+      - '127.0.0.1:9090:9090'
+    volumes:
+      - ./observability/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./observability/prometheus/rules:/etc/prometheus/rules:ro
+      - prometheusdata:/prometheus
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
+    networks:
+      - default
+      - popchoice-app
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'wget --no-verbose --tries=1 --spider http://127.0.0.1:9090/-/ready || exit 1',
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+
+  observability-cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.52.1
+    container_name: popchoice-observability-cadvisor
+    restart: unless-stopped
+    command: ['--docker_only=true', '--housekeeping_interval=30s']
+    privileged: true
+    devices:
+      - /dev/kmsg:/dev/kmsg
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+
+  observability-node-exporter:
+    image: prom/node-exporter:v1.9.1
+    container_name: popchoice-observability-node-exporter
+    restart: unless-stopped
+    command:
+      [
+        '--path.rootfs=/host',
+        '--collector.filesystem.mount-points-exclude=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($$|/)',
+      ]
+    pid: host
+    volumes:
+      - /:/host:ro,rslave
+
+  observability-postgres-exporter:
+    image: prometheuscommunity/postgres-exporter:v0.18.1
+    container_name: popchoice-observability-postgres-exporter
+    restart: unless-stopped
+    environment:
+      DATA_SOURCE_URI: ${POSTGRES_EXPORTER_DATA_SOURCE_URI:-db:5432/popchoice?sslmode=disable}
+      DATA_SOURCE_USER: ${POSTGRES_EXPORTER_DATA_SOURCE_USER:-popchoice}
+      DATA_SOURCE_PASS: ${POSTGRES_EXPORTER_DATA_SOURCE_PASS:-}
+    networks:
+      - default
+      - popchoice-app
+
+  observability-redis-exporter:
+    image: oliver006/redis_exporter:v1.80.1
+    container_name: popchoice-observability-redis-exporter
+    restart: unless-stopped
+    environment:
+      REDIS_ADDR: ${REDIS_EXPORTER_REDIS_ADDR:-redis://redis:6379}
+    networks:
+      - default
+      - popchoice-app
+
   observability-uptime-kuma:
     image: louislam/uptime-kuma:1.23.16
     container_name: popchoice-observability-uptime-kuma
@@ -71,13 +157,22 @@ services:
       - '127.0.0.1:3001:3000'
     volumes:
       - grafanadata:/var/lib/grafana
+      - ./observability/grafana/dashboards:/var/lib/grafana/dashboards:ro
       - ./observability/grafana/provisioning:/etc/grafana/provisioning:ro
     depends_on:
       observability-loki:
+        condition: service_healthy
+      observability-prometheus:
         condition: service_healthy
 
 volumes:
   alloydata:
   grafanadata:
   lokidata:
+  prometheusdata:
   uptime-kuma-data:
+
+networks:
+  popchoice-app:
+    name: ${POPCHOICE_APP_NETWORK:-popchoice_default}
+    external: true

--- a/docs/COOLIFY.md
+++ b/docs/COOLIFY.md
@@ -251,6 +251,22 @@ separate observability stack and configure the monitors in
 read-only by default so production monitoring does not spend AI-provider
 credits.
 
+For Prometheus metrics and the initial Grafana dashboard, enable the app metrics
+endpoints on the PopChoice resource:
+
+```env
+METRICS_ENABLED=true
+METRICS_BEARER_TOKEN=<long-random-token>
+```
+
+Then run the separate observability stack documented in
+[OBSERVABILITY-METRICS.md](./OBSERVABILITY-METRICS.md). The stack listens locally
+on `127.0.0.1:9090` for Prometheus and `127.0.0.1:3001` for Grafana. Set
+`POPCHOICE_APP_NETWORK` if Coolify names the app resource network differently
+from `popchoice_default`, and set the Postgres exporter credentials with
+`POSTGRES_EXPORTER_DATA_SOURCE_URI`, `POSTGRES_EXPORTER_DATA_SOURCE_USER`, and
+`POSTGRES_EXPORTER_DATA_SOURCE_PASS`.
+
 ## Automatic redeploys
 
 For a simple continuous deployment path:

--- a/docs/OBSERVABILITY-LOGS.md
+++ b/docs/OBSERVABILITY-LOGS.md
@@ -2,7 +2,9 @@
 
 PopChoice can run a small self-hosted log stack for production or preview VPS
 debugging: Grafana Loki stores logs, Grafana Alloy tails Docker containers, and
-Grafana provides search through the provisioned Loki data source.
+Grafana provides search through the provisioned Loki data source. The same
+Grafana instance can also load the Prometheus metrics dashboard documented in
+[OBSERVABILITY-METRICS.md](./OBSERVABILITY-METRICS.md).
 
 This stack is intentionally separate from the PopChoice app stack. Web,
 workers, Bull Board, PostgreSQL, Redis, and one-shot service containers keep
@@ -12,8 +14,8 @@ its local container logs.
 
 ## Files
 
-- `docker-compose.observability.yml` starts Loki, Alloy, Grafana, and the
-  Uptime Kuma service documented separately in
+- `docker-compose.observability.yml` starts Loki, Alloy, Grafana, Prometheus,
+  metrics exporters, and the Uptime Kuma service documented separately in
   [OBSERVABILITY-UPTIME.md](./OBSERVABILITY-UPTIME.md).
 - `observability/loki/loki.yaml` configures single-binary Loki with filesystem
   TSDB storage and seven-day retention.

--- a/docs/OBSERVABILITY-METRICS.md
+++ b/docs/OBSERVABILITY-METRICS.md
@@ -1,0 +1,144 @@
+# Observability Metrics
+
+PopChoice can run a small self-hosted Prometheus stack for application and VPS
+health. It is intentionally separate from the app stack: if Prometheus,
+exporters, or Grafana are down, recommendations keep running.
+
+## Files
+
+- `docker-compose.observability.yml` starts Prometheus, cAdvisor, node exporter,
+  Postgres exporter, Redis exporter, Grafana, Loki, Alloy, and Uptime Kuma.
+- `observability/prometheus/prometheus.yml` configures scrape targets.
+- `observability/prometheus/rules/popchoice.yml` adds starter recording rules.
+- `observability/grafana/provisioning/datasources/prometheus.yaml` provisions
+  the Prometheus data source.
+- `observability/grafana/provisioning/dashboards/popchoice.yaml` loads
+  dashboards from `observability/grafana/dashboards`.
+- `observability/grafana/dashboards/popchoice-overview.json` is the initial
+  PopChoice overview dashboard.
+
+## App Metrics
+
+The web app exposes metrics at:
+
+```txt
+/api/metrics
+```
+
+The worker process exposes metrics at:
+
+```txt
+:9464/metrics
+```
+
+Production metrics are disabled by default. Enable them on the app stack with:
+
+```env
+METRICS_ENABLED=true
+METRICS_BEARER_TOKEN=<long-random-token>
+WORKER_METRICS_PORT=9464
+```
+
+Prometheus must use the same `METRICS_BEARER_TOKEN`. In development, metrics are
+enabled without a token unless `METRICS_ENABLED=false` is set.
+
+## Scrape Targets
+
+Prometheus scrapes:
+
+- `popchoice-web` via `${POPCHOICE_WEB_METRICS_TARGET:-web:3000}/api/metrics`
+- `popchoice-workers` via
+  `${POPCHOICE_WORKERS_METRICS_TARGET:-workers:9464}/metrics`
+- `postgres` via `observability-postgres-exporter:9187`
+- `redis` via `observability-redis-exporter:9121`
+- `cadvisor` via `observability-cadvisor:8080`
+- `node` via `observability-node-exporter:9100`
+- `prometheus` itself
+
+The observability compose file joins an external app network named
+`${POPCHOICE_APP_NETWORK:-popchoice_default}`. If Coolify gives the app resource
+a different Docker network name, set `POPCHOICE_APP_NETWORK` on the
+observability resource.
+
+For the Postgres exporter, configure:
+
+```env
+POSTGRES_EXPORTER_DATA_SOURCE_URI=db:5432/popchoice?sslmode=disable
+POSTGRES_EXPORTER_DATA_SOURCE_USER=popchoice
+POSTGRES_EXPORTER_DATA_SOURCE_PASS=<postgres-password>
+```
+
+For the Redis exporter, configure when the Redis host is not `redis:6379`:
+
+```env
+REDIS_EXPORTER_REDIS_ADDR=redis://redis:6379
+```
+
+## Local or VPS Start
+
+From the repo root:
+
+```bash
+export GRAFANA_ADMIN_PASSWORD='replace-with-a-long-password'
+export METRICS_BEARER_TOKEN='replace-with-a-long-token'
+docker compose -f docker-compose.observability.yml up -d
+```
+
+Prometheus listens on `127.0.0.1:9090`; Grafana listens on `127.0.0.1:3001`.
+On a VPS, keep both behind Coolify authentication or an SSH tunnel.
+
+## Metrics Included
+
+Application metrics keep labels low-cardinality. They do not include user ids,
+request ids, recommendation ids, job ids, or movie titles.
+
+- `popchoice_recommendations_total{mode,status}` counts recommendation
+  completions and failures.
+- `popchoice_recommendation_duration_seconds{mode,status}` tracks recommendation
+  processing latency.
+- `popchoice_provider_errors_total{provider,operation,reason}` counts OpenAI and
+  TMDB degradation, including timeouts, HTTP errors, validation errors, and
+  rate limits.
+- `popchoice_queue_depth{queue,status}` reports BullMQ waiting, active, delayed,
+  completed, failed, and paused counts at scrape time.
+- `popchoice_queue_jobs_total{queue,job,event,final}` counts worker job
+  completions and retry/final failures.
+- `popchoice_dependency_health{dependency}` reports the most recent web health
+  check view of Postgres and Redis.
+- `popchoice_dependency_health_failures_total{dependency}` counts health check
+  failures.
+
+Prometheus also collects default Node.js process metrics from the web and
+worker processes, container CPU/memory/filesystem metrics from cAdvisor, host
+CPU/memory/disk metrics from node exporter, and `pg_up` / `redis_up` from the
+database exporters.
+
+## Dashboard
+
+Grafana provisions the `PopChoice Overview` dashboard. It starts with:
+
+- web and worker scrape target health
+- Postgres and Redis exporter health
+- recommendation throughput and p50/p95 duration
+- BullMQ queue depth and final failures
+- OpenAI/TMDB degradation events
+- container CPU and memory
+- host disk usage
+
+Panels may be empty until the relevant metric has been emitted. For example,
+recommendation latency appears only after a recommendation completes, and
+dependency health appears after `/api/health` has been called.
+
+## Alert Candidates
+
+No alert routing is enabled by default yet; that belongs to
+[#503](https://github.com/shchilkin/PopChoice/issues/503). Good candidates for
+the next step:
+
+- `up{job="popchoice-web"} == 0` for more than 2 minutes
+- `up{job="popchoice-workers"} == 0` for more than 2 minutes
+- `pg_up == 0` or `redis_up == 0` for more than 2 minutes
+- non-zero final queue failures over 10 minutes
+- high recommendation failure ratio over 10 minutes
+- host disk usage above 85%
+- repeated OpenAI/TMDB timeouts

--- a/docs/ROADMAP-ARCHITECTURE.md
+++ b/docs/ROADMAP-ARCHITECTURE.md
@@ -153,7 +153,7 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 - [ ] Build the self-hosted observability stack under [#498](https://github.com/shchilkin/PopChoice/issues/498). This is intentionally a learning track: SaaS tools would be simpler, but self-hosting teaches uptime checks, log shipping, metrics, traces, alerts, retention, and backups.
 - [x] Add Uptime Kuma health and synthetic monitoring in [#502](https://github.com/shchilkin/PopChoice/issues/502) for `/api/health`, build metadata, and cheap smoke checks before deeper instrumentation. See [Uptime Kuma Monitoring](./OBSERVABILITY-UPTIME.md).
 - [x] Add Grafana Loki log aggregation in [#499](https://github.com/shchilkin/PopChoice/issues/499) so Coolify/Docker logs are searchable by service, level, request id, recommendation id, queue, job id, and stage. See [Observability Logs](./OBSERVABILITY-LOGS.md).
-- [ ] Add Prometheus metrics and Grafana dashboards in [#501](https://github.com/shchilkin/PopChoice/issues/501) for container health, Postgres, Redis, BullMQ queues, recommendation latency, provider timeouts, and failed jobs.
+- [x] Add Prometheus metrics and Grafana dashboards in [#501](https://github.com/shchilkin/PopChoice/issues/501) for container health, Postgres, Redis, BullMQ queues, recommendation latency, provider timeouts, and failed jobs. See [Observability Metrics](./OBSERVABILITY-METRICS.md).
 - [ ] Add OpenTelemetry traces with Tempo in [#500](https://github.com/shchilkin/PopChoice/issues/500) once the low-noise uptime/logs/metrics foundation exists.
 - [ ] Add alert routing, retention, backups, and incident runbooks in [#503](https://github.com/shchilkin/PopChoice/issues/503) so the monitoring stack stays useful and recoverable.
 - Enable Coolify notifications for failed deploys, failed backups, server disk/resource warnings, and unhealthy or restarting containers where supported.
@@ -277,7 +277,7 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 10. [x] Move TMDB discovery/backfill/metadata refresh into shared rate-limited BullMQ catalog workers in [#492](https://github.com/shchilkin/PopChoice/issues/492) before increasing catalog expansion volume.
 11. [ ] Plan and split the [#493](https://github.com/shchilkin/PopChoice/issues/493) backoffice/catalog-health epic, including shared login protection for it and `apps/bull-board`.
 12. [ ] Clarify production migration/versioning expectations in [#494](https://github.com/shchilkin/PopChoice/issues/494) for schema changes, rollbacks, and preview volume recreation.
-13. [ ] Start the self-hosted observability epic in [#498](https://github.com/shchilkin/PopChoice/issues/498), beginning with Uptime Kuma in [#502](https://github.com/shchilkin/PopChoice/issues/502) and log aggregation in [#499](https://github.com/shchilkin/PopChoice/issues/499).
+13. [ ] Continue the self-hosted observability epic in [#498](https://github.com/shchilkin/PopChoice/issues/498) with traces in [#500](https://github.com/shchilkin/PopChoice/issues/500) and alerting/runbooks in [#503](https://github.com/shchilkin/PopChoice/issues/503).
 
 ## Working Checklist
 

--- a/observability/grafana/dashboards/popchoice-overview.json
+++ b/observability/grafana/dashboards/popchoice-overview.json
@@ -1,0 +1,583 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "expr": "min(up{job=~\"popchoice-web|popchoice-workers\"})",
+          "legendFormat": "app targets",
+          "refId": "A"
+        }
+      ],
+      "title": "App Targets Up",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "expr": "min(pg_up)",
+          "legendFormat": "postgres",
+          "refId": "A"
+        }
+      ],
+      "title": "Postgres Up",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "expr": "min(redis_up)",
+          "legendFormat": "redis",
+          "refId": "A"
+        }
+      ],
+      "title": "Redis Up",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (status, mode) (rate(popchoice_recommendations_total[5m]))",
+          "legendFormat": "{{mode}} {{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Recommendation Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, mode) (rate(popchoice_recommendation_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95 {{mode}}",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.50, sum by (le, mode) (rate(popchoice_recommendation_duration_seconds_bucket[5m])))",
+          "legendFormat": "p50 {{mode}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Recommendation Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (queue, status) (popchoice_queue_depth)",
+          "legendFormat": "{{queue}} {{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "BullMQ Queue Depth",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (queue) (increase(popchoice_queue_jobs_total{event=\"failed\",final=\"true\"}[1h]))",
+          "legendFormat": "{{queue}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Final Queue Failures",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (provider, operation, reason) (increase(popchoice_provider_errors_total[1h]))",
+          "legendFormat": "{{provider}} {{operation}} {{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Provider Degradation",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (name) (rate(container_cpu_usage_seconds_total{name=~\".*popchoice.*\"}[5m]))",
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Container CPU",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 28
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum by (name) (container_memory_working_set_bytes{name=~\".*popchoice.*\"})",
+          "legendFormat": "{{name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Container Memory",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "showPoints": "never"
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 28
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "expr": "1 - (node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay\"} / node_filesystem_size_bytes{fstype!~\"tmpfs|overlay\"})",
+          "legendFormat": "{{mountpoint}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Host Disk Used",
+      "type": "timeseries"
+    }
+  ],
+  "preload": false,
+  "refresh": "30s",
+  "schemaVersion": 42,
+  "tags": ["popchoice", "observability"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "PopChoice Overview",
+  "uid": "popchoice-overview",
+  "version": 1
+}

--- a/observability/grafana/provisioning/dashboards/popchoice.yaml
+++ b/observability/grafana/provisioning/dashboards/popchoice.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: PopChoice
+    orgId: 1
+    folder: PopChoice
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/observability/grafana/provisioning/datasources/prometheus.yaml
+++ b/observability/grafana/provisioning/datasources/prometheus.yaml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://observability-prometheus:9090
+    isDefault: true
+    editable: true

--- a/observability/prometheus/prometheus.yml
+++ b/observability/prometheus/prometheus.yml
@@ -1,0 +1,50 @@
+global:
+  scrape_interval: 30s
+  evaluation_interval: 30s
+
+rule_files:
+  - /etc/prometheus/rules/*.yml
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets:
+          - observability-prometheus:9090
+
+  - job_name: cadvisor
+    static_configs:
+      - targets:
+          - observability-cadvisor:8080
+
+  - job_name: node
+    static_configs:
+      - targets:
+          - observability-node-exporter:9100
+
+  - job_name: postgres
+    static_configs:
+      - targets:
+          - observability-postgres-exporter:9187
+
+  - job_name: redis
+    static_configs:
+      - targets:
+          - observability-redis-exporter:9121
+
+  - job_name: popchoice-web
+    metrics_path: /api/metrics
+    authorization:
+      type: Bearer
+      credentials: ${METRICS_BEARER_TOKEN}
+    static_configs:
+      - targets:
+          - ${POPCHOICE_WEB_METRICS_TARGET}
+
+  - job_name: popchoice-workers
+    metrics_path: /metrics
+    authorization:
+      type: Bearer
+      credentials: ${METRICS_BEARER_TOKEN}
+    static_configs:
+      - targets:
+          - ${POPCHOICE_WORKERS_METRICS_TARGET}

--- a/observability/prometheus/rules/popchoice.yml
+++ b/observability/prometheus/rules/popchoice.yml
@@ -1,0 +1,12 @@
+groups:
+  - name: popchoice-recording-rules
+    interval: 30s
+    rules:
+      - record: popchoice:recommendation_failure_rate5m
+        expr: |
+          sum(rate(popchoice_recommendations_total{status="failure"}[5m]))
+          /
+          clamp_min(sum(rate(popchoice_recommendations_total[5m])), 1)
+
+      - record: popchoice:queue_failed_jobs5m
+        expr: sum by (queue) (increase(popchoice_queue_jobs_total{event="failed",final="true"}[5m]))

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,7 @@
         "openai": "^6.38.0",
         "pg": "^8.21.0",
         "pino": "^10.3.1",
+        "prom-client": "^15.1.3",
         "react": "^19.2.6",
         "react-canvas-confetti": "^2.0.7",
         "react-dom": "^19.2.6",
@@ -2174,6 +2175,16 @@
       "version": "2.1.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/@oxc-parser/binding-android-arm-eabi": {
       "version": "0.127.0",
@@ -5901,6 +5912,12 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -11175,6 +11192,19 @@
       ],
       "license": "MIT"
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "dev": true,
@@ -12691,6 +12721,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/terser": {


### PR DESCRIPTION
## Summary
- add Prometheus, cAdvisor, node, Postgres, and Redis exporters to the self-hosted observability compose stack
- add protected web and worker metrics endpoints using prom-client
- record recommendation lifecycle, provider degradation, dependency health, and BullMQ queue metrics with low-cardinality labels
- provision a Prometheus datasource and PopChoice overview dashboard in Grafana
- document metrics setup, Coolify env, scrape targets, dashboard panels, and alert candidates
- mark #501 complete in the architecture roadmap

## Issues
Closes #501
Part of #498

## Verification
- npm run format:check
- npm run lint:check
- npm run type-check
- npm run test:server
- npm run test:server --workspace=apps/web -- src/app/api/metrics/route.test.ts
- npm run eval:recommendations
- npm run build
- GRAFANA_ADMIN_PASSWORD=example METRICS_BEARER_TOKEN=example POSTGRES_EXPORTER_DATA_SOURCE_PASS=example docker compose -f docker-compose.observability.yml config
- docker run --rm --entrypoint promtool -v /Users/shchilkin/dev/PopChoice/observability/prometheus:/etc/prometheus:ro prom/prometheus:v3.7.3 check config /etc/prometheus/prometheus.yml
- docker manifest inspect prom/prometheus:v3.7.3
- docker manifest inspect gcr.io/cadvisor/cadvisor:v0.52.1
- docker manifest inspect prom/node-exporter:v1.9.1
- docker manifest inspect prometheuscommunity/postgres-exporter:v0.18.1
- docker manifest inspect oliver006/redis_exporter:v1.80.1
- pre-push hook: lint, server tests, production build