### PR TITLE
Resolve catalog repair items against issue predicates

### DIFF
--- a/apps/web/src/lib/workers/catalogMaintenanceWorker.ts
+++ b/apps/web/src/lib/workers/catalogMaintenanceWorker.ts
@@ -1,10 +1,12 @@
 import {
+  catalogRepairCompletionStatusForResolution,
   createEmbeddings,
   ensureCatalogRepairActionSchema,
   ensureCatalogMetadataSchema,
   getPool,
   initDatabase,
   insertMovies,
+  isCatalogHealthIssueResolvedForMovie,
   refreshCatalogRepairBatchCounts,
   updateCatalogRepairBatchItemStatus,
   upsertMovieCatalogMetadata,
@@ -39,7 +41,11 @@ import type {
   CatalogMaintenanceJobName,
   CatalogSeedTMDBMovieJobData,
 } from '@/lib/jobQueue';
-import type { MovieRecord } from '@pop-choice/shared';
+import type {
+  CatalogRepairBatchItem,
+  CatalogRepairItemStatus,
+  MovieRecord,
+} from '@pop-choice/shared';
 import type { Job } from 'bullmq';
 
 type CatalogWorker = Worker<CatalogMaintenanceJobData, void, CatalogMaintenanceJobName>;
@@ -65,6 +71,7 @@ const DEFAULT_TMDB_WINDOW_MS = 10_000;
 const DEFAULT_TMDB_429_BACKOFF_MS = 30_000;
 const DEFAULT_MIN_VOTE_COUNT = 500;
 const DEFAULT_MIN_VOTE_AVERAGE = 6.5;
+const DEFAULT_CATALOG_HEALTH_STALE_DAYS = 180;
 
 let databaseInitialized = false;
 let schemaReadyPromise: Promise<void> | null = null;
@@ -99,14 +106,22 @@ async function ensureCatalogSchema(): Promise<void> {
 
 async function updateRepairBatchItem(
   job: Job<CatalogMaintenanceJobData, void, CatalogMaintenanceJobName> | undefined,
-  status: 'processing' | 'completed' | 'failed' | 'skipped',
+  status: Extract<
+    CatalogRepairItemStatus,
+    | 'processing'
+    | 'completed'
+    | 'completed_resolved'
+    | 'completed_unresolved'
+    | 'failed'
+    | 'skipped'
+  >,
   options: { errorMessage?: string; result?: Record<string, unknown> } = {},
-): Promise<void> {
+): Promise<CatalogRepairBatchItem | null> {
   const repairBatchItemId =
     job?.data && 'repairBatchItemId' in job.data ? job.data.repairBatchItemId : undefined;
-  if (!repairBatchItemId) return;
+  if (!repairBatchItemId) return null;
 
-  await updateCatalogRepairBatchItemStatus({
+  const item = await updateCatalogRepairBatchItemStatus({
     itemId: repairBatchItemId,
     status,
     errorMessage: options.errorMessage,
@@ -123,6 +138,40 @@ async function updateRepairBatchItem(
   if (repairBatchId) {
     await refreshCatalogRepairBatchCounts(repairBatchId);
   }
+
+  return item;
+}
+
+async function completeRepairBatchItemAfterBackfill({
+  job,
+  repairItem,
+  result,
+}: {
+  job: Job<CatalogMaintenanceJobData, void, CatalogMaintenanceJobName>;
+  repairItem: CatalogRepairBatchItem | null;
+  result: Record<string, unknown>;
+}): Promise<void> {
+  if (!repairItem) {
+    await updateRepairBatchItem(job, 'completed', { result });
+    return;
+  }
+
+  const issueResolved = await isCatalogHealthIssueResolvedForMovie({
+    issueKey: repairItem.issueKey,
+    movieId: repairItem.movieId,
+    staleAfterDays: parsePositiveIntEnv(
+      'CATALOG_HEALTH_STALE_DAYS',
+      DEFAULT_CATALOG_HEALTH_STALE_DAYS,
+    ),
+  });
+
+  await updateRepairBatchItem(job, catalogRepairCompletionStatusForResolution(issueResolved), {
+    result: {
+      ...result,
+      issueKey: repairItem.issueKey,
+      issueResolved,
+    },
+  });
 }
 
 async function handleRateLimit(
@@ -335,7 +384,7 @@ async function loadBackfillMovie(movieId: string | number): Promise<BackfillMovi
 
 async function processBackfillMovie(job: Job<CatalogBackfillMovieJobData>): Promise<void> {
   await ensureCatalogSchema();
-  await updateRepairBatchItem(
+  const repairItem = await updateRepairBatchItem(
     job as Job<CatalogMaintenanceJobData, void, CatalogMaintenanceJobName>,
     'processing',
   );
@@ -346,13 +395,11 @@ async function processBackfillMovie(job: Job<CatalogBackfillMovieJobData>): Prom
   const movie = await loadBackfillMovie(job.data.movieId);
   if (!movie) {
     logger.warn({ jobId: job.id, movieId: job.data.movieId }, 'Catalog backfill movie not found');
-    await updateRepairBatchItem(
-      job as Job<CatalogMaintenanceJobData, void, CatalogMaintenanceJobName>,
-      'skipped',
-      {
-        result: { reason: 'movie_not_found', movieId: String(job.data.movieId) },
-      },
-    );
+    await completeRepairBatchItemAfterBackfill({
+      job: job as Job<CatalogMaintenanceJobData, void, CatalogMaintenanceJobName>,
+      repairItem,
+      result: { reason: 'movie_not_found', movieId: String(job.data.movieId) },
+    });
     return;
   }
 
@@ -370,31 +417,27 @@ async function processBackfillMovie(job: Job<CatalogBackfillMovieJobData>): Prom
       },
       'Catalog backfill skipped movie without confident TMDB match',
     );
-    await updateRepairBatchItem(
-      job as Job<CatalogMaintenanceJobData, void, CatalogMaintenanceJobName>,
-      'skipped',
-      {
-        result: {
-          reason: 'tmdb_match_not_confident',
-          movieId: movie.id,
-          matchStatus: match.status,
-          candidateCount: match.candidates.length,
-        },
+    await completeRepairBatchItemAfterBackfill({
+      job: job as Job<CatalogMaintenanceJobData, void, CatalogMaintenanceJobName>,
+      repairItem,
+      result: {
+        reason: 'tmdb_match_not_confident',
+        movieId: movie.id,
+        matchStatus: match.status,
+        candidateCount: match.candidates.length,
       },
-    );
+    });
     return;
   }
 
   const details = await fetchMovieDetails(apiKey, match.tmdbId, job.data.language);
   if (!details) {
     logger.warn({ jobId: job.id, tmdbId: match.tmdbId }, 'Catalog backfill found no details');
-    await updateRepairBatchItem(
-      job as Job<CatalogMaintenanceJobData, void, CatalogMaintenanceJobName>,
-      'skipped',
-      {
-        result: { reason: 'tmdb_details_missing', movieId: movie.id, tmdbId: match.tmdbId },
-      },
-    );
+    await completeRepairBatchItemAfterBackfill({
+      job: job as Job<CatalogMaintenanceJobData, void, CatalogMaintenanceJobName>,
+      repairItem,
+      result: { reason: 'tmdb_details_missing', movieId: movie.id, tmdbId: match.tmdbId },
+    });
     return;
   }
 
@@ -451,13 +494,11 @@ async function processBackfillMovie(job: Job<CatalogBackfillMovieJobData>): Prom
     { jobId: job.id, movieId: movie.id, tmdbId: match.tmdbId },
     'Catalog backfill completed',
   );
-  await updateRepairBatchItem(
-    job as Job<CatalogMaintenanceJobData, void, CatalogMaintenanceJobName>,
-    'completed',
-    {
-      result: { movieId: movie.id, tmdbId: match.tmdbId },
-    },
-  );
+  await completeRepairBatchItemAfterBackfill({
+    job: job as Job<CatalogMaintenanceJobData, void, CatalogMaintenanceJobName>,
+    repairItem,
+    result: { movieId: movie.id, tmdbId: match.tmdbId },
+  });
 }
 
 export function createCatalogMaintenanceWorker(): CatalogWorker | null {

--- a/db/createDB.sql
+++ b/db/createDB.sql
@@ -313,11 +313,50 @@ CREATE TABLE IF NOT EXISTS catalog_repair_batch_items (
       'enqueue_failed',
       'processing',
       'completed',
+      'completed_resolved',
+      'completed_unresolved',
       'failed',
       'skipped'
     )
   )
 );
+
+ALTER TABLE catalog_repair_batches
+  DROP CONSTRAINT IF EXISTS catalog_repair_batches_status_check;
+
+ALTER TABLE catalog_repair_batches
+  ADD CONSTRAINT catalog_repair_batches_status_check CHECK (
+    status IN (
+      'enqueueing',
+      'queued',
+      'processing',
+      'partial',
+      'failed',
+      'unavailable',
+      'empty',
+      'completed'
+    )
+  );
+
+ALTER TABLE catalog_repair_batch_items
+  DROP CONSTRAINT IF EXISTS catalog_repair_batch_items_status_check;
+
+ALTER TABLE catalog_repair_batch_items
+  ADD CONSTRAINT catalog_repair_batch_items_status_check CHECK (
+    status IN (
+      'pending',
+      'queued',
+      'deduped',
+      'unavailable',
+      'enqueue_failed',
+      'processing',
+      'completed',
+      'completed_resolved',
+      'completed_unresolved',
+      'failed',
+      'skipped'
+    )
+  );
 
 ALTER TABLE catalog_repair_audit
   ADD COLUMN IF NOT EXISTS repair_batch_id bigint REFERENCES catalog_repair_batches(id) ON DELETE SET NULL;

--- a/db/init/01_schema.sql
+++ b/db/init/01_schema.sql
@@ -326,11 +326,50 @@ CREATE TABLE IF NOT EXISTS catalog_repair_batch_items (
       'enqueue_failed',
       'processing',
       'completed',
+      'completed_resolved',
+      'completed_unresolved',
       'failed',
       'skipped'
     )
   )
 );
+
+ALTER TABLE catalog_repair_batches
+  DROP CONSTRAINT IF EXISTS catalog_repair_batches_status_check;
+
+ALTER TABLE catalog_repair_batches
+  ADD CONSTRAINT catalog_repair_batches_status_check CHECK (
+    status IN (
+      'enqueueing',
+      'queued',
+      'processing',
+      'partial',
+      'failed',
+      'unavailable',
+      'empty',
+      'completed'
+    )
+  );
+
+ALTER TABLE catalog_repair_batch_items
+  DROP CONSTRAINT IF EXISTS catalog_repair_batch_items_status_check;
+
+ALTER TABLE catalog_repair_batch_items
+  ADD CONSTRAINT catalog_repair_batch_items_status_check CHECK (
+    status IN (
+      'pending',
+      'queued',
+      'deduped',
+      'unavailable',
+      'enqueue_failed',
+      'processing',
+      'completed',
+      'completed_resolved',
+      'completed_unresolved',
+      'failed',
+      'skipped'
+    )
+  );
 
 ALTER TABLE catalog_repair_audit
   ADD COLUMN IF NOT EXISTS repair_batch_id bigint REFERENCES catalog_repair_batches(id) ON DELETE SET NULL;

--- a/packages/shared/src/catalogHealth.test.ts
+++ b/packages/shared/src/catalogHealth.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { closeDatabase, initDatabase } from './db.js';
 import {
+  isCatalogHealthIssueResolvedForMovie,
   isCatalogHealthIssueKey,
   listCatalogHealthIssueMoviePage,
   MAX_CATALOG_HEALTH_ISSUE_OFFSET,
@@ -94,6 +95,39 @@ describe('catalog health issue movie pages', () => {
     expect(String(poolMock.query.mock.calls[1][0])).toContain('OFFSET $3');
   });
 
+  it('re-checks whether one movie still matches the original issue predicate', async () => {
+    poolMock.query.mockResolvedValueOnce({ rows: [{ issue_exists: false }] });
+
+    await expect(
+      isCatalogHealthIssueResolvedForMovie({
+        issueKey: 'missing_poster_url',
+        movieId: '334',
+        staleAfterDays: 180,
+      }),
+    ).resolves.toBe(true);
+
+    expect(String(poolMock.query.mock.calls[0][0])).toContain('WHERE id = $1');
+    expect(String(poolMock.query.mock.calls[0][0])).toContain(
+      "poster_url IS NULL OR btrim(poster_url) = ''",
+    );
+    expect(poolMock.query.mock.calls[0][1]).toEqual(['334']);
+  });
+
+  it('keeps stale metadata threshold parameterized when re-checking one movie', async () => {
+    poolMock.query.mockResolvedValueOnce({ rows: [{ issue_exists: true }] });
+
+    await expect(
+      isCatalogHealthIssueResolvedForMovie({
+        issueKey: 'stale_tmdb_metadata',
+        movieId: '334',
+        staleAfterDays: 90,
+      }),
+    ).resolves.toBe(false);
+
+    expect(String(poolMock.query.mock.calls[0][0])).toContain('WHERE id = $2');
+    expect(poolMock.query.mock.calls[0][1]).toEqual([90, '334']);
+  });
+
   it('rejects unknown issue keys before building SQL', async () => {
     expect(isCatalogHealthIssueKey('missing_poster_url')).toBe(true);
     expect(isCatalogHealthIssueKey('drop table movies')).toBe(false);
@@ -107,5 +141,13 @@ describe('catalog health issue movie pages', () => {
       }),
     ).rejects.toThrow('Unsupported catalog-health issue');
     expect(poolMock.query).not.toHaveBeenCalled();
+
+    await expect(
+      isCatalogHealthIssueResolvedForMovie({
+        issueKey: 'drop table movies',
+        movieId: '334',
+        staleAfterDays: 90,
+      }),
+    ).rejects.toThrow('Unsupported catalog-health issue');
   });
 });

--- a/packages/shared/src/catalogHealth.ts
+++ b/packages/shared/src/catalogHealth.ts
@@ -182,6 +182,35 @@ export function isCatalogHealthIssueKey(issueKey: string): boolean {
   return getIssueDefinition(issueKey) !== null;
 }
 
+export async function isCatalogHealthIssueResolvedForMovie({
+  issueKey,
+  movieId,
+  staleAfterDays,
+}: {
+  issueKey: string;
+  movieId: string | number;
+  staleAfterDays: number;
+}): Promise<boolean> {
+  const issue = getIssueDefinition(issueKey);
+  if (!issue) {
+    throw new Error(`Unsupported catalog-health issue "${issueKey}".`);
+  }
+
+  const params = issue.key === 'stale_tmdb_metadata' ? [staleAfterDays, movieId] : [movieId];
+  const movieIdParam = issue.key === 'stale_tmdb_metadata' ? '$2' : '$1';
+  const result = await getPool().query<{ issue_exists: boolean }>(
+    `SELECT EXISTS (
+       SELECT 1
+         FROM movies
+        WHERE id = ${movieIdParam}
+          AND (${issue.where})
+     ) AS issue_exists`,
+    params,
+  );
+
+  return !Boolean(result.rows[0]?.issue_exists);
+}
+
 export async function listCatalogHealthIssueMoviePage({
   issueKey,
   limit,

--- a/packages/shared/src/catalogRepairActions.test.ts
+++ b/packages/shared/src/catalogRepairActions.test.ts
@@ -3,12 +3,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { closeDatabase, initDatabase } from './db.js';
 import {
+  catalogRepairCompletionStatusForResolution,
   createCatalogRepairBatch,
   createCatalogRepairBatchItem,
   ensureCatalogRepairActionSchema,
   listCatalogRepairAuditPage,
   refreshCatalogRepairBatchCounts,
   updateCatalogRepairBatchItemEnqueueResult,
+  updateCatalogRepairBatchItemStatus,
 } from './catalogRepairActions.js';
 
 vi.mock('pg', () => {
@@ -91,6 +93,9 @@ describe('catalog repair audit pages', () => {
     expect(sql).toContain('CREATE TABLE IF NOT EXISTS catalog_repair_batch_items');
     expect(sql).toContain('repair_batch_id bigint REFERENCES catalog_repair_batches');
     expect(sql).toContain("'enqueue_failed'");
+    expect(sql).toContain("'completed_resolved'");
+    expect(sql).toContain("'completed_unresolved'");
+    expect(sql).toContain('DROP CONSTRAINT IF EXISTS catalog_repair_batch_items_status_check');
     expect(sql).toContain('idx_catalog_repair_batch_items_job_id');
   });
 
@@ -255,5 +260,110 @@ describe('catalog repair audit pages', () => {
       failedCount: 1,
     });
     expect(poolMock.query.mock.calls[0][1]).toEqual(['7']);
+    expect(String(poolMock.query.mock.calls[0][0])).toContain(
+      "status IN ('completed', 'completed_resolved')",
+    );
+    expect(String(poolMock.query.mock.calls[0][0])).toContain("status = 'completed_unresolved'");
+    expect(String(poolMock.query.mock.calls[0][0])).toContain("'completedUnresolved'");
+    expect(String(poolMock.query.mock.calls[0][0])).toContain(
+      'WHEN completed_count = attempted_count THEN',
+    );
+  });
+
+  it('records resolved and unresolved terminal item statuses', async () => {
+    poolMock.query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: '11',
+            batch_id: '7',
+            movie_id: '334',
+            issue_key: 'missing_poster_url',
+            status: 'completed_resolved',
+            queue_name: 'catalog-maintenance',
+            job_name: 'backfill-movie',
+            job_id: 'backfill-334',
+            language: 'en-US',
+            reason: 'missing_metadata',
+            error_message: null,
+            movie_snapshot: { id: '334' },
+            result: { issueResolved: true },
+            created_at: '2026-05-28 09:00:01+00',
+            updated_at: '2026-05-28 09:00:02+00',
+            completed_at: '2026-05-28 09:00:02+00',
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: '12',
+            batch_id: '7',
+            movie_id: '335',
+            issue_key: 'missing_localized_name',
+            status: 'completed_unresolved',
+            queue_name: 'catalog-maintenance',
+            job_name: 'backfill-movie',
+            job_id: 'backfill-335',
+            language: 'en-US',
+            reason: 'missing_metadata',
+            error_message: null,
+            movie_snapshot: { id: '335' },
+            result: { issueResolved: false },
+            created_at: '2026-05-28 09:00:01+00',
+            updated_at: '2026-05-28 09:00:02+00',
+            completed_at: '2026-05-28 09:00:02+00',
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: '13',
+            batch_id: '7',
+            movie_id: '336',
+            issue_key: 'missing_tmdb_id',
+            status: 'failed',
+            queue_name: 'catalog-maintenance',
+            job_name: 'backfill-movie',
+            job_id: 'backfill-336',
+            language: 'en-US',
+            reason: 'missing_tmdb_id',
+            error_message: 'TMDB unavailable',
+            movie_snapshot: { id: '336' },
+            result: { reason: 'worker_failed' },
+            created_at: '2026-05-28 09:00:01+00',
+            updated_at: '2026-05-28 09:00:02+00',
+            completed_at: '2026-05-28 09:00:02+00',
+          },
+        ],
+      });
+
+    const resolved = await updateCatalogRepairBatchItemStatus({
+      itemId: '11',
+      status: catalogRepairCompletionStatusForResolution(true),
+      result: { issueResolved: true },
+    });
+    const unresolved = await updateCatalogRepairBatchItemStatus({
+      itemId: '12',
+      status: catalogRepairCompletionStatusForResolution(false),
+      result: { issueResolved: false },
+    });
+    const failed = await updateCatalogRepairBatchItemStatus({
+      itemId: '13',
+      status: 'failed',
+      errorMessage: 'TMDB unavailable',
+      result: { reason: 'worker_failed' },
+    });
+
+    expect(resolved).toMatchObject({ id: '11', status: 'completed_resolved' });
+    expect(unresolved).toMatchObject({ id: '12', status: 'completed_unresolved' });
+    expect(failed).toMatchObject({ id: '13', status: 'failed', errorMessage: 'TMDB unavailable' });
+    expect(poolMock.query.mock.calls[0][1][1]).toBe('completed_resolved');
+    expect(poolMock.query.mock.calls[1][1][1]).toBe('completed_unresolved');
+    expect(poolMock.query.mock.calls[2][1][1]).toBe('failed');
+    expect(String(poolMock.query.mock.calls[0][0])).toContain("'completed_resolved'");
+    expect(String(poolMock.query.mock.calls[0][0])).toContain("'completed_unresolved'");
+    expect(String(poolMock.query.mock.calls[0][0])).toContain("'failed'");
   });
 });

--- a/packages/shared/src/catalogRepairActions.ts
+++ b/packages/shared/src/catalogRepairActions.ts
@@ -18,6 +18,8 @@ export type CatalogRepairItemStatus =
   | 'enqueue_failed'
   | 'processing'
   | 'completed'
+  | 'completed_resolved'
+  | 'completed_unresolved'
   | 'failed'
   | 'skipped';
 
@@ -150,9 +152,23 @@ export interface UpdateCatalogRepairBatchItemEnqueueInput {
 
 export interface UpdateCatalogRepairBatchItemStatusInput {
   itemId: string | number;
-  status: Extract<CatalogRepairItemStatus, 'processing' | 'completed' | 'failed' | 'skipped'>;
+  status: Extract<
+    CatalogRepairItemStatus,
+    | 'processing'
+    | 'completed'
+    | 'completed_resolved'
+    | 'completed_unresolved'
+    | 'failed'
+    | 'skipped'
+  >;
   errorMessage?: string;
   result?: Record<string, unknown>;
+}
+
+export function catalogRepairCompletionStatusForResolution(
+  resolved: boolean,
+): Extract<CatalogRepairItemStatus, 'completed_resolved' | 'completed_unresolved'> {
+  return resolved ? 'completed_resolved' : 'completed_unresolved';
 }
 
 export interface CatalogRepairBatchPage {
@@ -410,14 +426,53 @@ export const CATALOG_REPAIR_BATCH_SCHEMA_SQL = `
         'queued',
         'deduped',
         'unavailable',
+          'enqueue_failed',
+          'processing',
+          'completed',
+          'completed_resolved',
+          'completed_unresolved',
+          'failed',
+          'skipped'
+        )
+      )
+    );
+
+  ALTER TABLE catalog_repair_batches
+    DROP CONSTRAINT IF EXISTS catalog_repair_batches_status_check;
+
+  ALTER TABLE catalog_repair_batches
+    ADD CONSTRAINT catalog_repair_batches_status_check CHECK (
+      status IN (
+        'enqueueing',
+        'queued',
+        'processing',
+        'partial',
+        'failed',
+        'unavailable',
+        'empty',
+        'completed'
+      )
+    );
+
+  ALTER TABLE catalog_repair_batch_items
+    DROP CONSTRAINT IF EXISTS catalog_repair_batch_items_status_check;
+
+  ALTER TABLE catalog_repair_batch_items
+    ADD CONSTRAINT catalog_repair_batch_items_status_check CHECK (
+      status IN (
+        'pending',
+        'queued',
+        'deduped',
+        'unavailable',
         'enqueue_failed',
         'processing',
         'completed',
+        'completed_resolved',
+        'completed_unresolved',
         'failed',
         'skipped'
       )
-    )
-  );
+    );
 
   ALTER TABLE catalog_repair_audit
     ADD COLUMN IF NOT EXISTS repair_batch_id bigint REFERENCES catalog_repair_batches(id) ON DELETE SET NULL;
@@ -670,7 +725,13 @@ export async function updateCatalogRepairBatchItemStatus(
             result = COALESCE($4::jsonb, result),
             updated_at = now(),
             completed_at = CASE
-              WHEN $2 IN ('completed', 'failed', 'skipped') THEN COALESCE(completed_at, now())
+              WHEN $2 IN (
+                'completed',
+                'completed_resolved',
+                'completed_unresolved',
+                'failed',
+                'skipped'
+              ) THEN COALESCE(completed_at, now())
               ELSE completed_at
             END
       WHERE id = $1
@@ -713,7 +774,8 @@ export async function refreshCatalogRepairBatchCounts(
          COUNT(*) FILTER (WHERE status = 'deduped')::int AS deduped_count,
          COUNT(*) FILTER (WHERE status = 'unavailable')::int AS unavailable_count,
          COUNT(*) FILTER (WHERE status IN ('enqueue_failed', 'failed'))::int AS failed_count,
-         COUNT(*) FILTER (WHERE status = 'completed')::int AS completed_count,
+         COUNT(*) FILTER (WHERE status IN ('completed', 'completed_resolved'))::int AS completed_count,
+         COUNT(*) FILTER (WHERE status = 'completed_unresolved')::int AS unresolved_count,
          COUNT(*) FILTER (WHERE status = 'skipped')::int AS skipped_count,
          COUNT(*) FILTER (WHERE status = 'processing')::int AS processing_count
        FROM catalog_repair_batch_items
@@ -724,12 +786,16 @@ export async function refreshCatalogRepairBatchCounts(
          *,
          CASE
            WHEN attempted_count = 0 THEN 'empty'
-           WHEN completed_count + skipped_count = attempted_count THEN 'completed'
+           WHEN completed_count = attempted_count THEN 'completed'
            WHEN failed_count = attempted_count THEN 'failed'
            WHEN unavailable_count = attempted_count THEN 'unavailable'
-           WHEN completed_count + skipped_count + failed_count + unavailable_count = attempted_count
+           WHEN completed_count
+             + unresolved_count
+             + skipped_count
+             + failed_count
+             + unavailable_count = attempted_count
              THEN 'partial'
-           WHEN failed_count + unavailable_count > 0 THEN 'partial'
+           WHEN failed_count + unavailable_count + unresolved_count + skipped_count > 0 THEN 'partial'
            WHEN processing_count > 0 THEN 'processing'
            WHEN queued_count + deduped_count > 0 THEN 'queued'
            ELSE 'enqueueing'
@@ -752,6 +818,7 @@ export async function refreshCatalogRepairBatchCounts(
               'unavailable', next_values.unavailable_count,
               'failed', next_values.failed_count,
               'completed', next_values.completed_count,
+              'completedUnresolved', next_values.unresolved_count,
               'skipped', next_values.skipped_count
             ),
             updated_at = now(),
@@ -760,6 +827,7 @@ export async function refreshCatalogRepairBatchCounts(
                 OR (
                   next_values.next_status = 'partial'
                   AND next_values.completed_count
+                    + next_values.unresolved_count
                     + next_values.skipped_count
                     + next_values.failed_count
                     + next_values.unavailable_count = next_values.attempted_count

--- a/packages/shared/src/db.ts
+++ b/packages/shared/src/db.ts
@@ -403,11 +403,50 @@ export async function ensureSchema(): Promise<void> {
           'enqueue_failed',
           'processing',
           'completed',
+          'completed_resolved',
+          'completed_unresolved',
           'failed',
           'skipped'
         )
       )
     );
+
+    ALTER TABLE catalog_repair_batches
+      DROP CONSTRAINT IF EXISTS catalog_repair_batches_status_check;
+
+    ALTER TABLE catalog_repair_batches
+      ADD CONSTRAINT catalog_repair_batches_status_check CHECK (
+        status IN (
+          'enqueueing',
+          'queued',
+          'processing',
+          'partial',
+          'failed',
+          'unavailable',
+          'empty',
+          'completed'
+        )
+      );
+
+    ALTER TABLE catalog_repair_batch_items
+      DROP CONSTRAINT IF EXISTS catalog_repair_batch_items_status_check;
+
+    ALTER TABLE catalog_repair_batch_items
+      ADD CONSTRAINT catalog_repair_batch_items_status_check CHECK (
+        status IN (
+          'pending',
+          'queued',
+          'deduped',
+          'unavailable',
+          'enqueue_failed',
+          'processing',
+          'completed',
+          'completed_resolved',
+          'completed_unresolved',
+          'failed',
+          'skipped'
+        )
+      );
 
     ALTER TABLE catalog_repair_audit
       ADD COLUMN IF NOT EXISTS repair_batch_id bigint REFERENCES catalog_repair_batches(id) ON DELETE SET NULL;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -44,6 +44,7 @@ export type { BackofficeRuntimeConfig, BullBoardRuntimeConfig } from './runtimeC
 export {
   formatCatalogHealthReport,
   getCatalogHealthReport,
+  isCatalogHealthIssueResolvedForMovie,
   isCatalogHealthIssueKey,
   listCatalogHealthIssueMoviePage,
   MAX_CATALOG_HEALTH_ISSUE_OFFSET,
@@ -60,6 +61,7 @@ export type {
 } from './catalogHealth.js';
 export {
   CATALOG_REPAIR_BATCH_SCHEMA_SQL,
+  catalogRepairCompletionStatusForResolution,
   createCatalogRepairBatch,
   createCatalogRepairBatchItem,
   ensureCatalogRepairActionSchema,

--- a/services/movie-backfill/src/database.ts
+++ b/services/movie-backfill/src/database.ts
@@ -193,11 +193,50 @@ export async function ensureTMDBMatchReviewSchema(): Promise<void> {
           'enqueue_failed',
           'processing',
           'completed',
+          'completed_resolved',
+          'completed_unresolved',
           'failed',
           'skipped'
         )
       )
     );
+
+    ALTER TABLE catalog_repair_batches
+      DROP CONSTRAINT IF EXISTS catalog_repair_batches_status_check;
+
+    ALTER TABLE catalog_repair_batches
+      ADD CONSTRAINT catalog_repair_batches_status_check CHECK (
+        status IN (
+          'enqueueing',
+          'queued',
+          'processing',
+          'partial',
+          'failed',
+          'unavailable',
+          'empty',
+          'completed'
+        )
+      );
+
+    ALTER TABLE catalog_repair_batch_items
+      DROP CONSTRAINT IF EXISTS catalog_repair_batch_items_status_check;
+
+    ALTER TABLE catalog_repair_batch_items
+      ADD CONSTRAINT catalog_repair_batch_items_status_check CHECK (
+        status IN (
+          'pending',
+          'queued',
+          'deduped',
+          'unavailable',
+          'enqueue_failed',
+          'processing',
+          'completed',
+          'completed_resolved',
+          'completed_unresolved',
+          'failed',
+          'skipped'
+        )
+      );
 
     ALTER TABLE catalog_repair_audit
       ADD COLUMN IF NOT EXISTS repair_batch_id bigint REFERENCES catalog_repair_batches(id) ON DELETE SET NULL;


### PR DESCRIPTION
## Summary
- re-check the original catalog-health predicate after repair work finishes
- add explicit completed_resolved and completed_unresolved item states
- aggregate unresolved completions as partial batches instead of treating job completion as full repair success

Fixes #574.

## Verification
- npm run test --workspace=packages/shared -- catalogHealth catalogRepairActions
- npm run build --workspace=packages/shared
- npm run type-check --workspace=apps/web
- pre-commit type-check
- pre-push lint, server tests, web build