### PR TITLE
Add backoffice repair batch history

### DIFF
--- a/apps/backoffice/src/app/api/catalog-repair-batches/[id]/route.ts
+++ b/apps/backoffice/src/app/api/catalog-repair-batches/[id]/route.ts
@@ -1,0 +1,45 @@
+import { getCatalogRepairBatchDetail } from '@pop-choice/shared';
+import { NextResponse } from 'next/server';
+
+import {
+  ensureBackofficeReady,
+  logBackofficeError,
+  parseRepairBatchItemParams,
+} from '../../../../lib/backoffice';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+type CatalogRepairBatchContext = {
+  params: Promise<{ id: string }>;
+};
+
+export async function GET(request: Request, context: CatalogRepairBatchContext) {
+  const { id } = await context.params;
+
+  try {
+    await ensureBackofficeReady();
+    const searchParams = Object.fromEntries(new URL(request.url).searchParams.entries());
+    const pagination = parseRepairBatchItemParams(searchParams);
+    const detail = await getCatalogRepairBatchDetail(id, {
+      limit: pagination.limit,
+      offset: pagination.offset,
+    });
+
+    if (!detail) {
+      return NextResponse.json({ error: 'Catalog repair batch not found.' }, { status: 404 });
+    }
+
+    return NextResponse.json(detail, {
+      headers: {
+        'Cache-Control': 'no-store',
+      },
+    });
+  } catch (error) {
+    logBackofficeError('Failed to read catalog repair batch detail', error);
+    return NextResponse.json(
+      { error: 'Failed to read catalog repair batch detail.' },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/backoffice/src/app/api/catalog-repair-batches/route.ts
+++ b/apps/backoffice/src/app/api/catalog-repair-batches/route.ts
@@ -1,0 +1,35 @@
+import { listCatalogRepairBatchPage } from '@pop-choice/shared';
+import { NextResponse } from 'next/server';
+
+import {
+  ensureBackofficeReady,
+  logBackofficeError,
+  parseRepairBatchListParams,
+} from '../../../lib/backoffice';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+export async function GET(request: Request) {
+  try {
+    await ensureBackofficeReady();
+    const searchParams = Object.fromEntries(new URL(request.url).searchParams.entries());
+    const pagination = parseRepairBatchListParams(searchParams);
+    const batchPage = await listCatalogRepairBatchPage({
+      limit: pagination.limit,
+      offset: pagination.offset,
+    });
+
+    return NextResponse.json(batchPage, {
+      headers: {
+        'Cache-Control': 'no-store',
+      },
+    });
+  } catch (error) {
+    logBackofficeError('Failed to read catalog repair batch history', error);
+    return NextResponse.json(
+      { error: 'Failed to read catalog repair batch history.' },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/backoffice/src/app/globals.css
+++ b/apps/backoffice/src/app/globals.css
@@ -657,6 +657,32 @@ input:disabled {
   color: var(--accent);
   background: var(--accent-soft);
 }
+.repair-status {
+  text-transform: capitalize;
+  white-space: nowrap;
+}
+.repair-completed,
+.repair-completed_resolved,
+.repair-queued,
+.repair-deduped {
+  color: var(--good);
+  background: var(--good-soft);
+}
+.repair-completed_unresolved,
+.repair-enqueueing,
+.repair-processing,
+.repair-pending,
+.repair-partial,
+.repair-empty {
+  color: var(--warn);
+  background: var(--warn-soft);
+}
+.repair-failed,
+.repair-enqueue_failed,
+.repair-unavailable {
+  color: var(--bad);
+  background: var(--bad-soft);
+}
 .pill.reason-runtime {
   color: var(--bad);
   background: var(--bad-soft);
@@ -760,6 +786,30 @@ input:disabled {
   color: var(--muted);
   font-weight: 750;
   text-align: center;
+}
+.repair-batch-table {
+  min-width: 980px;
+}
+.repair-counts {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 750;
+}
+.repair-counts span {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 1px 7px;
+  background: #111419;
+  white-space: nowrap;
+}
+.batch-summary {
+  margin-top: 0;
+}
+.loading-panel {
+  min-height: 150px;
 }
 .pagination {
   display: flex;

--- a/apps/backoffice/src/app/repair-batches/[id]/loading.tsx
+++ b/apps/backoffice/src/app/repair-batches/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import { BackofficeLoadingPage } from '../../../components/backoffice';
+
+export default function RepairBatchDetailLoading() {
+  return <BackofficeLoadingPage active="repair-batches" title="Loading Repair Batch" />;
+}

--- a/apps/backoffice/src/app/repair-batches/[id]/page.tsx
+++ b/apps/backoffice/src/app/repair-batches/[id]/page.tsx
@@ -1,0 +1,49 @@
+import { getCatalogRepairBatchDetail } from '@pop-choice/shared';
+
+import {
+  BackofficeErrorPage,
+  RepairBatchDetailPage,
+  RepairBatchNotFoundPage,
+} from '../../../components/backoffice';
+import {
+  ensureBackofficeReady,
+  logBackofficeError,
+  parseRepairBatchItemParams,
+} from '../../../lib/backoffice';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+type RepairBatchDetailProps = {
+  params: Promise<{ id: string }>;
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function RepairBatchDetail({ params, searchParams }: RepairBatchDetailProps) {
+  const { id } = await params;
+
+  try {
+    await ensureBackofficeReady();
+    const query = (await searchParams) ?? {};
+    const pagination = parseRepairBatchItemParams(query);
+    const detail = await getCatalogRepairBatchDetail(id, {
+      limit: pagination.limit,
+      offset: pagination.offset,
+    });
+
+    if (!detail) {
+      return <RepairBatchNotFoundPage batchId={id} />;
+    }
+
+    return <RepairBatchDetailPage detail={detail} />;
+  } catch (error) {
+    logBackofficeError('Failed to render catalog repair batch detail', error);
+    return (
+      <BackofficeErrorPage
+        active="repair-batches"
+        error={error}
+        retryHref={`/repair-batches/${encodeURIComponent(id)}`}
+      />
+    );
+  }
+}

--- a/apps/backoffice/src/app/repair-batches/loading.tsx
+++ b/apps/backoffice/src/app/repair-batches/loading.tsx
@@ -1,0 +1,5 @@
+import { BackofficeLoadingPage } from '../../components/backoffice';
+
+export default function RepairBatchesLoading() {
+  return <BackofficeLoadingPage active="repair-batches" title="Loading Repair Batches" />;
+}

--- a/apps/backoffice/src/app/repair-batches/page.tsx
+++ b/apps/backoffice/src/app/repair-batches/page.tsx
@@ -1,0 +1,34 @@
+import { listCatalogRepairBatchPage } from '@pop-choice/shared';
+
+import { BackofficeErrorPage, RepairBatchListPage } from '../../components/backoffice';
+import {
+  ensureBackofficeReady,
+  logBackofficeError,
+  parseRepairBatchListParams,
+} from '../../lib/backoffice';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+type RepairBatchesPageProps = {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function RepairBatchesPage({ searchParams }: RepairBatchesPageProps) {
+  try {
+    await ensureBackofficeReady();
+    const params = (await searchParams) ?? {};
+    const pagination = parseRepairBatchListParams(params);
+    const batchPage = await listCatalogRepairBatchPage({
+      limit: pagination.limit,
+      offset: pagination.offset,
+    });
+
+    return <RepairBatchListPage batchPage={batchPage} />;
+  } catch (error) {
+    logBackofficeError('Failed to render catalog repair batch history', error);
+    return (
+      <BackofficeErrorPage active="repair-batches" error={error} retryHref="/repair-batches" />
+    );
+  }
+}

--- a/apps/backoffice/src/components/backoffice.tsx
+++ b/apps/backoffice/src/components/backoffice.tsx
@@ -5,6 +5,12 @@ import type {
   CatalogMovieSample,
   CatalogRepairActionAuditPage,
   CatalogRepairActionAudit,
+  CatalogRepairBatch,
+  CatalogRepairBatchDetail,
+  CatalogRepairBatchItem,
+  CatalogRepairBatchPage,
+  CatalogRepairBatchStatus,
+  CatalogRepairItemStatus,
   DuplicateIdentityGroup,
   TMDBMatchReview,
   TMDBMatchReviewAction,
@@ -27,7 +33,7 @@ import {
   REPAIRABLE_CATALOG_ISSUE_KEYS,
 } from '../lib/backoffice';
 
-type Section = 'health' | 'reviews';
+type Section = 'health' | 'repair-batches' | 'reviews';
 
 type ShellProps = {
   active: Section;
@@ -77,6 +83,9 @@ export function BackofficeShell({
           </a>
           <a className={active === 'reviews' ? 'active' : ''} href="/tmdb-reviews">
             TMDB reviews
+          </a>
+          <a className={active === 'repair-batches' ? 'active' : ''} href="/repair-batches">
+            Repair batches
           </a>
         </nav>
         {children}
@@ -607,6 +616,466 @@ function RepairAuditRows({ audit }: { audit: CatalogRepairActionAudit[] }) {
         ))}
       </tbody>
     </table>
+  );
+}
+
+function repairStatusLabel(status: CatalogRepairBatchStatus | CatalogRepairItemStatus): string {
+  const labels: Record<CatalogRepairBatchStatus | CatalogRepairItemStatus, string> = {
+    completed: 'Completed',
+    completed_resolved: 'Completed resolved',
+    completed_unresolved: 'Completed unresolved',
+    deduped: 'Deduped',
+    empty: 'Empty',
+    enqueue_failed: 'Enqueue failed',
+    enqueueing: 'Enqueueing',
+    failed: 'Failed',
+    partial: 'Partial',
+    pending: 'Pending',
+    processing: 'Processing',
+    queued: 'Queued',
+    skipped: 'Skipped',
+    unavailable: 'Unavailable',
+  };
+
+  return labels[status];
+}
+
+function RepairStatusBadge({
+  status,
+}: {
+  status: CatalogRepairBatchStatus | CatalogRepairItemStatus;
+}) {
+  return (
+    <span className={`status repair-status repair-${status}`}>{repairStatusLabel(status)}</span>
+  );
+}
+
+function getRepairBatchProgress(batch: CatalogRepairBatch): string {
+  const finished =
+    batch.completedCount +
+    batch.failedCount +
+    batch.skippedCount +
+    batch.dedupedCount +
+    batch.unavailableCount;
+  const attempted = Math.max(batch.attemptedCount, 0);
+  if (attempted === 0) return 'No items attempted';
+  return `${finished}/${attempted} finished`;
+}
+
+function buildRepairBatchPageHref({ page, pageSize }: { page: number; pageSize: number }) {
+  const params = new URLSearchParams();
+  params.set('page', String(page));
+  params.set('pageSize', String(pageSize));
+  return `/repair-batches?${params.toString()}`;
+}
+
+function buildRepairBatchItemPageHref({
+  batchId,
+  page,
+  pageSize,
+}: {
+  batchId: string;
+  page: number;
+  pageSize: number;
+}) {
+  const params = new URLSearchParams();
+  params.set('itemPage', String(page));
+  params.set('itemPageSize', String(pageSize));
+  return `/repair-batches/${encodeURIComponent(batchId)}?${params.toString()}`;
+}
+
+function snapshotValue(
+  snapshot: Record<string, unknown>,
+  key: string,
+): string | number | null | undefined {
+  const value = snapshot[key];
+  if (typeof value === 'string' || typeof value === 'number' || value === null) return value;
+  return undefined;
+}
+
+function RepairBatchRows({ batches }: { batches: CatalogRepairBatch[] }) {
+  if (batches.length === 0) {
+    return (
+      <tr>
+        <td colSpan={9} className="empty">
+          No durable catalog repair batches have been recorded yet.
+        </td>
+      </tr>
+    );
+  }
+
+  return (
+    <>
+      {batches.map((batch) => (
+        <tr key={batch.id}>
+          <td>
+            <a href={`/repair-batches/${encodeURIComponent(batch.id)}`}>#{batch.id}</a>
+          </td>
+          <td>
+            <RepairStatusBadge status={batch.status} />
+          </td>
+          <td>{batch.issueKey}</td>
+          <td>{batch.actor}</td>
+          <td>{batch.requestedLimit}</td>
+          <td>{batch.totalCandidates}</td>
+          <td>
+            <span className="repair-counts">
+              <span>{batch.queuedCount} queued</span>
+              <span>{batch.dedupedCount} deduped</span>
+              <span>{batch.failedCount} failed</span>
+            </span>
+          </td>
+          <td>{formatBackofficeDateTime(batch.createdAt)}</td>
+          <td>
+            <a className="button small" href={`/repair-batches/${encodeURIComponent(batch.id)}`}>
+              Open
+            </a>
+          </td>
+        </tr>
+      ))}
+    </>
+  );
+}
+
+function RepairBatchItemRows({ items }: { items: CatalogRepairBatchItem[] }) {
+  if (items.length === 0) {
+    return (
+      <tr>
+        <td colSpan={9} className="empty">
+          No item rows were recorded for this repair batch.
+        </td>
+      </tr>
+    );
+  }
+
+  return (
+    <>
+      {items.map((item) => {
+        const name = snapshotValue(item.movieSnapshot, 'name');
+        const year = snapshotValue(item.movieSnapshot, 'year');
+
+        return (
+          <tr key={item.id}>
+            <td>#{item.id}</td>
+            <td>
+              <a href={`/api/catalog-repair-batches/${encodeURIComponent(item.batchId)}`}>
+                batch:{item.batchId}
+              </a>
+            </td>
+            <td>
+              <div className="movie-title">
+                <strong>{name ?? `Movie ${item.movieId}`}</strong>
+                <span className="muted">
+                  #{item.movieId}
+                  {year === null || year === undefined ? '' : ` · ${year}`}
+                </span>
+              </div>
+            </td>
+            <td>
+              <RepairStatusBadge status={item.status} />
+            </td>
+            <td>{item.jobId ?? '-'}</td>
+            <td>{item.reason ?? '-'}</td>
+            <td>{item.language ?? '-'}</td>
+            <td>{item.errorMessage ?? '-'}</td>
+            <td>{formatBackofficeDateTime(item.updatedAt)}</td>
+          </tr>
+        );
+      })}
+    </>
+  );
+}
+
+function RepairBatchSummary({ batch }: { batch: CatalogRepairBatch }) {
+  return (
+    <section className="summary batch-summary" aria-label="Repair batch summary">
+      <CatalogStat
+        label="Status"
+        value={repairStatusLabel(batch.status)}
+        meta={getRepairBatchProgress(batch)}
+        state={
+          batch.status === 'completed'
+            ? 'healthy'
+            : batch.status === 'failed' || batch.status === 'partial'
+              ? 'warning'
+              : 'neutral'
+        }
+      />
+      <CatalogStat
+        label="Candidates"
+        value={batch.totalCandidates}
+        meta="Affected rows at queue time"
+      />
+      <CatalogStat
+        label="Attempted"
+        value={batch.attemptedCount}
+        meta={`Requested limit ${batch.requestedLimit}`}
+      />
+      <CatalogStat
+        label="Queued"
+        value={batch.queuedCount}
+        meta={`${batch.dedupedCount} deduped, ${batch.unavailableCount} unavailable`}
+        state={batch.failedCount > 0 ? 'warning' : 'neutral'}
+      />
+    </section>
+  );
+}
+
+export function RepairBatchListPage({ batchPage }: { batchPage: CatalogRepairBatchPage }) {
+  return (
+    <BackofficeShell
+      active="repair-batches"
+      title="Catalog Repair Batches"
+      eyebrow="Repair history"
+      description="Review durable bulk repair attempts, enqueue outcomes, and worker progress by item."
+      actions={
+        <a className="button" href="/repair-batches">
+          Refresh
+        </a>
+      }
+    >
+      <section className="panel">
+        <div className="panel-header">
+          <h2>Recent batches</h2>
+          <span className="count">{batchPage.totalCount}</span>
+        </div>
+        <SimplePaginationControls
+          ariaLabel="Catalog repair batch pagination"
+          emptyLabel="No repair batches"
+          itemLabel="repair batches"
+          limit={batchPage.limit}
+          offset={batchPage.offset}
+          totalCount={batchPage.totalCount}
+          hrefForPage={(page) => buildRepairBatchPageHref({ page, pageSize: batchPage.limit })}
+        />
+        <div className="table-scroll">
+          <table className="repair-batch-table">
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Status</th>
+                <th>Issue</th>
+                <th>Actor</th>
+                <th>Limit</th>
+                <th>Candidates</th>
+                <th>Outcomes</th>
+                <th>Created</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              <RepairBatchRows batches={batchPage.batches} />
+            </tbody>
+          </table>
+        </div>
+        <SimplePaginationControls
+          ariaLabel="Catalog repair batch pagination bottom"
+          emptyLabel="No repair batches"
+          itemLabel="repair batches"
+          limit={batchPage.limit}
+          offset={batchPage.offset}
+          totalCount={batchPage.totalCount}
+          hrefForPage={(page) => buildRepairBatchPageHref({ page, pageSize: batchPage.limit })}
+        />
+      </section>
+    </BackofficeShell>
+  );
+}
+
+export function RepairBatchDetailPage({ detail }: { detail: CatalogRepairBatchDetail }) {
+  const { batch, items } = detail;
+
+  return (
+    <BackofficeShell
+      active="repair-batches"
+      title={`Repair Batch #${batch.id}`}
+      eyebrow="Repair detail"
+      description={
+        <div className="toolbar-summary">
+          <RepairStatusBadge status={batch.status} />
+          <span>{batch.issueKey}</span>
+          <span>Updated {formatBackofficeDateTime(batch.updatedAt)}</span>
+        </div>
+      }
+      actions={
+        <>
+          <a className="button" href="/repair-batches">
+            Back to batches
+          </a>
+          <a
+            className="button quiet"
+            href={`/api/catalog-repair-batches/${encodeURIComponent(batch.id)}`}
+          >
+            JSON
+          </a>
+        </>
+      }
+    >
+      <RepairBatchSummary batch={batch} />
+      <section className="detail-grid">
+        <article className="panel">
+          <div className="panel-header">
+            <h2>Batch context</h2>
+          </div>
+          <dl className="facts">
+            <div>
+              <dt>Action</dt>
+              <dd>{batch.action.replaceAll('_', ' ')}</dd>
+            </div>
+            <div>
+              <dt>Actor</dt>
+              <dd>{batch.actor}</dd>
+            </div>
+            <div>
+              <dt>Target</dt>
+              <dd>
+                {batch.targetType}:{batch.targetId}
+              </dd>
+            </div>
+            <div>
+              <dt>Created</dt>
+              <dd>{formatBackofficeDateTime(batch.createdAt)}</dd>
+            </div>
+            <div>
+              <dt>Completed</dt>
+              <dd>{formatBackofficeDateTime(batch.completedAt)}</dd>
+            </div>
+            <div>
+              <dt>Note</dt>
+              <dd>{batch.note ?? '-'}</dd>
+            </div>
+          </dl>
+        </article>
+        <article className="panel">
+          <div className="panel-header">
+            <h2>Item status counts</h2>
+          </div>
+          <dl className="facts">
+            <div>
+              <dt>Queued</dt>
+              <dd>{batch.queuedCount}</dd>
+            </div>
+            <div>
+              <dt>Completed</dt>
+              <dd>{batch.completedCount}</dd>
+            </div>
+            <div>
+              <dt>Deduped</dt>
+              <dd>{batch.dedupedCount}</dd>
+            </div>
+            <div>
+              <dt>Skipped</dt>
+              <dd>{batch.skippedCount}</dd>
+            </div>
+            <div>
+              <dt>Unavailable</dt>
+              <dd>{batch.unavailableCount}</dd>
+            </div>
+            <div>
+              <dt>Failed</dt>
+              <dd>{batch.failedCount}</dd>
+            </div>
+          </dl>
+        </article>
+      </section>
+      <section className="panel">
+        <div className="panel-header">
+          <div>
+            <h2>Batch items</h2>
+            <div className="issue-hint">
+              Item rows preserve the movie snapshot and queue result for operator history.
+            </div>
+          </div>
+          <span className="count">{items.totalCount}</span>
+        </div>
+        <SimplePaginationControls
+          ariaLabel="Catalog repair batch item pagination"
+          emptyLabel="No repair batch items"
+          itemLabel="batch items"
+          limit={items.limit}
+          offset={items.offset}
+          totalCount={items.totalCount}
+          hrefForPage={(page) =>
+            buildRepairBatchItemPageHref({ batchId: batch.id, page, pageSize: items.limit })
+          }
+        />
+        <div className="table-scroll">
+          <table className="repair-batch-table">
+            <thead>
+              <tr>
+                <th>Item</th>
+                <th>Batch</th>
+                <th>Movie</th>
+                <th>Status</th>
+                <th>Job</th>
+                <th>Reason</th>
+                <th>Language</th>
+                <th>Error</th>
+                <th>Updated</th>
+              </tr>
+            </thead>
+            <tbody>
+              <RepairBatchItemRows items={items.items} />
+            </tbody>
+          </table>
+        </div>
+        <SimplePaginationControls
+          ariaLabel="Catalog repair batch item pagination bottom"
+          emptyLabel="No repair batch items"
+          itemLabel="batch items"
+          limit={items.limit}
+          offset={items.offset}
+          totalCount={items.totalCount}
+          hrefForPage={(page) =>
+            buildRepairBatchItemPageHref({ batchId: batch.id, page, pageSize: items.limit })
+          }
+        />
+      </section>
+    </BackofficeShell>
+  );
+}
+
+export function RepairBatchNotFoundPage({ batchId }: { batchId: string }) {
+  return (
+    <BackofficeShell
+      active="repair-batches"
+      title="Repair Batch Not Found"
+      eyebrow="Repair detail"
+      description={`No durable catalog repair batch exists for id ${batchId}.`}
+      actions={
+        <a className="button" href="/repair-batches">
+          Back to batches
+        </a>
+      }
+    >
+      <section className="panel">
+        <p className="empty">The batch may have been created in another environment or deleted.</p>
+      </section>
+    </BackofficeShell>
+  );
+}
+
+export function BackofficeLoadingPage({
+  active = 'health',
+  title = 'Loading backoffice',
+}: {
+  active?: Section;
+  title?: string;
+}) {
+  return (
+    <BackofficeShell
+      active={active}
+      title={title}
+      eyebrow="Loading"
+      description="Fetching the latest operator state."
+    >
+      <section className="panel loading-panel" aria-busy="true">
+        <div className="panel-header">
+          <h2>Loading</h2>
+        </div>
+        <p className="empty">Loading current records...</p>
+      </section>
+    </BackofficeShell>
   );
 }
 
@@ -1412,15 +1881,23 @@ export function ReviewDetailPage({
   );
 }
 
-export function BackofficeErrorPage({ error: _error }: { error: unknown }) {
+export function BackofficeErrorPage({
+  active = 'health',
+  error: _error,
+  retryHref = '/',
+}: {
+  active?: Section;
+  error: unknown;
+  retryHref?: string;
+}) {
   return (
     <BackofficeShell
-      active="health"
+      active={active}
       title="Backoffice unavailable"
       eyebrow="Operator error"
       description="The backoffice service is running, but the requested report could not be loaded."
       actions={
-        <a className="button" href="/">
+        <a className="button" href={retryHref}>
           Retry
         </a>
       }

--- a/apps/backoffice/src/lib/backoffice.test.ts
+++ b/apps/backoffice/src/lib/backoffice.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_REPAIR_BATCH_ITEM_PAGE_SIZE,
+  DEFAULT_REPAIR_BATCH_PAGE_SIZE,
+  MAX_REPAIR_BATCH_PAGE_SIZE,
+  parseRepairBatchItemParams,
+  parseRepairBatchListParams,
+} from './backoffice';
+
+describe('repair batch query params', () => {
+  it('defaults list pagination for recent repair batches', () => {
+    expect(parseRepairBatchListParams({})).toEqual({
+      page: 1,
+      pageSize: DEFAULT_REPAIR_BATCH_PAGE_SIZE,
+      limit: DEFAULT_REPAIR_BATCH_PAGE_SIZE,
+      offset: 0,
+    });
+  });
+
+  it('clamps list page size and calculates offset', () => {
+    expect(parseRepairBatchListParams({ page: '3', pageSize: '999' })).toEqual({
+      page: 3,
+      pageSize: MAX_REPAIR_BATCH_PAGE_SIZE,
+      limit: MAX_REPAIR_BATCH_PAGE_SIZE,
+      offset: 200,
+    });
+  });
+
+  it('uses independent item pagination names for detail pages', () => {
+    expect(parseRepairBatchItemParams({ itemPage: '2', itemPageSize: '10' })).toEqual({
+      page: 2,
+      pageSize: 10,
+      limit: 10,
+      offset: 10,
+    });
+  });
+
+  it('falls back for invalid item pagination values', () => {
+    expect(parseRepairBatchItemParams({ itemPage: 'zero', itemPageSize: '-1' })).toEqual({
+      page: 1,
+      pageSize: DEFAULT_REPAIR_BATCH_ITEM_PAGE_SIZE,
+      limit: DEFAULT_REPAIR_BATCH_ITEM_PAGE_SIZE,
+      offset: 0,
+    });
+  });
+});

--- a/apps/backoffice/src/lib/backoffice.ts
+++ b/apps/backoffice/src/lib/backoffice.ts
@@ -37,6 +37,10 @@ export const DEFAULT_REVIEW_PAGE_SIZE = 25;
 export const MAX_REVIEW_PAGE_SIZE = 100;
 export const DEFAULT_BULK_REPAIR_LIMIT = 25;
 export const MAX_BULK_REPAIR_LIMIT = 100;
+export const DEFAULT_REPAIR_BATCH_PAGE_SIZE = 25;
+export const DEFAULT_REPAIR_BATCH_ITEM_PAGE_SIZE = 100;
+export const MAX_REPAIR_BATCH_PAGE_SIZE = 100;
+export const MAX_REPAIR_BATCH_PAGE_NUMBER = 4_001;
 
 export const REPAIRABLE_CATALOG_ISSUE_KEYS = new Set([
   'missing_poster_url',
@@ -163,6 +167,57 @@ export function parsePositiveIntParam(
   const parsed = Number(value);
   if (!Number.isSafeInteger(parsed) || parsed < 1) return fallback;
   return Math.min(parsed, max);
+}
+
+export function firstSearchParam(value: string | string[] | undefined): string | null {
+  if (Array.isArray(value)) return value[0] ?? null;
+  return value ?? null;
+}
+
+export function parseRepairBatchListParams(params: Record<string, string | string[] | undefined>): {
+  page: number;
+  pageSize: number;
+  limit: number;
+  offset: number;
+} {
+  const pageSize = parsePositiveIntParam(
+    firstSearchParam(params.pageSize),
+    DEFAULT_REPAIR_BATCH_PAGE_SIZE,
+    { max: MAX_REPAIR_BATCH_PAGE_SIZE },
+  );
+  const page = parsePositiveIntParam(firstSearchParam(params.page), 1, {
+    max: MAX_REPAIR_BATCH_PAGE_NUMBER,
+  });
+
+  return {
+    page,
+    pageSize,
+    limit: pageSize,
+    offset: (page - 1) * pageSize,
+  };
+}
+
+export function parseRepairBatchItemParams(params: Record<string, string | string[] | undefined>): {
+  page: number;
+  pageSize: number;
+  limit: number;
+  offset: number;
+} {
+  const pageSize = parsePositiveIntParam(
+    firstSearchParam(params.itemPageSize),
+    DEFAULT_REPAIR_BATCH_ITEM_PAGE_SIZE,
+    { max: MAX_REPAIR_BATCH_PAGE_SIZE },
+  );
+  const page = parsePositiveIntParam(firstSearchParam(params.itemPage), 1, {
+    max: MAX_REPAIR_BATCH_PAGE_NUMBER,
+  });
+
+  return {
+    page,
+    pageSize,
+    limit: pageSize,
+    offset: (page - 1) * pageSize,
+  };
 }
 
 export function parseAction(value: FormDataEntryValue | null): TMDBMatchReviewAction {

--- a/docs/BACKOFFICE.md
+++ b/docs/BACKOFFICE.md
@@ -91,6 +91,13 @@ Mutation flows are deliberately narrow:
   stays immutable and links back to the batch, while the batch/item tables are
   the Postgres source of truth for enqueue and worker progress after BullMQ
   history is trimmed.
+- [#574](https://github.com/shchilkin/PopChoice/issues/574): completed repair
+  jobs re-check the original catalog-health predicate before finalizing durable
+  item status. This separates "the worker finished" from "the catalog issue is
+  resolved" in batch history.
+- [#575](https://github.com/shchilkin/PopChoice/issues/575): durable repair
+  batches are browsable from the backoffice at `/repair-batches`, with a detail
+  view for per-movie item status, queue metadata, and worker errors.
 
 Shared operator auth is the login model for public exposure:
 
@@ -165,8 +172,11 @@ intentionally conservative:
   which gives operators a recovery trail without depending on retained BullMQ
   jobs;
 - workers advance durable item status from `queued`/`deduped` to `processing`,
-  `completed`, `skipped`, or final `failed` when a repair job carries
-  `repairBatchId` and `repairBatchItemId`;
+  `completed_resolved`, `completed_unresolved`, `skipped`, or final `failed`
+  when a repair job carries `repairBatchId` and `repairBatchItemId`;
+- the repair batch history page at `/repair-batches` shows recent durable batch
+  attempts and links to per-item details, so operators do not need to infer
+  batch state from Bull Board history alone;
 - the recent repair audit is paginated so large repair histories do not render
   as one long operator table.
 


### PR DESCRIPTION
## Summary
- add /repair-batches list and detail pages for durable catalog repair batches
- add read-only JSON APIs for batch list/detail pagination
- show per-item queue metadata, statuses, worker errors, and summary counts

Stacked on #614 so this PR only shows the backoffice UI/API layer.

Fixes #575.

## Verification
- npm run test --workspace=apps/backoffice
- npm run build --workspace=apps/backoffice
- npm run test --workspace=packages/shared -- catalogHealth catalogRepairActions
- pre-commit type-check
- pre-push lint, server tests, web build