### PR TITLE
Fix backoffice bulk repair request URL

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -122,6 +122,29 @@ jobs:
           path: apps/web/coverage/
           retention-days: 30
 
+  backoffice-tests:
+    name: Backoffice Tests
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run backoffice tests
+        run: npm run test:backoffice
+
   recommendation-evals:
     name: Recommendation Evals
     needs: changes
@@ -346,6 +369,7 @@ jobs:
       - lint
       - type-check
       - server-tests
+      - backoffice-tests
       - recommendation-evals
       - storybook-tests
       - e2e-tests
@@ -361,6 +385,7 @@ jobs:
       LINT_RESULT: ${{ needs.lint.result }}
       TYPE_CHECK_RESULT: ${{ needs.type-check.result }}
       SERVER_TESTS_RESULT: ${{ needs.server-tests.result }}
+      BACKOFFICE_TESTS_RESULT: ${{ needs.backoffice-tests.result }}
       RECOMMENDATION_EVALS_RESULT: ${{ needs.recommendation-evals.result }}
       STORYBOOK_TESTS_RESULT: ${{ needs.storybook-tests.result }}
       E2E_TESTS_RESULT: ${{ needs.e2e-tests.result }}
@@ -385,6 +410,7 @@ jobs:
           [[ "$LINT_RESULT" == "success" ]] || failures+=("Lint & Format: $LINT_RESULT")
           [[ "$TYPE_CHECK_RESULT" == "success" ]] || failures+=("Type Check: $TYPE_CHECK_RESULT")
           [[ "$SERVER_TESTS_RESULT" == "success" ]] || failures+=("Server Tests: $SERVER_TESTS_RESULT")
+          [[ "$BACKOFFICE_TESTS_RESULT" == "success" ]] || failures+=("Backoffice Tests: $BACKOFFICE_TESTS_RESULT")
           [[ "$RECOMMENDATION_EVALS_RESULT" == "success" ]] || failures+=("Recommendation Evals: $RECOMMENDATION_EVALS_RESULT")
           [[ "$STORYBOOK_TESTS_RESULT" == "success" ]] || failures+=("Storybook Tests: $STORYBOOK_TESTS_RESULT")
           [[ "$E2E_TESTS_RESULT" == "success" ]] || failures+=("E2E Tests: $E2E_TESTS_RESULT")

--- a/apps/backoffice/package.json
+++ b/apps/backoffice/package.json
@@ -7,6 +7,7 @@
     "build": "next build --webpack",
     "dev": "next dev --port ${PORT:-3004}",
     "start": "next start",
+    "test": "vitest run",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
@@ -21,7 +22,8 @@
     "@types/node": "25.9.1",
     "@types/react": "19.2.15",
     "@types/react-dom": "^19",
-    "typescript": "6.0.3"
+    "typescript": "6.0.3",
+    "vitest": "^4.1.7"
   },
   "engines": {
     "node": ">=24",

--- a/apps/backoffice/src/catalogMaintenanceQueue.test.ts
+++ b/apps/backoffice/src/catalogMaintenanceQueue.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  enqueueCatalogBackfillMovieFromBackoffice,
+  getCatalogBackfillMovieJobId,
+} from './catalogMaintenanceQueue';
+
+describe('catalog maintenance queue helpers', () => {
+  it('sanitizes BullMQ job ids so operator-supplied ids cannot contain colons', () => {
+    expect(getCatalogBackfillMovieJobId('tmdb:331')).toBe('backfill-tmdb-331');
+  });
+
+  it('does not pretend to queue work when Redis is unavailable', async () => {
+    await expect(
+      enqueueCatalogBackfillMovieFromBackoffice(
+        { movieId: 331, reason: 'missing_metadata', language: 'en-US' },
+        undefined,
+      ),
+    ).resolves.toBeNull();
+  });
+});

--- a/apps/backoffice/src/components/catalogRepairEnhancement.test.ts
+++ b/apps/backoffice/src/components/catalogRepairEnhancement.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { formActionUrl } from './catalogRepairEnhancement';
+
+describe('formActionUrl', () => {
+  it('uses the action attribute instead of the clobberable form.action property', () => {
+    const form = {
+      action: '[object HTMLInputElement]',
+      getAttribute: (name: string) => (name === 'action' ? '/catalog-health/actions' : null),
+    } as Pick<HTMLFormElement, 'getAttribute'> & { action: string };
+
+    expect(formActionUrl(form, 'https://backoffice.pop-choice.shchilkin.dev/')).toBe(
+      'https://backoffice.pop-choice.shchilkin.dev/catalog-health/actions',
+    );
+  });
+
+  it('falls back to the current page URL when the form action is empty', () => {
+    const form = {
+      getAttribute: () => '',
+    } as Pick<HTMLFormElement, 'getAttribute'>;
+
+    expect(formActionUrl(form, 'https://backoffice.pop-choice.shchilkin.dev/catalog')).toBe(
+      'https://backoffice.pop-choice.shchilkin.dev/catalog',
+    );
+  });
+});

--- a/apps/backoffice/src/components/catalogRepairEnhancement.tsx
+++ b/apps/backoffice/src/components/catalogRepairEnhancement.tsx
@@ -44,6 +44,14 @@ function formBody(form: HTMLFormElement): URLSearchParams {
   return body;
 }
 
+export function formActionUrl(
+  form: Pick<HTMLFormElement, 'getAttribute'>,
+  baseUrl = window.location.href,
+): string {
+  const action = form.getAttribute('action');
+  return new URL(action || baseUrl, baseUrl).toString();
+}
+
 export function CatalogRepairEnhancement() {
   useEffect(() => {
     if (!window.fetch || !window.FormData) return undefined;
@@ -70,7 +78,7 @@ export function CatalogRepairEnhancement() {
         setMessage(form, 'Queueing...', '');
 
         try {
-          const response = await fetch(form.action, {
+          const response = await fetch(formActionUrl(form), {
             body: formBody(form),
             headers: { Accept: 'application/json', 'X-Requested-With': 'fetch' },
             method: 'POST',

--- a/apps/backoffice/src/lib/sameOriginRequest.test.ts
+++ b/apps/backoffice/src/lib/sameOriginRequest.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { isSameOriginRequest } from './sameOriginRequest';
+
+type SameOriginRequest = Parameters<typeof isSameOriginRequest>[0];
+
+function request(url: string, headers: HeadersInit): SameOriginRequest {
+  return { headers: new Headers(headers), url } as SameOriginRequest;
+}
+
+describe('isSameOriginRequest', () => {
+  it('accepts matching origin headers', () => {
+    expect(
+      isSameOriginRequest(
+        request('https://backoffice.pop-choice.shchilkin.dev/catalog-health/actions', {
+          origin: 'https://backoffice.pop-choice.shchilkin.dev',
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('accepts forwarded Coolify origins', () => {
+    expect(
+      isSameOriginRequest(
+        request('http://127.0.0.1:3004/catalog-health/actions', {
+          origin: 'https://backoffice.pop-choice.shchilkin.dev',
+          'x-forwarded-host': 'backoffice.pop-choice.shchilkin.dev',
+          'x-forwarded-proto': 'https',
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects requests without origin or referer evidence', () => {
+    expect(
+      isSameOriginRequest(
+        request('https://backoffice.pop-choice.shchilkin.dev/catalog-health/actions', {}),
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/backoffice/vitest.config.ts
+++ b/apps/backoffice/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    exclude: ['.next/**', 'node_modules/**'],
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,8 @@
         "@types/node": "25.9.1",
         "@types/react": "19.2.15",
         "@types/react-dom": "^19",
-        "typescript": "6.0.3"
+        "typescript": "6.0.3",
+        "vitest": "^4.1.7"
       },
       "engines": {
         "node": ">=24",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "start:storybook": "npm run start:storybook --workspace=apps/web",
     "storybook": "npm run storybook --workspace=apps/web",
     "test": "npm run test --workspace=apps/web",
+    "test:backoffice": "npm run build --workspace=packages/shared && npm run test --workspace=apps/backoffice",
     "test:e2e": "npm run test:e2e:setup && npm run test:e2e:run",
     "test:e2e:down": "node scripts/e2e/teardown-db.mjs",
     "test:e2e:run": "playwright test --config apps/web/playwright.e2e.config.ts",


### PR DESCRIPTION
## Summary
- resolve enhanced catalog repair form submissions from the form action attribute instead of the DOM action property
- prevent hidden input name=action from turning bulk repair POSTs into /[object HTMLInputElement]
- add a backoffice Vitest harness plus regression coverage for repair form URLs, BullMQ job id sanitization, and same-origin request checks
- run backoffice tests as a dedicated PR CI job

Refs #573

## Verification
- npm run test:backoffice
- npm run build --workspace=apps/backoffice
- npm run build:backoffice
- npm run type-check --workspace=apps/backoffice
- npm run type-check
- npm run format:check
- npm run lint:check
- git push pre-push checks: lint, server tests, production build