### PR TITLE
Backoffice: refresh repair batches from queue events

### DIFF
--- a/apps/backoffice/src/components/repair-batches/index.tsx
+++ b/apps/backoffice/src/components/repair-batches/index.tsx
@@ -13,6 +13,7 @@ import type {
 
 import { formatBackofficeDateTime } from '../../lib/backoffice';
 import { BackofficeLayout } from '../backoffice-layout';
+import { CatalogMaintenanceRealtimeRefresh } from '../catalogMaintenanceRealtimeRefresh';
 import { CatalogStat, SimplePaginationControls } from '../shared';
 
 export function repairStatusLabel(
@@ -336,12 +337,8 @@ export function RepairBatchListPage({
       title="Catalog Repair Batches"
       eyebrow="Repair history"
       description="Review durable bulk repair attempts, enqueue outcomes, and worker progress by item."
-      actions={
-        <a className="button" href="/repair-batches">
-          Refresh
-        </a>
-      }
     >
+      <CatalogMaintenanceRealtimeRefresh label="Realtime repair batch updates" />
       <section className="panel">
         <div className="panel-header">
           <div>
@@ -492,6 +489,7 @@ export function RepairBatchDetailPage({
         </>
       }
     >
+      <CatalogMaintenanceRealtimeRefresh label="Realtime repair batch item updates" />
       <RepairBatchSummary batch={batch} />
       <section className="panel triage-panel">
         <div className="panel-header">


### PR DESCRIPTION
## Summary
- add realtime queue-event refresh to repair batch list and detail pages
- remove the manual Refresh action from the repair batch list
- keep detail actions focused on navigation, issue context, and JSON inspection

## Verification
- npm run test --workspace=apps/backoffice
- npm run type-check --workspace=apps/backoffice
- npm run build:backoffice
- npx impeccable --json apps/backoffice/src/components/repair-batches apps/backoffice/src/components/catalogMaintenanceRealtimeRefresh.tsx
- pre-push: lint, 713 server tests, production build