### PR TITLE
Paginate TMDB review queue

### DIFF
--- a/apps/backoffice/src/app/globals.css
+++ b/apps/backoffice/src/app/globals.css
@@ -638,6 +638,36 @@ input:disabled {
   font-weight: 750;
   text-align: center;
 }
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 750;
+}
+.panel > .pagination:first-of-type {
+  border-top: 0;
+  border-bottom: 1px solid var(--border);
+}
+.pagination-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+.pagination-page {
+  color: var(--text);
+  white-space: nowrap;
+}
+.button.disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
 .detail-grid {
   display: grid;
   grid-template-columns: minmax(260px, 1fr) minmax(260px, 1fr);

--- a/apps/backoffice/src/app/tmdb-reviews/page.tsx
+++ b/apps/backoffice/src/app/tmdb-reviews/page.tsx
@@ -43,14 +43,15 @@ export default async function ReviewsPage({ searchParams }: ReviewsPageProps) {
       limit: pageSize,
       offset: (page - 1) * pageSize,
     });
+    const normalizedPage = Math.floor(reviewPage.offset / reviewPage.limit) + 1;
 
     return (
       <ReviewListPage
         reviews={reviewPage.reviews}
         filters={filters}
         pagination={{
-          page,
-          pageSize,
+          page: normalizedPage,
+          pageSize: reviewPage.limit,
           totalCount: reviewPage.totalCount,
         }}
       />

--- a/apps/backoffice/src/app/tmdb-reviews/page.tsx
+++ b/apps/backoffice/src/app/tmdb-reviews/page.tsx
@@ -1,4 +1,7 @@
-import { listTMDBMatchReviewPage } from '@pop-choice/shared';
+import {
+  listTMDBMatchReviewPage,
+  MAX_TMDB_MATCH_REVIEW_OFFSET,
+} from '@pop-choice/shared/tmdbMatchReviews';
 
 import { BackofficeErrorPage, ReviewListPage } from '../../components/backoffice';
 import {
@@ -32,10 +35,11 @@ export default async function ReviewsPage({ searchParams }: ReviewsPageProps) {
       reason: parseTMDBReviewReason(firstParam(params.reason)),
       sort: parseTMDBReviewSort(firstParam(params.sort)),
     };
-    const page = parsePositiveIntParam(firstParam(params.page), 1, { max: 10_000 });
     const pageSize = parsePositiveIntParam(firstParam(params.pageSize), DEFAULT_REVIEW_PAGE_SIZE, {
       max: MAX_REVIEW_PAGE_SIZE,
     });
+    const maxPage = Math.floor(MAX_TMDB_MATCH_REVIEW_OFFSET / pageSize) + 1;
+    const page = parsePositiveIntParam(firstParam(params.page), 1, { max: maxPage });
     const reviewPage = await listTMDBMatchReviewPage({
       status: filters.status,
       reason: filters.reason,

--- a/apps/backoffice/src/app/tmdb-reviews/page.tsx
+++ b/apps/backoffice/src/app/tmdb-reviews/page.tsx
@@ -1,9 +1,12 @@
-import { listTMDBMatchReviews } from '@pop-choice/shared';
+import { listTMDBMatchReviewPage } from '@pop-choice/shared';
 
 import { BackofficeErrorPage, ReviewListPage } from '../../components/backoffice';
 import {
+  DEFAULT_REVIEW_PAGE_SIZE,
   ensureBackofficeReady,
   logBackofficeError,
+  MAX_REVIEW_PAGE_SIZE,
+  parsePositiveIntParam,
   parseTMDBReviewReason,
   parseTMDBReviewSort,
   parseTMDBReviewStatus,
@@ -29,14 +32,29 @@ export default async function ReviewsPage({ searchParams }: ReviewsPageProps) {
       reason: parseTMDBReviewReason(firstParam(params.reason)),
       sort: parseTMDBReviewSort(firstParam(params.sort)),
     };
-    const reviews = await listTMDBMatchReviews({
+    const page = parsePositiveIntParam(firstParam(params.page), 1, { max: 10_000 });
+    const pageSize = parsePositiveIntParam(firstParam(params.pageSize), DEFAULT_REVIEW_PAGE_SIZE, {
+      max: MAX_REVIEW_PAGE_SIZE,
+    });
+    const reviewPage = await listTMDBMatchReviewPage({
       status: filters.status,
       reason: filters.reason,
       sort: filters.sort,
-      limit: 200,
+      limit: pageSize,
+      offset: (page - 1) * pageSize,
     });
 
-    return <ReviewListPage reviews={reviews} filters={filters} />;
+    return (
+      <ReviewListPage
+        reviews={reviewPage.reviews}
+        filters={filters}
+        pagination={{
+          page,
+          pageSize,
+          totalCount: reviewPage.totalCount,
+        }}
+      />
+    );
   } catch (error) {
     logBackofficeError('Failed to render TMDB match review queue', error);
     return <BackofficeErrorPage error={error} />;

--- a/apps/backoffice/src/components/backoffice.tsx
+++ b/apps/backoffice/src/components/backoffice.tsx
@@ -545,6 +545,91 @@ function ReviewFilterSummary({
   );
 }
 
+function buildReviewPageHref({
+  filters,
+  page,
+  pageSize,
+}: {
+  filters: {
+    status: TMDBMatchReviewStatus | 'all';
+    reason: TMDBMatchReviewReason | 'all';
+    sort: TMDBMatchReviewSort;
+  };
+  page: number;
+  pageSize: number;
+}) {
+  const params = new URLSearchParams();
+  params.set('status', filters.status);
+  params.set('reason', filters.reason);
+  params.set('sort', filters.sort);
+  params.set('page', String(page));
+  params.set('pageSize', String(pageSize));
+  return `/tmdb-reviews?${params.toString()}`;
+}
+
+function PaginationControls({
+  filters,
+  page,
+  pageSize,
+  totalCount,
+}: {
+  filters: {
+    status: TMDBMatchReviewStatus | 'all';
+    reason: TMDBMatchReviewReason | 'all';
+    sort: TMDBMatchReviewSort;
+  };
+  page: number;
+  pageSize: number;
+  totalCount: number;
+}) {
+  const totalPages = Math.max(Math.ceil(totalCount / pageSize), 1);
+  const currentPage = Math.max(page, 1);
+  const firstItem =
+    totalCount === 0 || currentPage > totalPages ? 0 : (currentPage - 1) * pageSize + 1;
+  const lastItem = currentPage > totalPages ? 0 : Math.min(currentPage * pageSize, totalCount);
+
+  return (
+    <nav className="pagination" aria-label="Review queue pagination">
+      <span className="pagination-summary">
+        {totalCount === 0
+          ? 'No reviews'
+          : currentPage > totalPages
+            ? `Page ${currentPage} is past ${totalCount} matching reviews`
+            : `Showing ${firstItem}-${lastItem} of ${totalCount} reviews`}
+      </span>
+      <div className="pagination-actions">
+        {currentPage > 1 ? (
+          <a
+            className="button small"
+            href={buildReviewPageHref({ filters, page: currentPage - 1, pageSize })}
+          >
+            Previous
+          </a>
+        ) : (
+          <span className="button small disabled" aria-disabled="true">
+            Previous
+          </span>
+        )}
+        <span className="pagination-page">
+          Page {currentPage} / {totalPages}
+        </span>
+        {currentPage < totalPages ? (
+          <a
+            className="button small"
+            href={buildReviewPageHref({ filters, page: currentPage + 1, pageSize })}
+          >
+            Next
+          </a>
+        ) : (
+          <span className="button small disabled" aria-disabled="true">
+            Next
+          </span>
+        )}
+      </div>
+    </nav>
+  );
+}
+
 function CandidateSummary({ candidates }: { candidates: TMDBReviewCandidate[] }) {
   if (candidates.length === 0) return <span className="muted">No candidates captured</span>;
 
@@ -629,12 +714,18 @@ function ReviewRows({ reviews }: { reviews: TMDBMatchReview[] }) {
 export function ReviewListPage({
   reviews,
   filters,
+  pagination,
 }: {
   reviews: TMDBMatchReview[];
   filters: {
     status: TMDBMatchReviewStatus | 'all';
     reason: TMDBMatchReviewReason | 'all';
     sort: TMDBMatchReviewSort;
+  };
+  pagination: {
+    page: number;
+    pageSize: number;
+    totalCount: number;
   };
 }) {
   return (
@@ -651,6 +742,8 @@ export function ReviewListPage({
     >
       <form className="review-toolbar" method="get" action="/tmdb-reviews">
         <div className="toolbar-fields">
+          <input type="hidden" name="page" value="1" />
+          <input type="hidden" name="pageSize" value={pagination.pageSize} />
           <label>
             Status
             <select name="status" defaultValue={filters.status}>
@@ -686,25 +779,29 @@ export function ReviewListPage({
       <section className="panel">
         <div className="panel-header">
           <h2>Review queue</h2>
-          <span className="count">{reviews.length}</span>
+          <span className="count">{pagination.totalCount}</span>
         </div>
-        <table className="review-table">
-          <thead>
-            <tr>
-              <th>ID</th>
-              <th>Local movie</th>
-              <th>Reason</th>
-              <th>Status</th>
-              <th>Candidates</th>
-              <th>Current TMDB</th>
-              <th>Updated</th>
-              <th />
-            </tr>
-          </thead>
-          <tbody>
-            <ReviewRows reviews={reviews} />
-          </tbody>
-        </table>
+        <PaginationControls filters={filters} {...pagination} />
+        <div className="table-scroll">
+          <table className="review-table">
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Local movie</th>
+                <th>Reason</th>
+                <th>Status</th>
+                <th>Candidates</th>
+                <th>Current TMDB</th>
+                <th>Updated</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              <ReviewRows reviews={reviews} />
+            </tbody>
+          </table>
+        </div>
+        <PaginationControls filters={filters} {...pagination} />
       </section>
     </BackofficeShell>
   );

--- a/apps/backoffice/src/lib/backoffice.ts
+++ b/apps/backoffice/src/lib/backoffice.ts
@@ -25,6 +25,8 @@ import {
 } from '../catalogMaintenanceQueue';
 
 export const DEFAULT_REPAIR_AUDIT_LIMIT = 25;
+export const DEFAULT_REVIEW_PAGE_SIZE = 25;
+export const MAX_REVIEW_PAGE_SIZE = 100;
 
 export const REPAIRABLE_CATALOG_ISSUE_KEYS = new Set([
   'missing_poster_url',
@@ -140,6 +142,17 @@ export function parseTMDBReviewReason(value: string | null): TMDBMatchReviewReas
 
 export function parseTMDBReviewSort(value: string | null): TMDBMatchReviewSort {
   return value && isTMDBMatchReviewSort(value) ? value : 'highest_risk';
+}
+
+export function parsePositiveIntParam(
+  value: string | null,
+  fallback: number,
+  { max }: { max: number },
+): number {
+  if (!value) return fallback;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) return fallback;
+  return Math.min(parsed, max);
 }
 
 export function parseAction(value: FormDataEntryValue | null): TMDBMatchReviewAction {

--- a/docs/BACKOFFICE.md
+++ b/docs/BACKOFFICE.md
@@ -165,7 +165,9 @@ The queue shows `tmdb_match_reviews` rows with:
 - review reason (`ambiguous_match` or `runtime_mismatch`);
 - status (`open`, `deferred`, `resolved`, or `ignored`);
 - captured TMDB candidate ids, titles, release years, and confidence scores;
-- newest, oldest, and highest-risk sorting.
+- newest, oldest, and highest-risk sorting;
+- server-side pagination that preserves status, reason, sort, page, and page
+  size in the URL so large queues do not render all rows at once;
 - readable UTC timestamps for generated reports, queue updates, match dates, and
   audit history.
 
@@ -206,7 +208,8 @@ Cover these operator states:
   empty/healthy states when available, and the `?repair=queued`,
   `?repair=unavailable`, and `?repair=failed` notices;
 - TMDB review queue at `/tmdb-reviews`, including open, deferred, resolved, and
-  ignored status filters when data exists;
+  ignored status filters when data exists, plus paginated states such as
+  `?page=2` and narrow table scrolling;
 - TMDB review detail pages for at least one open or deferred review, including
   apply, reject, defer, reopen, and note-entry states where practical;
 - future movie/detail repair pages when they are added under the backoffice

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -7,6 +7,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./tmdbMatchReviews": {
+      "types": "./dist/tmdbMatchReviews.d.ts",
+      "default": "./dist/tmdbMatchReviews.js"
     }
   },
   "scripts": {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -72,6 +72,7 @@ export {
   listTMDBMatchReviewAudit,
   listTMDBMatchReviewPage,
   listTMDBMatchReviews,
+  MAX_TMDB_MATCH_REVIEW_OFFSET,
 } from './tmdbMatchReviews.js';
 export type {
   ApplyTMDBMatchReviewActionInput,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -70,6 +70,7 @@ export {
   isTMDBMatchReviewSort,
   isTMDBMatchReviewStatus,
   listTMDBMatchReviewAudit,
+  listTMDBMatchReviewPage,
   listTMDBMatchReviews,
 } from './tmdbMatchReviews.js';
 export type {
@@ -81,6 +82,7 @@ export type {
   TMDBMatchReviewReason,
   TMDBMatchReviewSort,
   TMDBMatchReviewStatus,
+  TMDBMatchReviewPage,
   TMDBReviewCandidate,
   TMDBReviewMovieSnapshot,
 } from './tmdbMatchReviews.js';

--- a/packages/shared/src/tmdbMatchReviews.test.ts
+++ b/packages/shared/src/tmdbMatchReviews.test.ts
@@ -2,7 +2,11 @@ import pg from 'pg';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { closeDatabase, initDatabase } from './db.js';
-import { applyTMDBMatchReviewAction, listTMDBMatchReviewPage } from './tmdbMatchReviews.js';
+import {
+  applyTMDBMatchReviewAction,
+  listTMDBMatchReviewPage,
+  MAX_TMDB_MATCH_REVIEW_OFFSET,
+} from './tmdbMatchReviews.js';
 
 vi.mock('pg', () => {
   const mClient = {
@@ -219,7 +223,7 @@ describe('tmdb match review actions', () => {
     ).toBe(false);
   });
 
-  it('lists review pages with total count and bounded offset', async () => {
+  it('lists review pages with total count', async () => {
     poolMock.query
       .mockResolvedValueOnce({ rows: [{ total_count: 37 }] })
       .mockResolvedValueOnce({ rows: [reviewRow()] });
@@ -245,6 +249,38 @@ describe('tmdb match review actions', () => {
       2,
       expect.stringContaining('LIMIT $3\n      OFFSET $4'),
       ['deferred', 'runtime_mismatch', 25, 50],
+    );
+  });
+
+  it('clamps out-of-range review page limits and offsets', async () => {
+    poolMock.query
+      .mockResolvedValueOnce({ rows: [{ total_count: 37 }] })
+      .mockResolvedValueOnce({ rows: [reviewRow()] })
+      .mockResolvedValueOnce({ rows: [{ total_count: 37 }] })
+      .mockResolvedValueOnce({ rows: [reviewRow()] });
+
+    const cappedHigh = await listTMDBMatchReviewPage({
+      limit: 999,
+      offset: MAX_TMDB_MATCH_REVIEW_OFFSET + 1,
+    });
+    const cappedLow = await listTMDBMatchReviewPage({
+      limit: -10,
+      offset: -1,
+    });
+
+    expect(cappedHigh.limit).toBe(500);
+    expect(cappedHigh.offset).toBe(MAX_TMDB_MATCH_REVIEW_OFFSET);
+    expect(cappedLow.limit).toBe(1);
+    expect(cappedLow.offset).toBe(0);
+    expect(poolMock.query).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('LIMIT $2\n      OFFSET $3'),
+      ['open', 500, MAX_TMDB_MATCH_REVIEW_OFFSET],
+    );
+    expect(poolMock.query).toHaveBeenNthCalledWith(
+      4,
+      expect.stringContaining('LIMIT $2\n      OFFSET $3'),
+      ['open', 1, 0],
     );
   });
 });

--- a/packages/shared/src/tmdbMatchReviews.test.ts
+++ b/packages/shared/src/tmdbMatchReviews.test.ts
@@ -2,7 +2,7 @@ import pg from 'pg';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { closeDatabase, initDatabase } from './db.js';
-import { applyTMDBMatchReviewAction } from './tmdbMatchReviews.js';
+import { applyTMDBMatchReviewAction, listTMDBMatchReviewPage } from './tmdbMatchReviews.js';
 
 vi.mock('pg', () => {
   const mClient = {
@@ -217,5 +217,34 @@ describe('tmdb match review actions', () => {
         String(sql).includes('INSERT INTO tmdb_match_review_audit'),
       ),
     ).toBe(false);
+  });
+
+  it('lists review pages with total count and bounded offset', async () => {
+    poolMock.query
+      .mockResolvedValueOnce({ rows: [{ total_count: 37 }] })
+      .mockResolvedValueOnce({ rows: [reviewRow()] });
+
+    const page = await listTMDBMatchReviewPage({
+      status: 'deferred',
+      reason: 'runtime_mismatch',
+      sort: 'oldest',
+      limit: 25,
+      offset: 50,
+    });
+
+    expect(page.totalCount).toBe(37);
+    expect(page.limit).toBe(25);
+    expect(page.offset).toBe(50);
+    expect(page.reviews).toHaveLength(1);
+    expect(poolMock.query).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('COUNT(*)::int AS total_count'),
+      ['deferred', 'runtime_mismatch'],
+    );
+    expect(poolMock.query).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('LIMIT $3\n      OFFSET $4'),
+      ['deferred', 'runtime_mismatch', 25, 50],
+    );
   });
 });

--- a/packages/shared/src/tmdbMatchReviews.ts
+++ b/packages/shared/src/tmdbMatchReviews.ts
@@ -5,6 +5,8 @@ export type TMDBMatchReviewStatus = 'open' | 'resolved' | 'ignored' | 'deferred'
 export type TMDBMatchReviewSort = 'newest' | 'oldest' | 'highest_risk';
 export type TMDBMatchReviewAction = 'apply_candidate' | 'reject' | 'defer' | 'reopen';
 
+export const MAX_TMDB_MATCH_REVIEW_OFFSET = 100_000;
+
 export interface TMDBReviewCandidate {
   id: number | null;
   title: string;
@@ -288,7 +290,7 @@ export async function listTMDBMatchReviewPage(
   const reason = options.reason ?? 'all';
   const sort = options.sort ?? 'highest_risk';
   const limit = Math.min(Math.max(options.limit ?? 100, 1), 500);
-  const offset = Math.min(Math.max(options.offset ?? 0, 0), 100_000);
+  const offset = Math.min(Math.max(options.offset ?? 0, 0), MAX_TMDB_MATCH_REVIEW_OFFSET);
   const where: string[] = [];
   const params: unknown[] = [];
 

--- a/packages/shared/src/tmdbMatchReviews.ts
+++ b/packages/shared/src/tmdbMatchReviews.ts
@@ -58,6 +58,14 @@ export interface ListTMDBMatchReviewsOptions {
   reason?: TMDBMatchReviewReason | 'all';
   sort?: TMDBMatchReviewSort;
   limit?: number;
+  offset?: number;
+}
+
+export interface TMDBMatchReviewPage {
+  reviews: TMDBMatchReview[];
+  totalCount: number;
+  limit: number;
+  offset: number;
 }
 
 export interface ApplyTMDBMatchReviewActionInput {
@@ -269,10 +277,18 @@ export async function ensureTMDBMatchReviewActionSchema(): Promise<void> {
 export async function listTMDBMatchReviews(
   options: ListTMDBMatchReviewsOptions = {},
 ): Promise<TMDBMatchReview[]> {
+  const page = await listTMDBMatchReviewPage(options);
+  return page.reviews;
+}
+
+export async function listTMDBMatchReviewPage(
+  options: ListTMDBMatchReviewsOptions = {},
+): Promise<TMDBMatchReviewPage> {
   const status = options.status ?? 'open';
   const reason = options.reason ?? 'all';
   const sort = options.sort ?? 'highest_risk';
   const limit = Math.min(Math.max(options.limit ?? 100, 1), 500);
+  const offset = Math.min(Math.max(options.offset ?? 0, 0), 100_000);
   const where: string[] = [];
   const params: unknown[] = [];
 
@@ -296,16 +312,30 @@ export async function listTMDBMatchReviews(
            reviews.updated_at ASC,
            reviews.id ASC`;
 
-  params.push(limit);
-  const result = await getPool().query<TMDBMatchReviewRow>(
-    `${buildReviewSelectClause()}
-      ${where.length > 0 ? `WHERE ${where.join(' AND ')}` : ''}
-      ORDER BY ${orderBy}
-      LIMIT $${params.length}`,
+  const whereClause = where.length > 0 ? `WHERE ${where.join(' AND ')}` : '';
+  const countResult = await getPool().query<{ total_count: number | string }>(
+    `SELECT COUNT(*)::int AS total_count
+       FROM tmdb_match_reviews reviews
+      ${whereClause}`,
     params,
   );
 
-  return result.rows.map(normalizeReview);
+  const pageParams = [...params, limit, offset];
+  const result = await getPool().query<TMDBMatchReviewRow>(
+    `${buildReviewSelectClause()}
+      ${whereClause}
+      ORDER BY ${orderBy}
+      LIMIT $${pageParams.length - 1}
+      OFFSET $${pageParams.length}`,
+    pageParams,
+  );
+
+  return {
+    reviews: result.rows.map(normalizeReview),
+    totalCount: Number(countResult.rows[0]?.total_count ?? 0),
+    limit,
+    offset,
+  };
 }
 
 export async function getTMDBMatchReview(reviewId: string): Promise<TMDBMatchReview | null> {


### PR DESCRIPTION
## Summary
- add a paginated shared TMDB review query with total counts and bounded offsets
- render backoffice TMDB review pagination controls that preserve status, reason, sort, page, and page size in the URL
- wrap the review table for narrow-width scrolling and document the paginated queue behavior

## Validation
- npm run test --workspace=packages/shared
- npm run build --workspace=packages/shared
- npm run build --workspace=apps/backoffice
- npm run type-check --workspace=apps/backoffice
- npm run type-check
- npm run test:services

## Notes
- Playwright smoke reached the local backoffice dev server, but the page rendered the existing Backoffice unavailable state because the local DATABASE_URL credentials reject postgres auth in this workspace.

Part of #591.