### PR TITLE
Backoffice: add movie detail focused repair action

### DIFF
--- a/apps/backoffice/src/app/catalog-health/actions/route.ts
+++ b/apps/backoffice/src/app/catalog-health/actions/route.ts
@@ -4,6 +4,7 @@ import {
   catalogRepairMessage,
   getBackofficeErrorStatus,
   logBackofficeError,
+  parseBackofficeReturnPath,
   performCatalogRepairAction,
 } from '../../../lib/backoffice';
 import { isSameOriginRequest } from '../../../lib/sameOriginRequest';
@@ -16,7 +17,32 @@ function wantsJsonResponse(request: NextRequest): boolean {
   return accept.includes('application/json') || requestedWith.toLowerCase() === 'fetch';
 }
 
+function repairRedirectStatus(result: Awaited<ReturnType<typeof performCatalogRepairAction>>) {
+  if (result.status === 'queued') return result.mode === 'bulk' ? 'bulk-queued' : 'queued';
+  if (result.status === 'orchestration_queued') return 'bulk-orchestration-queued';
+  if (result.status === 'partial') return 'bulk-partial';
+  if (result.status === 'empty') return 'empty';
+  if (result.status === 'failed') return 'failed';
+  return 'unavailable';
+}
+
+function buildRepairRedirectUrl({
+  request,
+  returnPath,
+  repairStatus,
+}: {
+  request: NextRequest;
+  returnPath: string;
+  repairStatus: string;
+}) {
+  const url = new URL(returnPath, request.url);
+  url.searchParams.set('repair', repairStatus);
+  return url;
+}
+
 export async function POST(request: NextRequest) {
+  let returnPath = '/';
+
   try {
     if (!isSameOriginRequest(request)) {
       if (wantsJsonResponse(request)) {
@@ -30,6 +56,7 @@ export async function POST(request: NextRequest) {
     }
 
     const formData = await request.formData();
+    returnPath = parseBackofficeReturnPath(formData.get('return_to'));
     const result = await performCatalogRepairAction(formData, request.headers);
 
     if (wantsJsonResponse(request)) {
@@ -59,20 +86,11 @@ export async function POST(request: NextRequest) {
     }
 
     return NextResponse.redirect(
-      new URL(
-        result.status === 'queued'
-          ? `/?repair=${result.mode === 'bulk' ? 'bulk-queued' : 'queued'}`
-          : result.status === 'orchestration_queued'
-            ? '/?repair=bulk-orchestration-queued'
-            : result.status === 'partial'
-              ? '/?repair=bulk-partial'
-              : result.status === 'empty'
-                ? '/?repair=empty'
-                : result.status === 'failed'
-                  ? '/?repair=failed'
-                  : '/?repair=unavailable',
-        request.url,
-      ),
+      buildRepairRedirectUrl({
+        request,
+        returnPath,
+        repairStatus: repairRedirectStatus(result),
+      }),
       303,
     );
   } catch (error) {
@@ -97,6 +115,9 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    return NextResponse.redirect(new URL('/?repair=failed', request.url), 303);
+    return NextResponse.redirect(
+      buildRepairRedirectUrl({ request, returnPath, repairStatus: 'failed' }),
+      303,
+    );
   }
 }

--- a/apps/backoffice/src/app/globals.css
+++ b/apps/backoffice/src/app/globals.css
@@ -988,6 +988,35 @@ input:disabled {
   gap: 6px;
   margin: 0;
 }
+.movie-repair-panel {
+  display: grid;
+  gap: 14px;
+}
+.movie-repair-form {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: end;
+  gap: 12px;
+  margin: 0;
+}
+.movie-repair-form label {
+  display: grid;
+  gap: 6px;
+  min-width: min(320px, 100%);
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 800;
+}
+.movie-repair-form select {
+  min-height: 42px;
+  padding: 0 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text);
+  font: inherit;
+  font-weight: 800;
+}
 .bulk-repair-actions {
   display: grid;
   grid-template-columns: repeat(2, max-content);

--- a/apps/backoffice/src/app/movies/[id]/page.tsx
+++ b/apps/backoffice/src/app/movies/[id]/page.tsx
@@ -9,10 +9,21 @@ export const revalidate = 0;
 
 type CatalogMovieDetailRouteProps = {
   params: Promise<{ id: string }>;
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
 };
 
-export default async function CatalogMovieDetailRoute({ params }: CatalogMovieDetailRouteProps) {
+function getParamValue(value: string | string[] | undefined): string | null {
+  if (Array.isArray(value)) return value[0] ?? null;
+  return value ?? null;
+}
+
+export default async function CatalogMovieDetailRoute({
+  params,
+  searchParams,
+}: CatalogMovieDetailRouteProps) {
   const { id } = await params;
+  const query = (await searchParams) ?? {};
+  const repairStatus = getParamValue(query.repair)?.trim() ?? null;
   let result: Awaited<ReturnType<typeof getCatalogMovieDetail>>;
 
   try {
@@ -36,5 +47,5 @@ export default async function CatalogMovieDetailRoute({ params }: CatalogMovieDe
     notFound();
   }
 
-  return <CatalogMovieDetailPage detail={result.detail} />;
+  return <CatalogMovieDetailPage detail={result.detail} repairStatus={repairStatus} />;
 }

--- a/apps/backoffice/src/components/catalog-health/index.tsx
+++ b/apps/backoffice/src/components/catalog-health/index.tsx
@@ -362,9 +362,13 @@ function SampleRows({
         <tbody>
           {samples.map((movie) => (
             <tr key={movie.id} data-repair-row data-issue-key={issueKey} data-movie-id={movie.id}>
-              <td className="id-cell">#{movie.id}</td>
+              <td className="id-cell">
+                <a href={`/movies/${encodeURIComponent(movie.id)}`}>#{movie.id}</a>
+              </td>
               <td className="movie-cell">
-                <strong>{movie.name}</strong>
+                <strong>
+                  <a href={`/movies/${encodeURIComponent(movie.id)}`}>{movie.name}</a>
+                </strong>
               </td>
               <td>{movie.year}</td>
               <td>

--- a/apps/backoffice/src/components/movie-detail/index.tsx
+++ b/apps/backoffice/src/components/movie-detail/index.tsx
@@ -1,11 +1,16 @@
 import type {
   CatalogMovieDetail,
+  CatalogMovieDetailHealthFlag,
   CatalogMovieDetailPersonCredit,
   CatalogMovieDetailTaxonomyItem,
   CatalogMovieDetailTMDBReview,
 } from '@pop-choice/shared';
 
-import { formatBackofficeDateTime } from '../../lib/backoffice';
+import {
+  catalogRepairMessage,
+  formatBackofficeDateTime,
+  REPAIRABLE_CATALOG_ISSUE_KEYS,
+} from '../../lib/backoffice';
 import { BackofficeLayout } from '../backoffice-layout';
 import { RepairAuditRows } from '../catalog-health';
 import { ReasonBadge, StatusBadge } from '../tmdb-reviews/reviewPresentation';
@@ -384,7 +389,115 @@ function MetadataOverviewPanel({ detail }: { detail: CatalogMovieDetail }) {
   );
 }
 
-export function CatalogMovieDetailPage({ detail }: { detail: CatalogMovieDetail }) {
+type CatalogRepairFlashStatus = Parameters<typeof catalogRepairMessage>[0];
+
+function normalizeRepairFlashStatus(repairStatus: string | null): CatalogRepairFlashStatus | null {
+  if (!repairStatus) return null;
+
+  if (repairStatus === 'bulk-queued') return 'queued';
+  if (repairStatus === 'bulk-orchestration-queued') return 'orchestration_queued';
+  if (repairStatus === 'bulk-partial') return 'partial';
+
+  if (
+    repairStatus === 'queued' ||
+    repairStatus === 'unavailable' ||
+    repairStatus === 'failed' ||
+    repairStatus === 'empty' ||
+    repairStatus === 'partial' ||
+    repairStatus === 'orchestration_queued'
+  ) {
+    return repairStatus;
+  }
+
+  return null;
+}
+
+function repairFlashMessage(repairStatus: string | null): string | null {
+  const mappedStatus = normalizeRepairFlashStatus(repairStatus);
+  return mappedStatus ? catalogRepairMessage(mappedStatus) : null;
+}
+
+function repairFlashTone(repairStatus: string | null): 'accepted' | 'warn' {
+  const mappedStatus = normalizeRepairFlashStatus(repairStatus);
+  return mappedStatus === 'queued' || mappedStatus === 'orchestration_queued' ? 'accepted' : 'warn';
+}
+
+function repairableHealthFlags(flags: CatalogMovieDetailHealthFlag[]) {
+  return flags.filter((flag) => flag.isActive && REPAIRABLE_CATALOG_ISSUE_KEYS.has(flag.key));
+}
+
+function MovieRepairPanel({
+  detail,
+  repairStatus,
+}: {
+  detail: CatalogMovieDetail;
+  repairStatus: string | null;
+}) {
+  const repairableFlags = repairableHealthFlags(detail.healthFlags);
+  const activeFlags = detail.healthFlags.filter((flag) => flag.isActive);
+  const flash = repairFlashMessage(repairStatus);
+  const flashTone = repairFlashTone(repairStatus);
+
+  return (
+    <section className="panel movie-repair-panel">
+      <div className="panel-header">
+        <div>
+          <h2>Focused repair</h2>
+          <div className="issue-hint">
+            Queue one catalog-maintenance job for this movie through the existing paced worker path.
+          </div>
+        </div>
+        <span className={repairableFlags.length > 0 ? 'pill repairable' : 'pill'}>
+          {repairableFlags.length > 0 ? `${repairableFlags.length} repairable` : 'No action'}
+        </span>
+      </div>
+      {flash ? <p className={`repair-message ${flashTone}`}>{flash}</p> : null}
+      {repairableFlags.length > 0 ? (
+        <form className="movie-repair-form" action="/catalog-health/actions" method="post">
+          <input type="hidden" name="action" value="enqueue_backfill" />
+          <input type="hidden" name="movie_id" value={detail.movie.id} />
+          <input
+            type="hidden"
+            name="return_to"
+            value={`/movies/${encodeURIComponent(detail.movie.id)}`}
+          />
+          <input
+            type="hidden"
+            name="note"
+            value={`Queued from movie detail for ${detail.movie.name}`}
+          />
+          <label>
+            Repair reason
+            <select name="issue_key" defaultValue={repairableFlags[0]?.key}>
+              {repairableFlags.map((flag) => (
+                <option key={flag.key} value={flag.key}>
+                  {flag.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button className="button primary" type="submit">
+            Queue focused repair
+          </button>
+        </form>
+      ) : activeFlags.length > 0 ? (
+        <p className="empty">
+          Active issues for this movie need manual review or duplicate-merge tooling.
+        </p>
+      ) : (
+        <p className="empty">No active catalog-health flags need repair for this movie.</p>
+      )}
+    </section>
+  );
+}
+
+export function CatalogMovieDetailPage({
+  detail,
+  repairStatus,
+}: {
+  detail: CatalogMovieDetail;
+  repairStatus: string | null;
+}) {
   const { movie } = detail;
 
   return (
@@ -418,6 +531,7 @@ export function CatalogMovieDetailPage({ detail }: { detail: CatalogMovieDetail 
       }
     >
       <MovieIdentityPanel detail={detail} />
+      <MovieRepairPanel detail={detail} repairStatus={repairStatus} />
       <section className="detail-grid">
         <LocalFactsPanel detail={detail} />
         <HealthFlagsPanel detail={detail} />

--- a/apps/backoffice/src/components/tmdb-reviews/index.tsx
+++ b/apps/backoffice/src/components/tmdb-reviews/index.tsx
@@ -180,7 +180,8 @@ function ReviewRows({ reviews }: { reviews: TMDBMatchReview[] }) {
             <div className="movie-title">
               <strong>{review.movieName}</strong>
               <span className="muted">
-                {review.movieYear} · movie {review.movieId}
+                {review.movieYear} ·{' '}
+                <a href={`/movies/${encodeURIComponent(review.movieId)}`}>movie {review.movieId}</a>
               </span>
             </div>
           </td>
@@ -521,7 +522,9 @@ export function ReviewDetailPage({
           <dl className="facts">
             <div>
               <dt>ID</dt>
-              <dd>{review.movieId}</dd>
+              <dd>
+                <a href={`/movies/${encodeURIComponent(review.movieId)}`}>{review.movieId}</a>
+              </dd>
             </div>
             <div>
               <dt>Name</dt>

--- a/apps/backoffice/src/lib/backoffice.test.ts
+++ b/apps/backoffice/src/lib/backoffice.test.ts
@@ -6,10 +6,27 @@ import {
   DEFAULT_REPAIR_BATCH_PAGE_SIZE,
   MAX_QUEUE_JOB_PAGE_SIZE,
   MAX_REPAIR_BATCH_PAGE_SIZE,
+  parseBackofficeReturnPath,
   parseCatalogMaintenanceQueueParams,
   parseRepairBatchItemParams,
   parseRepairBatchListParams,
 } from './backoffice';
+
+describe('backoffice action return paths', () => {
+  it('keeps safe relative return paths with query and hash', () => {
+    expect(parseBackofficeReturnPath('/movies/42?tab=repair#audit')).toBe(
+      '/movies/42?tab=repair#audit',
+    );
+  });
+
+  it('falls back for external, protocol-relative, or missing return paths', () => {
+    expect(parseBackofficeReturnPath('https://evil.example/movies/42')).toBe('/');
+    expect(parseBackofficeReturnPath('//evil.example/movies/42')).toBe('/');
+    expect(parseBackofficeReturnPath('\\//evil.example/movies/42')).toBe('/');
+    expect(parseBackofficeReturnPath('\\/evil.example/movies/42')).toBe('/');
+    expect(parseBackofficeReturnPath(null)).toBe('/');
+  });
+});
 
 describe('repair batch query params', () => {
   it('defaults list pagination for recent repair batches', () => {

--- a/apps/backoffice/src/lib/backoffice.ts
+++ b/apps/backoffice/src/lib/backoffice.ts
@@ -382,6 +382,23 @@ function parseCatalogIssueKey(value: FormDataEntryValue | null): string {
   return value;
 }
 
+export function parseBackofficeReturnPath(value: FormDataEntryValue | null): string {
+  if (typeof value !== 'string') return '/';
+
+  const trimmed = value.trim();
+  if (trimmed === '' || !trimmed.startsWith('/') || trimmed.startsWith('//')) return '/';
+
+  try {
+    const base = 'https://backoffice.local';
+    const url = new URL(trimmed, base);
+    if (url.origin !== base) return '/';
+
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return '/';
+  }
+}
+
 function getBackfillReasonForIssue(issueKey: string): CatalogBackfillReason {
   if (issueKey === 'missing_tmdb_id') return 'missing_tmdb_id';
   if (issueKey === 'stale_tmdb_metadata') return 'manual_refresh';


### PR DESCRIPTION
Closes #578.

## Summary
- link catalog-health and TMDB review flows into the movie detail page
- add a focused repair panel on movie detail for one-movie catalog-maintenance backfills
- return action redirects safely back to the detail page with an in-page repair status message

## Verification
- npm run test --workspace=apps/backoffice
- npm run type-check --workspace=apps/backoffice
- npm run build:backoffice
- npx impeccable --json apps/backoffice/src/components/movie-detail apps/backoffice/src/components/catalog-health apps/backoffice/src/components/tmdb-reviews apps/backoffice/src/app/catalog-health/actions/route.ts apps/backoffice/src/app/globals.css
- pre-push: lint, 713 server tests, production build