### PR TITLE
Backoffice: polish live status copy

### DIFF
--- a/apps/backoffice/src/components/catalog-health/index.tsx
+++ b/apps/backoffice/src/components/catalog-health/index.tsx
@@ -759,7 +759,7 @@ export function CatalogHealthPage({
       }
     >
       <RepairFlash repairStatus={repairStatus} />
-      <CatalogMaintenanceRealtimeRefresh label="Realtime queue events trigger catalog refresh" />
+      <CatalogMaintenanceRealtimeRefresh label="Queue updates refresh the catalog view" />
       <CatalogHealthLiveRefresh initialData={initialLiveData} intervalSeconds={12} />
       <CatalogStatusStrip
         activeIssues={activeIssues}

--- a/apps/backoffice/src/components/catalog-queue/index.tsx
+++ b/apps/backoffice/src/components/catalog-queue/index.tsx
@@ -71,7 +71,7 @@ function getQueueHealth(jobPage: CatalogMaintenanceQueueJobPage): {
     return {
       state: 'active',
       title: 'Catalog maintenance has open work',
-      copy: 'Realtime queue events refresh this snapshot while workers move jobs through active and scheduled states.',
+      copy: 'Queue updates refresh this snapshot while workers move jobs through active and scheduled states.',
     };
   }
 
@@ -373,7 +373,7 @@ export function CatalogMaintenanceQueuePage({
                 <th>State</th>
                 <th>Details</th>
                 <th>Attempts</th>
-                <th>Last event</th>
+                <th>Last update</th>
                 <th>Links</th>
               </tr>
             </thead>

--- a/apps/backoffice/src/components/catalogHealthLiveRefresh.tsx
+++ b/apps/backoffice/src/components/catalogHealthLiveRefresh.tsx
@@ -10,11 +10,7 @@ import {
   type CatalogHealthLiveData,
 } from '../lib/catalogHealthLive';
 import { CATALOG_HEALTH_REFRESH_EVENT } from './catalogHealthRefreshEvent';
-
-const CLIENT_TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
-  dateStyle: 'medium',
-  timeStyle: 'short',
-});
+import { formatLiveSyncTime } from './liveRefreshTime';
 
 async function fetchCatalogHealthLive(search: string): Promise<CatalogHealthLiveData> {
   const response = await fetch(`/api/catalog-health${search}`, {
@@ -83,7 +79,8 @@ export function CatalogHealthLiveRefresh({
     });
   }, [data, router]);
 
-  const lastChecked = dataUpdatedAt ? CLIENT_TIME_FORMATTER.format(new Date(dataUpdatedAt)) : null;
+  const lastChecked = dataUpdatedAt ? formatLiveSyncTime(dataUpdatedAt) : null;
+  const syncLabel = isError ? 'Last sync' : 'Synced';
 
   return (
     <div className="live-refresh" aria-live="polite">
@@ -94,10 +91,10 @@ export function CatalogHealthLiveRefresh({
       <span>
         {isPending || isFetching
           ? 'Refreshing catalog snapshot'
-          : `Catalog status refreshes automatically every ${refreshSeconds}s`}
+          : `Catalog status updates automatically every ${refreshSeconds}s`}
       </span>
       <span className="live-refresh-meta">
-        {lastChecked ? `Last checked ${lastChecked}` : 'Waiting'}
+        {lastChecked ? `${syncLabel} ${lastChecked}` : 'Waiting'}
       </span>
       {isError ? <span className="live-refresh-error">Auto-refresh failed</span> : null}
     </div>

--- a/apps/backoffice/src/components/catalogMaintenanceRealtimeRefresh.tsx
+++ b/apps/backoffice/src/components/catalogMaintenanceRealtimeRefresh.tsx
@@ -3,16 +3,14 @@
 import { useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 
+import { formatLiveSyncTime } from './liveRefreshTime';
+
 type RealtimeStatus = 'connecting' | 'connected' | 'error';
 
 const REFRESH_DEBOUNCE_MS = 350;
-const CLIENT_TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
-  dateStyle: 'medium',
-  timeStyle: 'short',
-});
 
 export function CatalogMaintenanceRealtimeRefresh({
-  label = 'Realtime queue events',
+  label = 'Queue updates refresh this view',
 }: {
   label?: string;
 }) {
@@ -57,9 +55,10 @@ export function CatalogMaintenanceRealtimeRefresh({
     status === 'connected'
       ? label
       : status === 'connecting'
-        ? 'Connecting realtime queue events'
-        : 'Realtime queue events unavailable';
-  const lastEvent = lastEventAt ? CLIENT_TIME_FORMATTER.format(new Date(lastEventAt)) : null;
+        ? 'Connecting to queue updates'
+        : 'Queue updates unavailable';
+  const lastEvent = lastEventAt ? formatLiveSyncTime(lastEventAt) : null;
+  const syncLabel = status === 'connected' ? 'Synced' : 'Last sync';
 
   return (
     <div className={`live-refresh realtime-refresh ${status}`} aria-live="polite">
@@ -68,7 +67,9 @@ export function CatalogMaintenanceRealtimeRefresh({
         aria-hidden="true"
       />
       <span>{copy}</span>
-      <span className="live-refresh-meta">{lastEvent ? `Last event ${lastEvent}` : 'Waiting'}</span>
+      <span className="live-refresh-meta">
+        {lastEvent ? `${syncLabel} ${lastEvent}` : 'Waiting'}
+      </span>
     </div>
   );
 }

--- a/apps/backoffice/src/components/liveRefreshTime.test.ts
+++ b/apps/backoffice/src/components/liveRefreshTime.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { formatLiveSyncTime } from './liveRefreshTime';
+
+const TODAY_TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  hour: '2-digit',
+  minute: '2-digit',
+});
+
+const STALE_TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  month: 'short',
+});
+
+describe('formatLiveSyncTime', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns unknown for invalid timestamps', () => {
+    expect(formatLiveSyncTime('not-a-date')).toBe('unknown');
+  });
+
+  it('formats same-day timestamps as local time only', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 5, 2, 13, 45));
+
+    const timestamp = new Date(2026, 5, 2, 9, 13);
+
+    expect(formatLiveSyncTime(timestamp)).toBe(TODAY_TIME_FORMATTER.format(timestamp));
+  });
+
+  it('adds date context for stale timestamps', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 5, 2, 13, 45));
+
+    const timestamp = new Date(2026, 5, 1, 23, 55);
+
+    expect(formatLiveSyncTime(timestamp)).toBe(STALE_TIME_FORMATTER.format(timestamp));
+  });
+});

--- a/apps/backoffice/src/components/liveRefreshTime.ts
+++ b/apps/backoffice/src/components/liveRefreshTime.ts
@@ -1,0 +1,31 @@
+const TODAY_TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  hour: '2-digit',
+  minute: '2-digit',
+});
+
+const STALE_TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  month: 'short',
+});
+
+function isSameLocalDay(left: Date, right: Date): boolean {
+  return (
+    left.getFullYear() === right.getFullYear() &&
+    left.getMonth() === right.getMonth() &&
+    left.getDate() === right.getDate()
+  );
+}
+
+export function formatLiveSyncTime(value: string | number | Date): string {
+  const date = value instanceof Date ? value : new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return 'unknown';
+  }
+
+  return isSameLocalDay(date, new Date())
+    ? TODAY_TIME_FORMATTER.format(date)
+    : STALE_TIME_FORMATTER.format(date);
+}

--- a/apps/backoffice/src/components/repair-batches/index.tsx
+++ b/apps/backoffice/src/components/repair-batches/index.tsx
@@ -338,7 +338,7 @@ export function RepairBatchListPage({
       eyebrow="Repair history"
       description="Review durable bulk repair attempts, enqueue outcomes, and worker progress by item."
     >
-      <CatalogMaintenanceRealtimeRefresh label="Realtime repair batch updates" />
+      <CatalogMaintenanceRealtimeRefresh label="Repair batch updates refresh this view" />
       <section className="panel">
         <div className="panel-header">
           <div>
@@ -489,7 +489,7 @@ export function RepairBatchDetailPage({
         </>
       }
     >
-      <CatalogMaintenanceRealtimeRefresh label="Realtime repair batch item updates" />
+      <CatalogMaintenanceRealtimeRefresh label="Repair batch item updates refresh this view" />
       <RepairBatchSummary batch={batch} />
       <section className="panel triage-panel">
         <div className="panel-header">


### PR DESCRIPTION
## Summary
- use short local sync timestamps in live backoffice status indicators
- remove implementation-oriented realtime/event copy from catalog, queue, and repair batch screens
- keep auto-refresh messaging focused on operator value rather than internal libraries

## Verification
- npm run test --workspace=apps/backoffice
- npm run type-check --workspace=apps/backoffice
- npx impeccable --json apps/backoffice/src/components/catalogMaintenanceRealtimeRefresh.tsx apps/backoffice/src/components/catalogHealthLiveRefresh.tsx apps/backoffice/src/components/catalog-health apps/backoffice/src/components/repair-batches
- npm run build:backoffice
- pre-push lint/server tests/production build