### PR TITLE
Polish backoffice live update copy

### DIFF
--- a/apps/backoffice/src/components/catalog-health/index.tsx
+++ b/apps/backoffice/src/components/catalog-health/index.tsx
@@ -753,8 +753,8 @@ export function CatalogHealthPage({
       eyebrow="Catalog operations"
       description={
         <>
-          Updated {formatLiveSyncTime(report.generatedAt)}. Catalog and queue status update
-          automatically.
+          Last update {formatLiveSyncTime(report.generatedAt)}. Catalog and queue state stays
+          current while you work.
         </>
       }
     >

--- a/apps/backoffice/src/components/catalogHealthLiveRefresh.tsx
+++ b/apps/backoffice/src/components/catalogHealthLiveRefresh.tsx
@@ -195,14 +195,14 @@ export function CatalogHealthLiveRefresh({
   const statusCopy = isBusy
     ? 'Refreshing catalog status'
     : connectionState === 'connected'
-      ? 'Catalog and queue state updates live'
+      ? 'Auto-updating catalog and queue state'
       : connectionState === 'connecting'
-        ? 'Connecting to live catalog updates'
-        : 'Live updates are reconnecting; background checks continue';
+        ? 'Connecting to automatic updates'
+        : 'Automatic updates are reconnecting; background checks continue';
   const metaCopy =
     lastSnapshotTrigger === 'queue-event'
-      ? `Last queue change ${lastSnapshot}`
-      : `Last status update ${lastSnapshot}`;
+      ? `Queue changed ${lastSnapshot}`
+      : `Updated ${lastSnapshot}`;
 
   return (
     <div className={`live-refresh ${connectionState}`} aria-live="polite">
@@ -212,7 +212,9 @@ export function CatalogHealthLiveRefresh({
       />
       <span>{statusCopy}</span>
       <span className="live-refresh-meta">{metaCopy}</span>
-      {isStreamError ? <span className="live-refresh-error">Live stream recovering</span> : null}
+      {isStreamError ? (
+        <span className="live-refresh-error">Automatic updates are recovering</span>
+      ) : null}
     </div>
   );
 }

--- a/apps/backoffice/src/components/catalogMaintenanceRealtimeRefresh.tsx
+++ b/apps/backoffice/src/components/catalogMaintenanceRealtimeRefresh.tsx
@@ -31,7 +31,7 @@ function getReceivedAt(message: QueueSnapshotMessage): string {
 }
 
 export function CatalogMaintenanceRealtimeRefresh({
-  label = 'Queue changes update this view live',
+  label = 'Queue updates automatically',
 }: {
   label?: string;
 }) {
@@ -89,10 +89,9 @@ export function CatalogMaintenanceRealtimeRefresh({
     status === 'connected'
       ? label
       : status === 'connecting'
-        ? 'Connecting to queue updates'
-        : 'Queue updates unavailable';
+        ? 'Connecting to automatic updates'
+        : 'Automatic updates are reconnecting';
   const lastEvent = lastEventAt ? formatLiveSyncTime(lastEventAt) : null;
-  const syncLabel = status === 'connected' ? 'Synced' : 'Last sync';
 
   return (
     <div className={`live-refresh realtime-refresh ${status}`} aria-live="polite">
@@ -102,7 +101,7 @@ export function CatalogMaintenanceRealtimeRefresh({
       />
       <span>{copy}</span>
       <span className="live-refresh-meta">
-        {lastEvent ? `${syncLabel} ${lastEvent}` : 'Waiting'}
+        {lastEvent ? `Updated ${lastEvent}` : 'Waiting for the first update'}
       </span>
     </div>
   );

--- a/apps/backoffice/src/components/liveRefreshTime.test.ts
+++ b/apps/backoffice/src/components/liveRefreshTime.test.ts
@@ -2,16 +2,21 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { formatLiveSyncTime } from './liveRefreshTime';
 
-const TODAY_TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
+const TODAY_TIME_FORMATTER = new Intl.DateTimeFormat('en', {
+  hourCycle: 'h23',
   hour: '2-digit',
   minute: '2-digit',
 });
 
-const STALE_TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
+const STALE_DATE_FORMATTER = new Intl.DateTimeFormat('en', {
   day: '2-digit',
-  hour: '2-digit',
-  minute: '2-digit',
   month: 'short',
+});
+
+const OLD_DATE_FORMATTER = new Intl.DateTimeFormat('en', {
+  day: '2-digit',
+  month: 'short',
+  year: 'numeric',
 });
 
 describe('formatLiveSyncTime', () => {
@@ -23,13 +28,15 @@ describe('formatLiveSyncTime', () => {
     expect(formatLiveSyncTime('not-a-date')).toBe('unknown');
   });
 
-  it('formats same-day timestamps as local time only', () => {
+  it('formats same-day timestamps as an operator-friendly local update time', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(2026, 5, 2, 13, 45));
 
     const timestamp = new Date(2026, 5, 2, 9, 13);
 
-    expect(formatLiveSyncTime(timestamp)).toBe(TODAY_TIME_FORMATTER.format(timestamp));
+    expect(formatLiveSyncTime(timestamp)).toBe(
+      `today at ${TODAY_TIME_FORMATTER.format(timestamp)}`,
+    );
   });
 
   it('adds date context for stale timestamps', () => {
@@ -38,6 +45,19 @@ describe('formatLiveSyncTime', () => {
 
     const timestamp = new Date(2026, 5, 1, 23, 55);
 
-    expect(formatLiveSyncTime(timestamp)).toBe(STALE_TIME_FORMATTER.format(timestamp));
+    expect(formatLiveSyncTime(timestamp)).toBe(
+      `${STALE_DATE_FORMATTER.format(timestamp)} at ${TODAY_TIME_FORMATTER.format(timestamp)}`,
+    );
+  });
+
+  it('keeps the year for old timestamps', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 5, 2, 13, 45));
+
+    const timestamp = new Date(2025, 11, 31, 23, 55);
+
+    expect(formatLiveSyncTime(timestamp)).toBe(
+      `${OLD_DATE_FORMATTER.format(timestamp)} at ${TODAY_TIME_FORMATTER.format(timestamp)}`,
+    );
   });
 });

--- a/apps/backoffice/src/components/liveRefreshTime.ts
+++ b/apps/backoffice/src/components/liveRefreshTime.ts
@@ -1,13 +1,18 @@
-const TODAY_TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
+const TODAY_TIME_FORMATTER = new Intl.DateTimeFormat('en', {
+  hourCycle: 'h23',
   hour: '2-digit',
   minute: '2-digit',
 });
 
-const STALE_TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
+const STALE_DATE_FORMATTER = new Intl.DateTimeFormat('en', {
   day: '2-digit',
-  hour: '2-digit',
-  minute: '2-digit',
   month: 'short',
+});
+
+const OLD_DATE_FORMATTER = new Intl.DateTimeFormat('en', {
+  day: '2-digit',
+  month: 'short',
+  year: 'numeric',
 });
 
 function isSameLocalDay(left: Date, right: Date): boolean {
@@ -25,7 +30,14 @@ export function formatLiveSyncTime(value: string | number | Date): string {
     return 'unknown';
   }
 
-  return isSameLocalDay(date, new Date())
-    ? TODAY_TIME_FORMATTER.format(date)
-    : STALE_TIME_FORMATTER.format(date);
+  const now = new Date();
+  if (isSameLocalDay(date, now)) {
+    return `today at ${TODAY_TIME_FORMATTER.format(date)}`;
+  }
+
+  if (date.getFullYear() !== now.getFullYear()) {
+    return `${OLD_DATE_FORMATTER.format(date)} at ${TODAY_TIME_FORMATTER.format(date)}`;
+  }
+
+  return `${STALE_DATE_FORMATTER.format(date)} at ${TODAY_TIME_FORMATTER.format(date)}`;
 }

--- a/apps/backoffice/src/components/repair-batches/index.tsx
+++ b/apps/backoffice/src/components/repair-batches/index.tsx
@@ -338,7 +338,7 @@ export function RepairBatchListPage({
       eyebrow="Repair history"
       description="Review durable bulk repair attempts, enqueue outcomes, and worker progress by item."
     >
-      <CatalogMaintenanceRealtimeRefresh label="Repair batches update live" />
+      <CatalogMaintenanceRealtimeRefresh label="Repair batches update automatically" />
       <section className="panel">
         <div className="panel-header">
           <div>
@@ -489,7 +489,7 @@ export function RepairBatchDetailPage({
         </>
       }
     >
-      <CatalogMaintenanceRealtimeRefresh label="Repair batch items update live" />
+      <CatalogMaintenanceRealtimeRefresh label="Repair batch items update automatically" />
       <RepairBatchSummary batch={batch} />
       <section className="panel triage-panel">
         <div className="panel-header">


### PR DESCRIPTION
## Summary
- format live-update timestamps as operator-friendly local labels instead of UTC/generated copy
- remove implementation details from backoffice live-status text
- keep queue and repair-batch live strips consistent with the catalog health page

## Verification
- npm run test --workspace=apps/backoffice -- liveRefreshTime
- npm run type-check --workspace=apps/backoffice
- npm run build --workspace=apps/backoffice
- npx impeccable --json --fast apps/backoffice/src/components/catalog-health apps/backoffice/src/components/catalogHealthLiveRefresh.tsx apps/backoffice/src/components/catalogMaintenanceRealtimeRefresh.tsx
- pre-push: lint, server tests, production build