### PR TITLE
Stabilize production observability deployment

### DIFF
--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -96,6 +96,7 @@ services:
     pid: host
     volumes:
       - /:/host:ro,rslave
+      - /run/udev:/run/udev:ro
 
   observability-postgres-exporter:
     image: prometheuscommunity/postgres-exporter:v0.18.1

--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -46,8 +46,7 @@ services:
     restart: unless-stopped
     command:
       [
-        '--config.file=/etc/prometheus/prometheus.yml',
-        '--config.expand-env',
+        '--config.file=/tmp/prometheus.yml',
         '--storage.tsdb.path=/prometheus',
         '--storage.tsdb.retention.time=15d',
         '--web.enable-lifecycle',

--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -14,7 +14,7 @@ services:
     volumes:
       - tempodata:/var/tempo
     healthcheck:
-      test: ['CMD-SHELL', 'wget -q --spider -T 5 http://127.0.0.1:3200/ready || exit 1']
+      test: ['CMD', '/busybox/wget', '-q', '--spider', '-T', '5', 'http://127.0.0.1:3200/ready']
       interval: 30s
       timeout: 10s
       retries: 5
@@ -66,7 +66,7 @@ services:
       - default
       - popchoice-app
     healthcheck:
-      test: ['CMD-SHELL', 'wget -q --spider -T 5 http://127.0.0.1:9090/-/ready || exit 1']
+      test: ['CMD', '/bin/wget', '-q', '--spider', '-T', '5', 'http://127.0.0.1:9090/-/ready']
       interval: 30s
       timeout: 10s
       retries: 5
@@ -152,7 +152,7 @@ services:
     volumes:
       - lokidata:/loki
     healthcheck:
-      test: ['CMD-SHELL', 'wget -q --spider -T 5 http://127.0.0.1:3100/ready || exit 1']
+      test: ['CMD', '/busybox/wget', '-q', '--spider', '-T', '5', 'http://127.0.0.1:3100/ready']
       interval: 30s
       timeout: 10s
       retries: 5

--- a/docs/COOLIFY.md
+++ b/docs/COOLIFY.md
@@ -276,7 +276,10 @@ on `127.0.0.1:9090` for Prometheus and `127.0.0.1:3001` for Grafana. Set
 `POPCHOICE_APP_NETWORK` if Coolify names the app resource network differently
 from `popchoice_default`, and set the Postgres exporter credentials with
 `POSTGRES_EXPORTER_DATA_SOURCE_URI`, `POSTGRES_EXPORTER_DATA_SOURCE_USER`, and
-`POSTGRES_EXPORTER_DATA_SOURCE_PASS`.
+`POSTGRES_EXPORTER_DATA_SOURCE_PASS`. Because the observability stack is a
+separate Coolify resource, duplicate the app database password into
+`POSTGRES_EXPORTER_DATA_SOURCE_PASS`; it is not inherited automatically from the
+PopChoice app resource.
 
 ## Automatic redeploys
 

--- a/docs/OBSERVABILITY-METRICS.md
+++ b/docs/OBSERVABILITY-METRICS.md
@@ -72,6 +72,12 @@ POSTGRES_EXPORTER_DATA_SOURCE_USER=popchoice
 POSTGRES_EXPORTER_DATA_SOURCE_PASS=<postgres-password>
 ```
 
+In Coolify, the observability stack is a separate resource, so it does not
+inherit `POSTGRES_PASSWORD` from the PopChoice app resource. Copy the app
+database password into `POSTGRES_EXPORTER_DATA_SOURCE_PASS`; otherwise the
+exporter starts but Prometheus reports `up{job="postgres"} == 0` and the
+exporter logs `password authentication failed for user "popchoice"`.
+
 For the Redis exporter, configure when the Redis host is not `redis:6379`:
 
 ```env

--- a/observability/grafana/provisioning/datasources/loki.yaml
+++ b/observability/grafana/provisioning/datasources/loki.yaml
@@ -6,5 +6,4 @@ datasources:
     access: proxy
     url: http://observability-loki:3100
     uid: loki
-    isDefault: true
     editable: true

--- a/observability/images/prometheus/Dockerfile
+++ b/observability/images/prometheus/Dockerfile
@@ -1,4 +1,7 @@
 FROM prom/prometheus:v3.7.3
 
-COPY observability/prometheus/prometheus.yml /etc/prometheus/prometheus.yml
+COPY --chmod=755 observability/images/prometheus/entrypoint.sh /usr/local/bin/popchoice-prometheus-entrypoint
+COPY observability/prometheus/prometheus.yml /etc/prometheus/prometheus.yml.template
 COPY observability/prometheus/rules /etc/prometheus/rules
+
+ENTRYPOINT ["/usr/local/bin/popchoice-prometheus-entrypoint"]

--- a/observability/images/prometheus/entrypoint.sh
+++ b/observability/images/prometheus/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -eu
+
+token_file=/tmp/popchoice-metrics-bearer-token
+config_file=/tmp/prometheus.yml
+
+printf '%s' "${METRICS_BEARER_TOKEN:-}" > "$token_file"
+
+sed \
+  -e "s|\${POPCHOICE_WEB_METRICS_TARGET}|${POPCHOICE_WEB_METRICS_TARGET:-web:3000}|g" \
+  -e "s|\${POPCHOICE_WORKERS_METRICS_TARGET}|${POPCHOICE_WORKERS_METRICS_TARGET:-workers:9464}|g" \
+  /etc/prometheus/prometheus.yml.template > "$config_file"
+
+exec /bin/prometheus "$@"

--- a/observability/prometheus/prometheus.yml
+++ b/observability/prometheus/prometheus.yml
@@ -35,7 +35,7 @@ scrape_configs:
     metrics_path: /api/metrics
     authorization:
       type: Bearer
-      credentials: ${METRICS_BEARER_TOKEN}
+      credentials_file: /tmp/popchoice-metrics-bearer-token
     static_configs:
       - targets:
           - ${POPCHOICE_WEB_METRICS_TARGET}
@@ -44,7 +44,7 @@ scrape_configs:
     metrics_path: /metrics
     authorization:
       type: Bearer
-      credentials: ${METRICS_BEARER_TOKEN}
+      credentials_file: /tmp/popchoice-metrics-bearer-token
     static_configs:
       - targets:
           - ${POPCHOICE_WORKERS_METRICS_TARGET}


### PR DESCRIPTION
## Summary
- make the observability stack Coolify-friendly by baking config files into service images and using exec-form healthchecks
- generate Prometheus config at runtime so app targets and bearer token work without unsupported Prometheus env expansion
- fix Grafana datasource provisioning so only Prometheus is the default datasource
- document production observability env setup, including duplicating the Postgres password into the observability resource
- mount /run/udev for node-exporter to reduce disk metadata warnings

## Verification
- Deployed branch `codex/stabilize-prod-observability` in Coolify and verified the observability resource is running
- Verified Grafana opens from the generated domain
- Verified Prometheus `up` reports healthy targets for Prometheus, cAdvisor, node, Postgres, Redis, web, and workers
- `env GRAFANA_ADMIN_PASSWORD=dummy METRICS_BEARER_TOKEN=dummy POPCHOICE_APP_NETWORK=ze0vvy05sc6qitaz0bjoikoj POSTGRES_EXPORTER_DATA_SOURCE_PASS=dummy docker compose -f docker-compose.observability.yml config`
- `git diff --check`
- pre-push checks: lint, server tests, production build