### PR TITLE
Fix observability healthcheck wget flags

### DIFF
--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -14,8 +14,7 @@ services:
     volumes:
       - tempodata:/var/tempo
     healthcheck:
-      test:
-        ['CMD-SHELL', 'wget --no-verbose --tries=1 --spider http://127.0.0.1:3200/ready || exit 1']
+      test: ['CMD-SHELL', 'wget -q --spider -T 5 http://127.0.0.1:3200/ready || exit 1']
       interval: 30s
       timeout: 10s
       retries: 5
@@ -67,11 +66,7 @@ services:
       - default
       - popchoice-app
     healthcheck:
-      test:
-        [
-          'CMD-SHELL',
-          'wget --no-verbose --tries=1 --spider http://127.0.0.1:9090/-/ready || exit 1',
-        ]
+      test: ['CMD-SHELL', 'wget -q --spider -T 5 http://127.0.0.1:9090/-/ready || exit 1']
       interval: 30s
       timeout: 10s
       retries: 5
@@ -157,8 +152,7 @@ services:
     volumes:
       - lokidata:/loki
     healthcheck:
-      test:
-        ['CMD-SHELL', 'wget --no-verbose --tries=1 --spider http://127.0.0.1:3100/ready || exit 1']
+      test: ['CMD-SHELL', 'wget -q --spider -T 5 http://127.0.0.1:3100/ready || exit 1']
       interval: 30s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
## Summary
- Replace `wget --no-verbose --tries=1 --spider` healthchecks with busybox-compatible `wget -q --spider -T 5`.
- Fix Tempo/Prometheus/Loki healthchecks in Coolify so live containers are not marked unhealthy because of unsupported wget flags.

## Why
The production observability deploy got past the config image mount issue, then failed while waiting for Prometheus/Tempo healthchecks. Tempo starts successfully, but its image uses busybox wget, which does not support `--no-verbose`; the healthcheck failed even though the service was running.

## Verification
- `env GRAFANA_ADMIN_PASSWORD=dummy METRICS_BEARER_TOKEN=dummy POPCHOICE_APP_NETWORK=ze0vvy05sc6qitaz0bjoikoj docker compose -f docker-compose.observability.yml config`
- `docker run --rm --entrypoint sh grafana/tempo:2.9.0 -c 'wget -q --spider -T 5 http://127.0.0.1:1/ready; test $? -ne 127'`\n- `docker run --rm --entrypoint sh prom/prometheus:v3.7.3 -c 'wget -q --spider -T 5 http://127.0.0.1:1/-/ready; test $? -ne 127'`\n- `git diff --check`\n- pre-push: lint, server tests, production build