### PR TITLE
Format Grafana Telegram alerts

### DIFF
--- a/docs/OBSERVABILITY-ALERTS.md
+++ b/docs/OBSERVABILITY-ALERTS.md
@@ -9,8 +9,8 @@ without creating noisy paging habits while the project is still small.
 - `observability/grafana/provisioning/alerting/popchoice-alerts.yaml` provisions
   Grafana alert rules.
 - `observability/images/grafana/entrypoint.sh` optionally provisions the
-  `popchoice-telegram` contact point and notification policy when Telegram env
-  vars are present.
+  `popchoice-telegram` contact point, notification policy, and Telegram message
+  template when Telegram env vars are present.
 - `docs/OBSERVABILITY-RUNBOOKS.md` explains how to respond to each alert family.
 - `docs/OBSERVABILITY-METRICS.md` documents the metrics used by these alerts.
 
@@ -47,6 +47,18 @@ When either value is missing, Grafana starts without external receivers and
 alerts remain visible in the UI. The generated `popchoice-telegram` policy
 groups notifications by folder, alert name, and severity. After enabling it, use
 Grafana's contact point **Test** action before relying on alert delivery.
+
+Telegram messages use the `popchoice.telegram.message` template instead of
+Grafana's default message. The message is plain text and includes:
+
+- `FIRING` or `RESOLVED` plus the alert name.
+- Severity and summary when the alert provides them.
+- Firing and resolved alert instances with target labels and values when
+  available.
+- Silence, runbook, dashboard, and Grafana links when Grafana provides them.
+
+Set `GF_SERVER_ROOT_URL` on the Grafana service if Telegram links should point
+to the public Grafana domain instead of the container-local default URL.
 
 ## Alert Rules
 

--- a/docs/OBSERVABILITY-METRICS.md
+++ b/docs/OBSERVABILITY-METRICS.md
@@ -95,6 +95,10 @@ GRAFANA_TELEGRAM_CHAT_ID=<telegram-chat-id>
 If either value is missing, Grafana starts without provisioning the Telegram
 contact point so the observability stack can still run safely.
 
+Telegram alert notifications use a PopChoice-specific plain-text template. Set
+`GF_SERVER_ROOT_URL` to the public Grafana URL if silence, dashboard, and
+Grafana links should be useful outside the Docker network.
+
 ## Local or VPS Start
 
 From the repo root:

--- a/observability/images/grafana/entrypoint.sh
+++ b/observability/images/grafana/entrypoint.sh
@@ -4,9 +4,61 @@ set -eu
 telegram_file=/etc/grafana/provisioning/alerting/popchoice-telegram.yaml
 
 if [ -n "${GRAFANA_TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${GRAFANA_TELEGRAM_CHAT_ID:-}" ]; then
-  cat > "$telegram_file" <<YAML
+  cat > "$telegram_file" <<'YAML'
 apiVersion: 1
 
+templates:
+  - orgId: 1
+    name: popchoice.telegram.message
+    template: |
+      {{ define "popchoice.telegram.message" }}
+      {{ if eq .Status "firing" }}FIRING{{ else }}RESOLVED{{ end }}: {{ with index .CommonLabels "alertname" }}{{ . }}{{ else }}Grafana alert{{ end }}
+      {{ with index .CommonLabels "severity" }}
+      Severity: {{ . }}
+      {{ end }}
+      {{ with index .CommonAnnotations "summary" }}
+      Summary: {{ . }}
+      {{ end }}
+
+      {{ if .Alerts.Firing }}
+      Firing ({{ len .Alerts.Firing }}):
+      {{ range .Alerts.Firing }}
+      - {{ with index .Labels "instance" }}{{ . }}{{ else }}{{ with index .Labels "job" }}{{ . }}{{ else }}alert instance{{ end }}{{ end }}
+        {{ with index .Annotations "description" }}
+        Description: {{ . }}
+        {{ end }}
+        {{ with .ValueString }}
+        Value: {{ . }}
+        {{ end }}
+        {{ with .SilenceURL }}
+        Silence: {{ . }}
+        {{ end }}
+        {{ with index .Annotations "runbook_url" }}
+        Runbook: {{ . }}
+        {{ end }}
+      {{ end }}
+      {{ end }}
+
+      {{ if .Alerts.Resolved }}
+      Resolved ({{ len .Alerts.Resolved }}):
+      {{ range .Alerts.Resolved }}
+      - {{ with index .Labels "instance" }}{{ . }}{{ else }}{{ with index .Labels "job" }}{{ . }}{{ else }}alert instance{{ end }}{{ end }}
+        {{ with .ValueString }}
+        Last value: {{ . }}
+        {{ end }}
+        {{ with .DashboardURL }}
+        Dashboard: {{ . }}
+        {{ end }}
+      {{ end }}
+      {{ end }}
+
+      {{ with .ExternalURL }}
+      Grafana: {{ . }}
+      {{ end }}
+      {{- end }}
+YAML
+
+  cat >> "$telegram_file" <<YAML
 contactPoints:
   - orgId: 1
     name: popchoice-telegram
@@ -19,7 +71,7 @@ contactPoints:
           bottoken: "${GRAFANA_TELEGRAM_BOT_TOKEN}"
           uploadImage: false
           message: |
-            {{ template "default.message" . }}
+            {{ template "popchoice.telegram.message" . }}
 
 policies:
   - orgId: 1


### PR DESCRIPTION
## Summary
- add a provisioned PopChoice Telegram notification template for Grafana alerts
- keep the Telegram message plain-text and focused on status, severity, summary, affected targets, values, silence links, and runbooks
- document the formatted Telegram output and GF_SERVER_ROOT_URL follow-up for public links

## Verification
- git diff --check
- docker compose observability config with required dummy env
- docker compose build observability-grafana
- Grafana smoke-test with dummy Telegram env: /api/health ok
- Grafana provisioning API returns popchoice-telegram contact point using popchoice.telegram.message
- Grafana provisioning API returns popchoice.telegram.message template
- pre-push hook: lint, server tests, production build