### PR TITLE
Track durable catalog repair batches

### DIFF
--- a/apps/backoffice/src/catalogMaintenanceQueue.ts
+++ b/apps/backoffice/src/catalogMaintenanceQueue.ts
@@ -20,6 +20,8 @@ export interface EnqueueCatalogBackfillMovieInput {
   movieId: string | number;
   reason: CatalogBackfillReason;
   language?: string;
+  repairBatchId?: string | number;
+  repairBatchItemId?: string | number;
 }
 
 export interface EnqueueCatalogBackfillMovieResult {
@@ -51,6 +53,8 @@ type CatalogBackfillMovieJobData = {
   movieId: string | number;
   reason?: CatalogBackfillReason;
   language?: string;
+  repairBatchId?: string | number;
+  repairBatchItemId?: string | number;
 };
 
 let redisConnection: Redis | null = null;
@@ -184,6 +188,8 @@ export async function enqueueCatalogBackfillMovieFromBackoffice(
       movieId: input.movieId,
       reason: input.reason,
       language,
+      repairBatchId: input.repairBatchId,
+      repairBatchItemId: input.repairBatchItemId,
     },
     {
       ...CATALOG_MAINTENANCE_JOB_OPTIONS,

--- a/apps/backoffice/src/components/backoffice.tsx
+++ b/apps/backoffice/src/components/backoffice.tsx
@@ -599,7 +599,9 @@ function RepairAuditRows({ audit }: { audit: CatalogRepairActionAudit[] }) {
             </td>
             <td>{entry.action}</td>
             <td>
-              {String(entry.result.jobId ?? entry.result.status ?? JSON.stringify(entry.result))}
+              {entry.repairBatchId
+                ? `batch:${entry.repairBatchId}`
+                : String(entry.result.jobId ?? entry.result.status ?? JSON.stringify(entry.result))}
             </td>
           </tr>
         ))}

--- a/apps/backoffice/src/lib/backoffice.ts
+++ b/apps/backoffice/src/lib/backoffice.ts
@@ -1,5 +1,7 @@
 import {
   applyTMDBMatchReviewAction,
+  createCatalogRepairBatch,
+  createCatalogRepairBatchItem,
   ensureCatalogRepairActionSchema,
   ensureTMDBMatchReviewActionSchema,
   getCatalogRepairMovieSnapshot,
@@ -10,7 +12,9 @@ import {
   listCatalogHealthIssueMoviePage,
   logger,
   recordCatalogRepairAction,
+  refreshCatalogRepairBatchCounts,
   readBackofficeRuntimeConfig,
+  updateCatalogRepairBatchItemEnqueueResult,
 } from '@pop-choice/shared';
 import type {
   BackofficeRuntimeConfig,
@@ -256,6 +260,7 @@ export type CatalogRepairActionResult =
     };
 
 export type CatalogBulkRepairSummary = {
+  batchId?: string;
   issueKey: string;
   totalCandidates: number;
   attempted: number;
@@ -267,6 +272,7 @@ export type CatalogBulkRepairSummary = {
   movieIds: string[];
   jobs: Array<{
     movieId: string;
+    itemId?: string;
     jobId?: string;
     status: 'queued' | 'deduped' | 'failed' | 'unavailable';
   }>;
@@ -285,6 +291,8 @@ async function performBulkCatalogRepairAction(
   const config = await ensureBackofficeReady();
   const issueKey = parseCatalogIssueKey(formData.get('issue_key'));
   const limit = parseBulkRepairLimit(formData.get('batch_limit'));
+  const actor = parseOperatorActor(headers);
+  const note = typeof formData.get('note') === 'string' ? String(formData.get('note')) : undefined;
   const page = await listCatalogHealthIssueMoviePage({
     issueKey,
     limit,
@@ -303,29 +311,84 @@ async function performBulkCatalogRepairAction(
     movieIds: page.movies.map((movie) => movie.id),
     jobs: [],
   };
+  const batch = await createCatalogRepairBatch({
+    action: 'bulk_enqueue_backfill',
+    actor,
+    issueKey,
+    targetType: 'catalog_issue',
+    targetId: issueKey,
+    requestedLimit: page.limit,
+    totalCandidates: page.totalCount,
+    attemptedCount: page.movies.length,
+    note,
+    previousState: {
+      issueKey,
+      totalCandidates: page.totalCount,
+      sampledMovieIds: summary.movieIds,
+    },
+  });
+  summary.batchId = batch.id;
+  const reason = getBackfillReasonForIssue(issueKey);
 
   for (const movie of page.movies) {
+    const item = await createCatalogRepairBatchItem({
+      batchId: batch.id,
+      movieId: movie.id,
+      issueKey,
+      movieSnapshot: { ...movie },
+      reason,
+      language: config.tmdbLanguage,
+    });
+
     try {
       const job = await enqueueCatalogBackfillMovieFromBackoffice(
         {
           movieId: movie.id,
-          reason: getBackfillReasonForIssue(issueKey),
+          reason,
           language: config.tmdbLanguage,
+          repairBatchId: batch.id,
+          repairBatchItemId: item.id,
         },
         config.redisUrl,
       );
 
       if (!job) {
+        await updateCatalogRepairBatchItemEnqueueResult({
+          itemId: item.id,
+          status: 'unavailable',
+          errorMessage: 'REDIS_URL is unavailable or the catalog-maintenance queue is disabled.',
+          result: { status: 'queue_unavailable', queueName: 'catalog-maintenance' },
+        });
         summary.unavailable += 1;
-        summary.jobs.push({ movieId: movie.id, status: 'unavailable' });
+        summary.jobs.push({ movieId: movie.id, itemId: item.id, status: 'unavailable' });
         continue;
       }
 
+      await updateCatalogRepairBatchItemEnqueueResult({
+        itemId: item.id,
+        status: job.status,
+        queueName: job.queueName,
+        jobName: job.jobName,
+        jobId: job.jobId,
+        language: job.language,
+        result: { ...job },
+      });
       summary[job.status] += 1;
-      summary.jobs.push({ movieId: movie.id, jobId: job.jobId, status: job.status });
+      summary.jobs.push({
+        movieId: movie.id,
+        itemId: item.id,
+        jobId: job.jobId,
+        status: job.status,
+      });
     } catch (error) {
+      await updateCatalogRepairBatchItemEnqueueResult({
+        itemId: item.id,
+        status: 'enqueue_failed',
+        errorMessage: error instanceof Error ? error.message : String(error),
+        result: { status: 'enqueue_failed' },
+      });
       summary.failed += 1;
-      summary.jobs.push({ movieId: movie.id, status: 'failed' });
+      summary.jobs.push({ movieId: movie.id, itemId: item.id, status: 'failed' });
       logger.error('Failed to enqueue catalog repair job from bulk action', {
         err: error,
         issueKey,
@@ -334,19 +397,21 @@ async function performBulkCatalogRepairAction(
     }
   }
 
+  await refreshCatalogRepairBatchCounts(batch.id);
   await recordCatalogRepairAction({
     action: 'bulk_enqueue_backfill',
-    actor: parseOperatorActor(headers),
+    actor,
     issueKey,
     targetType: 'catalog_issue',
     targetId: issueKey,
-    note: typeof formData.get('note') === 'string' ? String(formData.get('note')) : undefined,
+    note,
     previousState: {
       issueKey,
       totalCandidates: page.totalCount,
       sampledMovieIds: summary.movieIds,
     },
     result: { ...summary },
+    repairBatchId: batch.id,
   });
 
   return {

--- a/apps/web/src/lib/jobQueue.ts
+++ b/apps/web/src/lib/jobQueue.ts
@@ -83,6 +83,8 @@ export type CatalogBackfillMovieJobData = {
   movieId: string | number;
   reason?: 'missing_tmdb_id' | 'missing_metadata' | 'manual_refresh';
   language?: string;
+  repairBatchId?: string | number;
+  repairBatchItemId?: string | number;
   trace?: TraceCarrier;
 };
 

--- a/apps/web/src/lib/workers/catalogMaintenanceWorker.ts
+++ b/apps/web/src/lib/workers/catalogMaintenanceWorker.ts
@@ -1,9 +1,12 @@
 import {
   createEmbeddings,
+  ensureCatalogRepairActionSchema,
   ensureCatalogMetadataSchema,
   getPool,
   initDatabase,
   insertMovies,
+  refreshCatalogRepairBatchCounts,
+  updateCatalogRepairBatchItemStatus,
   upsertMovieCatalogMetadata,
 } from '@pop-choice/shared';
 import { Worker } from 'bullmq';
@@ -87,8 +90,39 @@ function ensureDatabase(): void {
 
 async function ensureCatalogSchema(): Promise<void> {
   ensureDatabase();
-  schemaReadyPromise ??= ensureCatalogMetadataSchema();
+  schemaReadyPromise ??= Promise.all([
+    ensureCatalogMetadataSchema(),
+    ensureCatalogRepairActionSchema(),
+  ]).then(() => undefined);
   await schemaReadyPromise;
+}
+
+async function updateRepairBatchItem(
+  job: Job<CatalogMaintenanceJobData, void, CatalogMaintenanceJobName> | undefined,
+  status: 'processing' | 'completed' | 'failed' | 'skipped',
+  options: { errorMessage?: string; result?: Record<string, unknown> } = {},
+): Promise<void> {
+  const repairBatchItemId =
+    job?.data && 'repairBatchItemId' in job.data ? job.data.repairBatchItemId : undefined;
+  if (!repairBatchItemId) return;
+
+  await updateCatalogRepairBatchItemStatus({
+    itemId: repairBatchItemId,
+    status,
+    errorMessage: options.errorMessage,
+    result: {
+      jobId: String(job?.id ?? 'unknown'),
+      jobName: job?.name ?? 'unknown',
+      attemptsMade: job?.attemptsMade ?? 0,
+      ...options.result,
+    },
+  });
+
+  const repairBatchId =
+    job?.data && 'repairBatchId' in job.data ? job.data.repairBatchId : undefined;
+  if (repairBatchId) {
+    await refreshCatalogRepairBatchCounts(repairBatchId);
+  }
 }
 
 async function handleRateLimit(
@@ -301,6 +335,10 @@ async function loadBackfillMovie(movieId: string | number): Promise<BackfillMovi
 
 async function processBackfillMovie(job: Job<CatalogBackfillMovieJobData>): Promise<void> {
   await ensureCatalogSchema();
+  await updateRepairBatchItem(
+    job as Job<CatalogMaintenanceJobData, void, CatalogMaintenanceJobName>,
+    'processing',
+  );
 
   const apiKey = process.env.TMDB_API_KEY;
   if (!apiKey) throw new Error('TMDB_API_KEY is required for catalog backfill jobs');
@@ -308,6 +346,13 @@ async function processBackfillMovie(job: Job<CatalogBackfillMovieJobData>): Prom
   const movie = await loadBackfillMovie(job.data.movieId);
   if (!movie) {
     logger.warn({ jobId: job.id, movieId: job.data.movieId }, 'Catalog backfill movie not found');
+    await updateRepairBatchItem(
+      job as Job<CatalogMaintenanceJobData, void, CatalogMaintenanceJobName>,
+      'skipped',
+      {
+        result: { reason: 'movie_not_found', movieId: String(job.data.movieId) },
+      },
+    );
     return;
   }
 
@@ -325,12 +370,31 @@ async function processBackfillMovie(job: Job<CatalogBackfillMovieJobData>): Prom
       },
       'Catalog backfill skipped movie without confident TMDB match',
     );
+    await updateRepairBatchItem(
+      job as Job<CatalogMaintenanceJobData, void, CatalogMaintenanceJobName>,
+      'skipped',
+      {
+        result: {
+          reason: 'tmdb_match_not_confident',
+          movieId: movie.id,
+          matchStatus: match.status,
+          candidateCount: match.candidates.length,
+        },
+      },
+    );
     return;
   }
 
   const details = await fetchMovieDetails(apiKey, match.tmdbId, job.data.language);
   if (!details) {
     logger.warn({ jobId: job.id, tmdbId: match.tmdbId }, 'Catalog backfill found no details');
+    await updateRepairBatchItem(
+      job as Job<CatalogMaintenanceJobData, void, CatalogMaintenanceJobName>,
+      'skipped',
+      {
+        result: { reason: 'tmdb_details_missing', movieId: movie.id, tmdbId: match.tmdbId },
+      },
+    );
     return;
   }
 
@@ -386,6 +450,13 @@ async function processBackfillMovie(job: Job<CatalogBackfillMovieJobData>): Prom
   logger.info(
     { jobId: job.id, movieId: movie.id, tmdbId: match.tmdbId },
     'Catalog backfill completed',
+  );
+  await updateRepairBatchItem(
+    job as Job<CatalogMaintenanceJobData, void, CatalogMaintenanceJobName>,
+    'completed',
+    {
+      result: { movieId: movie.id, tmdbId: match.tmdbId },
+    },
   );
 }
 
@@ -466,12 +537,24 @@ export function createCatalogMaintenanceWorker(): CatalogWorker | null {
 
   worker.on('failed', (job, err) => {
     const attemptsMade = job?.attemptsMade ?? 0;
+    const finalFailure = attemptsMade >= MAX_CATALOG_ATTEMPTS;
     recordQueueJobEvent({
       queue: CATALOG_MAINTENANCE_QUEUE_NAME,
       job: job?.name ?? 'unknown',
       event: 'failed',
-      final: attemptsMade >= MAX_CATALOG_ATTEMPTS,
+      final: finalFailure,
     });
+    if (finalFailure) {
+      void updateRepairBatchItem(job, 'failed', {
+        errorMessage: err instanceof Error ? err.message : String(err),
+        result: { reason: 'worker_failed' },
+      }).catch((statusError) => {
+        logger.error(
+          { err: statusError, jobId: job?.id, jobName: job?.name },
+          'Failed to persist catalog repair batch item failure',
+        );
+      });
+    }
     logger.error(
       {
         err,

--- a/db/createDB.sql
+++ b/db/createDB.sql
@@ -247,6 +247,107 @@ CREATE INDEX IF NOT EXISTS idx_catalog_repair_audit_target_created_at
 CREATE INDEX IF NOT EXISTS idx_catalog_repair_audit_issue_created_at
   ON catalog_repair_audit (issue_key, created_at DESC);
 
+CREATE TABLE IF NOT EXISTS catalog_repair_batches (
+  id bigserial PRIMARY KEY,
+  action text NOT NULL,
+  actor text NOT NULL,
+  issue_key text NOT NULL,
+  target_type text NOT NULL,
+  target_id text NOT NULL,
+  status text NOT NULL DEFAULT 'enqueueing',
+  requested_limit integer NOT NULL DEFAULT 0,
+  total_candidates integer NOT NULL DEFAULT 0,
+  attempted_count integer NOT NULL DEFAULT 0,
+  queued_count integer NOT NULL DEFAULT 0,
+  deduped_count integer NOT NULL DEFAULT 0,
+  unavailable_count integer NOT NULL DEFAULT 0,
+  failed_count integer NOT NULL DEFAULT 0,
+  completed_count integer NOT NULL DEFAULT 0,
+  skipped_count integer NOT NULL DEFAULT 0,
+  note text,
+  previous_state jsonb NOT NULL DEFAULT '{}'::jsonb,
+  result jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  completed_at timestamptz,
+  CONSTRAINT catalog_repair_batches_action_check CHECK (
+    action IN ('enqueue_backfill', 'bulk_enqueue_backfill')
+  ),
+  CONSTRAINT catalog_repair_batches_status_check CHECK (
+    status IN (
+      'enqueueing',
+      'queued',
+      'processing',
+      'partial',
+      'failed',
+      'unavailable',
+      'empty',
+      'completed'
+    )
+  )
+);
+
+CREATE TABLE IF NOT EXISTS catalog_repair_batch_items (
+  id bigserial PRIMARY KEY,
+  batch_id bigint NOT NULL REFERENCES catalog_repair_batches(id) ON DELETE CASCADE,
+  movie_id bigint NOT NULL REFERENCES movies(id) ON DELETE RESTRICT,
+  issue_key text NOT NULL,
+  status text NOT NULL DEFAULT 'pending',
+  queue_name text,
+  job_name text,
+  job_id text,
+  language text,
+  reason text,
+  error_message text,
+  movie_snapshot jsonb NOT NULL DEFAULT '{}'::jsonb,
+  result jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  completed_at timestamptz,
+  CONSTRAINT catalog_repair_batch_items_status_check CHECK (
+    status IN (
+      'pending',
+      'queued',
+      'deduped',
+      'unavailable',
+      'enqueue_failed',
+      'processing',
+      'completed',
+      'failed',
+      'skipped'
+    )
+  )
+);
+
+ALTER TABLE catalog_repair_audit
+  ADD COLUMN IF NOT EXISTS repair_batch_id bigint REFERENCES catalog_repair_batches(id) ON DELETE SET NULL;
+
+ALTER TABLE catalog_repair_audit
+  ADD COLUMN IF NOT EXISTS repair_batch_item_id bigint REFERENCES catalog_repair_batch_items(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_catalog_repair_batches_created_at
+  ON catalog_repair_batches (created_at DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_catalog_repair_batches_issue_created_at
+  ON catalog_repair_batches (issue_key, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_catalog_repair_batches_status_updated_at
+  ON catalog_repair_batches (status, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_catalog_repair_batch_items_batch_status
+  ON catalog_repair_batch_items (batch_id, status, id);
+
+CREATE INDEX IF NOT EXISTS idx_catalog_repair_batch_items_movie_created_at
+  ON catalog_repair_batch_items (movie_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_catalog_repair_batch_items_job_id
+  ON catalog_repair_batch_items (job_id)
+  WHERE job_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_catalog_repair_audit_batch_created_at
+  ON catalog_repair_audit (repair_batch_id, created_at DESC)
+  WHERE repair_batch_id IS NOT NULL;
+
 CREATE TABLE IF NOT EXISTS users (
   id bigserial PRIMARY KEY,
   email text NOT NULL,

--- a/db/init/01_schema.sql
+++ b/db/init/01_schema.sql
@@ -260,6 +260,107 @@ CREATE INDEX IF NOT EXISTS idx_catalog_repair_audit_target_created_at
 CREATE INDEX IF NOT EXISTS idx_catalog_repair_audit_issue_created_at
   ON catalog_repair_audit (issue_key, created_at DESC);
 
+CREATE TABLE IF NOT EXISTS catalog_repair_batches (
+  id bigserial PRIMARY KEY,
+  action text NOT NULL,
+  actor text NOT NULL,
+  issue_key text NOT NULL,
+  target_type text NOT NULL,
+  target_id text NOT NULL,
+  status text NOT NULL DEFAULT 'enqueueing',
+  requested_limit integer NOT NULL DEFAULT 0,
+  total_candidates integer NOT NULL DEFAULT 0,
+  attempted_count integer NOT NULL DEFAULT 0,
+  queued_count integer NOT NULL DEFAULT 0,
+  deduped_count integer NOT NULL DEFAULT 0,
+  unavailable_count integer NOT NULL DEFAULT 0,
+  failed_count integer NOT NULL DEFAULT 0,
+  completed_count integer NOT NULL DEFAULT 0,
+  skipped_count integer NOT NULL DEFAULT 0,
+  note text,
+  previous_state jsonb NOT NULL DEFAULT '{}'::jsonb,
+  result jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  completed_at timestamptz,
+  CONSTRAINT catalog_repair_batches_action_check CHECK (
+    action IN ('enqueue_backfill', 'bulk_enqueue_backfill')
+  ),
+  CONSTRAINT catalog_repair_batches_status_check CHECK (
+    status IN (
+      'enqueueing',
+      'queued',
+      'processing',
+      'partial',
+      'failed',
+      'unavailable',
+      'empty',
+      'completed'
+    )
+  )
+);
+
+CREATE TABLE IF NOT EXISTS catalog_repair_batch_items (
+  id bigserial PRIMARY KEY,
+  batch_id bigint NOT NULL REFERENCES catalog_repair_batches(id) ON DELETE CASCADE,
+  movie_id bigint NOT NULL REFERENCES movies(id) ON DELETE RESTRICT,
+  issue_key text NOT NULL,
+  status text NOT NULL DEFAULT 'pending',
+  queue_name text,
+  job_name text,
+  job_id text,
+  language text,
+  reason text,
+  error_message text,
+  movie_snapshot jsonb NOT NULL DEFAULT '{}'::jsonb,
+  result jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  completed_at timestamptz,
+  CONSTRAINT catalog_repair_batch_items_status_check CHECK (
+    status IN (
+      'pending',
+      'queued',
+      'deduped',
+      'unavailable',
+      'enqueue_failed',
+      'processing',
+      'completed',
+      'failed',
+      'skipped'
+    )
+  )
+);
+
+ALTER TABLE catalog_repair_audit
+  ADD COLUMN IF NOT EXISTS repair_batch_id bigint REFERENCES catalog_repair_batches(id) ON DELETE SET NULL;
+
+ALTER TABLE catalog_repair_audit
+  ADD COLUMN IF NOT EXISTS repair_batch_item_id bigint REFERENCES catalog_repair_batch_items(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_catalog_repair_batches_created_at
+  ON catalog_repair_batches (created_at DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_catalog_repair_batches_issue_created_at
+  ON catalog_repair_batches (issue_key, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_catalog_repair_batches_status_updated_at
+  ON catalog_repair_batches (status, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_catalog_repair_batch_items_batch_status
+  ON catalog_repair_batch_items (batch_id, status, id);
+
+CREATE INDEX IF NOT EXISTS idx_catalog_repair_batch_items_movie_created_at
+  ON catalog_repair_batch_items (movie_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_catalog_repair_batch_items_job_id
+  ON catalog_repair_batch_items (job_id)
+  WHERE job_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_catalog_repair_audit_batch_created_at
+  ON catalog_repair_audit (repair_batch_id, created_at DESC)
+  WHERE repair_batch_id IS NOT NULL;
+
 CREATE TABLE IF NOT EXISTS users (
   id bigserial PRIMARY KEY,
   email text NOT NULL,

--- a/docs/BACKOFFICE.md
+++ b/docs/BACKOFFICE.md
@@ -85,6 +85,12 @@ Mutation flows are deliberately narrow:
   confirms the operator intent in the enhanced UI, reports partial enqueue
   results explicitly, and records a grouped `bulk_enqueue_backfill` audit
   summary with queued, deduped, unavailable, and failed counts.
+- [#572](https://github.com/shchilkin/PopChoice/issues/572): bulk repair
+  attempts now create durable `catalog_repair_batches` and
+  `catalog_repair_batch_items` rows before enqueueing BullMQ jobs. The audit row
+  stays immutable and links back to the batch, while the batch/item tables are
+  the Postgres source of truth for enqueue and worker progress after BullMQ
+  history is trimmed.
 
 Shared operator auth is the login model for public exposure:
 
@@ -154,9 +160,13 @@ intentionally conservative:
   repairs;
 - duplicate identity groups remain read-only because they can require manual
   merge decisions;
-- backoffice stores one-off movie snapshots and bulk queue summaries in
-  `catalog_repair_audit`, which gives operators a recovery trail without
-  editing the catalog directly from the HTML form;
+- backoffice stores immutable audit rows in `catalog_repair_audit` and durable
+  bulk progress in `catalog_repair_batches` plus `catalog_repair_batch_items`,
+  which gives operators a recovery trail without depending on retained BullMQ
+  jobs;
+- workers advance durable item status from `queued`/`deduped` to `processing`,
+  `completed`, `skipped`, or final `failed` when a repair job carries
+  `repairBatchId` and `repairBatchItemId`;
 - the recent repair audit is paginated so large repair histories do not render
   as one long operator table.
 

--- a/docs/ROADMAP-ARCHITECTURE.md
+++ b/docs/ROADMAP-ARCHITECTURE.md
@@ -73,7 +73,7 @@ The main remaining risks are:
 
 ### Issues Still Present
 
-- The current quiz is still a first-generation guided flow. It should evolve toward a signal-based recommendation model with a shorter "tonight" quiz, a swipe-based mode for movie-heavy users, and a TMDB-first catalog strategy. See [RECOMMENDATION-ROADMAP.md](/docs/RECOMMENDATION-ROADMAP).
+- The current quiz is still a first-generation guided flow. It should evolve toward a signal-based recommendation model with explicit Solo/Duo/Group audience modes, Fast/Normal effort modes, a shorter "tonight" quiz, a swipe-based mode for movie-heavy users, and a TMDB-first catalog strategy. See [RECOMMENDATION-ROADMAP.md](/docs/RECOMMENDATION-ROADMAP).
 - Route-local compatibility re-export files still exist under `src/app/api/movie-recommendation`; future recommendation changes should continue moving real logic into `src/features/recommendation`.
 - Account settings/profile/provider identity remain intentionally thin.
 
@@ -204,7 +204,8 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 - [x] Add responsive backoffice repair actions in [#592](https://github.com/shchilkin/PopChoice/issues/592), including pending/success/error states, duplicate-click protection, and live row updates after successful queued repair. The first slice keeps progressive-enhanced HTML with JSON responses for enhanced requests; a heavier client data layer is deferred until pagination, virtualization, or bulk repair flows need it.
 - [x] Migrate the dedicated backoffice app to Next.js in [#596](https://github.com/shchilkin/PopChoice/issues/596) before adding larger interactive operator workflows. The `apps/backoffice` deployment boundary, routes, health check, and Coolify port stay the same, while catalog health, TMDB reviews, and repair actions now run through React/App Router pages and route handlers.
 - [x] Add large backoffice table pagination in [#591](https://github.com/shchilkin/PopChoice/issues/591): TMDB review queue pagination landed in [#600](https://github.com/shchilkin/PopChoice/issues/600), and the follow-up slice adds catalog-health issue row browsing plus paginated catalog repair audit history.
-- [x] Add safe bulk catalog repair enqueueing in [#593](https://github.com/shchilkin/PopChoice/issues/593), with bounded batches, deduped `catalog-maintenance` jobs, grouped audit summaries, and worker-side TMDB/OpenAI pacing preserved. Durable repair batch status remains tracked separately in [#572](https://github.com/shchilkin/PopChoice/issues/572)-[#575](https://github.com/shchilkin/PopChoice/issues/575).
+- [x] Add safe bulk catalog repair enqueueing in [#593](https://github.com/shchilkin/PopChoice/issues/593), with bounded batches, deduped `catalog-maintenance` jobs, grouped audit summaries, and worker-side TMDB/OpenAI pacing preserved.
+- [x] Add durable repair batch/item storage in [#572](https://github.com/shchilkin/PopChoice/issues/572), so bulk repairs write `catalog_repair_batches` and `catalog_repair_batch_items` before enqueueing BullMQ jobs, and workers persist basic processing/completed/skipped/final-failed status. Follow-up issue re-checking and operator views stay in [#574](https://github.com/shchilkin/PopChoice/issues/574)-[#575](https://github.com/shchilkin/PopChoice/issues/575).
 - Periodically refresh TMDB-backed metadata for older records without destabilizing existing recommendation history.
 - Make seed, discovery, and backfill responsibilities explicit enough that data-quality fixes do not duplicate or fight each other.
 - Define migration/versioning expectations for schema changes in [#494](https://github.com/shchilkin/PopChoice/issues/494), including production migration safety, rollback notes, and seed/backfill coordination.
@@ -230,6 +231,7 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 - [x] [#475](https://github.com/shchilkin/PopChoice/issues/475): cover auth, catalog, quiz, recommendation, and feedback smoke flows through product-level e2e tests.
 - [x] [#476](https://github.com/shchilkin/PopChoice/issues/476): add an AI recommendation eval harness with deterministic fixtures by default and optional live model/provider runs.
 - [x] [#490](https://github.com/shchilkin/PopChoice/issues/490): add a scheduled or manually triggered real-data recommendation eval workflow with seeded database data and real catalog retrieval.
+- Add [#606](https://github.com/shchilkin/PopChoice/issues/606) deterministic recommendation scenarios for Solo/Fast, Solo/Normal, Duo/Fast, Duo/Normal, Group/Fast, and Group/Normal so the next recommendation UX/backend changes can be judged against meaningful-pick behavior, not only response shape.
 - Keep Storybook/component tests separate from full product e2e tests so UI component regressions and app-flow regressions fail with clear ownership.
 - Keep AI evals separate from normal e2e smoke tests because recommendation quality gates need fixture scoring, model controls, and optional API cost.
 
@@ -249,6 +251,7 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 
 - Pivot recommendation retrieval toward TMDB-backed catalog coverage instead of relying primarily on the embedded/course-sized movie database.
 - Keep the local `movies` table as a cache/index of known titles, embeddings, localized names, poster URLs, and TMDB ids rather than the full source of truth.
+- Plan [#607](https://github.com/shchilkin/PopChoice/issues/607) before switching defaults from local-vector-first plus TMDB fallback to TMDB-first broad candidate generation plus local cache, enrichment, memory, and reranking.
 - Backfill TMDB ids for existing local movies using exact title/year matches first, then persist ambiguous or low-confidence matches for manual review.
 - Add cast, director, genre, and keyword metadata as first-class catalog data before implementing actor/director/genre search.
 - [x] Move TMDB discovery, backfill, and metadata refresh into shared rate-limited BullMQ catalog workers in [#492](https://github.com/shchilkin/PopChoice/issues/492) before growing catalog volume. The worker enforces one configurable TMDB request budget across catalog-maintenance jobs, honors `429` with backoff, dedupes jobs by stable `tmdbId`/`movieId` keys, and exposes queue depth/failures in Bull Board.
@@ -266,8 +269,11 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 
 ### Recommendation Experience Track
 
+- Define Recommendation V2 in [#610](https://github.com/shchilkin/PopChoice/issues/610) around two explicit product axes: audience mode (Solo, Duo, Group) and effort mode (Fast, Normal).
 - Treat quiz answers, swipe reactions, account memory, and result feedback as inputs into a shared taste-signal model.
 - Rework the guided quiz around "what do you want tonight?" instead of relying on a favorite movie, broad genre labels, and optional actor input.
+- Build [#609](https://github.com/shchilkin/PopChoice/issues/609) as the Fast Pick guided flow with minimal intent, hard avoids, and discovery appetite.
+- Build [#608](https://github.com/shchilkin/PopChoice/issues/608) as the Normal mode flow with richer positive/negative signals, optional reference movies, and first-class Duo compromise handling.
 - Add an alternate taste-swipe mode for users who have watched many films and prefer to react to concrete movie cards instead of answering abstract questions.
 - Move toward TMDB-first candidate generation: use TMDB for broad discovery and keep the local database as a cache/enrichment/reranking layer rather than the whole movie universe.
 - Keep TMDB ids as the preferred movie identity and log ambiguous title/year matches for later admin/back-office review.

--- a/docs/SCHEMA-MIGRATIONS.md
+++ b/docs/SCHEMA-MIGRATIONS.md
@@ -57,13 +57,14 @@ forward-fix plan in the PR and create a follow-up issue before merging.
 When schema changes touch shared tables, update every relevant owner in the same
 PR unless there is a deliberate staged rollout.
 
-| Change type                 | Required files                                                                     |
-| --------------------------- | ---------------------------------------------------------------------------------- |
-| Core movie/catalog tables   | `db/init/01_schema.sql`, `db/createDB.sql`, `packages/shared/src/db.ts`            |
-| Vector search function      | `db/init/02_match_movies.sql`, `db/match_movies.sql`, `packages/shared/src/db.ts`  |
-| Recommendation persistence  | `db/init/03_recommendations.sql`, `db/recommendations.sql`, app repositories/tests |
-| Password reset/auth storage | `db/init/04_password_reset_tokens.sql`, `db/createDB.sql`, auth repositories/tests |
-| Service-written metadata    | Shared schema helper plus the owning service tests and docs                        |
+| Change type                 | Required files                                                                                                                                                                             |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Core movie/catalog tables   | `db/init/01_schema.sql`, `db/createDB.sql`, `packages/shared/src/db.ts`                                                                                                                    |
+| Vector search function      | `db/init/02_match_movies.sql`, `db/match_movies.sql`, `packages/shared/src/db.ts`                                                                                                          |
+| Recommendation persistence  | `db/init/03_recommendations.sql`, `db/recommendations.sql`, app repositories/tests                                                                                                         |
+| Password reset/auth storage | `db/init/04_password_reset_tokens.sql`, `db/createDB.sql`, auth repositories/tests                                                                                                         |
+| Backoffice repair batches   | `db/init/01_schema.sql`, `db/createDB.sql`, `packages/shared/src/db.ts`, `packages/shared/src/catalogRepairActions.ts`, `services/movie-backfill/src/database.ts`, backoffice/shared tests |
+| Service-written metadata    | Shared schema helper plus the owning service tests and docs                                                                                                                                |
 
 Do not rely only on service `ensureSchema()` for production. The canonical
 migration path is still `db/init/*.sql`; helpers are a compatibility layer for

--- a/docs/SERVICES.md
+++ b/docs/SERVICES.md
@@ -332,6 +332,13 @@ and are audited in `catalog_repair_audit` with actor, target movie, issue key,
 movie snapshot, and queued job result. Duplicate identity findings stay
 read-only until an operator can make a conservative merge decision.
 
+Bulk repair actions also create durable `catalog_repair_batches` and
+`catalog_repair_batch_items` rows before writing BullMQ jobs. Item enqueue
+statuses start as `pending` and move to `queued`, `deduped`, `unavailable`, or
+`enqueue_failed`; workers then move repair jobs through `processing`,
+`completed`, `skipped`, or final `failed`. Use these tables for operator history
+instead of relying on retained BullMQ jobs.
+
 Useful options:
 
 | Variable                      | Default | Description                                              |

--- a/packages/shared/src/catalogRepairActions.test.ts
+++ b/packages/shared/src/catalogRepairActions.test.ts
@@ -2,7 +2,14 @@ import pg from 'pg';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { closeDatabase, initDatabase } from './db.js';
-import { listCatalogRepairAuditPage } from './catalogRepairActions.js';
+import {
+  createCatalogRepairBatch,
+  createCatalogRepairBatchItem,
+  ensureCatalogRepairActionSchema,
+  listCatalogRepairAuditPage,
+  refreshCatalogRepairBatchCounts,
+  updateCatalogRepairBatchItemEnqueueResult,
+} from './catalogRepairActions.js';
 
 vi.mock('pg', () => {
   const mPool = {
@@ -44,6 +51,8 @@ describe('catalog repair audit pages', () => {
           note: null,
           previous_state: { issueKey: 'missing_poster_url' },
           result: { queued: 25 },
+          repair_batch_id: '7',
+          repair_batch_item_id: null,
           created_at: '2026-05-28 09:00:00+00',
         },
       ],
@@ -64,9 +73,187 @@ describe('catalog repair audit pages', () => {
           targetType: 'catalog_issue',
           targetId: 'missing_poster_url',
           result: { queued: 25 },
+          repairBatchId: '7',
+          repairBatchItemId: null,
         },
       ],
     });
     expect(poolMock.query.mock.calls[1][1]).toEqual([100, 100_000]);
+  });
+
+  it('ensures durable repair batch schema alongside audit schema', async () => {
+    poolMock.query.mockResolvedValueOnce({ rows: [] });
+
+    await ensureCatalogRepairActionSchema();
+
+    const sql = poolMock.query.mock.calls[0][0];
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS catalog_repair_batches');
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS catalog_repair_batch_items');
+    expect(sql).toContain('repair_batch_id bigint REFERENCES catalog_repair_batches');
+    expect(sql).toContain("'enqueue_failed'");
+    expect(sql).toContain('idx_catalog_repair_batch_items_job_id');
+  });
+
+  it('creates batch and item rows, then records enqueue status', async () => {
+    poolMock.query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: '7',
+            action: 'bulk_enqueue_backfill',
+            actor: 'operator',
+            issue_key: 'missing_poster_url',
+            target_type: 'catalog_issue',
+            target_id: 'missing_poster_url',
+            status: 'enqueueing',
+            requested_limit: 25,
+            total_candidates: 351,
+            attempted_count: 2,
+            queued_count: 0,
+            deduped_count: 0,
+            unavailable_count: 0,
+            failed_count: 0,
+            completed_count: 0,
+            skipped_count: 0,
+            note: null,
+            previous_state: { issueKey: 'missing_poster_url' },
+            result: {},
+            created_at: '2026-05-28 09:00:00+00',
+            updated_at: '2026-05-28 09:00:00+00',
+            completed_at: null,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: '11',
+            batch_id: '7',
+            movie_id: '334',
+            issue_key: 'missing_poster_url',
+            status: 'pending',
+            queue_name: null,
+            job_name: null,
+            job_id: null,
+            language: 'en-US',
+            reason: 'missing_metadata',
+            error_message: null,
+            movie_snapshot: { id: '334' },
+            result: {},
+            created_at: '2026-05-28 09:00:01+00',
+            updated_at: '2026-05-28 09:00:01+00',
+            completed_at: null,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: '11',
+            batch_id: '7',
+            movie_id: '334',
+            issue_key: 'missing_poster_url',
+            status: 'queued',
+            queue_name: 'catalog-maintenance',
+            job_name: 'backfill-movie',
+            job_id: 'backfill-334',
+            language: 'en-US',
+            reason: 'missing_metadata',
+            error_message: null,
+            movie_snapshot: { id: '334' },
+            result: { status: 'queued' },
+            created_at: '2026-05-28 09:00:01+00',
+            updated_at: '2026-05-28 09:00:02+00',
+            completed_at: null,
+          },
+        ],
+      });
+
+    const batch = await createCatalogRepairBatch({
+      action: 'bulk_enqueue_backfill',
+      actor: 'operator',
+      issueKey: 'missing_poster_url',
+      targetType: 'catalog_issue',
+      targetId: 'missing_poster_url',
+      requestedLimit: 25,
+      totalCandidates: 351,
+      attemptedCount: 2,
+      previousState: { issueKey: 'missing_poster_url' },
+    });
+    const item = await createCatalogRepairBatchItem({
+      batchId: batch.id,
+      movieId: '334',
+      issueKey: 'missing_poster_url',
+      movieSnapshot: { id: '334' },
+      reason: 'missing_metadata',
+      language: 'en-US',
+    });
+    const updated = await updateCatalogRepairBatchItemEnqueueResult({
+      itemId: item.id,
+      status: 'queued',
+      queueName: 'catalog-maintenance',
+      jobName: 'backfill-movie',
+      jobId: 'backfill-334',
+      language: 'en-US',
+      result: { status: 'queued' },
+    });
+
+    expect(batch).toMatchObject({ id: '7', status: 'enqueueing', attemptedCount: 2 });
+    expect(item).toMatchObject({ id: '11', batchId: '7', status: 'pending' });
+    expect(updated).toMatchObject({ id: '11', status: 'queued', jobId: 'backfill-334' });
+    expect(poolMock.query.mock.calls[0][1]).toEqual([
+      'bulk_enqueue_backfill',
+      'operator',
+      'missing_poster_url',
+      'catalog_issue',
+      'missing_poster_url',
+      25,
+      351,
+      2,
+      null,
+      JSON.stringify({ issueKey: 'missing_poster_url' }),
+    ]);
+    expect(poolMock.query.mock.calls[2][1][7]).toBe(JSON.stringify({ status: 'queued' }));
+  });
+
+  it('refreshes batch counts from durable item statuses', async () => {
+    poolMock.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: '7',
+          action: 'bulk_enqueue_backfill',
+          actor: 'operator',
+          issue_key: 'missing_poster_url',
+          target_type: 'catalog_issue',
+          target_id: 'missing_poster_url',
+          status: 'partial',
+          requested_limit: 25,
+          total_candidates: 351,
+          attempted_count: 2,
+          queued_count: 1,
+          deduped_count: 0,
+          unavailable_count: 0,
+          failed_count: 1,
+          completed_count: 0,
+          skipped_count: 0,
+          note: null,
+          previous_state: {},
+          result: { queued: 1, failed: 1 },
+          created_at: '2026-05-28 09:00:00+00',
+          updated_at: '2026-05-28 09:00:02+00',
+          completed_at: null,
+        },
+      ],
+    });
+
+    const batch = await refreshCatalogRepairBatchCounts('7');
+
+    expect(batch).toMatchObject({
+      id: '7',
+      status: 'partial',
+      queuedCount: 1,
+      failedCount: 1,
+    });
+    expect(poolMock.query.mock.calls[0][1]).toEqual(['7']);
   });
 });

--- a/packages/shared/src/catalogRepairActions.ts
+++ b/packages/shared/src/catalogRepairActions.ts
@@ -1,6 +1,25 @@
 import { getPool } from './db.js';
 
 export type CatalogRepairAction = 'enqueue_backfill' | 'bulk_enqueue_backfill';
+export type CatalogRepairBatchStatus =
+  | 'enqueueing'
+  | 'queued'
+  | 'processing'
+  | 'partial'
+  | 'failed'
+  | 'unavailable'
+  | 'empty'
+  | 'completed';
+export type CatalogRepairItemStatus =
+  | 'pending'
+  | 'queued'
+  | 'deduped'
+  | 'unavailable'
+  | 'enqueue_failed'
+  | 'processing'
+  | 'completed'
+  | 'failed'
+  | 'skipped';
 
 export interface CatalogRepairMovieSnapshot {
   id: string;
@@ -28,6 +47,8 @@ export interface CatalogRepairActionAudit {
   previousState: Record<string, unknown>;
   result: Record<string, unknown>;
   createdAt: string;
+  repairBatchId: string | null;
+  repairBatchItemId: string | null;
 }
 
 export interface CatalogRepairActionAuditPage {
@@ -46,6 +67,111 @@ export interface RecordCatalogRepairActionInput {
   note?: string;
   previousState: Record<string, unknown>;
   result: Record<string, unknown>;
+  repairBatchId?: string | number;
+  repairBatchItemId?: string | number;
+}
+
+export interface CatalogRepairBatch {
+  id: string;
+  action: CatalogRepairAction;
+  actor: string;
+  issueKey: string;
+  targetType: string;
+  targetId: string;
+  status: CatalogRepairBatchStatus;
+  requestedLimit: number;
+  totalCandidates: number;
+  attemptedCount: number;
+  queuedCount: number;
+  dedupedCount: number;
+  unavailableCount: number;
+  failedCount: number;
+  completedCount: number;
+  skippedCount: number;
+  note: string | null;
+  previousState: Record<string, unknown>;
+  result: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+  completedAt: string | null;
+}
+
+export interface CatalogRepairBatchItem {
+  id: string;
+  batchId: string;
+  movieId: string;
+  issueKey: string;
+  status: CatalogRepairItemStatus;
+  queueName: string | null;
+  jobName: string | null;
+  jobId: string | null;
+  language: string | null;
+  reason: string | null;
+  errorMessage: string | null;
+  movieSnapshot: Record<string, unknown>;
+  result: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+  completedAt: string | null;
+}
+
+export interface CreateCatalogRepairBatchInput {
+  action: CatalogRepairAction;
+  actor: string;
+  issueKey: string;
+  targetType: string;
+  targetId: string | number;
+  requestedLimit: number;
+  totalCandidates: number;
+  attemptedCount?: number;
+  note?: string;
+  previousState: Record<string, unknown>;
+}
+
+export interface CreateCatalogRepairBatchItemInput {
+  batchId: string | number;
+  movieId: string | number;
+  issueKey: string;
+  movieSnapshot: Record<string, unknown>;
+  reason?: string;
+  language?: string;
+}
+
+export interface UpdateCatalogRepairBatchItemEnqueueInput {
+  itemId: string | number;
+  status: Extract<CatalogRepairItemStatus, 'queued' | 'deduped' | 'unavailable' | 'enqueue_failed'>;
+  queueName?: string;
+  jobName?: string;
+  jobId?: string;
+  language?: string;
+  errorMessage?: string;
+  result?: Record<string, unknown>;
+}
+
+export interface UpdateCatalogRepairBatchItemStatusInput {
+  itemId: string | number;
+  status: Extract<CatalogRepairItemStatus, 'processing' | 'completed' | 'failed' | 'skipped'>;
+  errorMessage?: string;
+  result?: Record<string, unknown>;
+}
+
+export interface CatalogRepairBatchPage {
+  batches: CatalogRepairBatch[];
+  totalCount: number;
+  limit: number;
+  offset: number;
+}
+
+export interface CatalogRepairBatchItemPage {
+  items: CatalogRepairBatchItem[];
+  totalCount: number;
+  limit: number;
+  offset: number;
+}
+
+export interface CatalogRepairBatchDetail {
+  batch: CatalogRepairBatch;
+  items: CatalogRepairBatchItemPage;
 }
 
 type CatalogRepairMovieSnapshotRow = Omit<
@@ -70,6 +196,52 @@ type CatalogRepairActionAuditRow = {
   previous_state: unknown;
   result: unknown;
   created_at: string;
+  repair_batch_id?: string | number | null;
+  repair_batch_item_id?: string | number | null;
+};
+
+type CatalogRepairBatchRow = {
+  id: string | number;
+  action: CatalogRepairAction;
+  actor: string;
+  issue_key: string;
+  target_type: string;
+  target_id: string;
+  status: CatalogRepairBatchStatus;
+  requested_limit: string | number;
+  total_candidates: string | number;
+  attempted_count: string | number;
+  queued_count: string | number;
+  deduped_count: string | number;
+  unavailable_count: string | number;
+  failed_count: string | number;
+  completed_count: string | number;
+  skipped_count: string | number;
+  note: string | null;
+  previous_state: unknown;
+  result: unknown;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+};
+
+type CatalogRepairBatchItemRow = {
+  id: string | number;
+  batch_id: string | number;
+  movie_id: string | number;
+  issue_key: string;
+  status: CatalogRepairItemStatus;
+  queue_name: string | null;
+  job_name: string | null;
+  job_id: string | null;
+  language: string | null;
+  reason: string | null;
+  error_message: string | null;
+  movie_snapshot: unknown;
+  result: unknown;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
 };
 
 function toRecord(value: unknown): Record<string, unknown> {
@@ -102,6 +274,62 @@ function normalizeAudit(row: CatalogRepairActionAuditRow): CatalogRepairActionAu
     previousState: toRecord(row.previous_state),
     result: toRecord(row.result),
     createdAt: row.created_at,
+    repairBatchId:
+      row.repair_batch_id === null || row.repair_batch_id === undefined
+        ? null
+        : String(row.repair_batch_id),
+    repairBatchItemId:
+      row.repair_batch_item_id === null || row.repair_batch_item_id === undefined
+        ? null
+        : String(row.repair_batch_item_id),
+  };
+}
+
+function normalizeBatch(row: CatalogRepairBatchRow): CatalogRepairBatch {
+  return {
+    id: String(row.id),
+    action: row.action,
+    actor: row.actor,
+    issueKey: row.issue_key,
+    targetType: row.target_type,
+    targetId: row.target_id,
+    status: row.status,
+    requestedLimit: toNumber(row.requested_limit),
+    totalCandidates: toNumber(row.total_candidates),
+    attemptedCount: toNumber(row.attempted_count),
+    queuedCount: toNumber(row.queued_count),
+    dedupedCount: toNumber(row.deduped_count),
+    unavailableCount: toNumber(row.unavailable_count),
+    failedCount: toNumber(row.failed_count),
+    completedCount: toNumber(row.completed_count),
+    skippedCount: toNumber(row.skipped_count),
+    note: row.note,
+    previousState: toRecord(row.previous_state),
+    result: toRecord(row.result),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    completedAt: row.completed_at,
+  };
+}
+
+function normalizeBatchItem(row: CatalogRepairBatchItemRow): CatalogRepairBatchItem {
+  return {
+    id: String(row.id),
+    batchId: String(row.batch_id),
+    movieId: String(row.movie_id),
+    issueKey: row.issue_key,
+    status: row.status,
+    queueName: row.queue_name,
+    jobName: row.job_name,
+    jobId: row.job_id,
+    language: row.language,
+    reason: row.reason,
+    errorMessage: row.error_message,
+    movieSnapshot: toRecord(row.movie_snapshot),
+    result: toRecord(row.result),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    completedAt: row.completed_at,
   };
 }
 
@@ -117,6 +345,109 @@ function clampAuditLimit(limit: number): number {
 function clampAuditOffset(offset: number): number {
   return Number.isSafeInteger(offset) && offset > 0 ? Math.min(offset, 100_000) : 0;
 }
+
+export const CATALOG_REPAIR_BATCH_SCHEMA_SQL = `
+  CREATE TABLE IF NOT EXISTS catalog_repair_batches (
+    id bigserial PRIMARY KEY,
+    action text NOT NULL,
+    actor text NOT NULL,
+    issue_key text NOT NULL,
+    target_type text NOT NULL,
+    target_id text NOT NULL,
+    status text NOT NULL DEFAULT 'enqueueing',
+    requested_limit integer NOT NULL DEFAULT 0,
+    total_candidates integer NOT NULL DEFAULT 0,
+    attempted_count integer NOT NULL DEFAULT 0,
+    queued_count integer NOT NULL DEFAULT 0,
+    deduped_count integer NOT NULL DEFAULT 0,
+    unavailable_count integer NOT NULL DEFAULT 0,
+    failed_count integer NOT NULL DEFAULT 0,
+    completed_count integer NOT NULL DEFAULT 0,
+    skipped_count integer NOT NULL DEFAULT 0,
+    note text,
+    previous_state jsonb NOT NULL DEFAULT '{}'::jsonb,
+    result jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    completed_at timestamptz,
+    CONSTRAINT catalog_repair_batches_action_check CHECK (
+      action IN ('enqueue_backfill', 'bulk_enqueue_backfill')
+    ),
+    CONSTRAINT catalog_repair_batches_status_check CHECK (
+      status IN (
+        'enqueueing',
+        'queued',
+        'processing',
+        'partial',
+        'failed',
+        'unavailable',
+        'empty',
+        'completed'
+      )
+    )
+  );
+
+  CREATE TABLE IF NOT EXISTS catalog_repair_batch_items (
+    id bigserial PRIMARY KEY,
+    batch_id bigint NOT NULL REFERENCES catalog_repair_batches(id) ON DELETE CASCADE,
+    movie_id bigint NOT NULL REFERENCES movies(id) ON DELETE RESTRICT,
+    issue_key text NOT NULL,
+    status text NOT NULL DEFAULT 'pending',
+    queue_name text,
+    job_name text,
+    job_id text,
+    language text,
+    reason text,
+    error_message text,
+    movie_snapshot jsonb NOT NULL DEFAULT '{}'::jsonb,
+    result jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    completed_at timestamptz,
+    CONSTRAINT catalog_repair_batch_items_status_check CHECK (
+      status IN (
+        'pending',
+        'queued',
+        'deduped',
+        'unavailable',
+        'enqueue_failed',
+        'processing',
+        'completed',
+        'failed',
+        'skipped'
+      )
+    )
+  );
+
+  ALTER TABLE catalog_repair_audit
+    ADD COLUMN IF NOT EXISTS repair_batch_id bigint REFERENCES catalog_repair_batches(id) ON DELETE SET NULL;
+
+  ALTER TABLE catalog_repair_audit
+    ADD COLUMN IF NOT EXISTS repair_batch_item_id bigint REFERENCES catalog_repair_batch_items(id) ON DELETE SET NULL;
+
+  CREATE INDEX IF NOT EXISTS idx_catalog_repair_batches_created_at
+    ON catalog_repair_batches (created_at DESC, id DESC);
+
+  CREATE INDEX IF NOT EXISTS idx_catalog_repair_batches_issue_created_at
+    ON catalog_repair_batches (issue_key, created_at DESC);
+
+  CREATE INDEX IF NOT EXISTS idx_catalog_repair_batches_status_updated_at
+    ON catalog_repair_batches (status, updated_at DESC);
+
+  CREATE INDEX IF NOT EXISTS idx_catalog_repair_batch_items_batch_status
+    ON catalog_repair_batch_items (batch_id, status, id);
+
+  CREATE INDEX IF NOT EXISTS idx_catalog_repair_batch_items_movie_created_at
+    ON catalog_repair_batch_items (movie_id, created_at DESC);
+
+  CREATE INDEX IF NOT EXISTS idx_catalog_repair_batch_items_job_id
+    ON catalog_repair_batch_items (job_id)
+    WHERE job_id IS NOT NULL;
+
+  CREATE INDEX IF NOT EXISTS idx_catalog_repair_audit_batch_created_at
+    ON catalog_repair_audit (repair_batch_id, created_at DESC)
+    WHERE repair_batch_id IS NOT NULL;
+`;
 
 export async function ensureCatalogRepairActionSchema(): Promise<void> {
   await getPool().query(`
@@ -149,6 +480,8 @@ export async function ensureCatalogRepairActionSchema(): Promise<void> {
 
     CREATE INDEX IF NOT EXISTS idx_catalog_repair_audit_issue_created_at
       ON catalog_repair_audit (issue_key, created_at DESC);
+
+    ${CATALOG_REPAIR_BATCH_SCHEMA_SQL}
   `);
 }
 
@@ -177,6 +510,294 @@ export async function getCatalogRepairMovieSnapshot(
   return result.rows[0] ? normalizeMovieSnapshot(result.rows[0]) : null;
 }
 
+export async function createCatalogRepairBatch(
+  input: CreateCatalogRepairBatchInput,
+): Promise<CatalogRepairBatch> {
+  const result = await getPool().query<CatalogRepairBatchRow>(
+    `INSERT INTO catalog_repair_batches (
+        action,
+        actor,
+        issue_key,
+        target_type,
+        target_id,
+        requested_limit,
+        total_candidates,
+        attempted_count,
+        note,
+        previous_state
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb)
+      RETURNING
+        id::text,
+        action,
+        actor,
+        issue_key,
+        target_type,
+        target_id,
+        status,
+        requested_limit,
+        total_candidates,
+        attempted_count,
+        queued_count,
+        deduped_count,
+        unavailable_count,
+        failed_count,
+        completed_count,
+        skipped_count,
+        note,
+        previous_state,
+        result,
+        created_at::text,
+        updated_at::text,
+        completed_at::text`,
+    [
+      input.action,
+      input.actor,
+      input.issueKey,
+      input.targetType,
+      String(input.targetId),
+      input.requestedLimit,
+      input.totalCandidates,
+      input.attemptedCount ?? 0,
+      input.note?.trim() || null,
+      JSON.stringify(input.previousState),
+    ],
+  );
+
+  return normalizeBatch(result.rows[0]);
+}
+
+export async function createCatalogRepairBatchItem(
+  input: CreateCatalogRepairBatchItemInput,
+): Promise<CatalogRepairBatchItem> {
+  const result = await getPool().query<CatalogRepairBatchItemRow>(
+    `INSERT INTO catalog_repair_batch_items (
+        batch_id,
+        movie_id,
+        issue_key,
+        movie_snapshot,
+        reason,
+        language
+      )
+      VALUES ($1, $2, $3, $4::jsonb, $5, $6)
+      RETURNING
+        id::text,
+        batch_id::text,
+        movie_id::text,
+        issue_key,
+        status,
+        queue_name,
+        job_name,
+        job_id,
+        language,
+        reason,
+        error_message,
+        movie_snapshot,
+        result,
+        created_at::text,
+        updated_at::text,
+        completed_at::text`,
+    [
+      input.batchId,
+      input.movieId,
+      input.issueKey,
+      JSON.stringify(input.movieSnapshot),
+      input.reason ?? null,
+      input.language ?? null,
+    ],
+  );
+
+  return normalizeBatchItem(result.rows[0]);
+}
+
+export async function updateCatalogRepairBatchItemEnqueueResult(
+  input: UpdateCatalogRepairBatchItemEnqueueInput,
+): Promise<CatalogRepairBatchItem> {
+  const result = await getPool().query<CatalogRepairBatchItemRow>(
+    `UPDATE catalog_repair_batch_items
+        SET status = $2,
+            queue_name = COALESCE($3, queue_name),
+            job_name = COALESCE($4, job_name),
+            job_id = COALESCE($5, job_id),
+            language = COALESCE($6, language),
+            error_message = $7,
+            result = COALESCE($8::jsonb, result),
+            updated_at = now(),
+            completed_at = CASE
+              WHEN $2 IN ('unavailable', 'enqueue_failed') THEN now()
+              ELSE completed_at
+            END
+      WHERE id = $1
+      RETURNING
+        id::text,
+        batch_id::text,
+        movie_id::text,
+        issue_key,
+        status,
+        queue_name,
+        job_name,
+        job_id,
+        language,
+        reason,
+        error_message,
+        movie_snapshot,
+        result,
+        created_at::text,
+        updated_at::text,
+        completed_at::text`,
+    [
+      input.itemId,
+      input.status,
+      input.queueName ?? null,
+      input.jobName ?? null,
+      input.jobId ?? null,
+      input.language ?? null,
+      input.errorMessage ?? null,
+      input.result ? JSON.stringify(input.result) : null,
+    ],
+  );
+
+  return normalizeBatchItem(result.rows[0]);
+}
+
+export async function updateCatalogRepairBatchItemStatus(
+  input: UpdateCatalogRepairBatchItemStatusInput,
+): Promise<CatalogRepairBatchItem> {
+  const result = await getPool().query<CatalogRepairBatchItemRow>(
+    `UPDATE catalog_repair_batch_items
+        SET status = $2,
+            error_message = $3,
+            result = COALESCE($4::jsonb, result),
+            updated_at = now(),
+            completed_at = CASE
+              WHEN $2 IN ('completed', 'failed', 'skipped') THEN COALESCE(completed_at, now())
+              ELSE completed_at
+            END
+      WHERE id = $1
+      RETURNING
+        id::text,
+        batch_id::text,
+        movie_id::text,
+        issue_key,
+        status,
+        queue_name,
+        job_name,
+        job_id,
+        language,
+        reason,
+        error_message,
+        movie_snapshot,
+        result,
+        created_at::text,
+        updated_at::text,
+        completed_at::text`,
+    [
+      input.itemId,
+      input.status,
+      input.errorMessage ?? null,
+      input.result ? JSON.stringify(input.result) : null,
+    ],
+  );
+
+  return normalizeBatchItem(result.rows[0]);
+}
+
+export async function refreshCatalogRepairBatchCounts(
+  batchId: string | number,
+): Promise<CatalogRepairBatch> {
+  const result = await getPool().query<CatalogRepairBatchRow>(
+    `WITH counts AS (
+       SELECT
+         COUNT(*)::int AS attempted_count,
+         COUNT(*) FILTER (WHERE status = 'queued')::int AS queued_count,
+         COUNT(*) FILTER (WHERE status = 'deduped')::int AS deduped_count,
+         COUNT(*) FILTER (WHERE status = 'unavailable')::int AS unavailable_count,
+         COUNT(*) FILTER (WHERE status IN ('enqueue_failed', 'failed'))::int AS failed_count,
+         COUNT(*) FILTER (WHERE status = 'completed')::int AS completed_count,
+         COUNT(*) FILTER (WHERE status = 'skipped')::int AS skipped_count,
+         COUNT(*) FILTER (WHERE status = 'processing')::int AS processing_count
+       FROM catalog_repair_batch_items
+       WHERE batch_id = $1
+     ),
+     next_values AS (
+       SELECT
+         *,
+         CASE
+           WHEN attempted_count = 0 THEN 'empty'
+           WHEN completed_count + skipped_count = attempted_count THEN 'completed'
+           WHEN failed_count = attempted_count THEN 'failed'
+           WHEN unavailable_count = attempted_count THEN 'unavailable'
+           WHEN completed_count + skipped_count + failed_count + unavailable_count = attempted_count
+             THEN 'partial'
+           WHEN failed_count + unavailable_count > 0 THEN 'partial'
+           WHEN processing_count > 0 THEN 'processing'
+           WHEN queued_count + deduped_count > 0 THEN 'queued'
+           ELSE 'enqueueing'
+         END AS next_status
+       FROM counts
+     )
+     UPDATE catalog_repair_batches batch
+        SET status = next_values.next_status,
+            attempted_count = next_values.attempted_count,
+            queued_count = next_values.queued_count,
+            deduped_count = next_values.deduped_count,
+            unavailable_count = next_values.unavailable_count,
+            failed_count = next_values.failed_count,
+            completed_count = next_values.completed_count,
+            skipped_count = next_values.skipped_count,
+            result = jsonb_build_object(
+              'attempted', next_values.attempted_count,
+              'queued', next_values.queued_count,
+              'deduped', next_values.deduped_count,
+              'unavailable', next_values.unavailable_count,
+              'failed', next_values.failed_count,
+              'completed', next_values.completed_count,
+              'skipped', next_values.skipped_count
+            ),
+            updated_at = now(),
+            completed_at = CASE
+              WHEN next_values.next_status IN ('empty', 'failed', 'unavailable', 'completed')
+                OR (
+                  next_values.next_status = 'partial'
+                  AND next_values.completed_count
+                    + next_values.skipped_count
+                    + next_values.failed_count
+                    + next_values.unavailable_count = next_values.attempted_count
+                )
+                THEN COALESCE(batch.completed_at, now())
+              ELSE batch.completed_at
+            END
+       FROM next_values
+      WHERE batch.id = $1
+      RETURNING
+        batch.id::text,
+        batch.action,
+        batch.actor,
+        batch.issue_key,
+        batch.target_type,
+        batch.target_id,
+        batch.status,
+        batch.requested_limit,
+        batch.total_candidates,
+        batch.attempted_count,
+        batch.queued_count,
+        batch.deduped_count,
+        batch.unavailable_count,
+        batch.failed_count,
+        batch.completed_count,
+        batch.skipped_count,
+        batch.note,
+        batch.previous_state,
+        batch.result,
+        batch.created_at::text,
+        batch.updated_at::text,
+        batch.completed_at::text`,
+    [batchId],
+  );
+
+  return normalizeBatch(result.rows[0]);
+}
+
 export async function recordCatalogRepairAction(
   input: RecordCatalogRepairActionInput,
 ): Promise<CatalogRepairActionAudit> {
@@ -189,9 +810,11 @@ export async function recordCatalogRepairAction(
         target_id,
         note,
         previous_state,
-        result
+        result,
+        repair_batch_id,
+        repair_batch_item_id
       )
-      VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8::jsonb)
+      VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8::jsonb, $9, $10)
       RETURNING
         id::text,
         action,
@@ -202,6 +825,8 @@ export async function recordCatalogRepairAction(
         note,
         previous_state,
         result,
+        repair_batch_id::text,
+        repair_batch_item_id::text,
         created_at::text`,
     [
       input.action,
@@ -212,6 +837,8 @@ export async function recordCatalogRepairAction(
       input.note?.trim() || null,
       JSON.stringify(input.previousState),
       JSON.stringify(input.result),
+      input.repairBatchId ?? null,
+      input.repairBatchItemId ?? null,
     ],
   );
 
@@ -248,6 +875,8 @@ export async function listCatalogRepairAuditPage({
           note,
           previous_state,
           result,
+          repair_batch_id::text,
+          repair_batch_item_id::text,
           created_at::text
          FROM catalog_repair_audit
         ORDER BY created_at DESC, id DESC
@@ -262,5 +891,147 @@ export async function listCatalogRepairAuditPage({
     totalCount: toNumber(countResult.rows[0]?.count),
     limit: boundedLimit,
     offset: boundedOffset,
+  };
+}
+
+export async function listCatalogRepairBatchPage({
+  limit = 25,
+  offset = 0,
+}: {
+  limit?: number;
+  offset?: number;
+} = {}): Promise<CatalogRepairBatchPage> {
+  const boundedLimit = clampAuditLimit(limit);
+  const boundedOffset = clampAuditOffset(offset);
+  const [countResult, batchResult] = await Promise.all([
+    getPool().query<{ count: number | string }>(
+      `SELECT COUNT(*)::int AS count
+         FROM catalog_repair_batches`,
+    ),
+    getPool().query<CatalogRepairBatchRow>(
+      `SELECT
+          id::text,
+          action,
+          actor,
+          issue_key,
+          target_type,
+          target_id,
+          status,
+          requested_limit,
+          total_candidates,
+          attempted_count,
+          queued_count,
+          deduped_count,
+          unavailable_count,
+          failed_count,
+          completed_count,
+          skipped_count,
+          note,
+          previous_state,
+          result,
+          created_at::text,
+          updated_at::text,
+          completed_at::text
+         FROM catalog_repair_batches
+        ORDER BY created_at DESC, id DESC
+        LIMIT $1
+        OFFSET $2`,
+      [boundedLimit, boundedOffset],
+    ),
+  ]);
+
+  return {
+    batches: batchResult.rows.map(normalizeBatch),
+    totalCount: toNumber(countResult.rows[0]?.count),
+    limit: boundedLimit,
+    offset: boundedOffset,
+  };
+}
+
+export async function getCatalogRepairBatchDetail(
+  batchId: string | number,
+  {
+    limit = 100,
+    offset = 0,
+  }: {
+    limit?: number;
+    offset?: number;
+  } = {},
+): Promise<CatalogRepairBatchDetail | null> {
+  const boundedLimit = clampAuditLimit(limit);
+  const boundedOffset = clampAuditOffset(offset);
+  const batchResult = await getPool().query<CatalogRepairBatchRow>(
+    `SELECT
+        id::text,
+        action,
+        actor,
+        issue_key,
+        target_type,
+        target_id,
+        status,
+        requested_limit,
+        total_candidates,
+        attempted_count,
+        queued_count,
+        deduped_count,
+        unavailable_count,
+        failed_count,
+        completed_count,
+        skipped_count,
+        note,
+        previous_state,
+        result,
+        created_at::text,
+        updated_at::text,
+        completed_at::text
+       FROM catalog_repair_batches
+      WHERE id = $1`,
+    [batchId],
+  );
+
+  if (!batchResult.rows[0]) return null;
+
+  const [countResult, itemResult] = await Promise.all([
+    getPool().query<{ count: number | string }>(
+      `SELECT COUNT(*)::int AS count
+         FROM catalog_repair_batch_items
+        WHERE batch_id = $1`,
+      [batchId],
+    ),
+    getPool().query<CatalogRepairBatchItemRow>(
+      `SELECT
+          id::text,
+          batch_id::text,
+          movie_id::text,
+          issue_key,
+          status,
+          queue_name,
+          job_name,
+          job_id,
+          language,
+          reason,
+          error_message,
+          movie_snapshot,
+          result,
+          created_at::text,
+          updated_at::text,
+          completed_at::text
+         FROM catalog_repair_batch_items
+        WHERE batch_id = $1
+        ORDER BY id ASC
+        LIMIT $2
+        OFFSET $3`,
+      [batchId, boundedLimit, boundedOffset],
+    ),
+  ]);
+
+  return {
+    batch: normalizeBatch(batchResult.rows[0]),
+    items: {
+      items: itemResult.rows.map(normalizeBatchItem),
+      totalCount: toNumber(countResult.rows[0]?.count),
+      limit: boundedLimit,
+      offset: boundedOffset,
+    },
   };
 }

--- a/packages/shared/src/db.ts
+++ b/packages/shared/src/db.ts
@@ -336,6 +336,107 @@ export async function ensureSchema(): Promise<void> {
 
     CREATE INDEX IF NOT EXISTS idx_catalog_repair_audit_issue_created_at
       ON catalog_repair_audit (issue_key, created_at DESC);
+
+    CREATE TABLE IF NOT EXISTS catalog_repair_batches (
+      id bigserial PRIMARY KEY,
+      action text NOT NULL,
+      actor text NOT NULL,
+      issue_key text NOT NULL,
+      target_type text NOT NULL,
+      target_id text NOT NULL,
+      status text NOT NULL DEFAULT 'enqueueing',
+      requested_limit integer NOT NULL DEFAULT 0,
+      total_candidates integer NOT NULL DEFAULT 0,
+      attempted_count integer NOT NULL DEFAULT 0,
+      queued_count integer NOT NULL DEFAULT 0,
+      deduped_count integer NOT NULL DEFAULT 0,
+      unavailable_count integer NOT NULL DEFAULT 0,
+      failed_count integer NOT NULL DEFAULT 0,
+      completed_count integer NOT NULL DEFAULT 0,
+      skipped_count integer NOT NULL DEFAULT 0,
+      note text,
+      previous_state jsonb NOT NULL DEFAULT '{}'::jsonb,
+      result jsonb NOT NULL DEFAULT '{}'::jsonb,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now(),
+      completed_at timestamptz,
+      CONSTRAINT catalog_repair_batches_action_check CHECK (
+        action IN ('enqueue_backfill', 'bulk_enqueue_backfill')
+      ),
+      CONSTRAINT catalog_repair_batches_status_check CHECK (
+        status IN (
+          'enqueueing',
+          'queued',
+          'processing',
+          'partial',
+          'failed',
+          'unavailable',
+          'empty',
+          'completed'
+        )
+      )
+    );
+
+    CREATE TABLE IF NOT EXISTS catalog_repair_batch_items (
+      id bigserial PRIMARY KEY,
+      batch_id bigint NOT NULL REFERENCES catalog_repair_batches(id) ON DELETE CASCADE,
+      movie_id bigint NOT NULL REFERENCES movies(id) ON DELETE RESTRICT,
+      issue_key text NOT NULL,
+      status text NOT NULL DEFAULT 'pending',
+      queue_name text,
+      job_name text,
+      job_id text,
+      language text,
+      reason text,
+      error_message text,
+      movie_snapshot jsonb NOT NULL DEFAULT '{}'::jsonb,
+      result jsonb NOT NULL DEFAULT '{}'::jsonb,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now(),
+      completed_at timestamptz,
+      CONSTRAINT catalog_repair_batch_items_status_check CHECK (
+        status IN (
+          'pending',
+          'queued',
+          'deduped',
+          'unavailable',
+          'enqueue_failed',
+          'processing',
+          'completed',
+          'failed',
+          'skipped'
+        )
+      )
+    );
+
+    ALTER TABLE catalog_repair_audit
+      ADD COLUMN IF NOT EXISTS repair_batch_id bigint REFERENCES catalog_repair_batches(id) ON DELETE SET NULL;
+
+    ALTER TABLE catalog_repair_audit
+      ADD COLUMN IF NOT EXISTS repair_batch_item_id bigint REFERENCES catalog_repair_batch_items(id) ON DELETE SET NULL;
+
+    CREATE INDEX IF NOT EXISTS idx_catalog_repair_batches_created_at
+      ON catalog_repair_batches (created_at DESC, id DESC);
+
+    CREATE INDEX IF NOT EXISTS idx_catalog_repair_batches_issue_created_at
+      ON catalog_repair_batches (issue_key, created_at DESC);
+
+    CREATE INDEX IF NOT EXISTS idx_catalog_repair_batches_status_updated_at
+      ON catalog_repair_batches (status, updated_at DESC);
+
+    CREATE INDEX IF NOT EXISTS idx_catalog_repair_batch_items_batch_status
+      ON catalog_repair_batch_items (batch_id, status, id);
+
+    CREATE INDEX IF NOT EXISTS idx_catalog_repair_batch_items_movie_created_at
+      ON catalog_repair_batch_items (movie_id, created_at DESC);
+
+    CREATE INDEX IF NOT EXISTS idx_catalog_repair_batch_items_job_id
+      ON catalog_repair_batch_items (job_id)
+      WHERE job_id IS NOT NULL;
+
+    CREATE INDEX IF NOT EXISTS idx_catalog_repair_audit_batch_created_at
+      ON catalog_repair_audit (repair_batch_id, created_at DESC)
+      WHERE repair_batch_id IS NOT NULL;
   `);
 
   await getPool().query(`

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -59,18 +59,37 @@ export type {
   DuplicateIdentityReport,
 } from './catalogHealth.js';
 export {
+  CATALOG_REPAIR_BATCH_SCHEMA_SQL,
+  createCatalogRepairBatch,
+  createCatalogRepairBatchItem,
   ensureCatalogRepairActionSchema,
+  getCatalogRepairBatchDetail,
   getCatalogRepairMovieSnapshot,
+  listCatalogRepairBatchPage,
   listCatalogRepairAudit,
   listCatalogRepairAuditPage,
   recordCatalogRepairAction,
+  refreshCatalogRepairBatchCounts,
+  updateCatalogRepairBatchItemEnqueueResult,
+  updateCatalogRepairBatchItemStatus,
 } from './catalogRepairActions.js';
 export type {
   CatalogRepairAction,
   CatalogRepairActionAudit,
   CatalogRepairActionAuditPage,
+  CatalogRepairBatch,
+  CatalogRepairBatchDetail,
+  CatalogRepairBatchItem,
+  CatalogRepairBatchItemPage,
+  CatalogRepairBatchPage,
+  CatalogRepairBatchStatus,
+  CatalogRepairItemStatus,
   CatalogRepairMovieSnapshot,
+  CreateCatalogRepairBatchInput,
+  CreateCatalogRepairBatchItemInput,
   RecordCatalogRepairActionInput,
+  UpdateCatalogRepairBatchItemEnqueueInput,
+  UpdateCatalogRepairBatchItemStatusInput,
 } from './catalogRepairActions.js';
 export {
   applyTMDBMatchReviewAction,

--- a/services/movie-backfill/README.md
+++ b/services/movie-backfill/README.md
@@ -76,8 +76,10 @@ The workspace script loads `DATABASE_URL` from the repository root `.env`.
 
 The report counts missing `poster_url`, missing `localized_name`, missing `tmdb_id`, missing runtime, missing age rating, TMDB-backed rows without `tmdb_matched_at`, stale TMDB metadata, duplicate TMDB ids, and likely duplicate normalized title/year identities. It includes sample rows for each issue.
 
-Browser access should be added later through a dedicated backoffice app, not the
-user-facing web app.
+Browser access lives in the dedicated `apps/backoffice` operator app, not the
+user-facing web app. Backoffice repair batches use durable
+`catalog_repair_batches` and `catalog_repair_batch_items` rows so operator
+history survives BullMQ retention cleanup.
 
 Options:
 

--- a/services/movie-backfill/src/database.ts
+++ b/services/movie-backfill/src/database.ts
@@ -126,6 +126,107 @@ export async function ensureTMDBMatchReviewSchema(): Promise<void> {
 
     CREATE INDEX IF NOT EXISTS idx_catalog_repair_audit_issue_created_at
       ON catalog_repair_audit (issue_key, created_at DESC);
+
+    CREATE TABLE IF NOT EXISTS catalog_repair_batches (
+      id bigserial PRIMARY KEY,
+      action text NOT NULL,
+      actor text NOT NULL,
+      issue_key text NOT NULL,
+      target_type text NOT NULL,
+      target_id text NOT NULL,
+      status text NOT NULL DEFAULT 'enqueueing',
+      requested_limit integer NOT NULL DEFAULT 0,
+      total_candidates integer NOT NULL DEFAULT 0,
+      attempted_count integer NOT NULL DEFAULT 0,
+      queued_count integer NOT NULL DEFAULT 0,
+      deduped_count integer NOT NULL DEFAULT 0,
+      unavailable_count integer NOT NULL DEFAULT 0,
+      failed_count integer NOT NULL DEFAULT 0,
+      completed_count integer NOT NULL DEFAULT 0,
+      skipped_count integer NOT NULL DEFAULT 0,
+      note text,
+      previous_state jsonb NOT NULL DEFAULT '{}'::jsonb,
+      result jsonb NOT NULL DEFAULT '{}'::jsonb,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now(),
+      completed_at timestamptz,
+      CONSTRAINT catalog_repair_batches_action_check CHECK (
+        action IN ('enqueue_backfill', 'bulk_enqueue_backfill')
+      ),
+      CONSTRAINT catalog_repair_batches_status_check CHECK (
+        status IN (
+          'enqueueing',
+          'queued',
+          'processing',
+          'partial',
+          'failed',
+          'unavailable',
+          'empty',
+          'completed'
+        )
+      )
+    );
+
+    CREATE TABLE IF NOT EXISTS catalog_repair_batch_items (
+      id bigserial PRIMARY KEY,
+      batch_id bigint NOT NULL REFERENCES catalog_repair_batches(id) ON DELETE CASCADE,
+      movie_id bigint NOT NULL REFERENCES movies(id) ON DELETE RESTRICT,
+      issue_key text NOT NULL,
+      status text NOT NULL DEFAULT 'pending',
+      queue_name text,
+      job_name text,
+      job_id text,
+      language text,
+      reason text,
+      error_message text,
+      movie_snapshot jsonb NOT NULL DEFAULT '{}'::jsonb,
+      result jsonb NOT NULL DEFAULT '{}'::jsonb,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now(),
+      completed_at timestamptz,
+      CONSTRAINT catalog_repair_batch_items_status_check CHECK (
+        status IN (
+          'pending',
+          'queued',
+          'deduped',
+          'unavailable',
+          'enqueue_failed',
+          'processing',
+          'completed',
+          'failed',
+          'skipped'
+        )
+      )
+    );
+
+    ALTER TABLE catalog_repair_audit
+      ADD COLUMN IF NOT EXISTS repair_batch_id bigint REFERENCES catalog_repair_batches(id) ON DELETE SET NULL;
+
+    ALTER TABLE catalog_repair_audit
+      ADD COLUMN IF NOT EXISTS repair_batch_item_id bigint REFERENCES catalog_repair_batch_items(id) ON DELETE SET NULL;
+
+    CREATE INDEX IF NOT EXISTS idx_catalog_repair_batches_created_at
+      ON catalog_repair_batches (created_at DESC, id DESC);
+
+    CREATE INDEX IF NOT EXISTS idx_catalog_repair_batches_issue_created_at
+      ON catalog_repair_batches (issue_key, created_at DESC);
+
+    CREATE INDEX IF NOT EXISTS idx_catalog_repair_batches_status_updated_at
+      ON catalog_repair_batches (status, updated_at DESC);
+
+    CREATE INDEX IF NOT EXISTS idx_catalog_repair_batch_items_batch_status
+      ON catalog_repair_batch_items (batch_id, status, id);
+
+    CREATE INDEX IF NOT EXISTS idx_catalog_repair_batch_items_movie_created_at
+      ON catalog_repair_batch_items (movie_id, created_at DESC);
+
+    CREATE INDEX IF NOT EXISTS idx_catalog_repair_batch_items_job_id
+      ON catalog_repair_batch_items (job_id)
+      WHERE job_id IS NOT NULL;
+
+    CREATE INDEX IF NOT EXISTS idx_catalog_repair_audit_batch_created_at
+      ON catalog_repair_audit (repair_batch_id, created_at DESC)
+      WHERE repair_batch_id IS NOT NULL;
   `);
 }
 


### PR DESCRIPTION
## Summary
- add durable catalog repair batch and batch item tables, schema sync, and shared repository helpers
- link backoffice bulk repair enqueue actions to batch/item records and pass identifiers through BullMQ payloads
- persist basic worker lifecycle status for repair items and document the new audit flow

Fixes #572.

Follow-ups: #574 still needs issue-predicate re-check and resolved-vs-unresolved status handling; #575 should build the richer batch history/detail UI on top of these persisted records.

## Verification
- npm run test --workspace=packages/shared -- catalogRepairActions
- npm run test:backoffice
- npm run build --workspace=apps/backoffice
- npm run type-check
- npm run test:services
- npm run test:server
- npm run build --workspace=apps/web
- git diff --check
- pre-push hook: lint, server tests, web build