### PR TITLE
Deploy docs as a prebuilt service

### DIFF
--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -30,6 +30,8 @@ jobs:
             dockerfile: apps/web/workers.Dockerfile
           - name: bull-board
             dockerfile: apps/web/bull-board.Dockerfile
+          - name: docs
+            dockerfile: apps/docs/Dockerfile
           - name: db-migrate
             dockerfile: services/db-migrate/Dockerfile
           - name: movie-seed

--- a/apps/docs/Dockerfile
+++ b/apps/docs/Dockerfile
@@ -1,0 +1,78 @@
+# syntax=docker/dockerfile:1.7
+# Build context: repo root
+# docker build -f apps/docs/Dockerfile .
+
+FROM node:24-slim AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+COPY apps/docs/package.json ./apps/docs/
+COPY apps/web/package.json ./apps/web/
+COPY packages/shared/package.json ./packages/shared/
+COPY services/db-migrate/package.json ./services/db-migrate/
+COPY services/movie-backfill/package.json ./services/movie-backfill/
+COPY services/movie-discovery/package.json ./services/movie-discovery/
+COPY services/movie-seed/package.json ./services/movie-seed/
+RUN --mount=type=cache,target=/root/.npm,sharing=locked npm ci --no-audit --fund=false
+
+COPY apps/docs/next.config.mjs ./apps/docs/
+COPY apps/docs/postcss.config.mjs ./apps/docs/
+COPY apps/docs/source.config.ts ./apps/docs/
+COPY apps/docs/tsconfig.json ./apps/docs/
+COPY apps/docs/src ./apps/docs/src
+COPY docs ./docs
+RUN NEXT_TELEMETRY_DISABLED=1 npm run build --workspace=apps/docs
+
+FROM node:24-slim
+
+WORKDIR /app
+
+ARG APP_COMMIT_SHA
+ARG APP_GIT_BRANCH
+ARG APP_PR_NUMBER
+ARG APP_IMAGE_REPOSITORY
+ARG APP_IMAGE_TAG
+ARG APP_IMAGE_DIGEST
+ARG SOURCE_COMMIT
+ARG SOURCE_BRANCH
+ARG COOLIFY_BRANCH
+ARG COOLIFY_RESOURCE_UUID
+ARG GITHUB_SHA
+ARG VERCEL_GIT_COMMIT_SHA
+ARG VERCEL_GIT_COMMIT_REF
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV BUILD_APP_COMMIT_SHA=$APP_COMMIT_SHA
+ENV BUILD_APP_GIT_BRANCH=$APP_GIT_BRANCH
+ENV BUILD_APP_PR_NUMBER=$APP_PR_NUMBER
+ENV BUILD_APP_IMAGE_REPOSITORY=$APP_IMAGE_REPOSITORY
+ENV BUILD_APP_IMAGE_TAG=$APP_IMAGE_TAG
+ENV BUILD_APP_IMAGE_DIGEST=$APP_IMAGE_DIGEST
+ENV BUILD_SOURCE_COMMIT=$SOURCE_COMMIT
+ENV BUILD_SOURCE_BRANCH=$SOURCE_BRANCH
+ENV BUILD_COOLIFY_BRANCH=$COOLIFY_BRANCH
+ENV BUILD_COOLIFY_RESOURCE_UUID=$COOLIFY_RESOURCE_UUID
+ENV BUILD_GITHUB_SHA=$GITHUB_SHA
+ENV BUILD_VERCEL_GIT_COMMIT_SHA=$VERCEL_GIT_COMMIT_SHA
+ENV BUILD_VERCEL_GIT_COMMIT_REF=$VERCEL_GIT_COMMIT_REF
+
+COPY package.json package-lock.json ./
+COPY apps/docs/package.json ./apps/docs/
+COPY apps/web/package.json ./apps/web/
+COPY packages/shared/package.json ./packages/shared/
+COPY services/db-migrate/package.json ./services/db-migrate/
+COPY services/movie-backfill/package.json ./services/movie-backfill/
+COPY services/movie-discovery/package.json ./services/movie-discovery/
+COPY services/movie-seed/package.json ./services/movie-seed/
+RUN --mount=type=cache,target=/root/.npm,sharing=locked npm ci --omit=dev --no-audit --fund=false
+
+COPY --from=builder /app/apps/docs/.next ./apps/docs/.next
+COPY --from=builder /app/apps/docs/.source ./apps/docs/.source
+COPY apps/docs/next.config.mjs ./apps/docs/
+COPY apps/docs/source.config.ts ./apps/docs/
+COPY docs ./docs
+
+EXPOSE 3000
+CMD ["npm", "run", "start", "--workspace=apps/docs", "--", "--hostname", "0.0.0.0", "--port", "3000"]

--- a/coolify.compose.yml
+++ b/coolify.compose.yml
@@ -160,6 +160,40 @@ services:
       retries: 5
       start_period: 30s
 
+  docs:
+    image: ${APP_IMAGE_PREFIX:-ghcr.io/shchilkin/popchoice}/docs:${IMAGE_TAG:-development}
+    pull_policy: always
+    restart: unless-stopped
+    command:
+      [
+        'npm',
+        'run',
+        'start',
+        '--workspace=apps/docs',
+        '--',
+        '--hostname',
+        '0.0.0.0',
+        '--port',
+        '3000',
+      ]
+    environment:
+      NODE_ENV: production
+      NEXT_TELEMETRY_DISABLED: '1'
+      PORT: 3000
+      HOSTNAME: 0.0.0.0
+    expose:
+      - '3000'
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'node -e "fetch(''http://127.0.0.1:3000/docs'').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"',
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+
   movie-seed:
     profiles: ['tools']
     image: ${APP_IMAGE_PREFIX:-ghcr.io/shchilkin/popchoice}/movie-seed:${IMAGE_TAG:-development}

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -104,6 +104,7 @@ The `dependency-review` job uses `actions/dependency-review-action` to block any
 - `ghcr.io/<owner>/<repo>/web`
 - `ghcr.io/<owner>/<repo>/workers`
 - `ghcr.io/<owner>/<repo>/bull-board`
+- `ghcr.io/<owner>/<repo>/docs`
 - `ghcr.io/<owner>/<repo>/db-migrate`
 - `ghcr.io/<owner>/<repo>/movie-seed`
 - `ghcr.io/<owner>/<repo>/movie-discovery`
@@ -139,8 +140,8 @@ For simple continuous deployment, keep `IMAGE_TAG=development` in Coolify and
 let the optional deploy webhook run after the image matrix succeeds. For a
 stricter promotion flow, set `IMAGE_TAG=sha-<12-char-github-sha>` and redeploy
 that exact release bundle. Every PopChoice service must use the same
-`IMAGE_TAG`; mixing `web`, `workers`, `bull-board`, and service images from
-different commits is not a supported deployment shape.
+`IMAGE_TAG`; mixing `web`, `workers`, `bull-board`, `docs`, and service images
+from different commits is not a supported deployment shape.
 
 Set the repository secrets `COOLIFY_DEPLOY_WEBHOOK` and `COOLIFY_TOKEN` to
 enable redeploys after pushes to `development`. `COOLIFY_TOKEN` must be a

--- a/docs/COOLIFY.md
+++ b/docs/COOLIFY.md
@@ -235,6 +235,8 @@ to `db` and `redis`.
 Run this checklist after production deploys and after any infrastructure change:
 
 - `https://your-domain.example` loads with a trusted certificate.
+- `https://docs.your-domain.example/docs` loads the documentation site if the
+  `docs` service is enabled.
 - `https://your-domain.example/api/health` returns `200`.
 - `https://your-domain.example/api/build` shows the expected beta version and
   commit hash.
@@ -327,6 +329,25 @@ auditability at the cost of one manual promotion step.
 Do not point Coolify at source builds for production while also using GHCR
 images. Choose one deployment source of truth; the recommended production path
 is GHCR images plus this compose file.
+
+### Documentation service
+
+The `docs` service deploys the Fumadocs site from the same GHCR image bundle as
+the application runtime:
+
+```ini
+APP_IMAGE_PREFIX=ghcr.io/<owner>/<repo>
+IMAGE_TAG=development
+```
+
+Point a separate public domain, such as `docs.your-domain.example`, at the
+`docs` service in Coolify. The service listens on port `3000` and redirects `/`
+to `/docs`. It does not need application secrets, Postgres, Redis, OpenAI, or
+TMDB credentials.
+
+Keep the docs service on the same `IMAGE_TAG` as the app services. This makes
+the deployed documentation describe the same commit as the running app and keeps
+rollback behavior predictable.
 
 ## Pull request previews
 


### PR DESCRIPTION
## Summary
- add a production Docker image for the Fumadocs app
- publish a docs image from the container image matrix
- add a docs service to the Coolify compose stack, modeled after the other prebuilt services
- document the docs service deployment path and post-deploy smoke check

## Verification
- docker build -f apps/docs/Dockerfile -t popchoice-docs:test .
- docker run smoke: /docs, /docs/API-REFERENCE, and /api/search returned 200
- POSTGRES_PASSWORD=test OPENAI_API_KEY=test NEXT_PUBLIC_BASE_URL=https://example.com AUTH_SESSION_SECRET=test docker compose -f coolify.compose.yml config --quiet
- git diff --check
- NEXT_TELEMETRY_DISABLED=1 npm run build:docs
- npm run type-check:docs
- pre-push checks: lint, server tests, production app build