### PR TITLE
Fix observability Coolify config mounts

### DIFF
--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -2,14 +2,16 @@ name: popchoice-observability
 
 services:
   observability-tempo:
-    image: grafana/tempo:2.9.0
+    build:
+      context: .
+      dockerfile: observability/images/tempo/Dockerfile
+    image: popchoice-observability-tempo:${OBSERVABILITY_IMAGE_TAG:-local}
     container_name: popchoice-observability-tempo
     restart: unless-stopped
     command: ['-config.file=/etc/tempo/tempo.yaml']
     ports:
       - '127.0.0.1:3200:3200'
     volumes:
-      - ./observability/tempo/tempo.yaml:/etc/tempo/tempo.yaml:ro
       - tempodata:/var/tempo
     healthcheck:
       test:
@@ -19,15 +21,16 @@ services:
       retries: 5
 
   observability-otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.141.0
+    build:
+      context: .
+      dockerfile: observability/images/otel-collector/Dockerfile
+    image: popchoice-observability-otel-collector:${OBSERVABILITY_IMAGE_TAG:-local}
     container_name: popchoice-observability-otel-collector
     restart: unless-stopped
     command: ['--config=/etc/otelcol/config.yaml']
     ports:
       - '127.0.0.1:4317:4317'
       - '127.0.0.1:4318:4318'
-    volumes:
-      - ./observability/otel-collector/config.yaml:/etc/otelcol/config.yaml:ro
     depends_on:
       observability-tempo:
         condition: service_healthy
@@ -36,7 +39,10 @@ services:
       - popchoice-app
 
   observability-prometheus:
-    image: prom/prometheus:v3.7.3
+    build:
+      context: .
+      dockerfile: observability/images/prometheus/Dockerfile
+    image: popchoice-observability-prometheus:${OBSERVABILITY_IMAGE_TAG:-local}
     container_name: popchoice-observability-prometheus
     restart: unless-stopped
     command:
@@ -54,8 +60,6 @@ services:
     ports:
       - '127.0.0.1:9090:9090'
     volumes:
-      - ./observability/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
-      - ./observability/prometheus/rules:/etc/prometheus/rules:ro
       - prometheusdata:/prometheus
     extra_hosts:
       - 'host.docker.internal:host-gateway'
@@ -141,14 +145,16 @@ services:
       start_period: 30s
 
   observability-loki:
-    image: grafana/loki:3.5.7
+    build:
+      context: .
+      dockerfile: observability/images/loki/Dockerfile
+    image: popchoice-observability-loki:${OBSERVABILITY_IMAGE_TAG:-local}
     container_name: popchoice-observability-loki
     restart: unless-stopped
     command: ['-config.file=/etc/loki/loki.yaml']
     ports:
       - '127.0.0.1:3100:3100'
     volumes:
-      - ./observability/loki/loki.yaml:/etc/loki/loki.yaml:ro
       - lokidata:/loki
     healthcheck:
       test:
@@ -158,7 +164,10 @@ services:
       retries: 5
 
   observability-alloy:
-    image: grafana/alloy:v1.11.3
+    build:
+      context: .
+      dockerfile: observability/images/alloy/Dockerfile
+    image: popchoice-observability-alloy:${OBSERVABILITY_IMAGE_TAG:-local}
     container_name: popchoice-observability-alloy
     restart: unless-stopped
     command:
@@ -171,7 +180,6 @@ services:
     ports:
       - '127.0.0.1:12345:12345'
     volumes:
-      - ./observability/alloy/config.alloy:/etc/alloy/config.alloy:ro
       - alloydata:/var/lib/alloy/data
       - /var/run/docker.sock:/var/run/docker.sock:ro
     depends_on:
@@ -179,7 +187,10 @@ services:
         condition: service_healthy
 
   observability-grafana:
-    image: grafana/grafana:12.3.0
+    build:
+      context: .
+      dockerfile: observability/images/grafana/Dockerfile
+    image: popchoice-observability-grafana:${OBSERVABILITY_IMAGE_TAG:-local}
     container_name: popchoice-observability-grafana
     restart: unless-stopped
     environment:
@@ -191,8 +202,6 @@ services:
       - '127.0.0.1:3001:3000'
     volumes:
       - grafanadata:/var/lib/grafana
-      - ./observability/grafana/dashboards:/var/lib/grafana/dashboards:ro
-      - ./observability/grafana/provisioning:/etc/grafana/provisioning:ro
     depends_on:
       observability-loki:
         condition: service_healthy

--- a/docs/OBSERVABILITY-ALERTS.md
+++ b/docs/OBSERVABILITY-ALERTS.md
@@ -11,9 +11,8 @@ without creating noisy paging habits while the project is still small.
 - `docs/OBSERVABILITY-RUNBOOKS.md` explains how to respond to each alert family.
 - `docs/OBSERVABILITY-METRICS.md` documents the metrics used by these alerts.
 
-Grafana loads the alerting provisioning directory from the existing
-`./observability/grafana/provisioning:/etc/grafana/provisioning:ro` mount in
-`docker-compose.observability.yml`.
+Grafana loads the alerting provisioning directory from the observability
+Grafana config image built by `docker-compose.observability.yml`.
 
 ## Severity Groups
 
@@ -116,6 +115,7 @@ Back up two layers:
    - `prometheusdata`
    - `grafanadata`
    - `lokidata`
+   - `tempodata`
    - `alloydata`
    - `uptime-kuma-data`
 

--- a/docs/OBSERVABILITY-METRICS.md
+++ b/docs/OBSERVABILITY-METRICS.md
@@ -8,6 +8,8 @@ exporters, or Grafana are down, recommendations keep running.
 
 - `docker-compose.observability.yml` starts Prometheus, cAdvisor, node exporter,
   Postgres exporter, Redis exporter, Grafana, Loki, Alloy, and Uptime Kuma.
+- `observability/images/*/Dockerfile` builds small config images so Coolify can
+  deploy the stack without runtime bind mounts for repo-owned YAML/JSON files.
 - `observability/prometheus/prometheus.yml` configures scrape targets.
 - `observability/prometheus/rules/popchoice.yml` adds starter recording rules.
 - `observability/grafana/provisioning/datasources/prometheus.yaml` provisions

--- a/docs/ROADMAP-ARCHITECTURE.md
+++ b/docs/ROADMAP-ARCHITECTURE.md
@@ -150,12 +150,13 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 
 ### Operational Observability Track
 
-- [ ] Build the self-hosted observability stack under [#498](https://github.com/shchilkin/PopChoice/issues/498). This is intentionally a learning track: SaaS tools would be simpler, but self-hosting teaches uptime checks, log shipping, metrics, traces, alerts, retention, and backups.
+- [x] Build the self-hosted observability stack under [#498](https://github.com/shchilkin/PopChoice/issues/498). This is intentionally a learning track: SaaS tools would be simpler, but self-hosting teaches uptime checks, log shipping, metrics, traces, alerts, retention, and backups.
 - [x] Add Uptime Kuma health and synthetic monitoring in [#502](https://github.com/shchilkin/PopChoice/issues/502) for `/api/health`, build metadata, and cheap smoke checks before deeper instrumentation. See [Uptime Kuma Monitoring](./OBSERVABILITY-UPTIME.md).
 - [x] Add Grafana Loki log aggregation in [#499](https://github.com/shchilkin/PopChoice/issues/499) so Coolify/Docker logs are searchable by service, level, request id, recommendation id, queue, job id, and stage. See [Observability Logs](./OBSERVABILITY-LOGS.md).
 - [x] Add Prometheus metrics and Grafana dashboards in [#501](https://github.com/shchilkin/PopChoice/issues/501) for container health, Postgres, Redis, BullMQ queues, recommendation latency, provider timeouts, and failed jobs. See [Observability Metrics](./OBSERVABILITY-METRICS.md).
 - [x] Add OpenTelemetry traces with Tempo in [#500](https://github.com/shchilkin/PopChoice/issues/500) once the low-noise uptime/logs/metrics foundation exists. See [Observability Traces](./OBSERVABILITY-TRACES.md).
 - [x] Add alert routing, retention, backups, and incident runbooks in [#503](https://github.com/shchilkin/PopChoice/issues/503) so the monitoring stack stays useful and recoverable. See [Observability Alerts](./OBSERVABILITY-ALERTS.md) and [Observability Runbooks](./OBSERVABILITY-RUNBOOKS.md).
+- [ ] Deploy the self-hosted observability stack to production in [#508](https://github.com/shchilkin/PopChoice/issues/508), including Coolify wiring, secrets, access control, alert contact points, backup coverage, and post-deploy verification.
 - Enable Coolify notifications for failed deploys, failed backups, server disk/resource warnings, and unhealthy or restarting containers where supported.
 - Add external uptime monitoring for `https://pop-choice.shchilkin.dev/api/health`, then consider a deeper synthetic recommendation smoke check.
 - Add application error tracking for frontend, API routes, and workers so browser errors, API exceptions, and background job failures are visible outside Coolify logs.
@@ -278,6 +279,7 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 11. [ ] Plan and split the [#493](https://github.com/shchilkin/PopChoice/issues/493) backoffice/catalog-health epic, including shared login protection for it and `apps/bull-board`.
 12. [ ] Clarify production migration/versioning expectations in [#494](https://github.com/shchilkin/PopChoice/issues/494) for schema changes, rollbacks, and preview volume recreation.
 13. [x] Complete the first self-hosted observability track in [#498](https://github.com/shchilkin/PopChoice/issues/498) with uptime, logs, metrics, traces, alerts, retention, backups, and runbooks.
+14. [ ] Deploy the self-hosted observability stack to production in [#508](https://github.com/shchilkin/PopChoice/issues/508) and verify metrics, logs, traces, alerts, access control, and backups on the VPS.
 
 ## Working Checklist
 

--- a/observability/grafana/provisioning/dashboards/popchoice.yaml
+++ b/observability/grafana/provisioning/dashboards/popchoice.yaml
@@ -9,4 +9,4 @@ providers:
     updateIntervalSeconds: 30
     allowUiUpdates: true
     options:
-      path: /var/lib/grafana/dashboards
+      path: /etc/grafana/dashboards

--- a/observability/images/alloy/Dockerfile
+++ b/observability/images/alloy/Dockerfile
@@ -1,0 +1,3 @@
+FROM grafana/alloy:v1.11.3
+
+COPY observability/alloy/config.alloy /etc/alloy/config.alloy

--- a/observability/images/grafana/Dockerfile
+++ b/observability/images/grafana/Dockerfile
@@ -1,0 +1,4 @@
+FROM grafana/grafana:12.3.0
+
+COPY observability/grafana/dashboards /etc/grafana/dashboards
+COPY observability/grafana/provisioning /etc/grafana/provisioning

--- a/observability/images/loki/Dockerfile
+++ b/observability/images/loki/Dockerfile
@@ -1,0 +1,3 @@
+FROM grafana/loki:3.5.7
+
+COPY observability/loki/loki.yaml /etc/loki/loki.yaml

--- a/observability/images/otel-collector/Dockerfile
+++ b/observability/images/otel-collector/Dockerfile
@@ -1,0 +1,3 @@
+FROM otel/opentelemetry-collector-contrib:0.141.0
+
+COPY observability/otel-collector/config.yaml /etc/otelcol/config.yaml

--- a/observability/images/prometheus/Dockerfile
+++ b/observability/images/prometheus/Dockerfile
@@ -1,0 +1,4 @@
+FROM prom/prometheus:v3.7.3
+
+COPY observability/prometheus/prometheus.yml /etc/prometheus/prometheus.yml
+COPY observability/prometheus/rules /etc/prometheus/rules

--- a/observability/images/tempo/Dockerfile
+++ b/observability/images/tempo/Dockerfile
@@ -1,0 +1,3 @@
+FROM grafana/tempo:2.9.0
+
+COPY observability/tempo/tempo.yaml /etc/tempo/tempo.yaml


### PR DESCRIPTION
## Summary
- Build small observability config images for Prometheus, Grafana, Loki, Tempo, Alloy, and the OpenTelemetry Collector.
- Remove runtime bind mounts for repo-owned observability config files so Coolify deployments do not fail when the helper artifact path is not available to the Docker daemon.
- Update Grafana dashboard provisioning to load dashboards from the image path and document the Coolify-friendly config image approach.
- Track the production observability rollout in #508 and add `tempodata` to backup expectations.

## Verification
- `env GRAFANA_ADMIN_PASSWORD=dummy METRICS_BEARER_TOKEN=dummy POPCHOICE_APP_NETWORK=ze0vvy05sc6qitaz0bjoikoj docker compose -f docker-compose.observability.yml config`
- `docker compose -f docker-compose.observability.yml build observability-prometheus observability-grafana observability-tempo observability-loki observability-otel-collector observability-alloy`
- `git diff --check`
- pre-push: lint, server tests, production build

Fixes the failed production observability deployment where Docker tried to mount `observability/prometheus/prometheus.yml` from Coolify runtime storage as a file but found a directory/missing path instead.