### PR TITLE
Add plain Zod runtime config

### DIFF
--- a/apps/backoffice/src/catalogMaintenanceQueue.ts
+++ b/apps/backoffice/src/catalogMaintenanceQueue.ts
@@ -43,10 +43,11 @@ function normalizeLanguage(language?: string): string {
   return (language ?? DEFAULT_TMDB_LANGUAGE).trim() || DEFAULT_TMDB_LANGUAGE;
 }
 
-function getCatalogMaintenanceQueue(): Queue<CatalogBackfillMovieJobData> | null {
+function getCatalogMaintenanceQueue(
+  redisUrl: string | undefined,
+): Queue<CatalogBackfillMovieJobData> | null {
   if (catalogMaintenanceQueue) return catalogMaintenanceQueue;
 
-  const redisUrl = process.env.REDIS_URL;
   if (!redisUrl) return null;
 
   redisConnection = new Redis(redisUrl, { maxRetriesPerRequest: null });
@@ -66,8 +67,9 @@ export function getCatalogBackfillMovieJobId(movieId: string | number): string {
 
 export async function enqueueCatalogBackfillMovieFromBackoffice(
   input: EnqueueCatalogBackfillMovieInput,
+  redisUrl = process.env.REDIS_URL,
 ): Promise<EnqueueCatalogBackfillMovieResult | null> {
-  const queue = getCatalogMaintenanceQueue();
+  const queue = getCatalogMaintenanceQueue(redisUrl);
   if (!queue) return null;
 
   const language = normalizeLanguage(input.language);

--- a/apps/backoffice/src/index.ts
+++ b/apps/backoffice/src/index.ts
@@ -17,7 +17,7 @@ import {
   listTMDBMatchReviews,
   operatorAuthChallenge,
   recordCatalogRepairAction,
-  readOperatorAuthConfig,
+  readBackofficeRuntimeConfig,
   verifyOperatorBasicAuthHeader,
 } from '@pop-choice/shared';
 import type {
@@ -41,11 +41,6 @@ import {
   type CatalogBackfillReason,
 } from './catalogMaintenanceQueue.js';
 
-const DEFAULT_PORT = 3000;
-const DEFAULT_SAMPLE_LIMIT = 5;
-const DEFAULT_STALE_AFTER_DAYS = 180;
-const DEFAULT_OPERATOR_AUTH_RATE_LIMIT_WINDOW_SECONDS = 15 * 60;
-const DEFAULT_OPERATOR_AUTH_RATE_LIMIT_MAX = 30;
 const DEFAULT_REPAIR_AUDIT_LIMIT = 25;
 
 const REPAIRABLE_CATALOG_ISSUE_KEYS = new Set([
@@ -61,17 +56,6 @@ const REPAIRABLE_CATALOG_ISSUE_KEYS = new Set([
   'missing_genre_metadata',
   'missing_keyword_metadata',
 ]);
-
-function parsePositiveInteger(value: string | undefined, fallback: number): number {
-  if (!value || value.trim() === '') return fallback;
-
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    throw new Error(`Expected a positive integer, received "${value}".`);
-  }
-
-  return parsed;
-}
 
 function escapeHtml(value: string | number | null | undefined): string {
   if (value === null || value === undefined) return '-';
@@ -951,31 +935,9 @@ function renderErrorPage(error: unknown): string {
     </html>`;
 }
 
-const port = parsePositiveInteger(process.env.PORT, DEFAULT_PORT);
-const sampleLimit = parsePositiveInteger(
-  process.env.CATALOG_HEALTH_SAMPLE_LIMIT,
-  DEFAULT_SAMPLE_LIMIT,
-);
-const staleAfterDays = parsePositiveInteger(
-  process.env.CATALOG_HEALTH_STALE_DAYS,
-  DEFAULT_STALE_AFTER_DAYS,
-);
-const operatorAuthRateLimitWindowSeconds = parsePositiveInteger(
-  process.env.OPERATOR_AUTH_RATE_LIMIT_WINDOW_SECONDS,
-  DEFAULT_OPERATOR_AUTH_RATE_LIMIT_WINDOW_SECONDS,
-);
-const operatorAuthRateLimitMax = parsePositiveInteger(
-  process.env.OPERATOR_AUTH_RATE_LIMIT_MAX,
-  DEFAULT_OPERATOR_AUTH_RATE_LIMIT_MAX,
-);
-const operatorAuthConfig = readOperatorAuthConfig();
-const databaseUrl = process.env.DATABASE_URL;
+const config = readBackofficeRuntimeConfig();
 
-if (!databaseUrl) {
-  throw new Error('DATABASE_URL is required for the backoffice catalog-health report.');
-}
-
-initDatabase(databaseUrl);
+initDatabase(config.databaseUrl);
 await ensureCatalogRepairActionSchema();
 await ensureTMDBMatchReviewActionSchema();
 
@@ -986,20 +948,23 @@ app.get('/healthz', (_request, response) => response.status(200).send('ok'));
 app.use(express.urlencoded({ extended: false }));
 app.use(
   rateLimit({
-    windowMs: operatorAuthRateLimitWindowSeconds * 1000,
-    limit: operatorAuthRateLimitMax,
+    windowMs: config.operatorAuthRateLimitWindowSeconds * 1000,
+    limit: config.operatorAuthRateLimitMax,
     standardHeaders: 'draft-8',
     legacyHeaders: false,
     skipSuccessfulRequests: true,
     message: 'Too many backoffice requests, please try again later.',
   }),
 );
-app.use(createOperatorAuthMiddleware(operatorAuthConfig));
+app.use(createOperatorAuthMiddleware(config.operatorAuth));
 
 app.get('/', async (request, response) => {
   try {
     const [report, audit] = await Promise.all([
-      getCatalogHealthReport({ sampleLimit, staleAfterDays }),
+      getCatalogHealthReport({
+        sampleLimit: config.catalogHealthSampleLimit,
+        staleAfterDays: config.catalogHealthStaleDays,
+      }),
       listCatalogRepairAudit(DEFAULT_REPAIR_AUDIT_LIMIT),
     ]);
     const repairStatus =
@@ -1026,11 +991,14 @@ app.post('/catalog-health/actions', async (request, response) => {
       return;
     }
 
-    const job = await enqueueCatalogBackfillMovieFromBackoffice({
-      movieId,
-      reason: getBackfillReasonForIssue(issueKey),
-      language: process.env.TMDB_LANGUAGE,
-    });
+    const job = await enqueueCatalogBackfillMovieFromBackoffice(
+      {
+        movieId,
+        reason: getBackfillReasonForIssue(issueKey),
+        language: config.tmdbLanguage,
+      },
+      config.redisUrl,
+    );
 
     await recordCatalogRepairAction({
       action: 'enqueue_backfill',
@@ -1115,6 +1083,10 @@ app.post('/tmdb-reviews/:id/actions', async (request, response) => {
   }
 });
 
-app.listen(port, '0.0.0.0', () => {
-  logger.info('Backoffice listening', { port, sampleLimit, staleAfterDays });
+app.listen(config.port, '0.0.0.0', () => {
+  logger.info('Backoffice listening', {
+    catalogHealthSampleLimit: config.catalogHealthSampleLimit,
+    catalogHealthStaleDays: config.catalogHealthStaleDays,
+    port: config.port,
+  });
 });

--- a/apps/bull-board/src/index.ts
+++ b/apps/bull-board/src/index.ts
@@ -3,9 +3,10 @@ import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
 import { ExpressAdapter } from '@bull-board/express';
 import {
   operatorAuthChallenge,
-  readOperatorAuthConfig,
+  readBullBoardRuntimeConfig,
   verifyOperatorBasicAuthHeader,
 } from '@pop-choice/shared';
+import type { OperatorAuthConfig } from '@pop-choice/shared';
 import { Queue } from 'bullmq';
 import express from 'express';
 import rateLimit from 'express-rate-limit';
@@ -13,30 +14,9 @@ import { Redis } from 'ioredis';
 
 import type { RequestHandler } from 'express';
 
-const PORT = Number(process.env.PORT ?? process.env.BULL_BOARD_PORT ?? 4000);
-const REDIS_URL = process.env.REDIS_URL;
-const DEFAULT_OPERATOR_AUTH_RATE_LIMIT_WINDOW_SECONDS = 15 * 60;
-const DEFAULT_OPERATOR_AUTH_RATE_LIMIT_MAX = 30;
+const config = readBullBoardRuntimeConfig();
 
-if (!REDIS_URL) {
-  console.error('Error: REDIS_URL is not set. Add it to your .env file.');
-  process.exit(1);
-}
-
-function parsePositiveInteger(value: string | undefined, fallback: number): number {
-  if (!value || value.trim() === '') return fallback;
-
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
-    throw new Error(`Expected a positive integer, received "${value}".`);
-  }
-
-  return parsed;
-}
-
-function createOperatorAuthMiddleware(): RequestHandler {
-  const authConfig = readOperatorAuthConfig();
-
+function createOperatorAuthMiddleware(authConfig: OperatorAuthConfig | null): RequestHandler {
   if (!authConfig) {
     console.warn(
       'Warning: operator auth is disabled. Set OPERATOR_AUTH_USERNAME and OPERATOR_AUTH_PASSWORD before exposing Bull Board.',
@@ -56,7 +36,7 @@ function createOperatorAuthMiddleware(): RequestHandler {
   };
 }
 
-const connection = new Redis(REDIS_URL, { maxRetriesPerRequest: null });
+const connection = new Redis(config.redisUrl, { maxRetriesPerRequest: null });
 
 const seedQueue = new Queue('movie-seed', { connection });
 const catalogMaintenanceQueue = new Queue('catalog-maintenance', { connection });
@@ -65,15 +45,6 @@ const morePicksQueue = new Queue('more-picks', { connection });
 
 const serverAdapter = new ExpressAdapter();
 serverAdapter.setBasePath('/');
-
-const operatorAuthRateLimitWindowSeconds = parsePositiveInteger(
-  process.env.OPERATOR_AUTH_RATE_LIMIT_WINDOW_SECONDS,
-  DEFAULT_OPERATOR_AUTH_RATE_LIMIT_WINDOW_SECONDS,
-);
-const operatorAuthRateLimitMax = parsePositiveInteger(
-  process.env.OPERATOR_AUTH_RATE_LIMIT_MAX,
-  DEFAULT_OPERATOR_AUTH_RATE_LIMIT_MAX,
-);
 
 createBullBoard({
   queues: [
@@ -90,17 +61,17 @@ app.set('trust proxy', 1);
 app.get('/healthz', (_request, response) => response.status(200).send('ok'));
 app.use(
   rateLimit({
-    windowMs: operatorAuthRateLimitWindowSeconds * 1000,
-    limit: operatorAuthRateLimitMax,
+    windowMs: config.operatorAuthRateLimitWindowSeconds * 1000,
+    limit: config.operatorAuthRateLimitMax,
     standardHeaders: 'draft-8',
     legacyHeaders: false,
     skipSuccessfulRequests: true,
     message: 'Too many operator requests, please try again later.',
   }),
 );
-app.use(createOperatorAuthMiddleware());
+app.use(createOperatorAuthMiddleware(config.operatorAuth));
 app.use('/', serverAdapter.getRouter());
 
-app.listen(PORT, () => {
-  console.log(`Bull Board running at http://localhost:${PORT}`);
+app.listen(config.port, () => {
+  console.log(`Bull Board running at http://localhost:${config.port}`);
 });

--- a/apps/bull-board/src/types/redis-info.d.ts
+++ b/apps/bull-board/src/types/redis-info.d.ts
@@ -1,0 +1,5 @@
+declare module 'redis-info' {
+  export interface RedisInfo {
+    [section: string]: unknown;
+  }
+}

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -22,6 +22,13 @@ Redis credentials, session secrets, HMAC secrets, Resend tokens, Telegram bot
 tokens, and Grafana passwords in a local secret store or deployment secret
 manager. `NEXT_PUBLIC_*` values and build metadata are public by design.
 
+Runtime entrypoints should validate environment variables with process-specific
+plain Zod schemas in `packages/shared/src/runtimeConfig.ts`. This avoids a
+single global config object while still making misconfigured operator services
+fail early with actionable startup errors. The first rollout covers
+`apps/backoffice` and `apps/bull-board`; new services should add their own
+reader instead of parsing `process.env` inline.
+
 ## Runtime App
 
 These variables are used by `apps/web`, workers, Bull Board, and shared runtime
@@ -31,7 +38,7 @@ helpers.
 | ----------------------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
 | `OPENAI_API_KEY`                          | Web, workers, seed/discovery/backfill           | Required for realistic local/prod recommendations and embeddings; not required for deterministic CI evals/e2e          | None                                                                | Secret. Used for embeddings and recommendation text generation.                                             |
 | `DATABASE_URL`                            | Web, workers, services, migrations, backoffice  | Required for app DB behavior; CI/e2e may use `E2E_DATABASE_URL` instead                                                | Local setup generates it                                            | Secret if it contains credentials. PostgreSQL must support pgvector.                                        |
-| `REDIS_URL`                               | Web, workers, BullMQ, Bull Board, rate limiting | Optional local; required for queued recommendation flow in prod; e2e maps from `E2E_REDIS_URL`                         | Queue features disable or use limited inline fallback when missing  | Secret if it contains credentials. Backoffice only needs it for future queue state screens.                 |
+| `REDIS_URL`                               | Web, workers, BullMQ, Bull Board, rate limiting | Optional local; required for queued recommendation flow in prod; e2e maps from `E2E_REDIS_URL`                         | Queue features disable or use limited inline fallback when missing  | Secret if it contains credentials. Backoffice needs it for queued catalog repair actions.                   |
 | `TMDB_API_KEY`                            | Web, workers, services                          | Optional for local UI; required for TMDB enrichment, discovery, backfill, more picks, and production catalog freshness | None                                                                | Secret. Must be a TMDB v4 read access token for service/backfill flows.                                     |
 | `NEXT_PUBLIC_TMDB_API_KEY`                | Browser                                         | Optional                                                                                                               | None                                                                | Public. Enables client-side poster enrichment only; do not put privileged secrets here.                     |
 | `NEXT_PUBLIC_BASE_URL`                    | Web, auth, password reset, build info           | Optional local; required behind reverse proxy/prod                                                                     | Falls back to request origin or platform domain where supported     | Public. Use the browser-facing origin without a trailing slash.                                             |

--- a/docs/ROADMAP-ARCHITECTURE.md
+++ b/docs/ROADMAP-ARCHITECTURE.md
@@ -179,7 +179,7 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 - [x] Add request body size limits for externally facing routes before expensive parsing, moderation, embedding, or recommendation work begins.
 - Add retry/backoff and circuit-breaker behavior for expensive external dependencies where retrying is safe.
 - Sanitize client-facing error responses so internal exception details, upstream payloads, and infrastructure hints stay out of API responses.
-- Validate required environment variables on application startup for web, workers, and root services so misconfigured deployments fail early.
+- Validate required environment variables on application startup for web, workers, and root services so misconfigured deployments fail early. First slice: `apps/backoffice` and `apps/bull-board` now use process-specific plain Zod runtime configs from `@pop-choice/shared`; continue the same pattern for web, workers, and standalone catalog services.
 - Clarify idempotency and retry behavior for recommendation creation, worker retries, more-picks jobs, and failed queue recovery.
 - [x] Add a shared operator login model for operational apps in
       [#548](https://github.com/shchilkin/PopChoice/issues/548). `apps/bull-board`

--- a/docs/SERVICES.md
+++ b/docs/SERVICES.md
@@ -132,6 +132,11 @@ all Bull Board UI routes are behind the operator login when credentials are set.
 Operator routes are also rate-limited in-process to slow down repeated Basic
 Auth attempts.
 
+The dedicated `apps/bull-board` entrypoint reads a plain Zod runtime config from
+`@pop-choice/shared`. `REDIS_URL` must be present and use `redis://` or
+`rediss://`; `PORT`, `BULL_BOARD_PORT`, and operator-auth rate-limit values are
+validated as positive integers before the server starts.
+
 ### Backoffice
 
 Backoffice/catalog-health UI lives in the dedicated `apps/backoffice/` workspace
@@ -139,6 +144,10 @@ app and deploys as a separate Coolify service like `apps/bull-board`. The first
 screen is a protected catalog-health overview. It now also exposes narrow
 operator actions for TMDB review decisions and per-movie catalog-health repair
 jobs without putting admin UI inside `apps/web`.
+
+Backoffice also uses the shared plain Zod runtime config. It validates
+`DATABASE_URL`, optional `REDIS_URL`, catalog-health tuning values, TMDB
+language, and the shared operator-auth settings before opening the HTTP port.
 
 See [Backoffice Plan](/docs/BACKOFFICE) and
 [#493](https://github.com/shchilkin/PopChoice/issues/493).

--- a/package-lock.json
+++ b/package-lock.json
@@ -19865,7 +19865,8 @@
       "dependencies": {
         "openai": "^6.39.0",
         "pg": "^8.21.0",
-        "pino": "^10.3.1"
+        "pino": "^10.3.1",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@types/pg": "^8.20.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -16,7 +16,8 @@
   "dependencies": {
     "openai": "^6.39.0",
     "pg": "^8.21.0",
-    "pino": "^10.3.1"
+    "pino": "^10.3.1",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/pg": "^8.20.0",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -39,6 +39,8 @@ export {
   verifyOperatorBasicAuthHeader,
 } from './operatorAuth.js';
 export type { OperatorAuthConfig } from './operatorAuth.js';
+export { readBackofficeRuntimeConfig, readBullBoardRuntimeConfig } from './runtimeConfig.js';
+export type { BackofficeRuntimeConfig, BullBoardRuntimeConfig } from './runtimeConfig.js';
 export { formatCatalogHealthReport, getCatalogHealthReport } from './catalogHealth.js';
 export type {
   CatalogHealthIssue,

--- a/packages/shared/src/runtimeConfig.ts
+++ b/packages/shared/src/runtimeConfig.ts
@@ -1,0 +1,210 @@
+import { z, type ZodIssue } from 'zod';
+
+import type { OperatorAuthConfig } from './operatorAuth.js';
+
+type RuntimeEnv = Record<string, string | undefined>;
+
+const DEFAULT_OPERATOR_AUTH_REALM = 'PopChoice Operators';
+const DEFAULT_OPERATOR_AUTH_RATE_LIMIT_WINDOW_SECONDS = 15 * 60;
+const DEFAULT_OPERATOR_AUTH_RATE_LIMIT_MAX = 30;
+const DEFAULT_BACKOFFICE_PORT = 3000;
+const DEFAULT_BULL_BOARD_PORT = 4000;
+const DEFAULT_CATALOG_HEALTH_SAMPLE_LIMIT = 5;
+const DEFAULT_CATALOG_HEALTH_STALE_DAYS = 180;
+const DEFAULT_TMDB_LANGUAGE = 'en-US';
+
+function emptyStringToUndefined(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  const trimmed = value.trim();
+  return trimmed === '' ? undefined : trimmed;
+}
+
+function optionalNonEmptyString() {
+  return z.preprocess(emptyStringToUndefined, z.string().min(1).optional());
+}
+
+function booleanEnv(defaultValue: boolean) {
+  return z.preprocess((value) => {
+    const normalized = emptyStringToUndefined(value);
+    if (normalized === undefined) return defaultValue;
+    if (typeof normalized === 'boolean') return normalized;
+
+    if (typeof normalized === 'string') {
+      const lower = normalized.toLowerCase();
+      if (['1', 'true', 'yes', 'on'].includes(lower)) return true;
+      if (['0', 'false', 'no', 'off'].includes(lower)) return false;
+    }
+
+    return normalized;
+  }, z.boolean());
+}
+
+function positiveIntegerEnv(defaultValue: number) {
+  return z.preprocess((value) => {
+    const normalized = emptyStringToUndefined(value);
+    return normalized === undefined ? defaultValue : normalized;
+  }, z.coerce.number().int().positive());
+}
+
+function optionalPositiveIntegerEnv() {
+  return z.preprocess(emptyStringToUndefined, z.coerce.number().int().positive().optional());
+}
+
+function requiredUrlEnv(name: string, protocols: string[]) {
+  const schema = z
+    .string({ error: `${name} is required.` })
+    .min(1, `${name} is required.`)
+    .refine(
+      (value) => {
+        try {
+          const url = new URL(value);
+          return protocols.includes(url.protocol);
+        } catch {
+          return false;
+        }
+      },
+      { message: `${name} must use one of: ${protocols.join(', ')}` },
+    );
+
+  return z.preprocess(emptyStringToUndefined, schema);
+}
+
+function optionalUrlEnv(name: string, protocols: string[]) {
+  return z.preprocess(emptyStringToUndefined, requiredUrlEnv(name, protocols).optional());
+}
+
+const OperatorAuthRuntimeEnvSchema = z
+  .object({
+    OPERATOR_AUTH_PASSWORD: optionalNonEmptyString(),
+    OPERATOR_AUTH_REALM: z.preprocess(
+      emptyStringToUndefined,
+      z.string().min(1).default(DEFAULT_OPERATOR_AUTH_REALM),
+    ),
+    OPERATOR_AUTH_REQUIRED: booleanEnv(false),
+    OPERATOR_AUTH_USERNAME: optionalNonEmptyString(),
+  })
+  .superRefine((env, context) => {
+    const hasUsername = Boolean(env.OPERATOR_AUTH_USERNAME);
+    const hasPassword = Boolean(env.OPERATOR_AUTH_PASSWORD);
+
+    if (env.OPERATOR_AUTH_REQUIRED && !hasUsername && !hasPassword) {
+      context.addIssue({
+        code: 'custom',
+        message:
+          'OPERATOR_AUTH_USERNAME and OPERATOR_AUTH_PASSWORD must be set when operator auth is required.',
+        path: ['OPERATOR_AUTH_USERNAME'],
+      });
+      return;
+    }
+
+    if (hasUsername !== hasPassword) {
+      context.addIssue({
+        code: 'custom',
+        message:
+          'Set both OPERATOR_AUTH_USERNAME and OPERATOR_AUTH_PASSWORD, or set neither locally.',
+        path: ['OPERATOR_AUTH_USERNAME'],
+      });
+    }
+  });
+
+type OperatorAuthRuntimeEnv = z.infer<typeof OperatorAuthRuntimeEnvSchema>;
+
+export interface BackofficeRuntimeConfig {
+  catalogHealthSampleLimit: number;
+  catalogHealthStaleDays: number;
+  databaseUrl: string;
+  operatorAuth: OperatorAuthConfig | null;
+  operatorAuthRateLimitMax: number;
+  operatorAuthRateLimitWindowSeconds: number;
+  port: number;
+  redisUrl?: string;
+  tmdbLanguage: string;
+}
+
+export interface BullBoardRuntimeConfig {
+  operatorAuth: OperatorAuthConfig | null;
+  operatorAuthRateLimitMax: number;
+  operatorAuthRateLimitWindowSeconds: number;
+  port: number;
+  redisUrl: string;
+}
+
+const BackofficeRuntimeEnvSchema = OperatorAuthRuntimeEnvSchema.extend({
+  CATALOG_HEALTH_SAMPLE_LIMIT: positiveIntegerEnv(DEFAULT_CATALOG_HEALTH_SAMPLE_LIMIT),
+  CATALOG_HEALTH_STALE_DAYS: positiveIntegerEnv(DEFAULT_CATALOG_HEALTH_STALE_DAYS),
+  DATABASE_URL: requiredUrlEnv('DATABASE_URL', ['postgres:', 'postgresql:']),
+  OPERATOR_AUTH_RATE_LIMIT_MAX: positiveIntegerEnv(DEFAULT_OPERATOR_AUTH_RATE_LIMIT_MAX),
+  OPERATOR_AUTH_RATE_LIMIT_WINDOW_SECONDS: positiveIntegerEnv(
+    DEFAULT_OPERATOR_AUTH_RATE_LIMIT_WINDOW_SECONDS,
+  ),
+  PORT: positiveIntegerEnv(DEFAULT_BACKOFFICE_PORT),
+  REDIS_URL: optionalUrlEnv('REDIS_URL', ['redis:', 'rediss:']),
+  TMDB_LANGUAGE: z.preprocess(
+    emptyStringToUndefined,
+    z.string().min(1).default(DEFAULT_TMDB_LANGUAGE),
+  ),
+});
+
+const BullBoardRuntimeEnvSchema = OperatorAuthRuntimeEnvSchema.extend({
+  BULL_BOARD_PORT: optionalPositiveIntegerEnv(),
+  OPERATOR_AUTH_RATE_LIMIT_MAX: positiveIntegerEnv(DEFAULT_OPERATOR_AUTH_RATE_LIMIT_MAX),
+  OPERATOR_AUTH_RATE_LIMIT_WINDOW_SECONDS: positiveIntegerEnv(
+    DEFAULT_OPERATOR_AUTH_RATE_LIMIT_WINDOW_SECONDS,
+  ),
+  PORT: optionalPositiveIntegerEnv(),
+  REDIS_URL: requiredUrlEnv('REDIS_URL', ['redis:', 'rediss:']),
+});
+
+function formatIssue(issue: ZodIssue): string {
+  const path = issue.path.length > 0 ? issue.path.join('.') : 'env';
+  return `${path}: ${issue.message}`;
+}
+
+function parseRuntimeEnv<T>(name: string, schema: z.ZodType<T>, env: RuntimeEnv): T {
+  const result = schema.safeParse(env);
+
+  if (result.success) return result.data;
+
+  const details = result.error.issues.map(formatIssue).join('; ');
+  throw new Error(`${name} runtime config is invalid: ${details}`);
+}
+
+function toOperatorAuthConfig(env: OperatorAuthRuntimeEnv): OperatorAuthConfig | null {
+  if (!env.OPERATOR_AUTH_USERNAME && !env.OPERATOR_AUTH_PASSWORD) return null;
+
+  return {
+    password: env.OPERATOR_AUTH_PASSWORD ?? '',
+    realm: env.OPERATOR_AUTH_REALM,
+    username: env.OPERATOR_AUTH_USERNAME ?? '',
+  };
+}
+
+export function readBackofficeRuntimeConfig(
+  env: RuntimeEnv = process.env,
+): BackofficeRuntimeConfig {
+  const parsed = parseRuntimeEnv('Backoffice', BackofficeRuntimeEnvSchema, env);
+
+  return {
+    catalogHealthSampleLimit: parsed.CATALOG_HEALTH_SAMPLE_LIMIT,
+    catalogHealthStaleDays: parsed.CATALOG_HEALTH_STALE_DAYS,
+    databaseUrl: parsed.DATABASE_URL,
+    operatorAuth: toOperatorAuthConfig(parsed),
+    operatorAuthRateLimitMax: parsed.OPERATOR_AUTH_RATE_LIMIT_MAX,
+    operatorAuthRateLimitWindowSeconds: parsed.OPERATOR_AUTH_RATE_LIMIT_WINDOW_SECONDS,
+    port: parsed.PORT,
+    redisUrl: parsed.REDIS_URL,
+    tmdbLanguage: parsed.TMDB_LANGUAGE,
+  };
+}
+
+export function readBullBoardRuntimeConfig(env: RuntimeEnv = process.env): BullBoardRuntimeConfig {
+  const parsed = parseRuntimeEnv('Bull Board', BullBoardRuntimeEnvSchema, env);
+
+  return {
+    operatorAuth: toOperatorAuthConfig(parsed),
+    operatorAuthRateLimitMax: parsed.OPERATOR_AUTH_RATE_LIMIT_MAX,
+    operatorAuthRateLimitWindowSeconds: parsed.OPERATOR_AUTH_RATE_LIMIT_WINDOW_SECONDS,
+    port: parsed.PORT ?? parsed.BULL_BOARD_PORT ?? DEFAULT_BULL_BOARD_PORT,
+    redisUrl: parsed.REDIS_URL,
+  };
+}


### PR DESCRIPTION
## Summary
- add shared plain Zod runtime config readers for backoffice and Bull Board
- replace inline env parsing in operator apps with typed config objects
- document the runtime config pattern and roadmap rollout

## Verification
- npm run format:check
- npm run type-check
- npm run lint:check
- npm run test
- npm run build
- npm run build:bull-board
- npm run build --workspace=apps/backoffice
- ./node_modules/.bin/tsc -p apps/bull-board/tsconfig.json --noEmit
- node runtime config smoke check