### PR TITLE
Test TMDB review action audit flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,5 +112,5 @@ When adding new roadmap work:
 
 - Next.js uses `apps/web/src/proxy.ts` for the CSRF cookie path. Older docs or comments may still say middleware.
 - CI skips heavy jobs for docs-only PRs but still reports `PR Validation`.
-- Root `npm run test:services` uses Turbo across `services/*` packages that define a `test` script. Use `npm run build:services` for a service compile pass.
+- Root `npm run test:services` runs `packages/shared` tests, then uses Turbo across `services/*` packages that define a `test` script. Use `npm run build:services` for a service compile pass.
 - Coolify preview databases can preserve old volumes. New schema-dependent code may need migrations or preview recreation before it works.

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ npm run populate-db          # Populate database with movie data
 npm run catalog:health       # Report catalog metadata coverage and likely duplicates
 npm run analyze-movies       # Analyze movie data for embeddings
 npm run calibrate-similarity # Calibrate vector similarity thresholds
-npm run test:services        # Run service test scripts via Turbo
+npm run test:services        # Run shared package and service test scripts
 ```
 
 For detailed development workflows and project structure, see the **[Development Guide](./docs/DEVELOPMENT.md)**.

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -30,7 +30,7 @@ The PR validation workflows run automatically on pull requests targeting the `de
 | `pr.yml`                             | `storybook-tests`                | Playwright browser install + Storybook component tests                          |
 | `pr.yml`                             | `e2e-tests`                      | Playwright smoke tests against isolated PostgreSQL + Redis services             |
 | `pr.yml`                             | `build`                          | Next.js production build verification                                           |
-| `pr.yml`                             | `services-ci`                    | Turbo test pass for `services/*`                                                |
+| `pr.yml`                             | `services-ci`                    | Shared package tests plus Turbo test pass for `services/*`                      |
 | `pr.yml`                             | `dependency-review`              | Blocks PRs introducing vulnerable dependencies                                  |
 | `pr.yml`                             | `pr-validation`                  | Stable required check that always runs on every PR                              |
 | `container-images.yml`               | `build-images`                   | Builds and publishes GHCR production images with provenance                     |
@@ -83,7 +83,7 @@ The `build` job sets `NEXT_FONT_GOOGLE_DISABLE=1` to prevent flaky failures caus
 
 ### Services CI
 
-The `services-ci` job in `pr.yml` runs `npm run test:services`, which delegates to Turbo for root `services/*` packages that define a `test` script. Services without a `test` script are skipped by that command; use `npm run build:services` locally when you specifically need a compile pass across service workspaces.
+The `services-ci` job in `pr.yml` runs `npm run test:services`, which first runs `packages/shared` tests and then delegates to Turbo for root `services/*` packages that define a `test` script. Services without a `test` script are skipped by that command; use `npm run build:services` locally when you specifically need a compile pass across service workspaces.
 
 ### Movie Discovery CI
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -20,6 +20,7 @@ For docs ownership, navigation, and issue hygiene, use **[Documentation Governan
 
 - `npm run test` - Run all tests using Vitest
 - `npm run test:server` - Run utility function tests (Node.js environment)
+- `npm run test:services` - Run shared package and service tests
 - `npm run test:storybook` - Run Storybook component tests (browser environment)
 
 ### Code Quality

--- a/package-lock.json
+++ b/package-lock.json
@@ -19546,7 +19546,8 @@
       },
       "devDependencies": {
         "@types/pg": "^8.20.0",
-        "typescript": "6.0.3"
+        "typescript": "6.0.3",
+        "vitest": "^4.1.7"
       }
     },
     "services/db-migrate": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "test:e2e:run": "playwright test --config apps/web/playwright.e2e.config.ts",
     "test:e2e:setup": "node scripts/e2e/setup-db.mjs",
     "test:server": "npm run test:server --workspace=apps/web",
-    "test:services": "turbo run test --filter=./services/*",
+    "test:services": "npm run test --workspace=packages/shared && turbo run test --filter=./services/*",
     "test:storybook": "npm run test:storybook --workspace=apps/web",
     "type-check": "npm run build --workspace=packages/shared && npm run type-check --workspace=apps/web && npm run type-check --workspace=apps/backoffice",
     "type-check:docs": "npm run type-check --workspace=apps/docs"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "dev": "tsc --watch"
+    "dev": "tsc --watch",
+    "test": "vitest run"
   },
   "dependencies": {
     "openai": "^6.39.0",
@@ -21,6 +22,7 @@
   },
   "devDependencies": {
     "@types/pg": "^8.20.0",
-    "typescript": "6.0.3"
+    "typescript": "6.0.3",
+    "vitest": "^4.1.7"
   }
 }

--- a/packages/shared/src/tmdbMatchReviews.test.ts
+++ b/packages/shared/src/tmdbMatchReviews.test.ts
@@ -109,27 +109,27 @@ describe('tmdb match review actions', () => {
     const auditCall = clientMock.query.mock.calls.find(([sql]: [unknown]) =>
       String(sql).includes('INSERT INTO tmdb_match_review_audit'),
     );
-    expect(auditCall?.[1]).toEqual([
+    expect(auditCall?.[1]?.slice(0, 6)).toEqual([
       '7',
       'apply_candidate',
       'operator@example.test',
       'Confirmed manually.',
       'open',
       'resolved',
-      JSON.stringify({
-        id: 593,
-        title: 'Solaris',
-        releaseYear: 1972,
-        confidence: 0.94,
-      }),
-      JSON.stringify({
-        movieId: '42',
-        movieName: 'Solaris',
-        movieYear: 1972,
-        previousMovie: reviewRow().current_movie,
-        appliedCandidateId: 593,
-      }),
     ]);
+    expect(JSON.parse(auditCall?.[1]?.[6])).toEqual({
+      id: 593,
+      title: 'Solaris',
+      releaseYear: 1972,
+      confidence: 0.94,
+    });
+    expect(JSON.parse(auditCall?.[1]?.[7])).toEqual({
+      movieId: '42',
+      movieName: 'Solaris',
+      movieYear: 1972,
+      previousMovie: reviewRow().current_movie,
+      appliedCandidateId: 593,
+    });
   });
 
   it('rejects duplicate TMDB ownership and rolls back', async () => {

--- a/packages/shared/src/tmdbMatchReviews.test.ts
+++ b/packages/shared/src/tmdbMatchReviews.test.ts
@@ -1,0 +1,221 @@
+import pg from 'pg';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { closeDatabase, initDatabase } from './db.js';
+import { applyTMDBMatchReviewAction } from './tmdbMatchReviews.js';
+
+vi.mock('pg', () => {
+  const mClient = {
+    query: vi.fn(),
+    release: vi.fn(),
+  };
+  const mPool = {
+    query: vi.fn(),
+    end: vi.fn(),
+    connect: vi.fn(async () => mClient),
+  };
+  return {
+    default: {
+      Pool: vi.fn(function () {
+        return mPool;
+      }),
+    },
+  };
+});
+
+function reviewRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: '7',
+    movie_id: '42',
+    movie_name: 'Solaris',
+    movie_year: 1972,
+    reason: 'ambiguous_match',
+    status: 'open',
+    candidates: [
+      {
+        id: 593,
+        title: 'Solaris',
+        releaseYear: 1972,
+        confidence: 0.94,
+      },
+    ],
+    notes: 'Needs manual confirmation.',
+    created_at: '2026-05-01T00:00:00.000Z',
+    updated_at: '2026-05-02T00:00:00.000Z',
+    current_movie: {
+      id: '42',
+      name: 'Solaris',
+      year: 1972,
+      duration: 166,
+      age_rating: 'PG',
+      tmdb_id: null,
+      poster_url: null,
+      localized_name: null,
+      tmdb_match_confidence: null,
+      tmdb_match_source: null,
+      tmdb_matched_at: null,
+    },
+    ...overrides,
+  };
+}
+
+describe('tmdb match review actions', () => {
+  let poolMock: any;
+  let clientMock: any;
+
+  beforeEach(async () => {
+    initDatabase('postgres://user:pass@localhost:5432/db');
+    poolMock = new pg.Pool();
+    clientMock = await poolMock.connect();
+  });
+
+  afterEach(async () => {
+    await closeDatabase();
+    vi.clearAllMocks();
+  });
+
+  it('applies a candidate transactionally and writes an audit row', async () => {
+    poolMock.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [reviewRow({ status: 'resolved' })] });
+    clientMock.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [reviewRow()] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const updated = await applyTMDBMatchReviewAction({
+      reviewId: '7',
+      action: 'apply_candidate',
+      actor: 'operator@example.test',
+      candidateId: 593,
+      note: 'Confirmed manually.',
+    });
+
+    expect(updated.status).toBe('resolved');
+    expect(clientMock.query.mock.calls[0][0]).toBe('BEGIN');
+    expect(clientMock.query.mock.calls.at(-1)?.[0]).toBe('COMMIT');
+    expect(clientMock.query).not.toHaveBeenCalledWith('ROLLBACK');
+    expect(clientMock.release).toHaveBeenCalledTimes(1);
+
+    const updateMovieCall = clientMock.query.mock.calls.find(([sql]: [unknown]) =>
+      String(sql).includes('UPDATE movies'),
+    );
+    expect(updateMovieCall?.[1]).toEqual([593, 0.94, 'Solaris', '42']);
+
+    const auditCall = clientMock.query.mock.calls.find(([sql]: [unknown]) =>
+      String(sql).includes('INSERT INTO tmdb_match_review_audit'),
+    );
+    expect(auditCall?.[1]).toEqual([
+      '7',
+      'apply_candidate',
+      'operator@example.test',
+      'Confirmed manually.',
+      'open',
+      'resolved',
+      JSON.stringify({
+        id: 593,
+        title: 'Solaris',
+        releaseYear: 1972,
+        confidence: 0.94,
+      }),
+      JSON.stringify({
+        movieId: '42',
+        movieName: 'Solaris',
+        movieYear: 1972,
+        previousMovie: reviewRow().current_movie,
+        appliedCandidateId: 593,
+      }),
+    ]);
+  });
+
+  it('rejects duplicate TMDB ownership and rolls back', async () => {
+    poolMock.query.mockResolvedValueOnce({ rows: [] });
+    clientMock.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [reviewRow()] })
+      .mockResolvedValueOnce({ rows: [{ id: '9', name: 'Solaris', year: 1972 }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await expect(
+      applyTMDBMatchReviewAction({
+        reviewId: '7',
+        action: 'apply_candidate',
+        actor: 'operator@example.test',
+        candidateId: 593,
+      }),
+    ).rejects.toMatchObject({ statusCode: 409 });
+
+    expect(clientMock.query).toHaveBeenCalledWith('ROLLBACK');
+    expect(
+      clientMock.query.mock.calls.some(([sql]: [unknown]) => String(sql).includes('UPDATE movies')),
+    ).toBe(false);
+    expect(clientMock.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('records non-apply decisions without changing movie identity', async () => {
+    poolMock.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [reviewRow({ status: 'ignored' })] });
+    clientMock.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [reviewRow()] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const updated = await applyTMDBMatchReviewAction({
+      reviewId: '7',
+      action: 'reject',
+      actor: 'operator@example.test',
+    });
+
+    expect(updated.status).toBe('ignored');
+    expect(
+      clientMock.query.mock.calls.some(([sql]: [unknown]) => String(sql).includes('UPDATE movies')),
+    ).toBe(false);
+
+    const reviewUpdateCall = clientMock.query.mock.calls.find(([sql]: [unknown]) =>
+      String(sql).includes('UPDATE tmdb_match_reviews'),
+    );
+    expect(reviewUpdateCall?.[1]).toEqual(['ignored', '7']);
+
+    const auditCall = clientMock.query.mock.calls.find(([sql]: [unknown]) =>
+      String(sql).includes('INSERT INTO tmdb_match_review_audit'),
+    );
+    expect(auditCall?.[1]?.slice(0, 6)).toEqual([
+      '7',
+      'reject',
+      'operator@example.test',
+      null,
+      'open',
+      'ignored',
+    ]);
+  });
+
+  it('does not allow actions on resolved reviews', async () => {
+    poolMock.query.mockResolvedValueOnce({ rows: [] });
+    clientMock.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [reviewRow({ status: 'resolved' })] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await expect(
+      applyTMDBMatchReviewAction({
+        reviewId: '7',
+        action: 'reopen',
+        actor: 'operator@example.test',
+      }),
+    ).rejects.toMatchObject({ statusCode: 409 });
+
+    expect(clientMock.query).toHaveBeenCalledWith('ROLLBACK');
+    expect(
+      clientMock.query.mock.calls.some(([sql]: [unknown]) =>
+        String(sql).includes('INSERT INTO tmdb_match_review_audit'),
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -15,5 +15,5 @@
     "sourceMap": true
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    exclude: ['dist/**', 'node_modules/**'],
+  },
+});


### PR DESCRIPTION
## Summary
- add focused Vitest coverage for the shared TMDB review action/audit flow
- cover candidate application, duplicate TMDB ownership rollback, non-apply decisions, and resolved-review guards
- include shared package tests in the existing service test path so CI runs them

## Validation
- npm run test --workspace=packages/shared
- npm run build --workspace=packages/shared
- npm run test:services
- npm run type-check

Follow-up hardening for #551.