### PR TITLE
Make backoffice catalog health live

### DIFF
--- a/apps/backoffice/package.json
+++ b/apps/backoffice/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@pop-choice/shared": "*",
+    "@tanstack/react-query": "^5.100.14",
     "bullmq": "^5.77.3",
     "ioredis": "^5.10.1",
     "next": "^16.2.6",

--- a/apps/backoffice/src/app/api/catalog-health/route.ts
+++ b/apps/backoffice/src/app/api/catalog-health/route.ts
@@ -5,9 +5,9 @@ import {
   listCatalogRepairAuditPage,
   MAX_CATALOG_HEALTH_ISSUE_PAGE_SIZE,
 } from '@pop-choice/shared';
+import { NextResponse } from 'next/server';
 
-import { BackofficeErrorPage, CatalogHealthPage } from '../components/backoffice';
-import { getCatalogMaintenanceQueueSnapshot } from '../catalogMaintenanceQueue';
+import { getCatalogMaintenanceQueueSnapshot } from '../../../catalogMaintenanceQueue';
 import {
   DEFAULT_CATALOG_ISSUE_PAGE_SIZE,
   DEFAULT_REPAIR_AUDIT_LIMIT,
@@ -16,41 +16,31 @@ import {
   MAX_CATALOG_ISSUE_PAGE_NUMBER,
   MAX_REPAIR_AUDIT_PAGE_NUMBER,
   parsePositiveIntParam,
-} from '../lib/backoffice';
-import { toCatalogHealthLiveData } from '../lib/catalogHealthLive';
+} from '../../../lib/backoffice';
+import { toCatalogHealthLiveData } from '../../../lib/catalogHealthLive';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
-type HomePageProps = {
-  searchParams?: Promise<Record<string, string | string[] | undefined>>;
-};
-
-function getParamValue(value: string | string[] | undefined): string | null {
-  if (Array.isArray(value)) return value[0] ?? null;
-  return value ?? null;
-}
-
-export default async function HomePage({ searchParams }: HomePageProps) {
+export async function GET(request: Request) {
   try {
     const config = await ensureBackofficeReady();
-    const params = (await searchParams) ?? {};
-    const repairStatus = getParamValue(params.repair)?.trim() ?? null;
-    const selectedIssueKey = getParamValue(params.issue)?.trim() ?? null;
+    const params = new URL(request.url).searchParams;
+    const selectedIssueKey = params.get('issue')?.trim() ?? null;
     const issuePageSize = parsePositiveIntParam(
-      getParamValue(params.issuePageSize),
+      params.get('issuePageSize'),
       DEFAULT_CATALOG_ISSUE_PAGE_SIZE,
       { max: MAX_CATALOG_HEALTH_ISSUE_PAGE_SIZE },
     );
-    const issuePageNumber = parsePositiveIntParam(getParamValue(params.issuePage), 1, {
+    const issuePageNumber = parsePositiveIntParam(params.get('issuePage'), 1, {
       max: MAX_CATALOG_ISSUE_PAGE_NUMBER,
     });
     const auditPageSize = parsePositiveIntParam(
-      getParamValue(params.auditPageSize),
+      params.get('auditPageSize'),
       DEFAULT_REPAIR_AUDIT_LIMIT,
       { max: 100 },
     );
-    const auditPageNumber = parsePositiveIntParam(getParamValue(params.auditPage), 1, {
+    const auditPageNumber = parsePositiveIntParam(params.get('auditPage'), 1, {
       max: MAX_REPAIR_AUDIT_PAGE_NUMBER,
     });
 
@@ -74,23 +64,16 @@ export default async function HomePage({ searchParams }: HomePageProps) {
       getCatalogMaintenanceQueueSnapshot(config.redisUrl),
     ]);
 
-    return (
-      <CatalogHealthPage
-        report={report}
-        auditPage={auditPage}
-        initialLiveData={toCatalogHealthLiveData({
-          auditPage,
-          issueMoviePage,
-          queueSnapshot,
-          report,
-        })}
-        issueMoviePage={issueMoviePage}
-        queueSnapshot={queueSnapshot}
-        repairStatus={repairStatus}
-      />
+    return NextResponse.json(
+      toCatalogHealthLiveData({ auditPage, issueMoviePage, queueSnapshot, report }),
+      {
+        headers: {
+          'Cache-Control': 'no-store',
+        },
+      },
     );
   } catch (error) {
-    logBackofficeError('Failed to render catalog health report', error);
-    return <BackofficeErrorPage error={error} />;
+    logBackofficeError('Failed to read live catalog health state', error);
+    return NextResponse.json({ error: 'Failed to read catalog health state.' }, { status: 500 });
   }
 }

--- a/apps/backoffice/src/app/globals.css
+++ b/apps/backoffice/src/app/globals.css
@@ -434,6 +434,84 @@ input:disabled {
 .catalog-status.healthy {
   border-color: color-mix(in srgb, var(--good), var(--border) 62%);
 }
+.live-refresh,
+.queue-status {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  align-items: center;
+  margin-bottom: 14px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: rgba(21, 24, 29, 0.72);
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 800;
+}
+.live-refresh {
+  justify-content: flex-start;
+}
+.live-refresh-dot,
+.queue-dot {
+  width: 9px;
+  height: 9px;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: var(--good);
+  box-shadow: 0 0 0 4px var(--good-soft);
+}
+.live-refresh-dot.pending {
+  background: var(--warn);
+  box-shadow: 0 0 0 4px var(--warn-soft);
+}
+.live-refresh-meta {
+  color: var(--subtle);
+}
+.live-refresh-error {
+  color: var(--warn);
+}
+.queue-status {
+  align-items: flex-start;
+}
+.queue-status p {
+  margin: 2px 0 0;
+  color: var(--subtle);
+  font-weight: 700;
+}
+.queue-status-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text);
+}
+.queue-dot.warning {
+  background: var(--warn);
+  box-shadow: 0 0 0 4px var(--warn-soft);
+}
+.queue-dot.neutral {
+  background: var(--accent);
+  box-shadow: 0 0 0 4px var(--accent-soft);
+}
+.queue-counts {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+.queue-counts span {
+  display: inline-flex;
+  gap: 4px;
+  align-items: baseline;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 3px 8px;
+  background: #111419;
+  white-space: nowrap;
+}
+.queue-counts strong {
+  color: var(--text);
+}
 .status-heading {
   display: flex;
   align-items: center;
@@ -654,6 +732,30 @@ input:disabled {
 .repair-message.warn {
   color: var(--warn);
 }
+.inline-confirmation {
+  flex-basis: 100%;
+  min-width: min(340px, 100%);
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid color-mix(in srgb, var(--warn), var(--border) 45%);
+  border-radius: 8px;
+  background: linear-gradient(180deg, rgba(245, 197, 66, 0.12), rgba(21, 24, 29, 0.96));
+  box-shadow: 0 14px 40px rgba(0, 0, 0, 0.22);
+}
+.inline-confirmation p {
+  margin: 0;
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 750;
+  line-height: 1.35;
+}
+.inline-confirmation-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
 .repair-placeholder {
   color: var(--muted);
   font-weight: 750;
@@ -850,6 +952,14 @@ input:disabled {
     align-items: flex-start;
     flex-direction: column;
   }
+  .live-refresh,
+  .queue-status {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+  .queue-counts {
+    justify-content: flex-start;
+  }
   .status-metrics {
     justify-content: flex-start;
   }
@@ -880,7 +990,8 @@ input:disabled {
   .filters,
   .section-nav,
   .actions,
-  .decision-actions {
+  .decision-actions,
+  .bulk-repair-form {
     align-items: stretch;
     flex-direction: column;
   }

--- a/apps/backoffice/src/app/layout.tsx
+++ b/apps/backoffice/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next';
 
+import { BackofficeQueryProvider } from '../components/queryProvider';
+
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -12,7 +14,9 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <BackofficeQueryProvider>{children}</BackofficeQueryProvider>
+      </body>
     </html>
   );
 }

--- a/apps/backoffice/src/catalogMaintenanceQueue.test.ts
+++ b/apps/backoffice/src/catalogMaintenanceQueue.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   enqueueCatalogBackfillMovieFromBackoffice,
   getCatalogBackfillMovieJobId,
+  getCatalogMaintenanceQueueSnapshot,
 } from './catalogMaintenanceQueue';
 
 describe('catalog maintenance queue helpers', () => {
@@ -17,5 +18,22 @@ describe('catalog maintenance queue helpers', () => {
         undefined,
       ),
     ).resolves.toBeNull();
+  });
+
+  it('reports an unavailable queue snapshot when Redis is unavailable', async () => {
+    await expect(getCatalogMaintenanceQueueSnapshot(undefined)).resolves.toMatchObject({
+      available: false,
+      counts: {
+        active: 0,
+        completed: 0,
+        delayed: 0,
+        failed: 0,
+        prioritized: 0,
+        waiting: 0,
+        waitingChildren: 0,
+      },
+      openJobs: 0,
+      queueName: 'catalog-maintenance',
+    });
   });
 });

--- a/apps/backoffice/src/catalogMaintenanceQueue.ts
+++ b/apps/backoffice/src/catalogMaintenanceQueue.ts
@@ -30,6 +30,22 @@ export interface EnqueueCatalogBackfillMovieResult {
   status: 'queued' | 'deduped';
 }
 
+export interface CatalogMaintenanceQueueSnapshot {
+  queueName: string;
+  available: boolean;
+  counts: {
+    active: number;
+    completed: number;
+    delayed: number;
+    failed: number;
+    prioritized: number;
+    waiting: number;
+    waitingChildren: number;
+  };
+  openJobs: number;
+  updatedAt: string;
+}
+
 type CatalogBackfillMovieJobData = {
   version: 1;
   movieId: string | number;
@@ -76,6 +92,63 @@ function getCatalogMaintenanceQueue(
 
 export function getCatalogBackfillMovieJobId(movieId: string | number): string {
   return `backfill-${toBullMQJobIdPart(movieId)}`;
+}
+
+export async function getCatalogMaintenanceQueueSnapshot(
+  redisUrl = process.env.REDIS_URL,
+): Promise<CatalogMaintenanceQueueSnapshot> {
+  const emptyCounts: CatalogMaintenanceQueueSnapshot['counts'] = {
+    active: 0,
+    completed: 0,
+    delayed: 0,
+    failed: 0,
+    prioritized: 0,
+    waiting: 0,
+    waitingChildren: 0,
+  };
+  const queue = getCatalogMaintenanceQueue(redisUrl);
+
+  if (!queue) {
+    return {
+      queueName: CATALOG_MAINTENANCE_QUEUE_NAME,
+      available: false,
+      counts: emptyCounts,
+      openJobs: 0,
+      updatedAt: new Date().toISOString(),
+    };
+  }
+
+  const counts = await queue.getJobCounts(
+    'active',
+    'completed',
+    'delayed',
+    'failed',
+    'prioritized',
+    'waiting',
+    'waiting-children',
+  );
+  const normalizedCounts: CatalogMaintenanceQueueSnapshot['counts'] = {
+    active: counts.active ?? 0,
+    completed: counts.completed ?? 0,
+    delayed: counts.delayed ?? 0,
+    failed: counts.failed ?? 0,
+    prioritized: counts.prioritized ?? 0,
+    waiting: counts.waiting ?? 0,
+    waitingChildren: counts['waiting-children'] ?? 0,
+  };
+
+  return {
+    queueName: CATALOG_MAINTENANCE_QUEUE_NAME,
+    available: true,
+    counts: normalizedCounts,
+    openJobs:
+      normalizedCounts.active +
+      normalizedCounts.delayed +
+      normalizedCounts.prioritized +
+      normalizedCounts.waiting +
+      normalizedCounts.waitingChildren,
+    updatedAt: new Date().toISOString(),
+  };
 }
 
 export async function enqueueCatalogBackfillMovieFromBackoffice(

--- a/apps/backoffice/src/components/backoffice.tsx
+++ b/apps/backoffice/src/components/backoffice.tsx
@@ -16,7 +16,10 @@ import type {
 } from '@pop-choice/shared';
 import type { CSSProperties, ReactNode } from 'react';
 
+import type { CatalogMaintenanceQueueSnapshot } from '../catalogMaintenanceQueue';
+import { CatalogHealthLiveRefresh } from './catalogHealthLiveRefresh';
 import { CatalogRepairEnhancement } from './catalogRepairEnhancement';
+import type { CatalogHealthLiveData } from '../lib/catalogHealthLive';
 import {
   DEFAULT_BULK_REPAIR_LIMIT,
   DEFAULT_CATALOG_ISSUE_PAGE_SIZE,
@@ -32,7 +35,6 @@ type ShellProps = {
   eyebrow: string;
   description?: ReactNode;
   actions?: ReactNode;
-  autoRefreshSeconds?: number;
   children: ReactNode;
 };
 
@@ -42,14 +44,10 @@ export function BackofficeShell({
   eyebrow,
   description,
   actions,
-  autoRefreshSeconds,
   children,
 }: ShellProps) {
   return (
     <>
-      {autoRefreshSeconds ? (
-        <meta httpEquiv="refresh" content={String(autoRefreshSeconds)} />
-      ) : null}
       <div className="topbar">
         <div className="topbar-inner">
           <a className="brand" href="/" aria-label="PopChoice Backoffice home">
@@ -234,9 +232,11 @@ function CatalogStat({
 function CatalogStatusStrip({
   activeIssues,
   duplicateGroups,
+  queueSnapshot,
 }: {
   activeIssues: number;
   duplicateGroups: number;
+  queueSnapshot: CatalogMaintenanceQueueSnapshot;
 }) {
   const isHealthy = activeIssues === 0 && duplicateGroups === 0;
 
@@ -262,6 +262,48 @@ function CatalogStatusStrip({
         </span>
         <span className={`pill ${duplicateGroups > 0 ? 'warning' : 'good'}`}>
           {duplicateGroups} duplicate groups
+        </span>
+        <span className={`pill ${queueSnapshot.available ? 'good' : 'warning'}`}>
+          {queueSnapshot.available
+            ? `${queueSnapshot.openJobs} catalog queue open`
+            : 'Catalog queue unavailable'}
+        </span>
+      </div>
+    </section>
+  );
+}
+
+function CatalogQueueStatus({ snapshot }: { snapshot: CatalogMaintenanceQueueSnapshot }) {
+  const state = !snapshot.available ? 'warning' : snapshot.openJobs > 0 ? 'neutral' : 'healthy';
+
+  return (
+    <section className="queue-status" aria-label="Catalog maintenance queue status">
+      <div>
+        <div className="queue-status-title">
+          <span className={`queue-dot ${state}`} aria-hidden="true" />
+          <span>Catalog maintenance queue</span>
+        </div>
+        <p>
+          {snapshot.available
+            ? `Synced from BullMQ at ${formatBackofficeDateTime(snapshot.updatedAt)}.`
+            : 'REDIS_URL is unavailable, so backoffice cannot read BullMQ state.'}
+        </p>
+      </div>
+      <div className="queue-counts">
+        <span>
+          <strong>{snapshot.counts.waiting}</strong> waiting
+        </span>
+        <span>
+          <strong>{snapshot.counts.active}</strong> active
+        </span>
+        <span>
+          <strong>{snapshot.counts.delayed + snapshot.counts.prioritized}</strong> scheduled
+        </span>
+        <span>
+          <strong>{snapshot.counts.failed}</strong> failed
+        </span>
+        <span>
+          <strong>{snapshot.counts.completed}</strong> completed
         </span>
       </div>
     </section>
@@ -624,13 +666,17 @@ function DuplicateReport({
 
 export function CatalogHealthPage({
   auditPage,
+  initialLiveData,
   issueMoviePage,
+  queueSnapshot,
   report,
   repairStatus,
 }: {
   report: CatalogHealthReport;
   auditPage: CatalogRepairActionAuditPage;
+  initialLiveData: CatalogHealthLiveData;
   issueMoviePage: CatalogHealthIssueMoviePage | null;
+  queueSnapshot: CatalogMaintenanceQueueSnapshot;
   repairStatus: string | null;
 }) {
   const activeIssues = report.issues.filter((issue) => issue.count > 0).length;
@@ -643,17 +689,25 @@ export function CatalogHealthPage({
       title="Catalog Health"
       eyebrow="Catalog operations"
       description={
-        <>Generated {formatBackofficeDateTime(report.generatedAt)}. Refreshes every 60 seconds.</>
+        <>
+          Generated {formatBackofficeDateTime(report.generatedAt)}. Live refresh is enabled without
+          a full page reload.
+        </>
       }
       actions={
         <a className="button" href="/">
           Refresh
         </a>
       }
-      autoRefreshSeconds={60}
     >
       <RepairFlash repairStatus={repairStatus} />
-      <CatalogStatusStrip activeIssues={activeIssues} duplicateGroups={duplicateGroups} />
+      <CatalogHealthLiveRefresh initialData={initialLiveData} intervalSeconds={12} />
+      <CatalogStatusStrip
+        activeIssues={activeIssues}
+        duplicateGroups={duplicateGroups}
+        queueSnapshot={queueSnapshot}
+      />
+      <CatalogQueueStatus snapshot={queueSnapshot} />
       <section className="summary" aria-label="Catalog health summary">
         <CatalogStat label="Movies" value={report.totalMovies} meta="Catalog rows tracked" />
         <CatalogStat

--- a/apps/backoffice/src/components/catalogHealthLiveRefresh.tsx
+++ b/apps/backoffice/src/components/catalogHealthLiveRefresh.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+import { useEffect, useMemo, useRef, useTransition } from 'react';
+
+import {
+  CATALOG_HEALTH_LIVE_QUERY_KEY,
+  catalogHealthLiveFingerprint,
+  type CatalogHealthLiveData,
+} from '../lib/catalogHealthLive';
+import { CATALOG_HEALTH_REFRESH_EVENT } from './catalogHealthRefreshEvent';
+
+async function fetchCatalogHealthLive(search: string): Promise<CatalogHealthLiveData> {
+  const response = await fetch(`/api/catalog-health${search}`, {
+    cache: 'no-store',
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch live catalog health state.');
+  }
+
+  return (await response.json()) as CatalogHealthLiveData;
+}
+
+export function CatalogHealthLiveRefresh({
+  initialData,
+  intervalSeconds,
+}: {
+  initialData: CatalogHealthLiveData;
+  intervalSeconds: number;
+}) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const initialFingerprint = useMemo(
+    () => catalogHealthLiveFingerprint(initialData),
+    [initialData],
+  );
+  const lastFingerprint = useRef(initialFingerprint);
+  const search = typeof window === 'undefined' ? '' : window.location.search;
+  const query = useQuery({
+    initialData,
+    queryFn: () => fetchCatalogHealthLive(search),
+    queryKey: [...CATALOG_HEALTH_LIVE_QUERY_KEY, search],
+    refetchInterval: Math.max(intervalSeconds, 5) * 1000,
+  });
+  const { data, dataUpdatedAt, isError, isFetching, refetch } = query;
+
+  useEffect(() => {
+    const refresh = () => {
+      void refetch();
+    };
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') refresh();
+    };
+
+    window.addEventListener(CATALOG_HEALTH_REFRESH_EVENT, refresh);
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    return () => {
+      window.removeEventListener(CATALOG_HEALTH_REFRESH_EVENT, refresh);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+  }, [refetch]);
+
+  useEffect(() => {
+    if (!data) return;
+
+    const nextFingerprint = catalogHealthLiveFingerprint(data);
+    if (nextFingerprint === lastFingerprint.current) return;
+
+    lastFingerprint.current = nextFingerprint;
+    startTransition(() => {
+      router.refresh();
+    });
+  }, [data, router]);
+
+  return (
+    <div className="live-refresh" aria-live="polite">
+      <span
+        className={`live-refresh-dot ${isPending || isFetching ? 'pending' : ''}`}
+        aria-hidden="true"
+      />
+      <span>
+        {isPending || isFetching
+          ? 'Syncing DB and BullMQ state'
+          : 'Live DB and BullMQ sync via TanStack Query'}
+      </span>
+      <span className="live-refresh-meta">
+        {dataUpdatedAt ? `Last checked ${new Date(dataUpdatedAt).toLocaleTimeString()}` : 'Waiting'}
+      </span>
+      {isError ? <span className="live-refresh-error">Live sync failed</span> : null}
+    </div>
+  );
+}

--- a/apps/backoffice/src/components/catalogHealthRefreshEvent.ts
+++ b/apps/backoffice/src/components/catalogHealthRefreshEvent.ts
@@ -1,0 +1,5 @@
+export const CATALOG_HEALTH_REFRESH_EVENT = 'popchoice:catalog-health-refresh';
+
+export function requestCatalogHealthRefresh(): void {
+  window.dispatchEvent(new CustomEvent(CATALOG_HEALTH_REFRESH_EVENT));
+}

--- a/apps/backoffice/src/components/catalogRepairEnhancement.tsx
+++ b/apps/backoffice/src/components/catalogRepairEnhancement.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect } from 'react';
 
+import { requestCatalogHealthRefresh } from './catalogHealthRefreshEvent';
+
 type RepairTone = '' | 'good' | 'warn';
 
 function setMessage(form: HTMLFormElement, text: string, tone: RepairTone): void {
@@ -19,6 +21,52 @@ function setButton(form: HTMLFormElement, text: string, disabled: boolean): void
 
   button.textContent = text;
   button.disabled = disabled;
+}
+
+function removeInlineConfirmation(form: HTMLFormElement): void {
+  form.querySelector('[data-inline-confirmation]')?.remove();
+}
+
+function showInlineConfirmation(form: HTMLFormElement, message: string): void {
+  const existing = form.querySelector<HTMLElement>('[data-inline-confirmation]');
+  if (existing) {
+    existing.querySelector<HTMLButtonElement>('[data-confirm-submit]')?.focus();
+    return;
+  }
+
+  const confirmation = document.createElement('div');
+  confirmation.className = 'inline-confirmation';
+  confirmation.dataset.inlineConfirmation = 'true';
+
+  const copy = document.createElement('p');
+  copy.textContent = message;
+
+  const actions = document.createElement('div');
+  actions.className = 'inline-confirmation-actions';
+
+  const confirm = document.createElement('button');
+  confirm.className = 'button success small';
+  confirm.dataset.confirmSubmit = 'true';
+  confirm.type = 'submit';
+  confirm.textContent = 'Confirm batch';
+  confirm.addEventListener('click', () => {
+    form.dataset.confirmed = 'true';
+  });
+
+  const cancel = document.createElement('button');
+  cancel.className = 'button quiet small';
+  cancel.type = 'button';
+  cancel.textContent = 'Cancel';
+  cancel.addEventListener('click', () => {
+    delete form.dataset.confirmed;
+    removeInlineConfirmation(form);
+    setMessage(form, 'Batch action cancelled.', '');
+  });
+
+  actions.append(confirm, cancel);
+  confirmation.append(copy, actions);
+  form.appendChild(confirmation);
+  confirm.focus();
 }
 
 function appendEmptyPlaceholder(body: HTMLElement | null, columnCount: number): void {
@@ -67,7 +115,13 @@ export function CatalogRepairEnhancement() {
         event.preventDefault();
 
         const confirmMessage = form.dataset.confirmMessage;
-        if (confirmMessage && !window.confirm(confirmMessage)) return;
+        if (confirmMessage && form.dataset.confirmed !== 'true') {
+          showInlineConfirmation(form, confirmMessage);
+          setMessage(form, 'Confirm this batch in-place to continue.', 'warn');
+          return;
+        }
+        delete form.dataset.confirmed;
+        removeInlineConfirmation(form);
 
         const row = form.closest<HTMLTableRowElement>('[data-repair-row]');
         const originalText =
@@ -96,6 +150,7 @@ export function CatalogRepairEnhancement() {
           } | null;
 
           if (response.ok && payload?.status === 'queued') {
+            requestCatalogHealthRefresh();
             row?.classList.remove('repair-pending');
             row?.classList.add('repair-queued');
             setButton(form, 'Queued', true);
@@ -118,6 +173,7 @@ export function CatalogRepairEnhancement() {
           }
 
           if (response.ok && payload?.status === 'partial') {
+            requestCatalogHealthRefresh();
             const bulkSummary = payload.summary;
             row?.classList.remove('repair-pending');
             setButton(form, originalText, false);

--- a/apps/backoffice/src/components/queryProvider.tsx
+++ b/apps/backoffice/src/components/queryProvider.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useState, type ReactNode } from 'react';
+
+export function BackofficeQueryProvider({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            refetchOnWindowFocus: true,
+            retry: 1,
+            staleTime: 5_000,
+          },
+        },
+      }),
+  );
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/apps/backoffice/src/lib/catalogHealthLive.ts
+++ b/apps/backoffice/src/lib/catalogHealthLive.ts
@@ -1,0 +1,76 @@
+import type {
+  CatalogHealthIssueMoviePage,
+  CatalogHealthReport,
+  CatalogRepairActionAuditPage,
+} from '@pop-choice/shared';
+
+import type { CatalogMaintenanceQueueSnapshot } from '../catalogMaintenanceQueue';
+
+export const CATALOG_HEALTH_LIVE_QUERY_KEY = ['backoffice', 'catalog-health-live'] as const;
+
+export interface CatalogHealthLiveData {
+  auditPage: Pick<CatalogRepairActionAuditPage, 'limit' | 'offset' | 'totalCount'>;
+  issueMoviePage: Pick<
+    CatalogHealthIssueMoviePage,
+    'issueKey' | 'limit' | 'offset' | 'totalCount'
+  > | null;
+  queueSnapshot: CatalogMaintenanceQueueSnapshot;
+  report: {
+    activeIssues: number;
+    duplicateGroups: number;
+    generatedAt: string;
+    issueCounts: Record<string, number>;
+    totalMovies: number;
+  };
+}
+
+export function toCatalogHealthLiveData({
+  auditPage,
+  issueMoviePage,
+  queueSnapshot,
+  report,
+}: {
+  auditPage: CatalogRepairActionAuditPage;
+  issueMoviePage: CatalogHealthIssueMoviePage | null;
+  queueSnapshot: CatalogMaintenanceQueueSnapshot;
+  report: CatalogHealthReport;
+}): CatalogHealthLiveData {
+  return {
+    auditPage: {
+      limit: auditPage.limit,
+      offset: auditPage.offset,
+      totalCount: auditPage.totalCount,
+    },
+    issueMoviePage: issueMoviePage
+      ? {
+          issueKey: issueMoviePage.issueKey,
+          limit: issueMoviePage.limit,
+          offset: issueMoviePage.offset,
+          totalCount: issueMoviePage.totalCount,
+        }
+      : null,
+    queueSnapshot,
+    report: {
+      activeIssues: report.issues.filter((issue) => issue.count > 0).length,
+      duplicateGroups:
+        report.duplicateTmdbIds.totalGroups + report.duplicateNormalizedTitleYears.totalGroups,
+      generatedAt: report.generatedAt,
+      issueCounts: Object.fromEntries(report.issues.map((issue) => [issue.key, issue.count])),
+      totalMovies: report.totalMovies,
+    },
+  };
+}
+
+export function catalogHealthLiveFingerprint(data: CatalogHealthLiveData): string {
+  return JSON.stringify({
+    auditTotalCount: data.auditPage.totalCount,
+    issueMoviePage: data.issueMoviePage,
+    queueCounts: data.queueSnapshot.counts,
+    queueOpenJobs: data.queueSnapshot.openJobs,
+    report: {
+      duplicateGroups: data.report.duplicateGroups,
+      issueCounts: data.report.issueCounts,
+      totalMovies: data.report.totalMovies,
+    },
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
       "version": "0.1.0-beta.0",
       "dependencies": {
         "@pop-choice/shared": "*",
+        "@tanstack/react-query": "^5.100.14",
         "bullmq": "^5.77.3",
         "ioredis": "^5.10.1",
         "next": "^16.2.6",


### PR DESCRIPTION
## Summary
- add TanStack Query provider and live catalog-health endpoint for DB/BullMQ snapshots
- sync the catalog-health page without a full browser reload and show BullMQ queue counts from the catalog-maintenance queue
- replace blocking native bulk repair confirmation with an inline in-page confirmation panel

## Verification
- npm run test:backoffice
- npm run type-check --workspace=apps/backoffice
- npm run build --workspace=apps/backoffice
- npm run format:package
- git diff --check
- pre-push: lint, server tests, production web build

## Notes
- The server-rendered page remains the source of truth; TanStack Query polls the live endpoint and triggers an RSC refresh when DB or BullMQ state changes.
- Local dev server announced http://localhost:4030, but sandbox curl could not connect back to that port, so browser smoke will be easiest to verify from Coolify/dev deployment.