### PR TITLE
Document deploy-aware alerting follow-ups

### DIFF
--- a/docs/COOLIFY.md
+++ b/docs/COOLIFY.md
@@ -302,6 +302,18 @@ The webhook call is an authenticated `GET` request using
 `Authorization: Bearer ${COOLIFY_TOKEN}`. Coolify then pulls the already-built
 `development` images and restarts the stack.
 
+Current observability caveat: a normal redeploy may briefly stop or replace the
+web container before Prometheus can scrape `web:3000` again. If that gap lasts
+longer than the current Grafana alert window, Telegram can report the app
+metrics target as down even when the deploy eventually recovers. Treat that as
+deployment-context signal, not as proof of a user-facing outage by itself.
+Follow-up issues track the planned improvements: Telegram formatting in
+[#525](https://github.com/shchilkin/PopChoice/issues/525), deploy-sensitive
+alert severity tuning in
+[#526](https://github.com/shchilkin/PopChoice/issues/526), and short
+deploy-aware silences plus post-deploy health verification in
+[#527](https://github.com/shchilkin/PopChoice/issues/527).
+
 To smoke-test the same path without a new merge, manually run the
 `Container Images` workflow on the `development` branch. Manual runs rebuild and
 republish the same image set, update the `development` image tag, then call the

--- a/docs/OBSERVABILITY-ALERTS.md
+++ b/docs/OBSERVABILITY-ALERTS.md
@@ -64,6 +64,11 @@ Grafana's default message. The message is plain text and includes:
 Set `GF_SERVER_ROOT_URL` on the Grafana service if Telegram links should point
 to the public Grafana domain instead of the container-local default URL.
 
+Known follow-up: the first production Telegram examples show that the current
+message still exposes too much raw Grafana expression state for mobile triage.
+Track template cleanup in
+[#525](https://github.com/shchilkin/PopChoice/issues/525).
+
 ## Alert Rules
 
 ### P1
@@ -73,6 +78,10 @@ to the public Grafana domain instead of the container-local default URL.
   - Trigger: `popchoice-web` scrape target stays down for 5 minutes.
   - Action: check Coolify web service, restart loops, recent deploy, and
     `/api/health`.
+  - Current caveat: ordinary redeploys can briefly make the metrics target
+    unavailable even when the user-facing app recovers normally. Track severity
+    and threshold tuning in
+    [#526](https://github.com/shchilkin/PopChoice/issues/526).
 - `P1 Postgres exporter reports database down`
   - Owner: Database operator.
   - Trigger: `pg_up` stays below 1 for 5 minutes.
@@ -186,3 +195,20 @@ This first alert set avoids:
 
 Tighten thresholds only after observing a few weeks of real traffic and
 maintenance patterns.
+
+## Deploy-Aware Alerting Follow-Ups
+
+Production redeploys can intentionally restart web and worker containers. Until
+the deploy pipeline creates short maintenance silences, a metrics scrape target
+alert during a normal redeploy should be investigated in context with Coolify
+deployment status, public `/api/health`, and `/api/build`.
+
+Track the next alerting pass in:
+
+- [#525](https://github.com/shchilkin/PopChoice/issues/525): improve Telegram
+  alert message formatting.
+- [#526](https://github.com/shchilkin/PopChoice/issues/526): reclassify
+  deploy-sensitive metrics target alerts so they do not page like confirmed
+  user-facing outages.
+- [#527](https://github.com/shchilkin/PopChoice/issues/527): add
+  deployment-aware silences and post-deploy verification.

--- a/docs/OBSERVABILITY-METRICS.md
+++ b/docs/OBSERVABILITY-METRICS.md
@@ -170,6 +170,13 @@ by severity and include owner/action annotations:
 - P3: monitoring scrape target failures and elevated recommendation failure
   ratio.
 
+The current app target alert is intentionally conservative, but first
+production examples show it can be noisy during normal Coolify redeploys. Track
+message formatting in [#525](https://github.com/shchilkin/PopChoice/issues/525),
+severity tuning in [#526](https://github.com/shchilkin/PopChoice/issues/526),
+and deploy-aware silences in
+[#527](https://github.com/shchilkin/PopChoice/issues/527).
+
 See [Observability Alerts](/docs/OBSERVABILITY-ALERTS) for thresholds, retention,
 and backup expectations. See
 [Observability Runbooks](/docs/OBSERVABILITY-RUNBOOKS) for incident response.

--- a/docs/OBSERVABILITY-RUNBOOKS.md
+++ b/docs/OBSERVABILITY-RUNBOOKS.md
@@ -38,6 +38,9 @@ Symptoms:
 - Grafana alert: `P1 App metrics target down`.
 - `/api/health` fails or times out.
 - Coolify shows the web container unhealthy or restarting.
+- During a redeploy, the metrics target can be down briefly while the public app
+  is still recovering. Confirm public health before treating the scrape alert as
+  a user-facing outage.
 
 Immediate checks:
 
@@ -57,6 +60,11 @@ Actions:
 4. Check DB and Redis health because `/api/health` depends on both.
 5. If the latest deploy caused the outage, roll back to the last known good
    image tag.
+
+Follow-up alerting work is tracked in
+[#526](https://github.com/shchilkin/PopChoice/issues/526) and
+[#527](https://github.com/shchilkin/PopChoice/issues/527) so normal redeploy
+churn can be separated from confirmed outages.
 
 Recovery check:
 

--- a/docs/ROADMAP-ARCHITECTURE.md
+++ b/docs/ROADMAP-ARCHITECTURE.md
@@ -161,6 +161,9 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 - [x] Add OpenTelemetry traces with Tempo in [#500](https://github.com/shchilkin/PopChoice/issues/500) once the low-noise uptime/logs/metrics foundation exists. See [Observability Traces](/docs/OBSERVABILITY-TRACES).
 - [x] Add alert routing, retention, backups, and incident runbooks in [#503](https://github.com/shchilkin/PopChoice/issues/503) so the monitoring stack stays useful and recoverable. See [Observability Alerts](/docs/OBSERVABILITY-ALERTS) and [Observability Runbooks](/docs/OBSERVABILITY-RUNBOOKS).
 - [ ] Deploy the self-hosted observability stack to production in [#508](https://github.com/shchilkin/PopChoice/issues/508), including Coolify wiring, secrets, access control, alert contact points, backup coverage, and post-deploy verification.
+- [ ] Improve Telegram alert readability in [#525](https://github.com/shchilkin/PopChoice/issues/525) so mobile notifications show concise firing/resolved state, service, instance, severity, runbook, and silence links instead of raw Grafana expression payloads.
+- [ ] Tune deploy-sensitive metrics target alerts in [#526](https://github.com/shchilkin/PopChoice/issues/526) so scrape visibility gaps during ordinary redeploys are not treated like confirmed user-facing P1 outages.
+- [ ] Add deployment-aware alert silences and post-deploy verification in [#527](https://github.com/shchilkin/PopChoice/issues/527) so normal Coolify redeploys do not create avoidable alert noise while failed or unrecovered deploys still notify clearly.
 - Enable Coolify notifications for failed deploys, failed backups, server disk/resource warnings, and unhealthy or restarting containers where supported.
 - Add external uptime monitoring for `https://pop-choice.shchilkin.dev/api/health`, then consider a deeper synthetic recommendation smoke check.
 - Add application error tracking for frontend, API routes, and workers so browser errors, API exceptions, and background job failures are visible outside Coolify logs.
@@ -281,9 +284,12 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 9. [x] Expand available-movies search in [#473](https://github.com/shchilkin/PopChoice/issues/473) across title, actor/director, and genre metadata populated by #472.
 10. [x] Move TMDB discovery/backfill/metadata refresh into shared rate-limited BullMQ catalog workers in [#492](https://github.com/shchilkin/PopChoice/issues/492) before increasing catalog expansion volume.
 11. [ ] Plan and split the [#493](https://github.com/shchilkin/PopChoice/issues/493) backoffice/catalog-health epic, including shared login protection for it and `apps/bull-board`.
-12. [ ] Clarify production migration/versioning expectations in [#494](https://github.com/shchilkin/PopChoice/issues/494) for schema changes, rollbacks, and preview volume recreation.
+12. [x] Clarify production migration/versioning expectations in [#494](https://github.com/shchilkin/PopChoice/issues/494) for schema changes, rollbacks, and preview volume recreation.
 13. [x] Complete the first self-hosted observability track in [#498](https://github.com/shchilkin/PopChoice/issues/498) with uptime, logs, metrics, traces, alerts, retention, backups, and runbooks.
 14. [ ] Deploy the self-hosted observability stack to production in [#508](https://github.com/shchilkin/PopChoice/issues/508) and verify metrics, logs, traces, alerts, access control, and backups on the VPS.
+15. [ ] Improve Grafana Telegram alert formatting in [#525](https://github.com/shchilkin/PopChoice/issues/525) after the first production alert examples.
+16. [ ] Reclassify deploy-sensitive app metrics target alerts in [#526](https://github.com/shchilkin/PopChoice/issues/526) so P1 remains reserved for user-facing or core dependency outages.
+17. [ ] Plan deploy-aware alert silences and post-deploy verification in [#527](https://github.com/shchilkin/PopChoice/issues/527).
 
 ## Working Checklist
 


### PR DESCRIPTION
## Summary
- add focused roadmap issues for Telegram alert formatting, deploy-sensitive alert severity, and deploy-aware silences/post-deploy checks
- document the current Coolify redeploy alerting caveat in operational docs
- mark the production migration/versioning roadmap item as completed now that #494 is closed

## Issues
- Tracks #525
- Tracks #526
- Tracks #527

## Verification
- git diff --check -- docs
- npm run type-check:docs
- NEXT_TELEMETRY_DISABLED=1 npm run build:docs
- pre-push checks: lint, server tests, production app build