### PR TITLE
Clarify backoffice repair state labels

### DIFF
--- a/apps/backoffice/src/app/globals.css
+++ b/apps/backoffice/src/app/globals.css
@@ -413,6 +413,9 @@ input:disabled {
 .notice.good {
   border-color: color-mix(in srgb, var(--good), var(--border) 45%);
 }
+.notice.neutral {
+  border-color: color-mix(in srgb, var(--accent), var(--border) 55%);
+}
 .notice.warn {
   border-color: color-mix(in srgb, var(--warn), var(--border) 45%);
 }
@@ -822,8 +825,8 @@ input:disabled {
 .sample-table tr.repair-pending td {
   background: rgba(124, 199, 255, 0.05);
 }
-.sample-table tr.repair-queued td {
-  background: rgba(64, 196, 99, 0.06);
+.sample-table tr.repair-accepted td {
+  background: rgba(124, 199, 255, 0.05);
 }
 .data-pill {
   display: inline-flex;
@@ -909,15 +912,15 @@ input:disabled {
   white-space: nowrap;
 }
 .repair-completed,
-.repair-completed_resolved,
-.repair-queued,
-.repair-deduped {
+.repair-completed_resolved {
   color: var(--good);
   background: var(--good-soft);
 }
 .repair-completed_unresolved,
+.repair-deduped,
 .repair-enqueueing,
 .repair-processing,
+.repair-queued,
 .repair-pending,
 .repair-partial,
 .repair-empty {
@@ -1013,6 +1016,9 @@ input:disabled {
 }
 .repair-message.good {
   color: var(--good);
+}
+.repair-message.accepted {
+  color: var(--accent);
 }
 .repair-message.warn {
   color: var(--warn);

--- a/apps/backoffice/src/components/catalog-health/index.tsx
+++ b/apps/backoffice/src/components/catalog-health/index.tsx
@@ -110,8 +110,8 @@ function formatRepairTarget(entry: CatalogRepairActionAudit) {
 
 function repairResultChips(result: Record<string, unknown>) {
   const fields = [
-    ['queued', 'Queued'],
-    ['deduped', 'Deduped'],
+    ['queued', 'Accepted'],
+    ['deduped', 'Already queued'],
     ['failed', 'Failed'],
     ['unavailable', 'Unavailable'],
     ['attempted', 'Attempted'],
@@ -122,6 +122,26 @@ function repairResultChips(result: Record<string, unknown>) {
     const value = numberFromResult(result, key);
     return value === null ? [] : [{ key, label, value }];
   });
+}
+
+export function repairResultStatusLabel(status: string): string {
+  const labels: Record<string, string> = {
+    deduped: 'Already queued',
+    enqueue_failed: 'Enqueue failed',
+    failed: 'Failed',
+    partial: 'Partially accepted',
+    queued: 'Accepted',
+    unavailable: 'Unavailable',
+  };
+
+  return labels[status] ?? humanizeIdentifier(status);
+}
+
+export function repairResultStatusTone(status: string): 'good' | 'neutral' | 'warn' {
+  if (status === 'failed' || status === 'enqueue_failed' || status === 'unavailable') {
+    return 'warn';
+  }
+  return status === 'completed_resolved' ? 'good' : 'neutral';
 }
 
 function RepairResultSummary({ entry }: { entry: CatalogRepairActionAudit }) {
@@ -143,7 +163,9 @@ function RepairResultSummary({ entry }: { entry: CatalogRepairActionAudit }) {
           <span className="repair-result-primary">{status ?? 'Recorded'}</span>
         )}
         {status ? (
-          <span className={`data-pill ${status === 'queued' ? 'good' : 'neutral'}`}>{status}</span>
+          <span className={`data-pill ${repairResultStatusTone(status)}`}>
+            {repairResultStatusLabel(status)}
+          </span>
         ) : null}
       </div>
       {chips.length > 0 ? (
@@ -545,18 +567,18 @@ function CatalogIssuePanel({
 function RepairFlash({ repairStatus }: { repairStatus: string | null }) {
   if (repairStatus === 'queued') {
     return (
-      <div className="notice good">
-        Catalog backfill job queued. Workers will process it through the existing rate-limited TMDB
-        path.
+      <div className="notice neutral">
+        Catalog backfill work accepted. This row is not resolved yet; workers will process it
+        through the existing rate-limited TMDB path.
       </div>
     );
   }
 
   if (repairStatus === 'bulk-queued') {
     return (
-      <div className="notice good">
-        Catalog repair batch queued. Workers will process jobs through the existing rate-limited
-        TMDB path.
+      <div className="notice neutral">
+        Catalog repair batch accepted. Issues stay open until workers update the catalog and the
+        next health report clears them.
       </div>
     );
   }
@@ -718,14 +740,9 @@ export function CatalogHealthPage({
       eyebrow="Catalog operations"
       description={
         <>
-          Generated {formatBackofficeDateTime(report.generatedAt)}. Auto-refresh checks DB and
-          BullMQ changes, and queue events trigger immediate refreshes.
+          Updated {formatBackofficeDateTime(report.generatedAt)}. Catalog and queue status refresh
+          automatically.
         </>
-      }
-      actions={
-        <a className="button" href="/">
-          Refresh
-        </a>
       }
     >
       <RepairFlash repairStatus={repairStatus} />

--- a/apps/backoffice/src/components/catalog-queue/index.tsx
+++ b/apps/backoffice/src/components/catalog-queue/index.tsx
@@ -324,24 +324,16 @@ export function CatalogMaintenanceQueuePage({
       eyebrow="Worker operations"
       description={
         <>
-          Snapshot from BullMQ at {formatBackofficeDateTime(jobPage.updatedAt)}. Realtime queue
-          events refresh the page automatically; use Refresh if the stream disconnects.
+          Updated {formatBackofficeDateTime(jobPage.updatedAt)}. Queue changes refresh
+          automatically.
         </>
       }
       actions={
-        <>
-          {bullBoardUrl ? (
-            <a className="button" href={bullBoardUrl}>
-              Open Bull Board
-            </a>
-          ) : null}
-          <a
-            className="button"
-            href={buildQueueHref({ page: 1, pageSize: jobPage.limit, state: jobPage.state })}
-          >
-            Refresh
+        bullBoardUrl ? (
+          <a className="button" href={bullBoardUrl}>
+            Open Bull Board
           </a>
-        </>
+        ) : null
       }
     >
       <CatalogMaintenanceRealtimeRefresh />

--- a/apps/backoffice/src/components/catalogHealthLiveRefresh.tsx
+++ b/apps/backoffice/src/components/catalogHealthLiveRefresh.tsx
@@ -11,6 +11,11 @@ import {
 } from '../lib/catalogHealthLive';
 import { CATALOG_HEALTH_REFRESH_EVENT } from './catalogHealthRefreshEvent';
 
+const CLIENT_TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+});
+
 async function fetchCatalogHealthLive(search: string): Promise<CatalogHealthLiveData> {
   const response = await fetch(`/api/catalog-health${search}`, {
     cache: 'no-store',
@@ -78,6 +83,8 @@ export function CatalogHealthLiveRefresh({
     });
   }, [data, router]);
 
+  const lastChecked = dataUpdatedAt ? CLIENT_TIME_FORMATTER.format(new Date(dataUpdatedAt)) : null;
+
   return (
     <div className="live-refresh" aria-live="polite">
       <span
@@ -87,10 +94,10 @@ export function CatalogHealthLiveRefresh({
       <span>
         {isPending || isFetching
           ? 'Refreshing catalog snapshot'
-          : `Auto-refresh checks DB and BullMQ every ${refreshSeconds}s`}
+          : `Catalog status refreshes automatically every ${refreshSeconds}s`}
       </span>
       <span className="live-refresh-meta">
-        {dataUpdatedAt ? `Last checked ${new Date(dataUpdatedAt).toLocaleTimeString()}` : 'Waiting'}
+        {lastChecked ? `Last checked ${lastChecked}` : 'Waiting'}
       </span>
       {isError ? <span className="live-refresh-error">Auto-refresh failed</span> : null}
     </div>

--- a/apps/backoffice/src/components/catalogMaintenanceRealtimeRefresh.tsx
+++ b/apps/backoffice/src/components/catalogMaintenanceRealtimeRefresh.tsx
@@ -6,6 +6,10 @@ import { useEffect, useRef, useState } from 'react';
 type RealtimeStatus = 'connecting' | 'connected' | 'error';
 
 const REFRESH_DEBOUNCE_MS = 350;
+const CLIENT_TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+});
 
 export function CatalogMaintenanceRealtimeRefresh({
   label = 'Realtime queue events',
@@ -54,7 +58,8 @@ export function CatalogMaintenanceRealtimeRefresh({
       ? label
       : status === 'connecting'
         ? 'Connecting realtime queue events'
-        : 'Realtime queue events unavailable, use Refresh';
+        : 'Realtime queue events unavailable';
+  const lastEvent = lastEventAt ? CLIENT_TIME_FORMATTER.format(new Date(lastEventAt)) : null;
 
   return (
     <div className={`live-refresh realtime-refresh ${status}`} aria-live="polite">
@@ -63,9 +68,7 @@ export function CatalogMaintenanceRealtimeRefresh({
         aria-hidden="true"
       />
       <span>{copy}</span>
-      <span className="live-refresh-meta">
-        {lastEventAt ? `Last event ${new Date(lastEventAt).toLocaleTimeString()}` : 'Waiting'}
-      </span>
+      <span className="live-refresh-meta">{lastEvent ? `Last event ${lastEvent}` : 'Waiting'}</span>
     </div>
   );
 }

--- a/apps/backoffice/src/components/catalogRepairEnhancement.tsx
+++ b/apps/backoffice/src/components/catalogRepairEnhancement.tsx
@@ -4,13 +4,14 @@ import { useEffect } from 'react';
 
 import { requestCatalogHealthRefresh } from './catalogHealthRefreshEvent';
 
-type RepairTone = '' | 'good' | 'warn';
+type RepairTone = '' | 'accepted' | 'good' | 'warn';
 
 function setMessage(form: HTMLFormElement, text: string, tone: RepairTone): void {
   const message = form.querySelector<HTMLElement>('[data-repair-message]');
   if (!message) return;
 
   message.textContent = text;
+  message.classList.toggle('accepted', tone === 'accepted');
   message.classList.toggle('good', tone === 'good');
   message.classList.toggle('warn', tone === 'warn');
 }
@@ -77,7 +78,7 @@ function appendEmptyPlaceholder(body: HTMLElement | null, columnCount: number): 
   cell.className = 'repair-placeholder';
   cell.colSpan = columnCount;
   cell.textContent =
-    'Visible sample queued. Refresh after workers complete to verify catalog health.';
+    'Visible sample accepted. It stays unresolved until workers update catalog health.';
   placeholder.appendChild(cell);
   body.appendChild(placeholder);
 }
@@ -152,13 +153,13 @@ export function CatalogRepairEnhancement() {
           if (response.ok && payload?.status === 'queued') {
             requestCatalogHealthRefresh();
             row?.classList.remove('repair-pending');
-            row?.classList.add('repair-queued');
-            setButton(form, 'Queued', true);
+            row?.classList.add('repair-accepted');
+            setButton(form, 'Accepted', true);
             const bulkSummary = payload.mode === 'bulk' ? payload.summary : null;
             const bulkMessage = bulkSummary
-              ? `Queued ${bulkSummary.queued ?? 0}, deduped ${bulkSummary.deduped ?? 0}`
-              : 'Queued for workers';
-            setMessage(form, bulkMessage, 'good');
+              ? `Accepted ${bulkSummary.queued ?? 0}, already queued ${bulkSummary.deduped ?? 0}`
+              : 'Accepted for worker';
+            setMessage(form, bulkMessage, 'accepted');
 
             if (row) {
               const timeoutId = window.setTimeout(() => {

--- a/apps/backoffice/src/components/repair-batches/index.tsx
+++ b/apps/backoffice/src/components/repair-batches/index.tsx
@@ -11,12 +11,14 @@ import { formatBackofficeDateTime } from '../../lib/backoffice';
 import { BackofficeLayout } from '../backoffice-layout';
 import { CatalogStat, SimplePaginationControls } from '../shared';
 
-function repairStatusLabel(status: CatalogRepairBatchStatus | CatalogRepairItemStatus): string {
+export function repairStatusLabel(
+  status: CatalogRepairBatchStatus | CatalogRepairItemStatus,
+): string {
   const labels: Record<CatalogRepairBatchStatus | CatalogRepairItemStatus, string> = {
-    completed: 'Completed',
-    completed_resolved: 'Completed resolved',
-    completed_unresolved: 'Completed unresolved',
-    deduped: 'Deduped',
+    completed: 'Completed, verify',
+    completed_resolved: 'Issue cleared',
+    completed_unresolved: 'Still flagged',
+    deduped: 'Already queued',
     empty: 'Empty',
     enqueue_failed: 'Enqueue failed',
     enqueueing: 'Enqueueing',
@@ -24,7 +26,7 @@ function repairStatusLabel(status: CatalogRepairBatchStatus | CatalogRepairItemS
     partial: 'Partial',
     pending: 'Pending',
     processing: 'Processing',
-    queued: 'Queued',
+    queued: 'Accepted',
     skipped: 'Skipped',
     unavailable: 'Unavailable',
   };
@@ -112,8 +114,8 @@ function RepairBatchRows({ batches }: { batches: CatalogRepairBatch[] }) {
           <td>{batch.totalCandidates}</td>
           <td>
             <span className="repair-counts">
-              <span>{batch.queuedCount} queued</span>
-              <span>{batch.dedupedCount} deduped</span>
+              <span>{batch.queuedCount} accepted</span>
+              <span>{batch.dedupedCount} already queued</span>
               <span>{batch.failedCount} failed</span>
             </span>
           </td>
@@ -204,9 +206,9 @@ function RepairBatchSummary({ batch }: { batch: CatalogRepairBatch }) {
         meta={`Requested limit ${batch.requestedLimit}`}
       />
       <CatalogStat
-        label="Queued"
+        label="Accepted"
         value={batch.queuedCount}
-        meta={`${batch.dedupedCount} deduped, ${batch.unavailableCount} unavailable`}
+        meta={`${batch.dedupedCount} already queued, ${batch.unavailableCount} unavailable`}
         state={batch.failedCount > 0 ? 'warning' : 'neutral'}
       />
     </section>
@@ -344,7 +346,7 @@ export function RepairBatchDetailPage({ detail }: { detail: CatalogRepairBatchDe
           </div>
           <dl className="facts">
             <div>
-              <dt>Queued</dt>
+              <dt>Accepted</dt>
               <dd>{batch.queuedCount}</dd>
             </div>
             <div>

--- a/apps/backoffice/src/components/repairStateLabels.test.ts
+++ b/apps/backoffice/src/components/repairStateLabels.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { repairResultStatusLabel, repairResultStatusTone } from './catalog-health';
+import { repairStatusLabel } from './repair-batches';
+
+describe('repair state presentation', () => {
+  it('labels accepted work separately from resolved work', () => {
+    expect(repairStatusLabel('queued')).toBe('Accepted');
+    expect(repairStatusLabel('deduped')).toBe('Already queued');
+    expect(repairStatusLabel('completed_resolved')).toBe('Issue cleared');
+    expect(repairStatusLabel('completed_unresolved')).toBe('Still flagged');
+  });
+
+  it('does not use success tone for queued audit results', () => {
+    expect(repairResultStatusLabel('queued')).toBe('Accepted');
+    expect(repairResultStatusTone('queued')).toBe('neutral');
+    expect(repairResultStatusTone('deduped')).toBe('neutral');
+    expect(repairResultStatusTone('completed_resolved')).toBe('good');
+    expect(repairResultStatusTone('failed')).toBe('warn');
+  });
+});

--- a/apps/backoffice/src/lib/backoffice.ts
+++ b/apps/backoffice/src/lib/backoffice.ts
@@ -66,9 +66,6 @@ const DATE_TIME_FORMATTER = new Intl.DateTimeFormat('en', {
   hour: '2-digit',
   minute: '2-digit',
   month: 'short',
-  second: '2-digit',
-  timeZone: 'UTC',
-  timeZoneName: 'short',
   year: 'numeric',
 });
 

--- a/docs/BACKOFFICE.md
+++ b/docs/BACKOFFICE.md
@@ -74,9 +74,10 @@ Mutation flows are deliberately narrow:
   records actor, issue key, movie snapshot, queue/job result, optional note, and
   timestamp in `catalog_repair_audit`.
 - [#592](https://github.com/shchilkin/PopChoice/issues/592): repair actions are
-  progressively enhanced. Operators get pending, queued, unavailable, and error
-  states without a full page reload, successful enqueue attempts disable the
-  clicked action, and the queued sample row is removed from the visible table.
+  progressively enhanced. Operators get pending, accepted, unavailable, and
+  error states without a full page reload, successful enqueue attempts disable
+  the clicked action, and the accepted sample row is removed from the visible
+  table.
   The non-JavaScript form redirect flow remains available.
 - [#593](https://github.com/shchilkin/PopChoice/issues/593): repairable
   catalog-health panels can queue a bounded batch of `backfill-movie` jobs from
@@ -84,7 +85,7 @@ Mutation flows are deliberately narrow:
   `catalog-maintenance` worker pacing, uses deterministic job ids for dedupe,
   confirms the operator intent in the enhanced UI, reports partial enqueue
   results explicitly, and records a grouped `bulk_enqueue_backfill` audit
-  summary with queued, deduped, unavailable, and failed counts.
+  summary with accepted, already queued, unavailable, and failed counts.
 - [#572](https://github.com/shchilkin/PopChoice/issues/572): bulk repair
   attempts now create durable `catalog_repair_batches` and
   `catalog_repair_batch_items` rows before enqueueing BullMQ jobs. The audit row
@@ -185,9 +186,11 @@ intentionally conservative:
   bulk progress in `catalog_repair_batches` plus `catalog_repair_batch_items`,
   which gives operators a recovery trail without depending on retained BullMQ
   jobs;
-- workers advance durable item status from `queued`/`deduped` to `processing`,
-  `completed_resolved`, `completed_unresolved`, `skipped`, or final `failed`
-  when a repair job carries `repairBatchId` and `repairBatchItemId`;
+- workers advance durable item status from `queued`/`deduped` (shown as
+  "accepted" and "already queued") to `processing`, `completed_resolved` (shown
+  as "issue cleared"), `completed_unresolved` (shown as "still flagged"),
+  `skipped`, or final `failed` when a repair job carries `repairBatchId` and
+  `repairBatchItemId`;
 - the queue page at `/queue` shows a read-only BullMQ lens for the
   `catalog-maintenance` queue, including waiting, active, scheduled, failed, and
   completed jobs with compact payload fields;
@@ -200,10 +203,10 @@ intentionally conservative:
 - the recent repair audit is paginated so large repair histories do not render
   as one long operator table.
 
-If a queued repair does not resolve the row, use Bull Board to inspect the job,
-check worker logs, and rerun the backfill or TMDB review flow manually. Prefer a
-manual migration only when the issue is an identity conflict rather than missing
-or stale metadata.
+If an accepted repair does not resolve the row, use Bull Board to inspect the
+job, check worker logs, and rerun the backfill or TMDB review flow manually.
+Prefer a manual migration only when the issue is an identity conflict rather
+than missing or stale metadata.
 
 The auto-refresh UI treats enqueue success as "work accepted", not "catalog
 fixed". It removes the clicked sample row to keep the operator surface

--- a/docs/ROADMAP-ARCHITECTURE.md
+++ b/docs/ROADMAP-ARCHITECTURE.md
@@ -212,7 +212,7 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 - [x] Add a native backoffice `catalog-maintenance` queue view in [#627](https://github.com/shchilkin/PopChoice/issues/627), keeping Bull Board as the deeper queue console while surfacing operator-friendly counts, job summaries, and links.
 - [x] Add realtime backoffice `catalog-maintenance` queue updates in [#638](https://github.com/shchilkin/PopChoice/issues/638), using server-sent BullMQ `QueueEvents` to refresh queue and catalog-health snapshots without waiting for manual refresh.
 - [ ] Improve repair batch triage for failed and unresolved items in [#628](https://github.com/shchilkin/PopChoice/issues/628), including filters for partial, stuck, failed, and `completed_unresolved` items plus recovery links.
-- [ ] Clarify queued vs resolved repair states across catalog health in [#629](https://github.com/shchilkin/PopChoice/issues/629), reserving success language and styling for actually resolved catalog issues.
+- [x] Clarify queued vs resolved repair states across catalog health in [#629](https://github.com/shchilkin/PopChoice/issues/629), reserving success language and styling for actually resolved catalog issues.
 - Periodically refresh TMDB-backed metadata for older records without destabilizing existing recommendation history.
 - Make seed, discovery, and backfill responsibilities explicit enough that data-quality fixes do not duplicate or fight each other.
 - Define migration/versioning expectations for schema changes in [#494](https://github.com/shchilkin/PopChoice/issues/494), including production migration safety, rollback notes, and seed/backfill coordination.


### PR DESCRIPTION
## Summary
- distinguish accepted/already-queued repair work from actually resolved catalog issues
- update catalog health, repair batch views, recent action labels, and docs to use consistent repair state language
- add tests for repair state labels and tones

## Verification
- npm run test --workspace=apps/backoffice
- npm run type-check --workspace=apps/backoffice
- npm run build:backoffice
- npx impeccable --json apps/backoffice/src/components/catalog-health apps/backoffice/src/components/repair-batches apps/backoffice/src/components/catalogRepairEnhancement.tsx
- git push pre-push checks: lint, server tests, production web build

Stacked on #639. Closes #629.