### PR TITLE
Add recommendation source strategy foundation

### DIFF
--- a/apps/web/src/app/api/movie-recommendation/route.test.ts
+++ b/apps/web/src/app/api/movie-recommendation/route.test.ts
@@ -86,8 +86,11 @@ import { MIN_HIGH_QUALITY_LOCAL, SIMILARITY_THRESHOLD, shouldFallBackToTMDB } fr
 import { POST } from './route';
 import { recommendationResponseJsonSchema, recommendationResponseSchema } from './types';
 
+const originalTMDBApiKey = process.env.TMDB_API_KEY;
+
 // Inject the mock OpenAI client before each test and reset after.
 beforeEach(() => {
+  delete process.env.TMDB_API_KEY;
   setOpenAIClient({
     embeddings: {
       create: (...args: Parameters<typeof mockEmbeddingsCreate>) => mockEmbeddingsCreate(...args),
@@ -105,6 +108,11 @@ beforeEach(() => {
 
 afterEach(() => {
   resetOpenAIClient();
+  if (originalTMDBApiKey) {
+    process.env.TMDB_API_KEY = originalTMDBApiKey;
+  } else {
+    delete process.env.TMDB_API_KEY;
+  }
 });
 
 const validBody = {
@@ -875,6 +883,62 @@ describe('POST /api/movie-recommendation — TMDB fallback scoring', () => {
     const embeddingCalls = mockEmbeddingsCreate.mock.calls as unknown as { input: unknown }[][];
     const tmdbBatchCall = embeddingCalls.find((call) => Array.isArray(call[0]?.input));
     expect(tmdbBatchCall).toBeDefined();
+  });
+
+  it('uses TMDB retrieval for normal solo tmdb-first even when local results are strong', async () => {
+    process.env.TMDB_API_KEY = tmdbEnv.TMDB_API_KEY;
+
+    const { getDbClient } = vi.mocked(await import('@/clients/dbClient'));
+    (getDbClient as ReturnType<typeof vi.fn>).mockReturnValue({
+      isConfigured: vi.fn().mockReturnValue(false),
+      rpc: vi.fn().mockResolvedValue({
+        data: [
+          {
+            id: 1,
+            name: 'Strong Local Match',
+            age_rating: 'PG',
+            description: 'A strong local match.',
+            duration: 100,
+            score_rating: 8.2,
+            year: 2021,
+            similarity: 0.9,
+            content: 'Strong Local Match (2021)',
+          },
+        ],
+        error: null,
+      }),
+    });
+
+    const queryEmbedding = Array(3072).fill(0);
+    queryEmbedding[0] = 1;
+    const tmdbWeakerEmbedding = Array(3072).fill(0);
+    tmdbWeakerEmbedding[0] = 0.4;
+    const tmdbWeakestEmbedding = Array(3072).fill(0);
+    tmdbWeakestEmbedding[1] = 1;
+
+    mockEmbeddingsCreate
+      .mockResolvedValueOnce({ data: [{ embedding: queryEmbedding }] })
+      .mockResolvedValueOnce({
+        data: [{ embedding: tmdbWeakerEmbedding }, { embedding: tmdbWeakestEmbedding }],
+      })
+      .mockResolvedValue({ data: [{ embedding: Array(3072).fill(0) }] });
+
+    const res = await POST(makeRequest(validPerson));
+    const data = await res.json();
+
+    expect(res.status).not.toBe(500);
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/discover/movie'),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(data.similarMovies[0]).toMatchObject({
+      name: 'Strong Local Match',
+      source: 'curated',
+    });
+    expect(data.candidateSourceDistribution).toMatchObject({
+      curated: 1,
+      'tmdb-discover': 2,
+    });
   });
 
   it('falls back to similarity 0.35 when the TMDB embeddings call throws', async () => {

--- a/apps/web/src/app/api/movie-recommendation/route.ts
+++ b/apps/web/src/app/api/movie-recommendation/route.ts
@@ -3,6 +3,7 @@ import z from 'zod';
 
 import { getRecommendationInputBlock, normalizePeopleData } from '@/features/recommendation/input';
 import { runRecommendationPipeline } from '@/features/recommendation/pipeline';
+import { resolveRecommendationSourceStrategy } from '@/features/recommendation/sourceStrategyPolicy';
 import { apiResponseSchema, requestBodySchema } from '@/features/recommendation/types';
 import { parseLocaleFromRequest } from '@/lib/locale';
 import logger from '@/lib/logger';
@@ -44,8 +45,16 @@ async function postHandler(req: NextRequest): Promise<Response> {
 
     // Normalize to array format for consistent processing
     const allPeopleData = normalizePeopleData(validatedBody);
+    const experienceMode = 'normal-match';
+    const sourceStrategy = resolveRecommendationSourceStrategy({
+      experienceMode,
+      people: allPeopleData,
+    }).id;
 
-    logger.info({ personCount: allPeopleData.length, locale }, 'Processing recommendation request');
+    logger.info(
+      { experienceMode, personCount: allPeopleData.length, locale, sourceStrategy },
+      'Processing recommendation request',
+    );
 
     const inputBlock = await getRecommendationInputBlock(allPeopleData);
     if (inputBlock) {
@@ -63,8 +72,10 @@ async function postHandler(req: NextRequest): Promise<Response> {
       {
         attributes: {
           'http.route': '/api/movie-recommendation',
+          'recommendation.experience_mode': experienceMode,
           'recommendation.mode': 'legacy_sync',
           'recommendation.people.count': allPeopleData.length,
+          'recommendation.source_strategy': sourceStrategy,
           locale,
         },
       },
@@ -73,6 +84,8 @@ async function postHandler(req: NextRequest): Promise<Response> {
           onStageChange: (stage) => {
             setActiveTraceAttributes({ 'recommendation.stage': stage });
           },
+          experienceMode,
+          sourceStrategy,
         }),
     );
 

--- a/apps/web/src/app/api/recommendations/route.test.ts
+++ b/apps/web/src/app/api/recommendations/route.test.ts
@@ -25,6 +25,17 @@ vi.mock('@/features/recommendation/input', () => ({
   getRecommendationInputBlock: (allPeopleData: unknown[]) =>
     mockGetRecommendationInputBlock(allPeopleData),
   normalizePeopleData: (body: unknown) => mockNormalizePeopleData(body),
+  normalizeRecommendationCreateRequest: (body: unknown) => {
+    if (typeof body === 'object' && body !== null && 'people' in body) {
+      const wrapped = body as { experienceMode?: unknown; people: unknown };
+      return { experienceMode: wrapped.experienceMode, quizData: wrapped.people };
+    }
+    if (typeof body === 'object' && body !== null && 'quizData' in body) {
+      const wrapped = body as { experienceMode?: unknown; quizData: unknown };
+      return { experienceMode: wrapped.experienceMode, quizData: wrapped.quizData };
+    }
+    return { quizData: body };
+  },
 }));
 
 const mockCreateAndStartRecommendation = vi.fn<(...args: unknown[]) => Promise<{ slug: string }>>(
@@ -83,7 +94,30 @@ describe('POST /api/recommendations', () => {
     expect(response.status).toBe(201);
     expect(data).toEqual({ id: 'rec-test-slug' });
     expect(mockGetRecommendationInputBlock).toHaveBeenCalled();
-    expect(mockCreateAndStartRecommendation).toHaveBeenCalled();
+    expect(mockCreateAndStartRecommendation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.any(Array),
+      'en',
+      expect.objectContaining({ experienceMode: 'normal-match', sourceStrategy: 'tmdb-first' }),
+    );
+  });
+
+  it('accepts an explicit fast-pick experience mode wrapper', async () => {
+    const response = await POST(
+      makeRequest({
+        experienceMode: 'fast-pick',
+        people: validBody,
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(mockNormalizePeopleData).toHaveBeenCalledWith(validBody);
+    expect(mockCreateAndStartRecommendation).toHaveBeenCalledWith(
+      validBody,
+      expect.any(Array),
+      'en',
+      expect.objectContaining({ experienceMode: 'fast-pick', sourceStrategy: 'hybrid-fast' }),
+    );
   });
 
   it('skips AI moderation when deterministic e2e recommendations are enabled', async () => {
@@ -93,6 +127,14 @@ describe('POST /api/recommendations', () => {
 
     expect(response.status).toBe(201);
     expect(mockGetRecommendationInputBlock).not.toHaveBeenCalled();
-    expect(mockCreateAndStartRecommendation).toHaveBeenCalled();
+    expect(mockCreateAndStartRecommendation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.any(Array),
+      'en',
+      expect.objectContaining({
+        experienceMode: 'curated-showcase',
+        sourceStrategy: 'curated-showcase',
+      }),
+    );
   });
 });

--- a/apps/web/src/app/api/recommendations/route.ts
+++ b/apps/web/src/app/api/recommendations/route.ts
@@ -1,11 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-import { getRecommendationInputBlock, normalizePeopleData } from '@/features/recommendation/input';
+import {
+  getRecommendationInputBlock,
+  normalizePeopleData,
+  normalizeRecommendationCreateRequest,
+} from '@/features/recommendation/input';
 import {
   createAndStartRecommendation,
   usesDeterministicE2ERecommendations,
 } from '@/features/recommendation/jobs';
-import { requestBodySchema } from '@/features/recommendation/types';
+import { resolveRecommendationSourceStrategy } from '@/features/recommendation/sourceStrategyPolicy';
+import { recommendationCreateRequestSchema } from '@/features/recommendation/types';
 import { parseLocaleFromRequest } from '@/lib/locale';
 import logger from '@/lib/logger';
 import { applyRateLimit } from '@/lib/rateLimit';
@@ -34,7 +39,7 @@ async function postHandler(req: NextRequest, clientId: string): Promise<Response
   }
 
   // Validate request body
-  const parsed = requestBodySchema.safeParse(body);
+  const parsed = recommendationCreateRequestSchema.safeParse(body);
   if (!parsed.success) {
     return NextResponse.json(
       {
@@ -45,16 +50,24 @@ async function postHandler(req: NextRequest, clientId: string): Promise<Response
     );
   }
 
-  const validatedBody = parsed.data;
+  const createInput = normalizeRecommendationCreateRequest(parsed.data);
+  const validatedBody = createInput.quizData;
   const locale = parseLocaleFromRequest(req);
   const allPeopleData = normalizePeopleData(validatedBody);
+  const isDeterministic = usesDeterministicE2ERecommendations();
+  const experienceMode = isDeterministic
+    ? 'curated-showcase'
+    : (createInput.experienceMode ?? 'normal-match');
+  const sourceStrategy = isDeterministic
+    ? 'curated-showcase'
+    : resolveRecommendationSourceStrategy({ experienceMode, people: allPeopleData }).id;
 
   logger.info(
-    { personCount: allPeopleData.length, locale },
+    { experienceMode, personCount: allPeopleData.length, locale, sourceStrategy },
     'Creating recommendation via /api/recommendations',
   );
 
-  if (!usesDeterministicE2ERecommendations()) {
+  if (!isDeterministic) {
     const inputBlock = await getRecommendationInputBlock(allPeopleData);
     if (inputBlock) {
       return NextResponse.json(inputBlock, { status: 422 });
@@ -69,11 +82,18 @@ async function postHandler(req: NextRequest, clientId: string): Promise<Response
         attributes: {
           'http.route': '/api/recommendations',
           'recommendation.mode': 'async',
+          'recommendation.experience_mode': experienceMode,
           'recommendation.people.count': allPeopleData.length,
+          'recommendation.source_strategy': sourceStrategy,
           locale,
         },
       },
-      async () => createAndStartRecommendation(validatedBody, allPeopleData, locale, userId),
+      async () =>
+        createAndStartRecommendation(validatedBody, allPeopleData, locale, {
+          experienceMode,
+          sourceStrategy,
+          userId,
+        }),
     );
     return NextResponse.json({ id: created.slug }, { status: 201 });
   } catch (err) {

--- a/apps/web/src/features/recommendation/candidateSources.test.ts
+++ b/apps/web/src/features/recommendation/candidateSources.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getCandidateSource,
+  getLocalCandidateSource,
+  summarizeCandidateSources,
+} from './candidateSources';
+
+describe('candidate source helpers', () => {
+  it('classifies seeded local rows without TMDB match source as curated', () => {
+    expect(getLocalCandidateSource(null)).toBe('curated');
+    expect(getCandidateSource({ id: 42 })).toBe('curated');
+  });
+
+  it('classifies TMDB-backed local cache rows separately from direct TMDB candidates', () => {
+    expect(getLocalCandidateSource('tmdb_discovery')).toBe('local-cache');
+    expect(getCandidateSource({ id: 42, tmdbMatchSource: 'backfill_auto' })).toBe('local-cache');
+    expect(getCandidateSource({ id: -77, fromTMDB: true })).toBe('tmdb-discover');
+  });
+
+  it('summarizes mixed source distributions', () => {
+    expect(
+      summarizeCandidateSources([
+        { id: 1 },
+        { id: 2, tmdbMatchSource: 'tmdb_discovery' },
+        { id: -3, fromTMDB: true },
+        { id: 4, source: 'memory' },
+      ]),
+    ).toEqual({
+      curated: 1,
+      'local-cache': 1,
+      memory: 1,
+      'tmdb-discover': 1,
+    });
+  });
+});

--- a/apps/web/src/features/recommendation/candidateSources.ts
+++ b/apps/web/src/features/recommendation/candidateSources.ts
@@ -1,0 +1,33 @@
+import type { CandidateSource, CandidateSourceDistribution } from './types';
+
+type SourceCandidate = {
+  fromTMDB?: boolean;
+  id?: number;
+  source?: CandidateSource;
+  tmdbMatchSource?: string | null;
+};
+
+export function getLocalCandidateSource(tmdbMatchSource?: string | null): CandidateSource {
+  return tmdbMatchSource ? 'local-cache' : 'curated';
+}
+
+export function getCandidateSource(candidate: SourceCandidate): CandidateSource {
+  if (candidate.source) return candidate.source;
+  if (candidate.fromTMDB || (typeof candidate.id === 'number' && candidate.id < 0)) {
+    return 'tmdb-discover';
+  }
+  return getLocalCandidateSource(candidate.tmdbMatchSource);
+}
+
+export function summarizeCandidateSources(
+  candidates: SourceCandidate[] | undefined,
+): CandidateSourceDistribution {
+  const distribution: NonNullable<CandidateSourceDistribution> = {};
+
+  for (const candidate of candidates ?? []) {
+    const source = getCandidateSource(candidate);
+    distribution[source] = (distribution[source] ?? 0) + 1;
+  }
+
+  return distribution;
+}

--- a/apps/web/src/features/recommendation/evals/fixtures.ts
+++ b/apps/web/src/features/recommendation/evals/fixtures.ts
@@ -1,225 +1,320 @@
-import type { RecommendationEvalFixture } from './types';
+import type { ApiResponse, CandidateSource, PersonFormData } from '../types';
+import type {
+  RecommendationEvalAudience,
+  RecommendationEvalCandidate,
+  RecommendationEvalDepth,
+  RecommendationEvalFixture,
+  RecommendationEvalMemory,
+  RecommendationEvalSourceStrategy,
+} from './types';
 
-export const recommendationEvalFixtures: RecommendationEvalFixture[] = [
+export const recommendationEvalAudiences = [
+  'solo',
+  'family',
+  'group',
+] as const satisfies readonly RecommendationEvalAudience[];
+export const recommendationEvalDepths = [
+  'focused',
+  'memory-aware',
+  'compromise',
+] as const satisfies readonly RecommendationEvalDepth[];
+export const recommendationEvalSourceStrategies = [
+  'curated-showcase',
+  'hybrid-fast',
+  'tmdb-first',
+] as const satisfies readonly RecommendationEvalSourceStrategy[];
+
+export const recommendationEvalScenarioMatrix = recommendationEvalAudiences.flatMap((audience) =>
+  recommendationEvalDepths.flatMap((depth) =>
+    recommendationEvalSourceStrategies.map((sourceStrategy) => ({
+      audience,
+      depth,
+      sourceStrategy,
+    })),
+  ),
+);
+
+const candidateCatalog: RecommendationEvalCandidate[] = [
+  { name: 'PopChoice E2E Space Opera', year: 2024 },
+  { name: 'PopChoice E2E Family Adventure', year: 2018 },
+  { name: 'PopChoice E2E Classic Drama', year: 1998 },
+  { name: 'PopChoice E2E Cozy Mystery', year: 2021 },
+  { name: 'PopChoice E2E Ensemble Comedy', year: 2020 },
+  { name: 'PopChoice E2E Grounded Thriller', year: 2016 },
+];
+
+const movieDetailsByName: Record<
+  string,
   {
-    id: 'solo-sci-fi-adventure',
-    name: 'Solo sci-fi adventure',
-    description: 'A single viewer asks for a clever modern sci-fi pick after The Matrix.',
-    locale: 'en',
-    people: [
+    age_rating: string;
+    aiDescription: string;
+    duration: number;
+    score_rating: number;
+    tmdbId: number;
+  }
+> = {
+  'PopChoice E2E Classic Drama': {
+    age_rating: 'PG-13',
+    aiDescription: 'A patient character drama for viewers who want emotional depth.',
+    duration: 126,
+    score_rating: 9.1,
+    tmdbId: 900003,
+  },
+  'PopChoice E2E Cozy Mystery': {
+    age_rating: 'PG',
+    aiDescription: 'A gentle mystery with soft humor and enough plot to stay engaging.',
+    duration: 108,
+    score_rating: 7.8,
+    tmdbId: 900005,
+  },
+  'PopChoice E2E Ensemble Comedy': {
+    age_rating: 'PG-13',
+    aiDescription: 'A bridge pick with playful character beats and energetic pacing.',
+    duration: 115,
+    score_rating: 8.3,
+    tmdbId: 900006,
+  },
+  'PopChoice E2E Family Adventure': {
+    age_rating: 'G',
+    aiDescription: 'A warm family pick with gentle jokes and adventure momentum.',
+    duration: 101,
+    score_rating: 8.1,
+    tmdbId: 900004,
+  },
+  'PopChoice E2E Grounded Thriller': {
+    age_rating: 'PG-13',
+    aiDescription: 'A precise thriller with grounded stakes and clean momentum.',
+    duration: 112,
+    score_rating: 7.9,
+    tmdbId: 900007,
+  },
+  'PopChoice E2E Space Opera': {
+    age_rating: 'PG-13',
+    aiDescription:
+      'A sci-fi adventure pick for viewers who want sleek action and thoughtful spectacle.',
+    duration: 142,
+    score_rating: 8.7,
+    tmdbId: 900001,
+  },
+};
+
+const mainTitleByDepth: Record<RecommendationEvalDepth, string> = {
+  compromise: 'PopChoice E2E Ensemble Comedy',
+  focused: 'PopChoice E2E Space Opera',
+  'memory-aware': 'PopChoice E2E Family Adventure',
+};
+
+const alternateTitlesByDepth: Record<RecommendationEvalDepth, string[]> = {
+  compromise: ['PopChoice E2E Family Adventure', 'PopChoice E2E Space Opera'],
+  focused: ['PopChoice E2E Grounded Thriller', 'PopChoice E2E Classic Drama'],
+  'memory-aware': ['PopChoice E2E Cozy Mystery', 'PopChoice E2E Ensemble Comedy'],
+};
+
+function hasMemoryRequirement(depth: RecommendationEvalDepth): boolean {
+  return depth === 'memory-aware';
+}
+
+function hasCompromiseRequirement(depth: RecommendationEvalDepth): boolean {
+  return depth === 'compromise';
+}
+
+function getPeople(audience: RecommendationEvalAudience): PersonFormData[] {
+  if (audience === 'solo') {
+    return [
       {
         favoriteMovie: 'The Matrix',
-        favoriteMovieWhy: 'I like clever world-building and tense action.',
+        favoriteMovieWhy: 'I like smart genre movies that balance ideas and momentum.',
         moodPreference: ['Sci-Fi', 'Adventurous'],
+        name: 'Riley',
         newVsClassic: 'Balanced',
         tonePreference: 'Smart and exciting',
       },
-    ],
-    userMemories: [],
-    candidates: [
-      { name: 'PopChoice E2E Space Opera', year: 2024 },
-      { name: 'PopChoice E2E Family Adventure', year: 2018 },
-      { name: 'PopChoice E2E Classic Drama', year: 1998 },
-    ],
-    expectations: {
-      allowedMainTitles: ['PopChoice E2E Space Opera'],
-      forbiddenTerms: ['sexual minors', 'self-harm instructions'],
-      minDescriptionCharacters: 80,
-      minPassingScore: 90,
-      minSimilarMovies: 3,
-      requiredExplanationTerms: ['sci-fi', 'adventure'],
-    },
-    mockResponse: {
-      title: 'PopChoice E2E Space Opera',
-      description:
-        'A polished sci-fi adventure with big world-building, brisk momentum, and enough emotional stakes to satisfy a Matrix-inspired mood.',
-      usedBroaderSearch: false,
-      dbMovieCount: 3,
-      similarMovies: [
-        {
-          id: 1,
-          tmdbId: 900001,
-          name: 'PopChoice E2E Space Opera',
-          year: 2024,
-          similarity: 0.97,
-          age_rating: 'PG-13',
-          duration: 142,
-          score_rating: 8.7,
-          aiDescription:
-            'A sci-fi adventure pick for viewers who want sleek action and thoughtful spectacle.',
-          isMainRecommendation: true,
-        },
-        {
-          id: 2,
-          tmdbId: 900004,
-          name: 'PopChoice E2E Family Adventure',
-          year: 2018,
-          similarity: 0.81,
-          age_rating: 'G',
-          duration: 101,
-          score_rating: 8.1,
-          aiDescription: 'A lighter alternate with adventure energy and broad appeal.',
-        },
-        {
-          id: 3,
-          tmdbId: 900003,
-          name: 'PopChoice E2E Classic Drama',
-          year: 1998,
-          similarity: 0.74,
-          age_rating: 'R',
-          duration: 126,
-          score_rating: 9.1,
-          aiDescription: 'A more serious backup when the viewer wants a slower classic.',
-        },
-      ],
-    },
-  },
-  {
-    id: 'family-night-repeat-avoidance',
-    name: 'Family night repeat avoidance',
-    description: 'A family prompt should avoid movies already watched or marked not interested.',
-    locale: 'en',
-    people: [
+    ];
+  }
+
+  if (audience === 'family') {
+    return [
       {
         favoriteMovie: 'Paddington 2',
-        favoriteMovieWhy: 'Warm, funny, and easy for everyone to enjoy together.',
+        favoriteMovieWhy: 'Warm, funny, and easy for different ages to enjoy together.',
         moodPreference: ['Funny', 'Heartwarming'],
+        name: 'Family',
         newVsClassic: 'New',
         tonePreference: 'Light',
       },
-    ],
-    userMemories: [
-      { kind: 'watched', movieName: 'PopChoice E2E Space Opera', movieYear: 2024 },
-      { kind: 'not_interested', movieName: 'PopChoice E2E Classic Drama', movieYear: 1998 },
-    ],
-    candidates: [
-      { name: 'PopChoice E2E Family Adventure', year: 2018 },
-      { name: 'PopChoice E2E Space Opera', year: 2024 },
-      { name: 'PopChoice E2E Classic Drama', year: 1998 },
-      { name: 'PopChoice E2E Cozy Mystery', year: 2021 },
-    ],
+    ];
+  }
+
+  return [
+    {
+      favoriteMovie: 'Amelie',
+      favoriteMovieWhy: 'Playful, humane, and visually charming.',
+      moodPreference: ['Whimsical', 'Romantic'],
+      name: 'Alex',
+      newVsClassic: 'Balanced',
+      tonePreference: 'Playful',
+    },
+    {
+      favoriteMovie: 'Mad Max: Fury Road',
+      favoriteMovieWhy: 'Kinetic and stylish without too much exposition.',
+      moodPreference: ['Energetic', 'Stylish'],
+      name: 'Sam',
+      newVsClassic: 'Balanced',
+      tonePreference: 'Bold',
+    },
+  ];
+}
+
+function getMemories(depth: RecommendationEvalDepth): RecommendationEvalMemory[] {
+  if (!hasMemoryRequirement(depth)) return [];
+
+  return [
+    { kind: 'watched', movieName: 'PopChoice E2E Classic Drama', movieYear: 1998 },
+    { kind: 'not_interested', movieName: 'PopChoice E2E Grounded Thriller', movieYear: 2016 },
+  ];
+}
+
+function getRequiredExplanationTerms(
+  audience: RecommendationEvalAudience,
+  depth: RecommendationEvalDepth,
+): string[] {
+  const terms: string[] = [audience];
+  if (hasMemoryRequirement(depth)) terms.push('avoid');
+  if (hasCompromiseRequirement(depth)) terms.push('both');
+  return terms;
+}
+
+function getDescription(
+  audience: RecommendationEvalAudience,
+  depth: RecommendationEvalDepth,
+  sourceStrategy: RecommendationEvalSourceStrategy,
+): string {
+  const audienceText = {
+    family: 'for the family',
+    group: 'for the group',
+    solo: 'for the solo viewer',
+  }[audience];
+  const sourceText = {
+    'curated-showcase': 'using curated showcase candidates only',
+    'hybrid-fast': 'mixing local cache candidates with bounded TMDB discovery fallbacks',
+    'tmdb-first': 'starting from TMDB discovery and search candidates',
+  }[sourceStrategy];
+  const memoryText = hasMemoryRequirement(depth)
+    ? ' It explicitly avoids watched or rejected titles from memory.'
+    : '';
+  const compromiseText = hasCompromiseRequirement(depth)
+    ? ' It explains how both preference sets are represented without letting one side dominate.'
+    : '';
+
+  return `A ${depth} ${sourceStrategy} recommendation ${audienceText} ${sourceText}.${memoryText}${compromiseText}`;
+}
+
+function getMockSource(
+  sourceStrategy: RecommendationEvalSourceStrategy,
+  index: number,
+): CandidateSource {
+  if (sourceStrategy === 'curated-showcase') return 'curated';
+  if (sourceStrategy === 'tmdb-first') return index % 2 === 0 ? 'tmdb-discover' : 'tmdb-search';
+  return index === 0 ? 'local-cache' : 'tmdb-discover';
+}
+
+function toSimilarMovie(
+  name: string,
+  index: number,
+  sourceStrategy: RecommendationEvalSourceStrategy,
+  isMainRecommendation = false,
+) {
+  const candidate = candidateCatalog.find((movie) => movie.name === name);
+  const details = movieDetailsByName[name];
+  if (!candidate || !details) {
+    throw new Error(`Missing deterministic eval movie fixture for "${name}".`);
+  }
+  const source = getMockSource(sourceStrategy, index);
+  const fromTMDB = source === 'tmdb-discover' || source === 'tmdb-search';
+
+  return {
+    id: fromTMDB ? -details.tmdbId : index + 1,
+    name,
+    similarity: Number((0.96 - index * 0.06).toFixed(2)),
+    year: candidate.year,
+    ...details,
+    fromTMDB,
+    source,
+    ...(isMainRecommendation ? { isMainRecommendation } : {}),
+  };
+}
+
+function getMockSourceDistribution(
+  sourceStrategy: RecommendationEvalSourceStrategy,
+  movieCount: number,
+): NonNullable<ApiResponse['candidateSourceDistribution']> {
+  const distribution: NonNullable<ApiResponse['candidateSourceDistribution']> = {};
+  for (let index = 0; index < movieCount; index += 1) {
+    const source = getMockSource(sourceStrategy, index);
+    distribution[source] = (distribution[source] ?? 0) + 1;
+  }
+  return distribution;
+}
+
+function getMinCandidateSources(
+  sourceStrategy: RecommendationEvalSourceStrategy,
+): NonNullable<RecommendationEvalFixture['expectations']['minCandidateSources']> {
+  if (sourceStrategy === 'curated-showcase') return { curated: 3 };
+  if (sourceStrategy === 'hybrid-fast') return { 'local-cache': 1, 'tmdb-discover': 1 };
+  return { 'tmdb-discover': 1, 'tmdb-search': 1 };
+}
+
+function getMockResponse(
+  audience: RecommendationEvalAudience,
+  depth: RecommendationEvalDepth,
+  sourceStrategy: RecommendationEvalSourceStrategy,
+): ApiResponse {
+  const mainTitle = mainTitleByDepth[depth];
+  const memoryTitles = new Set(getMemories(depth).map((memory) => memory.movieName));
+  const alternateTitles = alternateTitlesByDepth[depth]
+    .filter((title) => !memoryTitles.has(title))
+    .concat(candidateCatalog.map((movie) => movie.name).filter((title) => title !== mainTitle))
+    .filter((title, index, titles) => !memoryTitles.has(title) && titles.indexOf(title) === index)
+    .slice(0, 2);
+  const similarMovieTitles = [mainTitle, ...alternateTitles];
+
+  return {
+    dbMovieCount: candidateCatalog.length,
+    description: getDescription(audience, depth, sourceStrategy),
+    similarMovies: similarMovieTitles.map((title, index) =>
+      toSimilarMovie(title, index, sourceStrategy, index === 0),
+    ),
+    candidateSourceDistribution: getMockSourceDistribution(
+      sourceStrategy,
+      similarMovieTitles.length,
+    ),
+    sourceStrategy,
+    title: mainTitle,
+    usedBroaderSearch: sourceStrategy !== 'curated-showcase',
+  };
+}
+
+export const recommendationEvalFixtures: RecommendationEvalFixture[] =
+  recommendationEvalScenarioMatrix.map(({ audience, depth, sourceStrategy }) => ({
+    audience,
+    candidates: candidateCatalog,
+    depth,
+    description: getDescription(audience, depth, sourceStrategy),
     expectations: {
-      allowedMainTitles: ['PopChoice E2E Family Adventure'],
-      forbiddenTitles: ['PopChoice E2E Space Opera', 'PopChoice E2E Classic Drama'],
-      forbiddenTerms: ['R-rated', 'bleak violence'],
-      minDescriptionCharacters: 70,
+      allowedMainTitles: [mainTitleByDepth[depth]],
+      forbiddenTerms: ['sexual minors', 'self-harm instructions', 'bleak violence'],
+      minCandidateSources: getMinCandidateSources(sourceStrategy),
+      minDescriptionCharacters: 80,
+      minMetadataCompleteCandidates: 3,
       minPassingScore: 90,
-      minSimilarMovies: 2,
-      requiredExplanationTerms: ['family', 'warm'],
-    },
-    mockResponse: {
-      title: 'PopChoice E2E Family Adventure',
-      description:
-        'A warm family adventure that keeps the mood light, avoids already-watched options, and gives the group an upbeat movie-night choice.',
-      usedBroaderSearch: false,
-      dbMovieCount: 3,
-      similarMovies: [
-        {
-          id: 4,
-          tmdbId: 900004,
-          name: 'PopChoice E2E Family Adventure',
-          year: 2018,
-          similarity: 0.93,
-          age_rating: 'G',
-          duration: 101,
-          score_rating: 8.1,
-          aiDescription: 'A warm family pick with gentle jokes and adventure momentum.',
-          isMainRecommendation: true,
-        },
-        {
-          id: 5,
-          tmdbId: 900005,
-          name: 'PopChoice E2E Cozy Mystery',
-          year: 2021,
-          similarity: 0.77,
-          age_rating: 'PG',
-          duration: 108,
-          score_rating: 7.8,
-          aiDescription: 'A soft backup for groups that want a little puzzle without heaviness.',
-        },
-      ],
-    },
-  },
-  {
-    id: 'two-person-compromise',
-    name: 'Two-person compromise',
-    description:
-      'A mixed group should explain why the pick bridges both viewers instead of only one.',
-    locale: 'en',
-    people: [
-      {
-        favoriteMovie: 'Amelie',
-        favoriteMovieWhy: 'Playful, humane, and visually charming.',
-        moodPreference: ['Whimsical', 'Romantic'],
-        name: 'Alex',
-        newVsClassic: 'Balanced',
-        tonePreference: 'Playful',
-      },
-      {
-        favoriteMovie: 'Mad Max: Fury Road',
-        favoriteMovieWhy: 'Kinetic and stylish without too much exposition.',
-        moodPreference: ['Energetic', 'Stylish'],
-        name: 'Sam',
-        newVsClassic: 'Balanced',
-        tonePreference: 'Bold',
-      },
-    ],
-    userMemories: [{ kind: 'liked', movieName: 'PopChoice E2E Space Opera', movieYear: 2024 }],
-    candidates: [
-      { name: 'PopChoice E2E Ensemble Comedy', year: 2020 },
-      { name: 'PopChoice E2E Space Opera', year: 2024 },
-      { name: 'PopChoice E2E Family Adventure', year: 2018 },
-    ],
-    expectations: {
-      allowedMainTitles: ['PopChoice E2E Ensemble Comedy'],
-      forbiddenTerms: ['only Alex', 'only Sam'],
-      minDescriptionCharacters: 90,
-      minPassingScore: 85,
       minSimilarMovies: 3,
-      requiredExplanationTerms: ['both', 'playful', 'energy'],
+      requiredExplanationTerms: getRequiredExplanationTerms(audience, depth),
     },
-    mockResponse: {
-      title: 'PopChoice E2E Ensemble Comedy',
-      description:
-        'A playful ensemble comedy with enough visual energy for both viewers: it keeps the human charm upfront while still moving with bold, stylish rhythm.',
-      usedBroaderSearch: false,
-      dbMovieCount: 3,
-      similarMovies: [
-        {
-          id: 6,
-          tmdbId: 900006,
-          name: 'PopChoice E2E Ensemble Comedy',
-          year: 2020,
-          similarity: 0.9,
-          age_rating: 'PG-13',
-          duration: 115,
-          score_rating: 8.3,
-          aiDescription: 'A bridge pick for both whimsical romance and kinetic style.',
-          isMainRecommendation: true,
-        },
-        {
-          id: 1,
-          tmdbId: 900001,
-          name: 'PopChoice E2E Space Opera',
-          year: 2024,
-          similarity: 0.82,
-          age_rating: 'PG-13',
-          duration: 142,
-          score_rating: 8.7,
-          aiDescription: 'A higher-energy alternate if the group leans toward spectacle.',
-        },
-        {
-          id: 4,
-          tmdbId: 900004,
-          name: 'PopChoice E2E Family Adventure',
-          year: 2018,
-          similarity: 0.76,
-          age_rating: 'G',
-          duration: 101,
-          score_rating: 8.1,
-          aiDescription: 'A warmer alternate if the group wants something gentler.',
-        },
-      ],
-    },
-  },
-];
+    id: `${audience}-${depth}-${sourceStrategy}`,
+    locale: 'en',
+    mockResponse: getMockResponse(audience, depth, sourceStrategy),
+    name: `${audience} / ${depth} / ${sourceStrategy}`,
+    people: getPeople(audience),
+    sourceStrategy,
+    userMemories: getMemories(depth),
+  }));

--- a/apps/web/src/features/recommendation/evals/scoring.test.ts
+++ b/apps/web/src/features/recommendation/evals/scoring.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { recommendationEvalFixtures } from './fixtures';
+import {
+  recommendationEvalAudiences,
+  recommendationEvalDepths,
+  recommendationEvalFixtures,
+  recommendationEvalScenarioMatrix,
+  recommendationEvalSourceStrategies,
+} from './fixtures';
 import { buildRecommendationEvalReport, scoreRecommendationEvalFixture } from './scoring';
 
 describe('recommendation eval scoring', () => {
@@ -9,13 +15,134 @@ describe('recommendation eval scoring', () => {
       scoreRecommendationEvalFixture(fixture, fixture.mockResponse),
     );
 
-    expect(results).toHaveLength(3);
+    expect(results).toHaveLength(recommendationEvalScenarioMatrix.length);
     expect(results.every((result) => result.passed)).toBe(true);
-    expect(results.map((result) => result.score)).toEqual([100, 100, 100]);
+    expect(results.every((result) => result.score === 100)).toBe(true);
+  });
+
+  it('covers the full audience, depth, and source strategy scenario matrix', () => {
+    const actualScenarioKeys = new Set(
+      recommendationEvalFixtures.map(
+        (fixture) => `${fixture.audience}/${fixture.depth}/${fixture.sourceStrategy}`,
+      ),
+    );
+    const expectedScenarioKeys = new Set(
+      recommendationEvalAudiences.flatMap((audience) =>
+        recommendationEvalDepths.flatMap((depth) =>
+          recommendationEvalSourceStrategies.map(
+            (sourceStrategy) => `${audience}/${depth}/${sourceStrategy}`,
+          ),
+        ),
+      ),
+    );
+
+    expect(actualScenarioKeys).toEqual(expectedScenarioKeys);
+    expect(recommendationEvalFixtures).toHaveLength(
+      recommendationEvalAudiences.length *
+        recommendationEvalDepths.length *
+        recommendationEvalSourceStrategies.length,
+    );
+  });
+
+  it('requires scenario metadata to be represented in deterministic fixture responses', () => {
+    const results = recommendationEvalFixtures.map((fixture) =>
+      scoreRecommendationEvalFixture(fixture, fixture.mockResponse),
+    );
+
+    for (const result of results) {
+      expect(
+        result.checks
+          .filter((check) => check.id.startsWith('scenario-'))
+          .map((check) => ({ id: check.id, maxScore: check.maxScore, passed: check.passed })),
+      ).toEqual([
+        { id: 'scenario-audience-representation', maxScore: 0, passed: true },
+        { id: 'scenario-depth-representation', maxScore: 0, passed: true },
+        { id: 'scenario-source-strategy-representation', maxScore: 0, passed: true },
+        { id: 'scenario-quality-thresholds', maxScore: 0, passed: true },
+      ]);
+    }
+  });
+
+  it('fails when the response does not represent the fixture audience', () => {
+    const fixture = getFixture('solo', 'focused', 'curated-showcase');
+    const result = scoreRecommendationEvalFixture(fixture, {
+      ...fixture.mockResponse,
+      description:
+        'A polished sci-fi adventure with big world-building, brisk momentum, and enough emotional stakes to satisfy a Matrix-inspired mood.',
+    });
+
+    expect(result.passed).toBe(false);
+    expect(
+      result.checks.find((check) => check.id === 'scenario-audience-representation')?.passed,
+    ).toBe(false);
+  });
+
+  it('fails when the response does not represent the fixture source strategy', () => {
+    const fixture = getFixture('solo', 'focused', 'curated-showcase');
+    const result = scoreRecommendationEvalFixture(fixture, {
+      ...fixture.mockResponse,
+      similarMovies: fixture.mockResponse.similarMovies?.map((movie) => ({
+        ...movie,
+        source: 'tmdb-discover' as const,
+      })),
+      candidateSourceDistribution: { 'tmdb-discover': 3 },
+      usedBroaderSearch: true,
+    });
+
+    expect(result.passed).toBe(false);
+    expect(
+      result.checks.find((check) => check.id === 'scenario-source-strategy-representation')?.passed,
+    ).toBe(false);
+  });
+
+  it('fails when the response does not represent the fixture depth', () => {
+    const compromiseFixture = getFixture('group', 'compromise', 'hybrid-fast');
+    const fixture = {
+      ...compromiseFixture,
+      expectations: {
+        ...compromiseFixture.expectations,
+        requiredExplanationTerms: [],
+      },
+    };
+    const result = scoreRecommendationEvalFixture(fixture, {
+      ...fixture.mockResponse,
+      description:
+        'A playful ensemble comedy with enough visual energy for the pair: it keeps the human charm upfront while still moving with bold, stylish rhythm.',
+      similarMovies: fixture.mockResponse.similarMovies?.map((movie) => ({
+        ...movie,
+        aiDescription: movie.aiDescription?.replace('both ', ''),
+      })),
+    });
+
+    expect(result.passed).toBe(false);
+    expect(
+      result.checks.find((check) => check.id === 'scenario-depth-representation')?.passed,
+    ).toBe(false);
+  });
+
+  it('fails when source and metadata quality thresholds are not met', () => {
+    const fixture = getFixture('solo', 'focused', 'tmdb-first');
+    const result = scoreRecommendationEvalFixture(fixture, {
+      ...fixture.mockResponse,
+      candidateSourceDistribution: { curated: 3 },
+      similarMovies: fixture.mockResponse.similarMovies?.map((movie) => ({
+        ...movie,
+        age_rating: '',
+        duration: 0,
+        source: 'curated' as const,
+      })),
+    });
+
+    expect(result.passed).toBe(false);
+    expect(result.checks.find((check) => check.id === 'scenario-quality-thresholds')).toMatchObject(
+      {
+        passed: false,
+      },
+    );
   });
 
   it('fails when the main recommendation is outside the fixture candidates', () => {
-    const fixture = recommendationEvalFixtures[0];
+    const fixture = getFixture('solo', 'focused', 'curated-showcase');
     const result = scoreRecommendationEvalFixture(fixture, {
       ...fixture.mockResponse,
       title: 'Unknown Movie',
@@ -38,20 +165,20 @@ describe('recommendation eval scoring', () => {
   });
 
   it('fails when the response repeats watched or rejected memory titles', () => {
-    const fixture = recommendationEvalFixtures[1];
+    const fixture = getFixture('family', 'memory-aware', 'hybrid-fast');
     const result = scoreRecommendationEvalFixture(fixture, {
       ...fixture.mockResponse,
-      title: 'PopChoice E2E Space Opera',
+      title: 'PopChoice E2E Classic Drama',
       similarMovies: [
         {
-          id: 1,
-          name: 'PopChoice E2E Space Opera',
-          year: 2024,
-          similarity: 0.99,
           age_rating: 'PG-13',
-          duration: 142,
-          score_rating: 8.7,
+          duration: 126,
+          id: 3,
           isMainRecommendation: true,
+          name: 'PopChoice E2E Classic Drama',
+          score_rating: 9.1,
+          similarity: 0.99,
+          year: 1998,
         },
       ],
     });
@@ -72,9 +199,26 @@ describe('recommendation eval scoring', () => {
       passed: true,
       summary: {
         failed: 0,
-        fixtureCount: 3,
-        passed: 3,
+        fixtureCount: recommendationEvalFixtures.length,
+        passed: recommendationEvalFixtures.length,
       },
     });
   });
 });
+
+function getFixture(
+  audience: (typeof recommendationEvalAudiences)[number],
+  depth: (typeof recommendationEvalDepths)[number],
+  sourceStrategy: (typeof recommendationEvalSourceStrategies)[number],
+) {
+  const fixture = recommendationEvalFixtures.find(
+    (candidate) =>
+      candidate.audience === audience &&
+      candidate.depth === depth &&
+      candidate.sourceStrategy === sourceStrategy,
+  );
+  if (!fixture) {
+    throw new Error(`Missing eval fixture for ${audience}/${depth}/${sourceStrategy}`);
+  }
+  return fixture;
+}

--- a/apps/web/src/features/recommendation/evals/scoring.ts
+++ b/apps/web/src/features/recommendation/evals/scoring.ts
@@ -1,16 +1,25 @@
+import { summarizeCandidateSources } from '../candidateSources';
 import { apiResponseSchema } from '../types';
 
 import type {
+  RecommendationEvalAudience,
   RecommendationEvalCheck,
+  RecommendationEvalDepth,
   RecommendationEvalFixture,
   RecommendationEvalReport,
   RecommendationEvalResult,
   RecommendationEvalRunMode,
+  RecommendationEvalSourceStrategy,
 } from './types';
 import type { ApiResponse } from '../types';
 
 const DEFAULT_MIN_PASSING_SCORE = 85;
 const TOTAL_SCORE = 100;
+const AUDIENCE_REPRESENTATION_TERMS: Record<RecommendationEvalAudience, string[]> = {
+  family: ['family'],
+  group: ['both', 'group'],
+  solo: ['solo'],
+};
 
 function normalizeText(value: string): string {
   return value.toLocaleLowerCase('en-US').replace(/\s+/g, ' ').trim();
@@ -28,6 +37,10 @@ function collectResponseText(response: ApiResponse): string {
       .filter((text): text is string => typeof text === 'string' && text.trim().length > 0)
       .join(' ') ?? '';
   return normalizeText([response.title, response.description, movieText].join(' '));
+}
+
+function textIncludesAnyTerm(text: string, terms: string[]): boolean {
+  return terms.some((term) => text.includes(normalizeText(term)));
 }
 
 function getMainRecommendationTitle(response: ApiResponse): string {
@@ -185,6 +198,52 @@ export function scoreRecommendationEvalFixture(
     ),
   );
 
+  const audienceTerms = AUDIENCE_REPRESENTATION_TERMS[fixture.audience];
+  checks.push(
+    buildCheck(
+      'scenario-audience-representation',
+      'Scenario audience representation',
+      0,
+      textIncludesAnyTerm(responseText, audienceTerms),
+      textIncludesAnyTerm(responseText, audienceTerms)
+        ? `Response represents the ${fixture.audience} audience.`
+        : `Expected response text to include one of: ${audienceTerms.join(', ')}`,
+    ),
+  );
+
+  const depthResult = getScenarioDepthResult(fixture.depth, fixture, response, responseText);
+  checks.push(
+    buildCheck(
+      'scenario-depth-representation',
+      'Scenario depth representation',
+      0,
+      depthResult.passed,
+      depthResult.details,
+    ),
+  );
+
+  const sourceResult = getScenarioSourceStrategyResult(fixture.sourceStrategy, response);
+  checks.push(
+    buildCheck(
+      'scenario-source-strategy-representation',
+      'Scenario source strategy representation',
+      0,
+      sourceResult.passed,
+      sourceResult.details,
+    ),
+  );
+
+  const qualityThresholdResult = getQualityThresholdResult(fixture, response);
+  checks.push(
+    buildCheck(
+      'scenario-quality-thresholds',
+      'Scenario quality thresholds',
+      0,
+      qualityThresholdResult.passed,
+      qualityThresholdResult.details,
+    ),
+  );
+
   const score = checks.reduce((sum, check) => sum + check.score, 0);
   const minPassingScore = fixture.expectations.minPassingScore ?? DEFAULT_MIN_PASSING_SCORE;
 
@@ -197,6 +256,132 @@ export function scoreRecommendationEvalFixture(
     mode,
     passed: score >= minPassingScore && checks.every((check) => check.passed),
     score,
+    sourceDistribution:
+      response.candidateSourceDistribution ?? summarizeCandidateSources(response.similarMovies),
+  };
+}
+
+function getScenarioDepthResult(
+  depth: RecommendationEvalDepth,
+  fixture: RecommendationEvalFixture,
+  response: ApiResponse,
+  responseText: string,
+): { details: string; passed: boolean } {
+  const minDescriptionCharacters = fixture.expectations.minDescriptionCharacters ?? 60;
+
+  if (depth === 'focused') {
+    const minSimilarMovies = fixture.expectations.minSimilarMovies ?? 1;
+    const passed =
+      response.description.trim().length >= minDescriptionCharacters &&
+      (response.similarMovies?.length ?? 0) >= minSimilarMovies;
+    return {
+      details: passed
+        ? 'Focused scenario includes a concise rationale and enough ranked candidates.'
+        : `Expected description of at least ${minDescriptionCharacters} characters and ${minSimilarMovies} similar movies.`,
+      passed,
+    };
+  }
+
+  if (depth === 'memory-aware') {
+    const passed = responseText.includes('avoid');
+    return {
+      details: passed
+        ? 'Memory-aware scenario explicitly acknowledges repeat avoidance.'
+        : 'Expected memory-aware response text to mention avoiding repeat or rejected movies.',
+      passed,
+    };
+  }
+
+  const passed = responseText.includes('both');
+  return {
+    details: passed
+      ? 'Compromise scenario explains the pick in terms of both viewers.'
+      : 'Expected compromise response text to explain why the pick works for both viewers.',
+    passed,
+  };
+}
+
+function getScenarioSourceStrategyResult(
+  sourceStrategy: RecommendationEvalSourceStrategy,
+  response: ApiResponse,
+): { details: string; passed: boolean } {
+  const distribution =
+    response.candidateSourceDistribution ?? summarizeCandidateSources(response.similarMovies);
+  const curatedCount = distribution?.curated ?? 0;
+  const localCacheCount = distribution?.['local-cache'] ?? 0;
+  const tmdbCount = (distribution?.['tmdb-discover'] ?? 0) + (distribution?.['tmdb-search'] ?? 0);
+  const totalCount = Object.values(distribution ?? {}).reduce((sum, count) => sum + count, 0);
+
+  if (sourceStrategy === 'curated-showcase') {
+    const passed =
+      totalCount > 0 && curatedCount === totalCount && response.usedBroaderSearch !== true;
+    return {
+      details: passed
+        ? 'Result stays within curated showcase candidates.'
+        : 'Expected curated-only candidates without TMDB broadening.',
+      passed,
+    };
+  }
+
+  if (sourceStrategy === 'hybrid-fast') {
+    const passed =
+      localCacheCount + curatedCount > 0 && tmdbCount > 0 && response.usedBroaderSearch === true;
+    return {
+      details: passed
+        ? 'Result mixes local/cache candidates with bounded TMDB fallback candidates.'
+        : 'Expected a hybrid source mix with local/cache candidates and TMDB fallback candidates.',
+      passed,
+    };
+  }
+
+  const passed = tmdbCount > 0 && tmdbCount >= localCacheCount + curatedCount;
+  return {
+    details: passed
+      ? 'Result prioritizes TMDB discovery/search candidates.'
+      : 'Expected TMDB-first candidate distribution to dominate local/cache candidates.',
+    passed,
+  };
+}
+
+function getQualityThresholdResult(
+  fixture: RecommendationEvalFixture,
+  response: ApiResponse,
+): { details: string; passed: boolean } {
+  const distribution =
+    response.candidateSourceDistribution ?? summarizeCandidateSources(response.similarMovies);
+  const minSources = fixture.expectations.minCandidateSources ?? {};
+  const missingSourceThresholds = Object.entries(minSources).flatMap(([source, minCount]) => {
+    const actualCount = distribution?.[source as keyof typeof distribution] ?? 0;
+    return actualCount >= minCount
+      ? []
+      : [`${source}: expected at least ${minCount}, got ${actualCount}`];
+  });
+
+  const minMetadataComplete = fixture.expectations.minMetadataCompleteCandidates ?? 0;
+  const metadataCompleteCount =
+    response.similarMovies?.filter(
+      (movie) =>
+        movie.name.trim().length > 0 &&
+        movie.year > 0 &&
+        movie.duration > 0 &&
+        movie.score_rating > 0 &&
+        movie.age_rating.trim().length > 0,
+    ).length ?? 0;
+  const metadataPassed = metadataCompleteCount >= minMetadataComplete;
+
+  const passed = missingSourceThresholds.length === 0 && metadataPassed;
+  return {
+    details: passed
+      ? 'Candidate source and metadata thresholds are satisfied.'
+      : [
+          ...missingSourceThresholds,
+          metadataPassed
+            ? null
+            : `metadata-complete candidates: expected at least ${minMetadataComplete}, got ${metadataCompleteCount}`,
+        ]
+          .filter((detail): detail is string => typeof detail === 'string')
+          .join('; '),
+    passed,
   };
 }
 
@@ -206,6 +391,7 @@ export function buildRecommendationEvalReport(
   generatedAt = new Date().toISOString(),
 ): RecommendationEvalReport {
   const failed = results.filter((result) => !result.passed).length;
+  const sourceDistribution = summarizeEvalSourceDistribution(results);
 
   return {
     generatedAt,
@@ -214,10 +400,26 @@ export function buildRecommendationEvalReport(
     mode,
     passed: failed === 0,
     results,
+    sourceDistribution,
     summary: {
       failed,
       fixtureCount: results.length,
       passed: results.length - failed,
     },
   };
+}
+
+function summarizeEvalSourceDistribution(
+  results: RecommendationEvalResult[],
+): RecommendationEvalReport['sourceDistribution'] {
+  const distribution: NonNullable<RecommendationEvalReport['sourceDistribution']> = {};
+
+  for (const result of results) {
+    for (const [source, count] of Object.entries(result.sourceDistribution ?? {})) {
+      const candidateSource = source as keyof typeof distribution;
+      distribution[candidateSource] = (distribution[candidateSource] ?? 0) + count;
+    }
+  }
+
+  return distribution;
 }

--- a/apps/web/src/features/recommendation/evals/types.ts
+++ b/apps/web/src/features/recommendation/evals/types.ts
@@ -1,4 +1,10 @@
-import type { ApiResponse, PersonFormData } from '../types';
+import type { CandidateSourceStrategyId } from '../sourceStrategyPolicy';
+import type {
+  ApiResponse,
+  CandidateSource,
+  CandidateSourceDistribution,
+  PersonFormData,
+} from '../types';
 import type { Locale } from '@/lib/locale';
 
 export type RecommendationEvalMemoryKind = 'watched' | 'liked' | 'not_interested' | 'wrong_mood';
@@ -14,25 +20,39 @@ export type RecommendationEvalCandidate = {
   year: number;
 };
 
+export type RecommendationEvalAudience = 'solo' | 'family' | 'group';
+
+export type RecommendationEvalDepth = 'focused' | 'memory-aware' | 'compromise';
+
+export type RecommendationEvalSourceStrategy = Extract<
+  CandidateSourceStrategyId,
+  'curated-showcase' | 'hybrid-fast' | 'tmdb-first'
+>;
+
 export type RecommendationEvalExpectations = {
   allowedMainTitles: string[];
   forbiddenTitles?: string[];
   forbiddenTerms?: string[];
+  minCandidateSources?: Partial<Record<CandidateSource, number>>;
   minDescriptionCharacters?: number;
+  minMetadataCompleteCandidates?: number;
   minPassingScore?: number;
   minSimilarMovies?: number;
   requiredExplanationTerms?: string[];
 };
 
 export type RecommendationEvalFixture = {
+  audience: RecommendationEvalAudience;
   candidates: RecommendationEvalCandidate[];
   description: string;
+  depth: RecommendationEvalDepth;
   expectations: RecommendationEvalExpectations;
   id: string;
   locale: Locale;
   mockResponse: ApiResponse;
   name: string;
   people: PersonFormData[];
+  sourceStrategy: RecommendationEvalSourceStrategy;
   userMemories: RecommendationEvalMemory[];
 };
 
@@ -54,6 +74,7 @@ export type RecommendationEvalResult = {
   mode: RecommendationEvalRunMode;
   passed: boolean;
   score: number;
+  sourceDistribution: CandidateSourceDistribution;
 };
 
 export type RecommendationEvalRunMode = 'mock' | 'real-data' | 'live';
@@ -65,6 +86,7 @@ export type RecommendationEvalReport = {
   mode: RecommendationEvalRunMode;
   passed: boolean;
   results: RecommendationEvalResult[];
+  sourceDistribution: CandidateSourceDistribution;
   summary: {
     failed: number;
     fixtureCount: number;

--- a/apps/web/src/features/recommendation/helpers.test.ts
+++ b/apps/web/src/features/recommendation/helpers.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { getTMDBFallbackDecision } from './helpers';
+
+const strongLocalMovies = [{ similarity: 0.55 }, { similarity: 0.48 }, { similarity: 0.43 }];
+
+const weakLocalMovies = [{ similarity: 0.15 }, { similarity: 0.2 }];
+
+describe('recommendation retrieval policy helpers', () => {
+  it('uses bounded TMDB fallback for hybrid-fast when local results are weak', () => {
+    expect(getTMDBFallbackDecision('hybrid-fast', weakLocalMovies)).toEqual({
+      reason: 'local-results-insufficient',
+      shouldAttempt: true,
+    });
+  });
+
+  it('does not use TMDB fallback for hybrid-fast when local results are sufficient', () => {
+    expect(getTMDBFallbackDecision('hybrid-fast', strongLocalMovies)).toEqual({
+      reason: 'local-results-sufficient',
+      shouldAttempt: false,
+    });
+  });
+
+  it('uses TMDB as the primary retrieval path for tmdb-first even when local results are strong', () => {
+    expect(getTMDBFallbackDecision('tmdb-first', strongLocalMovies)).toEqual({
+      reason: 'tmdb-first-primary',
+      shouldAttempt: true,
+    });
+  });
+
+  it('keeps curated and memory-aware local strategies inside local candidates', () => {
+    expect(getTMDBFallbackDecision('curated-showcase', weakLocalMovies)).toEqual({
+      reason: 'external-lookup-disabled',
+      shouldAttempt: false,
+    });
+    expect(getTMDBFallbackDecision('memory-aware-local', weakLocalMovies)).toEqual({
+      reason: 'external-lookup-disabled',
+      shouldAttempt: false,
+    });
+  });
+});

--- a/apps/web/src/features/recommendation/helpers.ts
+++ b/apps/web/src/features/recommendation/helpers.ts
@@ -1,8 +1,50 @@
 import { MIN_HIGH_QUALITY_LOCAL, SIMILARITY_THRESHOLD } from './config';
 
+import type { RecommendationSourceStrategy } from './types';
+
 export { MIN_HIGH_QUALITY_LOCAL, SIMILARITY_THRESHOLD } from './config';
 
 /** Pure routing helper — separated so it can be unit-tested without mocking the full route. */
 export function shouldFallBackToTMDB(movies: { similarity: number }[]): boolean {
   return movies.filter((m) => m.similarity >= SIMILARITY_THRESHOLD).length < MIN_HIGH_QUALITY_LOCAL;
+}
+
+export type TMDBFallbackDecision = {
+  reason:
+    | 'external-lookup-disabled'
+    | 'local-results-sufficient'
+    | 'local-results-insufficient'
+    | 'tmdb-first-primary';
+  shouldAttempt: boolean;
+};
+
+export function getTMDBFallbackDecision(
+  sourceStrategy: RecommendationSourceStrategy,
+  movies: { similarity: number }[],
+): TMDBFallbackDecision {
+  if (sourceStrategy === 'curated-showcase' || sourceStrategy === 'memory-aware-local') {
+    return {
+      reason: 'external-lookup-disabled',
+      shouldAttempt: false,
+    };
+  }
+
+  if (sourceStrategy === 'tmdb-first') {
+    return {
+      reason: 'tmdb-first-primary',
+      shouldAttempt: true,
+    };
+  }
+
+  if (shouldFallBackToTMDB(movies)) {
+    return {
+      reason: 'local-results-insufficient',
+      shouldAttempt: true,
+    };
+  }
+
+  return {
+    reason: 'local-results-sufficient',
+    shouldAttempt: false,
+  };
 }

--- a/apps/web/src/features/recommendation/input.ts
+++ b/apps/web/src/features/recommendation/input.ts
@@ -6,7 +6,12 @@ import {
   moderateInput,
 } from '@/utils/ai/moderation';
 
-import type { PersonFormData, RecommendationRequestBody } from './types';
+import type {
+  PersonFormData,
+  RecommendationCreateRequestBody,
+  RecommendationExperienceMode,
+  RecommendationRequestBody,
+} from './types';
 
 const BLOCKED_INPUT_ERROR =
   'Your input contains content that cannot be processed. Please revise your preferences and try again.';
@@ -18,6 +23,31 @@ type RecommendationInputBlock = {
 
 export function normalizePeopleData(validatedBody: RecommendationRequestBody): PersonFormData[] {
   return Array.isArray(validatedBody) ? validatedBody : [validatedBody];
+}
+
+export function normalizeRecommendationCreateRequest(
+  validatedBody: RecommendationCreateRequestBody,
+): {
+  experienceMode?: RecommendationExperienceMode;
+  quizData: RecommendationRequestBody;
+} {
+  if (typeof validatedBody === 'object' && validatedBody !== null && 'people' in validatedBody) {
+    return {
+      experienceMode: validatedBody.experienceMode,
+      quizData: validatedBody.people,
+    };
+  }
+
+  if (typeof validatedBody === 'object' && validatedBody !== null && 'quizData' in validatedBody) {
+    return {
+      experienceMode: validatedBody.experienceMode,
+      quizData: validatedBody.quizData,
+    };
+  }
+
+  return {
+    quizData: validatedBody,
+  };
 }
 
 export async function getRecommendationInputBlock(

--- a/apps/web/src/features/recommendation/jobs.ts
+++ b/apps/web/src/features/recommendation/jobs.ts
@@ -13,28 +13,67 @@ import {
   markRecommendationProcessing,
 } from './persistence';
 import { runRecommendationPipeline } from './pipeline';
+import { resolveRecommendationSourceStrategy } from './sourceStrategyPolicy';
 
-import type { ApiResponse, PersonFormData, RecommendationRequestBody } from './types';
+import type {
+  ApiResponse,
+  PersonFormData,
+  RecommendationExperienceMode,
+  RecommendationRequestBody,
+  RecommendationSourceStrategy,
+} from './types';
 import type { Locale } from '@/lib/locale';
+
+export type CreateRecommendationRunOptions = {
+  experienceMode?: RecommendationExperienceMode;
+  sourceStrategy?: RecommendationSourceStrategy;
+  userId?: string;
+};
 
 export async function createAndStartRecommendation(
   quizData: RecommendationRequestBody,
   allPeopleData: PersonFormData[],
   locale: Locale,
-  userId?: string,
+  options: CreateRecommendationRunOptions = {},
 ): Promise<{ id: string; slug: string }> {
-  const created = await createRecommendationRecord(quizData, userId);
+  const isDeterministic = usesDeterministicE2ERecommendations();
+  const experienceMode =
+    options.experienceMode ?? (isDeterministic ? 'curated-showcase' : 'normal-match');
+  const sourceStrategy =
+    options.sourceStrategy ??
+    (isDeterministic
+      ? 'curated-showcase'
+      : resolveRecommendationSourceStrategy({
+          experienceMode,
+          people: allPeopleData,
+        }).id);
+  const created = await createRecommendationRecord(
+    quizData,
+    options.userId,
+    sourceStrategy,
+    experienceMode,
+  );
   const recommendationId = created.id;
   const recommendationSlug = created.slug;
 
   setActiveTraceAttributes({
+    'recommendation.experience_mode': experienceMode,
     'recommendation.id': recommendationId,
     'recommendation.slug': recommendationSlug,
+    'recommendation.source_strategy': sourceStrategy,
   });
-  logger.info({ recommendationId, recommendationSlug }, 'Recommendation row created');
+  logger.info(
+    { experienceMode, recommendationId, recommendationSlug, sourceStrategy },
+    'Recommendation row created',
+  );
 
-  if (usesDeterministicE2ERecommendations()) {
-    await completeDeterministicE2ERecommendation(recommendationId, allPeopleData);
+  if (isDeterministic) {
+    await completeDeterministicE2ERecommendation(
+      recommendationId,
+      allPeopleData,
+      experienceMode,
+      sourceStrategy,
+    );
     return created;
   }
 
@@ -48,14 +87,24 @@ export async function createAndStartRecommendation(
             'messaging.system': 'bullmq',
             'messaging.destination.name': 'recommendation',
             'messaging.operation.name': 'enqueue',
+            'recommendation.experience_mode': experienceMode,
             'recommendation.id': recommendationId,
             'recommendation.slug': recommendationSlug,
+            'recommendation.source_strategy': sourceStrategy,
           },
         },
         async (span) => {
           const job = await queue.add(
             'recommendation',
-            { recommendationId, quizData, locale, userId, trace: getTraceCarrier() },
+            {
+              recommendationId,
+              quizData,
+              experienceMode,
+              locale,
+              sourceStrategy,
+              userId: options.userId,
+              trace: getTraceCarrier(),
+            },
             RECOMMENDATION_JOB_OPTIONS,
           );
           span.setAttribute('job.id', String(job.id ?? 'unknown'));
@@ -67,11 +116,19 @@ export async function createAndStartRecommendation(
         { err, recommendationId },
         'Failed to enqueue recommendation job — falling back to inline processing',
       );
-      void processInlineRecommendation(recommendationId, allPeopleData, locale, userId);
+      void processInlineRecommendation(recommendationId, allPeopleData, locale, {
+        experienceMode,
+        sourceStrategy,
+        userId: options.userId,
+      });
     }
   } else {
     logger.warn('Recommendation queue unavailable (no Redis) — processing inline');
-    void processInlineRecommendation(recommendationId, allPeopleData, locale, userId);
+    void processInlineRecommendation(recommendationId, allPeopleData, locale, {
+      experienceMode,
+      sourceStrategy,
+      userId: options.userId,
+    });
   }
 
   return created;
@@ -84,13 +141,17 @@ export function usesDeterministicE2ERecommendations(): boolean {
 async function completeDeterministicE2ERecommendation(
   recommendationId: string,
   allPeopleData: PersonFormData[],
+  experienceMode: RecommendationExperienceMode,
+  sourceStrategy: RecommendationSourceStrategy,
 ): Promise<void> {
   await withTraceSpan(
     'recommendation.process.deterministic_e2e',
     {
       attributes: {
+        'recommendation.experience_mode': experienceMode,
         'recommendation.id': recommendationId,
         'recommendation.mode': 'deterministic_e2e',
+        'recommendation.source_strategy': sourceStrategy,
       },
     },
     async () => {
@@ -100,7 +161,7 @@ async function completeDeterministicE2ERecommendation(
       await markRecommendationStage(recommendationId, 'complete');
       await completeRecommendationRecord(
         recommendationId,
-        buildDeterministicE2EResult(allPeopleData),
+        buildDeterministicE2EResult(allPeopleData, experienceMode, sourceStrategy),
       );
       recordRecommendationCompletion({
         mode: 'deterministic_e2e',
@@ -111,13 +172,19 @@ async function completeDeterministicE2ERecommendation(
   );
 }
 
-function buildDeterministicE2EResult(allPeopleData: PersonFormData[]): ApiResponse {
+function buildDeterministicE2EResult(
+  allPeopleData: PersonFormData[],
+  experienceMode: RecommendationExperienceMode,
+  sourceStrategy: RecommendationSourceStrategy,
+): ApiResponse {
   const primary = allPeopleData[0];
   const reference = primary?.favoriteMovie ? ` after your ${primary.favoriteMovie} cue` : '';
 
   return {
     title: 'PopChoice E2E Space Opera',
     description: `A deterministic e2e recommendation${reference}.`,
+    experienceMode,
+    sourceStrategy,
     usedBroaderSearch: false,
     dbMovieCount: 6,
     similarMovies: [
@@ -169,14 +236,23 @@ async function processInlineRecommendation(
   recommendationId: string,
   allPeopleData: PersonFormData[],
   locale: Locale,
-  userId?: string,
+  options: CreateRecommendationRunOptions = {},
 ): Promise<void> {
+  const sourceStrategy =
+    options.sourceStrategy ??
+    resolveRecommendationSourceStrategy({
+      experienceMode: options.experienceMode,
+      people: allPeopleData,
+    }).id;
+  const experienceMode = options.experienceMode ?? 'normal-match';
   await withTraceSpan(
     'recommendation.process.inline',
     {
       attributes: {
+        'recommendation.experience_mode': experienceMode,
         'recommendation.id': recommendationId,
         'recommendation.mode': 'async_inline',
+        'recommendation.source_strategy': sourceStrategy,
       },
     },
     async (span) => {
@@ -188,7 +264,9 @@ async function processInlineRecommendation(
             setActiveTraceAttributes({ 'recommendation.stage': stage });
             await markRecommendationStage(recommendationId, stage);
           },
-          userId,
+          experienceMode,
+          sourceStrategy,
+          userId: options.userId,
         });
 
         await completeRecommendationRecord(recommendationId, result);

--- a/apps/web/src/features/recommendation/morePicksPipeline.ts
+++ b/apps/web/src/features/recommendation/morePicksPipeline.ts
@@ -398,6 +398,7 @@ Respond in ${language} only.`;
           localizedName: localizedTitle !== tmdb.title ? localizedTitle : undefined,
           isMainRecommendation: false,
           fromTMDB: true,
+          source: 'tmdb-search',
         } satisfies MovieRowToInsert;
       }),
     );

--- a/apps/web/src/features/recommendation/persistence.ts
+++ b/apps/web/src/features/recommendation/persistence.ts
@@ -6,7 +6,12 @@ import {
   updateRecommendationStatus,
 } from '@/lib/db/recommendations';
 
-import type { ApiResponse, RecommendationRequestBody } from './types';
+import type {
+  ApiResponse,
+  RecommendationExperienceMode,
+  RecommendationRequestBody,
+  RecommendationSourceStrategy,
+} from './types';
 import type {
   MovieRowToInsert,
   RecommendationStage,
@@ -16,8 +21,10 @@ import type {
 export async function createRecommendationRecord(
   quizData: RecommendationRequestBody,
   userId?: string,
+  sourceStrategy?: RecommendationSourceStrategy,
+  experienceMode?: RecommendationExperienceMode,
 ): Promise<{ id: string; slug: string }> {
-  return createRecommendation(quizData, userId);
+  return createRecommendation(quizData, userId, sourceStrategy, experienceMode);
 }
 
 export async function getRecommendationRecord(
@@ -77,5 +84,6 @@ function toMovieRows(result: ApiResponse): MovieRowToInsert[] {
     localizedName: movie.localizedName,
     isMainRecommendation: movie.isMainRecommendation ?? false,
     fromTMDB: movie.fromTMDB ?? false,
+    source: movie.source,
   }));
 }

--- a/apps/web/src/features/recommendation/pipeline.ts
+++ b/apps/web/src/features/recommendation/pipeline.ts
@@ -19,12 +19,13 @@ import {
   getFeedbackCandidateSignals,
   getMentionedMovieTitleKeys,
 } from './candidateFilters';
+import { getCandidateSource, summarizeCandidateSources } from './candidateSources';
 import { createEmbedding, refineQueryWithLLM } from './embedding';
 import {
   findCandidateByRecommendedTitle,
   resolveGuardedRecommendation,
 } from './finalRecommendation';
-import { SIMILARITY_THRESHOLD, shouldFallBackToTMDB } from './helpers';
+import { SIMILARITY_THRESHOLD, getTMDBFallbackDecision } from './helpers';
 import {
   enhanceSimilarMoviesWithPosters,
   generateMovieDescriptions,
@@ -32,6 +33,7 @@ import {
   getRecommendation,
   getSimilarMovies,
 } from './recommendation';
+import { resolveRecommendationSourceStrategy } from './sourceStrategyPolicy';
 import {
   MAX_TOTAL_MOVIES,
   fetchTMDBDiscoverMovies,
@@ -40,7 +42,12 @@ import {
   seedMoviesInBackground,
 } from './tmdb';
 
-import type { ApiResponse, PersonFormData } from './types';
+import type {
+  ApiResponse,
+  PersonFormData,
+  RecommendationExperienceMode,
+  RecommendationSourceStrategy,
+} from './types';
 import type { RecommendationStage } from '@/lib/db/recommendations';
 import type { Locale } from '@/lib/locale';
 
@@ -99,11 +106,25 @@ export async function runRecommendationPipeline(
   allPeopleData: PersonFormData[],
   locale: Locale,
   options: {
+    experienceMode?: RecommendationExperienceMode;
     onStageChange?: (stage: RecommendationStage) => Promise<void> | void;
+    sourceStrategy?: RecommendationSourceStrategy;
     userId?: string;
   } = {},
 ): Promise<ApiResponse> {
   const mentionedTitleKeys = getMentionedMovieTitleKeys(allPeopleData);
+  const sourceStrategy =
+    options.sourceStrategy ??
+    resolveRecommendationSourceStrategy({
+      experienceMode: options.experienceMode,
+      people: allPeopleData,
+    }).id;
+  const experienceMode = options.experienceMode ?? 'normal-match';
+  setActiveTraceAttributes({
+    'recommendation.experience_mode': experienceMode,
+    'recommendation.source_strategy': sourceStrategy,
+  });
+  logger.info({ experienceMode, sourceStrategy }, 'Recommendation source strategy selected');
 
   async function emitStage(stage: RecommendationStage): Promise<void> {
     setActiveTraceAttributes({ 'recommendation.stage': stage });
@@ -155,18 +176,40 @@ export async function runRecommendationPipeline(
   );
   let similarMovies = applyFeedbackToLocalMovies(mentionedFilteredLocalMovies, feedbackSignals);
 
-  // Step 3: Hybrid search — fall back to TMDB if local results are insufficient
+  // Step 3: External catalog search — use TMDB as primary for tmdb-first, or as fallback
+  // for hybrid strategies when local results are insufficient.
   let usedBroaderSearch = false;
   const highQualityLocal = similarMovies.filter((m) => m.similarity >= SIMILARITY_THRESHOLD);
-  const needsTMDBFallback = shouldFallBackToTMDB(similarMovies);
+  const tmdbFallbackDecision = getTMDBFallbackDecision(sourceStrategy, similarMovies);
+  const shouldAttemptTMDB = tmdbFallbackDecision.shouldAttempt;
+  const prefersTMDBCandidates = sourceStrategy === 'tmdb-first';
 
-  if (needsTMDBFallback) {
+  if (shouldAttemptTMDB) {
     await emitStage('tmdb-search');
     logger.info(
-      { highQualityLocal: highQualityLocal.length, threshold: SIMILARITY_THRESHOLD },
-      'Local results below quality threshold — trying TMDB fallback',
+      {
+        highQualityLocal: highQualityLocal.length,
+        sourceStrategy,
+        threshold: SIMILARITY_THRESHOLD,
+        tmdbFallbackReason: tmdbFallbackDecision.reason,
+      },
+      prefersTMDBCandidates
+        ? 'Trying TMDB-first candidate retrieval'
+        : 'Local results below quality threshold — trying TMDB fallback',
     );
+  } else {
+    logger.info(
+      {
+        highQualityLocal: highQualityLocal.length,
+        sourceStrategy,
+        threshold: SIMILARITY_THRESHOLD,
+        tmdbFallbackReason: tmdbFallbackDecision.reason,
+      },
+      'TMDB fallback skipped by source strategy policy',
+    );
+  }
 
+  if (shouldAttemptTMDB) {
     const tmdbApiKey = process.env.TMDB_API_KEY;
     if (tmdbApiKey) {
       const tmdbMovies = excludeFeedbackTMDBMovies(
@@ -199,7 +242,13 @@ export async function runRecommendationPipeline(
           feedbackSignals,
         );
 
-        similarMovies = [...localResultsForMerge, ...newTMDBMatchList].slice(0, MAX_TOTAL_MOVIES);
+        if (prefersTMDBCandidates) {
+          similarMovies = [...newTMDBMatchList, ...localResultsForMerge]
+            .sort((a, b) => b.similarity - a.similarity)
+            .slice(0, MAX_TOTAL_MOVIES);
+        } else {
+          similarMovies = [...localResultsForMerge, ...newTMDBMatchList].slice(0, MAX_TOTAL_MOVIES);
+        }
 
         if (newTMDBMatchList.length > 0) {
           usedBroaderSearch = true;
@@ -210,8 +259,11 @@ export async function runRecommendationPipeline(
             localCount: localResultsForMerge.length,
             tmdbCount: newTMDBMatchList.length,
             finalCount: similarMovies.length,
+            sourceStrategy,
           },
-          'Merged local and TMDB results',
+          prefersTMDBCandidates
+            ? 'Merged score-ranked TMDB-first and local candidates'
+            : 'Merged local and TMDB results',
         );
 
         // Queue per-movie catalog maintenance jobs with deterministic ids so repeated
@@ -349,6 +401,32 @@ export async function runRecommendationPipeline(
     'Returning all movies in unified list',
   );
 
+  const responseSimilarMovies: NonNullable<ApiResponse['similarMovies']> =
+    moviesWithDescriptions.map((movie) => {
+      const source = getCandidateSource(movie);
+
+      return {
+        id: Number(movie.id),
+        tmdbId: movie.tmdbId ?? (Number(movie.id) < 0 ? Math.abs(Number(movie.id)) : null),
+        name: movie.name,
+        year: movie.year,
+        similarity: Number.isFinite(movie.similarity) ? movie.similarity : 0,
+        age_rating: movie.age_rating,
+        duration: movie.duration,
+        score_rating: movie.score_rating,
+        posterURL: movie.posterURL,
+        aiDescription: movie.aiDescription,
+        localizedName: movie.localizedName,
+        popularity: movie.popularity,
+        isMainRecommendation: recommendedMovie ? movie.id === recommendedMovie.id : false,
+        fromTMDB: Number(movie.id) < 0,
+        source,
+      };
+    });
+  const candidateSourceDistribution = summarizeCandidateSources(responseSimilarMovies);
+
+  logger.info({ candidateSourceDistribution }, 'Recommendation candidate source distribution');
+
   return {
     description: guardedRecommendation.description,
     title: guardedRecommendation.title,
@@ -364,21 +442,10 @@ export async function runRecommendationPipeline(
             : 0,
         }
       : undefined,
-    similarMovies: moviesWithDescriptions.map((movie) => ({
-      id: Number(movie.id),
-      tmdbId: movie.tmdbId ?? (Number(movie.id) < 0 ? Math.abs(Number(movie.id)) : null),
-      name: movie.name,
-      year: movie.year,
-      similarity: Number.isFinite(movie.similarity) ? movie.similarity : 0,
-      age_rating: movie.age_rating,
-      duration: movie.duration,
-      score_rating: movie.score_rating,
-      posterURL: movie.posterURL,
-      aiDescription: movie.aiDescription,
-      localizedName: movie.localizedName,
-      isMainRecommendation: recommendedMovie ? movie.id === recommendedMovie.id : false,
-      fromTMDB: Number(movie.id) < 0,
-    })),
+    similarMovies: responseSimilarMovies,
+    candidateSourceDistribution,
+    experienceMode,
+    sourceStrategy,
     usedBroaderSearch,
     dbMovieCount: dbMovieCountResult ?? undefined,
   };

--- a/apps/web/src/features/recommendation/recommendation.ts
+++ b/apps/web/src/features/recommendation/recommendation.ts
@@ -7,6 +7,7 @@ import { recordOpenAIProviderError } from '@/lib/metrics';
 import { MODELS } from '@/lib/models';
 import { OPENAI_TIMEOUTS_MS, openAIRequestOptions } from '@/lib/openaiTimeout';
 
+import { getLocalCandidateSource } from './candidateSources';
 import { LOCAL_VECTOR_MATCH_THRESHOLD, MAX_TOTAL_MOVIES } from './config';
 import { combineAllPeopleDataToString } from './embedding';
 import { recommendationResponseJsonSchema, recommendationResponseSchema } from './types';
@@ -58,6 +59,11 @@ IMPORTANT: The "title" field must be returned exactly as it appears in the provi
 
 const movieService = new MovieService();
 
+type LocalMatchRow = EnhancedMovieMatch & {
+  tmdb_id?: number | null;
+  tmdb_match_source?: string | null;
+};
+
 // ---------------------------------------------------------------------------
 // Vector DB search
 // ---------------------------------------------------------------------------
@@ -80,10 +86,14 @@ async function findNearestMatch(embedding: number[]): Promise<EnhancedMovieMatch
     return null;
   }
 
-  return (data as Array<EnhancedMovieMatch & { tmdb_id?: number | null }>).map((movie) => ({
-    ...movie,
-    tmdbId: movie.tmdb_id ?? movie.tmdbId ?? null,
-  }));
+  return (data as LocalMatchRow[])
+    .map((movie) => ({
+      ...movie,
+      source: getLocalCandidateSource(movie.tmdb_match_source),
+      tmdbId: movie.tmdb_id ?? movie.tmdbId ?? null,
+      tmdbMatchSource: movie.tmdb_match_source ?? movie.tmdbMatchSource ?? null,
+    }))
+    .sort((a, b) => b.similarity - a.similarity);
 }
 
 /** Find similar movies in the local vector store. Returns an empty array if none found or DB unavailable. */

--- a/apps/web/src/features/recommendation/sourceStrategyPolicy.test.ts
+++ b/apps/web/src/features/recommendation/sourceStrategyPolicy.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getOrderedCandidateSources,
+  getRecommendationAudienceMode,
+  resolveCandidateSourceStrategy,
+  resolveRecommendationSourceStrategy,
+} from './sourceStrategyPolicy';
+
+describe('source strategy policy', () => {
+  it('keeps curated showcase locked to curated records', () => {
+    const policy = resolveCandidateSourceStrategy({
+      audience: 'solo',
+      experienceMode: 'curated-showcase',
+    });
+
+    expect(policy).toMatchObject({
+      allowExternalLookup: false,
+      id: 'curated-showcase',
+      primarySources: ['curated'],
+    });
+  });
+
+  it('uses a bounded hybrid source mix for fast solo picks', () => {
+    const policy = resolveCandidateSourceStrategy({
+      audience: 'solo',
+      experienceMode: 'fast-pick',
+    });
+
+    expect(policy.id).toBe('hybrid-fast');
+    expect(getOrderedCandidateSources(policy.id)).toEqual([
+      'local-cache',
+      'curated',
+      'tmdb-discover',
+      'jit-enriched',
+    ]);
+  });
+
+  it('prefers TMDB-first discovery for normal and swipe solo modes', () => {
+    expect(
+      resolveCandidateSourceStrategy({
+        audience: 'solo',
+        experienceMode: 'normal-match',
+      }).id,
+    ).toBe('tmdb-first');
+    expect(
+      resolveCandidateSourceStrategy({
+        audience: 'solo',
+        experienceMode: 'taste-swipe',
+      }).id,
+    ).toBe('tmdb-first');
+  });
+
+  it('routes duo and group audiences through compromise-aware hybrid strategy', () => {
+    expect(
+      resolveCandidateSourceStrategy({
+        audience: 'duo',
+        experienceMode: 'normal-match',
+      }),
+    ).toMatchObject({
+      id: 'compromise-hybrid',
+      requiresParticipantOverlap: true,
+    });
+    expect(
+      resolveCandidateSourceStrategy({
+        audience: 'group',
+        experienceMode: 'fast-pick',
+      }).id,
+    ).toBe('compromise-hybrid');
+  });
+
+  it('classifies solo, duo, and group audience size independently from source strategy', () => {
+    const person = {
+      favoriteMovie: 'Arrival',
+      moodPreference: ['Thoughtful'],
+      newVsClassic: 'Balanced',
+      tonePreference: 'Smart',
+    };
+
+    expect(getRecommendationAudienceMode([person])).toBe('solo');
+    expect(getRecommendationAudienceMode([person, person])).toBe('duo');
+    expect(getRecommendationAudienceMode([person, person, person])).toBe('group');
+  });
+
+  it('resolves current recommendation runs to default normal-match source policy', () => {
+    const person = {
+      favoriteMovie: 'Arrival',
+      moodPreference: ['Thoughtful'],
+      newVsClassic: 'Balanced',
+      tonePreference: 'Smart',
+    };
+
+    expect(resolveRecommendationSourceStrategy({ people: [person] }).id).toBe('tmdb-first');
+    expect(resolveRecommendationSourceStrategy({ people: [person, person] }).id).toBe(
+      'compromise-hybrid',
+    );
+  });
+});

--- a/apps/web/src/features/recommendation/sourceStrategyPolicy.ts
+++ b/apps/web/src/features/recommendation/sourceStrategyPolicy.ts
@@ -1,0 +1,122 @@
+import type {
+  CandidateSource,
+  PersonFormData,
+  RecommendationExperienceMode,
+  RecommendationSourceStrategy,
+} from './types';
+
+export type CandidateSourceStrategyId = RecommendationSourceStrategy;
+
+export type RecommendationAudienceMode = 'solo' | 'duo' | 'group';
+
+export type CandidateSourceStrategyPolicy = {
+  allowExternalLookup: boolean;
+  id: CandidateSourceStrategyId;
+  primarySources: CandidateSource[];
+  fallbackSources: CandidateSource[];
+  requiresMemorySignals: boolean;
+  requiresParticipantOverlap: boolean;
+};
+
+const CANDIDATE_SOURCE_STRATEGIES: Record<
+  CandidateSourceStrategyId,
+  CandidateSourceStrategyPolicy
+> = {
+  'compromise-hybrid': {
+    allowExternalLookup: true,
+    fallbackSources: ['tmdb-discover', 'tmdb-search', 'jit-enriched'],
+    id: 'compromise-hybrid',
+    primarySources: ['local-cache', 'curated'],
+    requiresMemorySignals: false,
+    requiresParticipantOverlap: true,
+  },
+  'curated-showcase': {
+    allowExternalLookup: false,
+    fallbackSources: [],
+    id: 'curated-showcase',
+    primarySources: ['curated'],
+    requiresMemorySignals: false,
+    requiresParticipantOverlap: false,
+  },
+  'hybrid-fast': {
+    allowExternalLookup: true,
+    fallbackSources: ['tmdb-discover', 'jit-enriched'],
+    id: 'hybrid-fast',
+    primarySources: ['local-cache', 'curated'],
+    requiresMemorySignals: false,
+    requiresParticipantOverlap: false,
+  },
+  'memory-aware-local': {
+    allowExternalLookup: false,
+    fallbackSources: ['curated'],
+    id: 'memory-aware-local',
+    primarySources: ['memory', 'local-cache'],
+    requiresMemorySignals: true,
+    requiresParticipantOverlap: false,
+  },
+  'tmdb-first': {
+    allowExternalLookup: true,
+    fallbackSources: ['local-cache', 'curated', 'jit-enriched'],
+    id: 'tmdb-first',
+    primarySources: ['tmdb-discover', 'tmdb-search'],
+    requiresMemorySignals: false,
+    requiresParticipantOverlap: false,
+  },
+};
+
+export function getCandidateSourceStrategyPolicy(
+  strategyId: CandidateSourceStrategyId,
+): CandidateSourceStrategyPolicy {
+  return CANDIDATE_SOURCE_STRATEGIES[strategyId];
+}
+
+export function resolveCandidateSourceStrategy(input: {
+  audience: RecommendationAudienceMode;
+  experienceMode: RecommendationExperienceMode;
+  hasMemorySignals?: boolean;
+}): CandidateSourceStrategyPolicy {
+  if (input.experienceMode === 'curated-showcase') {
+    return getCandidateSourceStrategyPolicy('curated-showcase');
+  }
+
+  if (input.audience !== 'solo') {
+    return getCandidateSourceStrategyPolicy('compromise-hybrid');
+  }
+
+  if (input.experienceMode === 'normal-match' || input.experienceMode === 'taste-swipe') {
+    return getCandidateSourceStrategyPolicy('tmdb-first');
+  }
+
+  if (input.hasMemorySignals) {
+    return getCandidateSourceStrategyPolicy('memory-aware-local');
+  }
+
+  return getCandidateSourceStrategyPolicy('hybrid-fast');
+}
+
+export function getRecommendationAudienceMode(
+  people: PersonFormData[],
+): RecommendationAudienceMode {
+  if (people.length <= 1) return 'solo';
+  if (people.length === 2) return 'duo';
+  return 'group';
+}
+
+export function resolveRecommendationSourceStrategy(input: {
+  experienceMode?: RecommendationExperienceMode;
+  hasMemorySignals?: boolean;
+  people: PersonFormData[];
+}): CandidateSourceStrategyPolicy {
+  return resolveCandidateSourceStrategy({
+    audience: getRecommendationAudienceMode(input.people),
+    experienceMode: input.experienceMode ?? 'normal-match',
+    hasMemorySignals: input.hasMemorySignals,
+  });
+}
+
+export function getOrderedCandidateSources(
+  strategyId: CandidateSourceStrategyId,
+): CandidateSource[] {
+  const strategy = getCandidateSourceStrategyPolicy(strategyId);
+  return [...strategy.primarySources, ...strategy.fallbackSources];
+}

--- a/apps/web/src/features/recommendation/tmdb.ts
+++ b/apps/web/src/features/recommendation/tmdb.ts
@@ -36,6 +36,7 @@ const tmdbDiscoverMovieSchema = z.object({
   overview: z.string(),
   release_date: z.string(),
   vote_average: z.number(),
+  genre_ids: z.array(z.number()).optional(),
   poster_path: z.string().nullable(),
 });
 
@@ -56,12 +57,36 @@ const tmdbDiscoverResponseSchema = z.object({
  * The quiz sends human-readable labels (e.g. "Sci-Fi", "New", "Serious and thought-provoking")
  * which we normalize to stable keys before mapping.
  */
-function extractTMDBParams(allPeopleData: PersonFormData[]): {
-  genre_ids: number[];
-  sort_by: string;
+export type TMDBDiscoverQueryShape = {
+  genreIds: number[];
+  sortBy: string;
+  voteCountGte: number;
+  withoutGenreIds: number[];
   primary_release_date_gte?: string;
   primary_release_date_lte?: string;
-} {
+  with_runtime_lte?: number;
+};
+
+function getPreferenceText(allPeopleData: PersonFormData[]): string {
+  return allPeopleData
+    .flatMap((person) => [
+      person.favoriteMovieWhy,
+      person.newVsClassic,
+      person.tonePreference,
+      ...person.moodPreference,
+    ])
+    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    .join(' ')
+    .toLocaleLowerCase('en-US');
+}
+
+function hasAnyPreferenceTerm(text: string, terms: string[]): boolean {
+  return terms.some((term) => text.includes(term));
+}
+
+export function buildTMDBDiscoverQueryShape(
+  allPeopleData: PersonFormData[],
+): TMDBDiscoverQueryShape {
   // Aggregate mood preferences across all people.
   // Normalize labels: "Sci-Fi" → "scifi", "Action" → "action", etc.
   const moodCounts: Record<string, number> = {};
@@ -73,11 +98,20 @@ function extractTMDBParams(allPeopleData: PersonFormData[]): {
   });
 
   // Top genres (up to 3) mapped to TMDB IDs
-  const genre_ids = Object.entries(moodCounts)
+  const preferenceText = getPreferenceText(allPeopleData);
+  const withoutGenreIds = new Set<number>();
+  if (hasAnyPreferenceTerm(preferenceText, ['avoid: horror', 'avoid horror', 'no horror'])) {
+    withoutGenreIds.add(GENRE_LABEL_TO_TMDB_ID.horror);
+  }
+  if (hasAnyPreferenceTerm(preferenceText, ['avoid: gore', 'avoid gore', 'no gore'])) {
+    withoutGenreIds.add(GENRE_LABEL_TO_TMDB_ID.horror);
+  }
+
+  const genreIds = Object.entries(moodCounts)
     .sort(([, a], [, b]) => b - a)
     .slice(0, 3)
     .map(([key]) => GENRE_LABEL_TO_TMDB_ID[key])
-    .filter((id): id is number => id !== undefined);
+    .filter((id): id is number => id !== undefined && !withoutGenreIds.has(id));
 
   // Era preference: normalize to 'new' | 'classic' | 'both' by keyword matching.
   // Quiz sends e.g. "New", "Classic", "Both new and classic".
@@ -125,10 +159,44 @@ function extractTMDBParams(allPeopleData: PersonFormData[]): {
     toneCounts[key] = (toneCounts[key] ?? 0) + 1;
   });
   const dominantTone = Object.entries(toneCounts).sort(([, a], [, b]) => b - a)[0]?.[0] ?? 'light';
-  const sort_by =
+  let sortBy =
     dominantTone === 'serious' || dominantTone === 'dark' ? 'vote_average.desc' : 'popularity.desc';
 
-  return { genre_ids, sort_by, primary_release_date_gte, primary_release_date_lte };
+  let voteCountGte = 100;
+  if (
+    hasAnyPreferenceTerm(preferenceText, [
+      'discovery appetite: safe hit',
+      'proven hits',
+      'familiar crowd-pleasers',
+    ])
+  ) {
+    voteCountGte = 500;
+    sortBy = 'popularity.desc';
+  } else if (
+    hasAnyPreferenceTerm(preferenceText, [
+      'discovery appetite: surprise me',
+      'unexpected picks',
+      'surprise me',
+    ])
+  ) {
+    voteCountGte = 50;
+  }
+
+  if (hasAnyPreferenceTerm(preferenceText, ['slow pacing'])) {
+    voteCountGte = Math.max(voteCountGte, 250);
+  }
+
+  const with_runtime_lte = hasAnyPreferenceTerm(preferenceText, ['long runtime']) ? 125 : undefined;
+
+  return {
+    genreIds,
+    sortBy,
+    voteCountGte,
+    withoutGenreIds: Array.from(withoutGenreIds),
+    primary_release_date_gte,
+    primary_release_date_lte,
+    with_runtime_lte,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -144,14 +212,17 @@ export async function fetchTMDBDiscoverMovies(
   tmdbApiKey: string,
 ): Promise<TMDBDiscoverMovie[]> {
   try {
-    const params = extractTMDBParams(allPeopleData);
+    const params = buildTMDBDiscoverQueryShape(allPeopleData);
 
     const url = new URL(`${TMDB_API_BASE}/discover/movie`);
-    if (params.genre_ids.length > 0) {
-      url.searchParams.set('with_genres', params.genre_ids.join('|'));
+    if (params.genreIds.length > 0) {
+      url.searchParams.set('with_genres', params.genreIds.join('|'));
     }
-    url.searchParams.set('sort_by', params.sort_by);
-    url.searchParams.set('vote_count.gte', '100');
+    if (params.withoutGenreIds.length > 0) {
+      url.searchParams.set('without_genres', params.withoutGenreIds.join('|'));
+    }
+    url.searchParams.set('sort_by', params.sortBy);
+    url.searchParams.set('vote_count.gte', String(params.voteCountGte));
     url.searchParams.set('include_adult', 'false');
     url.searchParams.set('page', '1');
     if (params.primary_release_date_gte) {
@@ -159,6 +230,9 @@ export async function fetchTMDBDiscoverMovies(
     }
     if (params.primary_release_date_lte) {
       url.searchParams.set('primary_release_date.lte', params.primary_release_date_lte);
+    }
+    if (params.with_runtime_lte) {
+      url.searchParams.set('with_runtime.lte', String(params.with_runtime_lte));
     }
 
     const response = await fetch(url.toString(), {
@@ -281,6 +355,7 @@ function tmdbMovieToEnhancedMatch(
     similarity,
     content,
     posterURL,
+    source: 'tmdb-discover',
   };
 }
 

--- a/apps/web/src/features/recommendation/types.ts
+++ b/apps/web/src/features/recommendation/types.ts
@@ -54,6 +54,25 @@ export const requestBodySchema = z.union([
     .max(10, 'No more than 10 people allowed'), // Multiple people
 ]);
 
+export const recommendationExperienceModeSchema = z.enum([
+  'curated-showcase',
+  'fast-pick',
+  'normal-match',
+  'taste-swipe',
+]);
+
+export const recommendationCreateRequestSchema = z.union([
+  requestBodySchema,
+  z.object({
+    experienceMode: recommendationExperienceModeSchema.optional(),
+    people: requestBodySchema,
+  }),
+  z.object({
+    experienceMode: recommendationExperienceModeSchema.optional(),
+    quizData: requestBodySchema,
+  }),
+]);
+
 // ---------------------------------------------------------------------------
 // Response schemas
 // ---------------------------------------------------------------------------
@@ -77,6 +96,34 @@ export const recommendationResponseJsonSchema = {
   required: ['description', 'title'],
   additionalProperties: false,
 } as const;
+
+export const candidateSourceSchema = z.enum([
+  'curated',
+  'local-cache',
+  'tmdb-discover',
+  'tmdb-search',
+  'memory',
+  'jit-enriched',
+]);
+
+export const candidateSourceDistributionSchema = z
+  .object({
+    curated: z.number().optional(),
+    'local-cache': z.number().optional(),
+    'tmdb-discover': z.number().optional(),
+    'tmdb-search': z.number().optional(),
+    memory: z.number().optional(),
+    'jit-enriched': z.number().optional(),
+  })
+  .optional();
+
+export const recommendationSourceStrategySchema = z.enum([
+  'curated-showcase',
+  'hybrid-fast',
+  'memory-aware-local',
+  'tmdb-first',
+  'compromise-hybrid',
+]);
 
 export const apiResponseSchema = z.object({
   description: z.string(),
@@ -107,11 +154,19 @@ export const apiResponseSchema = z.object({
         posterURL: z.string().url().optional(), // Added poster URL support
         aiDescription: z.string().optional(), // Added AI-generated description
         localizedName: z.string().optional(), // Localized title from TMDB
+        popularity: z.number().nullable().optional(),
         isMainRecommendation: z.boolean().optional(), // Mark main recommendation
         fromTMDB: z.boolean().optional(), // True for movies sourced from TMDB fallback
+        source: candidateSourceSchema.optional(), // First-class candidate provenance
       }),
     )
     .optional(),
+  // Candidate source mix for evals, logs, and debugging.
+  candidateSourceDistribution: candidateSourceDistributionSchema,
+  // Product experience mode selected for this recommendation run.
+  experienceMode: recommendationExperienceModeSchema.optional(),
+  // Intended source strategy selected for this recommendation run.
+  sourceStrategy: recommendationSourceStrategySchema.optional(),
   // Flag indicating that TMDB fallback was used to broaden results
   usedBroaderSearch: z.boolean().optional(),
   // Actual number of movies in the local database (for display)
@@ -124,6 +179,11 @@ export const apiResponseSchema = z.object({
 
 export type PersonFormData = z.infer<typeof personFormDataSchema>;
 export type RecommendationRequestBody = z.infer<typeof requestBodySchema>;
+export type RecommendationCreateRequestBody = z.infer<typeof recommendationCreateRequestSchema>;
+export type RecommendationExperienceMode = z.infer<typeof recommendationExperienceModeSchema>;
+export type CandidateSource = z.infer<typeof candidateSourceSchema>;
+export type CandidateSourceDistribution = z.infer<typeof candidateSourceDistributionSchema>;
+export type RecommendationSourceStrategy = z.infer<typeof recommendationSourceStrategySchema>;
 export type ApiResponse = z.infer<typeof apiResponseSchema>;
 
 /** Full movie match enriched with metadata from the database or TMDB. */
@@ -140,6 +200,9 @@ export type EnhancedMovieMatch = {
   content: string;
   /** Pre-populated poster URL, e.g. from TMDB discover response — skips re-lookup if set. */
   posterURL?: string;
+  source?: CandidateSource;
+  tmdbMatchSource?: string | null;
+  popularity?: number | null;
 };
 
 /** Minimal movie match returned from the vector DB RPC. */

--- a/apps/web/src/lib/db/recommendations.test.ts
+++ b/apps/web/src/lib/db/recommendations.test.ts
@@ -101,6 +101,8 @@ describe('createRecommendation', () => {
     const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
     expect(sql).toContain('user_id');
     expect(params[2]).toBe('42');
+    expect(params[3]).toBe('hybrid-fast');
+    expect(params[4]).toBe('normal-match');
   });
 
   it('stores null owner for anonymous recommendations', async () => {
@@ -110,6 +112,23 @@ describe('createRecommendation', () => {
 
     const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
     expect(params[2]).toBeNull();
+  });
+
+  it('stores recommendation source strategy and experience mode metadata when present', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 'rec-id', slug: 'abc123' }] });
+
+    await createRecommendation(
+      { favoriteMovie: 'Arrival' } as never,
+      undefined,
+      'tmdb-first',
+      'fast-pick',
+    );
+
+    const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('source_strategy');
+    expect(sql).toContain('experience_mode');
+    expect(params[3]).toBe('tmdb-first');
+    expect(params[4]).toBe('fast-pick');
   });
 });
 
@@ -1170,6 +1189,7 @@ describe('insertRecommendationMovies', () => {
 
     const [, params] = mockClientQuery.mock.calls[2] as [string, unknown[]];
     expect(params).toContain(77);
+    expect(params).toContain('tmdb-discover');
   });
 
   it('stores a matched TMDB id for local recommendations', async () => {
@@ -1188,6 +1208,25 @@ describe('insertRecommendationMovies', () => {
     const [, params] = mockClientQuery.mock.calls[2] as [string, unknown[]];
     expect(params).toContain(129);
     expect(params).toContain(42);
+    expect(params).toContain('local-cache');
+  });
+
+  it('stores explicit recommendation candidate source provenance', async () => {
+    mockClientQuery
+      .mockResolvedValueOnce({}) // BEGIN
+      .mockResolvedValueOnce({}) // UPDATE recommendations metadata
+      .mockResolvedValueOnce({}) // INSERT
+      .mockResolvedValueOnce({}); // COMMIT
+
+    await insertRecommendationMovies(
+      'rec-id',
+      [makeMovie({ id: 42, fromTMDB: false, source: 'curated' })],
+      false,
+    );
+
+    const [sql, params] = mockClientQuery.mock.calls[2] as [string, unknown[]];
+    expect(sql).toContain('from_tmdb, source, tmdb_id');
+    expect(params).toContain('curated');
   });
 });
 
@@ -1217,7 +1256,9 @@ describe('getRecommendationWithMovies', () => {
             used_broader_search: false,
             db_movie_count: 12,
             quiz_data: null,
+            experience_mode: 'normal-match',
             more_picks_status: null,
+            source_strategy: 'tmdb-first',
             user_id: '42',
           },
         ],
@@ -1234,6 +1275,7 @@ describe('getRecommendationWithMovies', () => {
             localized_name: 'Localized',
             similarity: 0.8,
             from_tmdb: true,
+            source: 'tmdb-search',
             tmdb_id: 321,
             tmdb_name: 'TMDB Movie',
             tmdb_year: 2024,
@@ -1252,6 +1294,9 @@ describe('getRecommendationWithMovies', () => {
     const result = await getRecommendationWithMovies('slug-123', '42');
 
     expect(result?.movies[0]?.id).toBe(-321);
+    expect(result?.movies[0]?.source).toBe('tmdb-search');
+    expect(result?.experienceMode).toBe('normal-match');
+    expect(result?.sourceStrategy).toBe('tmdb-first');
     expect(result?.stage).toBe('complete');
     expect(result?.viewerCanRate).toBe(true);
     expect(result?.isSharedResult).toBe(false);
@@ -1269,7 +1314,9 @@ describe('getRecommendationWithMovies', () => {
             used_broader_search: false,
             db_movie_count: 12,
             quiz_data: null,
+            experience_mode: 'normal-match',
             more_picks_status: null,
+            source_strategy: 'tmdb-first',
             user_id: 42,
           },
         ],
@@ -1311,7 +1358,9 @@ describe('getRecommendationWithMovies', () => {
                 favoriteActor: 'Amy Adams',
               },
             ],
+            experience_mode: 'normal-match',
             more_picks_status: null,
+            source_strategy: 'compromise-hybrid',
             user_id: 'owner-1',
           },
         ],

--- a/apps/web/src/lib/db/recommendations.ts
+++ b/apps/web/src/lib/db/recommendations.ts
@@ -55,6 +55,24 @@ export type UserMovieInteractionKind =
   | 'wrong_mood'
   | 'not_seen';
 export type UserRecommendationMemoryKind = UserMovieInteractionKind | 'recently_recommended';
+export type RecommendationCandidateSource =
+  | 'curated'
+  | 'local-cache'
+  | 'tmdb-discover'
+  | 'tmdb-search'
+  | 'memory'
+  | 'jit-enriched';
+export type RecommendationSourceStrategy =
+  | 'curated-showcase'
+  | 'hybrid-fast'
+  | 'memory-aware-local'
+  | 'tmdb-first'
+  | 'compromise-hybrid';
+export type RecommendationExperienceMode =
+  | 'curated-showcase'
+  | 'fast-pick'
+  | 'normal-match'
+  | 'taste-swipe';
 
 export interface RecommendationMovie {
   id: number;
@@ -69,6 +87,7 @@ export interface RecommendationMovie {
   localizedName?: string;
   isMainRecommendation: boolean;
   fromTMDB: boolean;
+  source?: RecommendationCandidateSource;
 }
 
 export interface RecommendationWithMovies {
@@ -78,6 +97,8 @@ export interface RecommendationWithMovies {
   movies: RecommendationMovie[];
   usedBroaderSearch?: boolean;
   dbMovieCount?: number;
+  experienceMode?: RecommendationExperienceMode | null;
+  sourceStrategy?: RecommendationSourceStrategy | null;
   peopleCount?: number;
   hasActorSignal?: boolean;
   groupInsights?: ReturnType<typeof buildGroupResultInsights>;
@@ -164,6 +185,7 @@ export interface MovieRowToInsert {
   localizedName?: string;
   isMainRecommendation: boolean;
   fromTMDB: boolean;
+  source?: RecommendationCandidateSource;
 }
 
 function getInteractionKindForFeedback(
@@ -191,14 +213,24 @@ function getInteractionKindForFeedback(
 export async function createRecommendation(
   quizData: PersonFormData | PersonFormData[],
   userId?: string,
+  sourceStrategy?: RecommendationSourceStrategy,
+  experienceMode?: RecommendationExperienceMode,
 ): Promise<{ id: string; slug: string }> {
   const pool = getPool();
   const slug = nanoid(12);
   const result = await pool.query<{ id: string; slug: string }>(
-    `INSERT INTO recommendations (status, stage, quiz_data, slug, user_id)
-     VALUES ('pending', 'queued', $1, $2, $3)
+    `INSERT INTO recommendations (
+       status, stage, quiz_data, slug, user_id, source_strategy, experience_mode
+     )
+     VALUES ('pending', 'queued', $1, $2, $3, $4, $5)
      RETURNING id, slug`,
-    [JSON.stringify(quizData), slug, userId ?? null],
+    [
+      JSON.stringify(quizData),
+      slug,
+      userId ?? null,
+      sourceStrategy ?? 'hybrid-fast',
+      experienceMode ?? 'normal-match',
+    ],
   );
   const row = result.rows[0];
   if (!row) throw new Error('Failed to create recommendation row');
@@ -913,8 +945,8 @@ export async function insertRecommendationMovies(
         `INSERT INTO recommendation_movies (
           recommendation_id, movie_id, position, is_main_recommendation,
           ai_description, poster_url, localized_name, similarity,
-          from_tmdb, tmdb_id, tmdb_name, tmdb_year, tmdb_score_rating, tmdb_duration, tmdb_age_rating
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)`,
+          from_tmdb, source, tmdb_id, tmdb_name, tmdb_year, tmdb_score_rating, tmdb_duration, tmdb_age_rating
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`,
         [
           recommendationId,
           movieId,
@@ -925,6 +957,7 @@ export async function insertRecommendationMovies(
           m.localizedName ?? null,
           m.similarity ?? null,
           m.fromTMDB,
+          m.source ?? (m.fromTMDB ? 'tmdb-discover' : 'local-cache'),
           m.fromTMDB ? Math.abs(m.id) : (m.tmdbId ?? null),
           m.fromTMDB ? m.name : null,
           m.fromTMDB ? m.year : null,
@@ -963,11 +996,14 @@ export async function getRecommendationWithMovies(
     used_broader_search: boolean | null;
     db_movie_count: number | null;
     quiz_data: unknown;
+    experience_mode: RecommendationExperienceMode | null;
     more_picks_status: string | null;
+    source_strategy: RecommendationSourceStrategy | null;
     user_id: string | null;
   }>(
     `SELECT
-       id, status, error, stage, used_broader_search, db_movie_count, quiz_data, more_picks_status, user_id
+       id, status, error, stage, used_broader_search, db_movie_count, quiz_data,
+       experience_mode, more_picks_status, source_strategy, user_id
        FROM recommendations
       WHERE slug = $1`,
     [slug],
@@ -1021,6 +1057,7 @@ export async function getRecommendationWithMovies(
     tmdb_score_rating: number | null;
     tmdb_duration: number | null;
     tmdb_age_rating: string | null;
+    source: RecommendationCandidateSource | null;
     m_name: string | null;
     m_year: number | null;
     m_age_rating: string | null;
@@ -1037,7 +1074,8 @@ export async function getRecommendationWithMovies(
        rm.localized_name,
        rm.similarity,
        rm.from_tmdb,
-      rm.tmdb_id,
+       rm.source,
+       rm.tmdb_id,
        rm.tmdb_name,
        rm.tmdb_year,
        rm.tmdb_score_rating,
@@ -1070,6 +1108,7 @@ export async function getRecommendationWithMovies(
         localizedName: row.localized_name ?? undefined,
         isMainRecommendation: row.is_main_recommendation,
         fromTMDB: true,
+        source: row.source ?? 'tmdb-discover',
       };
     }
     return {
@@ -1085,6 +1124,7 @@ export async function getRecommendationWithMovies(
       localizedName: row.localized_name ?? undefined,
       isMainRecommendation: row.is_main_recommendation,
       fromTMDB: false,
+      source: row.source ?? 'local-cache',
     };
   });
 
@@ -1095,6 +1135,8 @@ export async function getRecommendationWithMovies(
     movies,
     usedBroaderSearch: rec.used_broader_search ?? false,
     dbMovieCount: rec.db_movie_count ?? undefined,
+    experienceMode: rec.experience_mode,
+    sourceStrategy: rec.source_strategy,
     peopleCount,
     hasActorSignal,
     groupInsights,
@@ -1328,8 +1370,8 @@ export async function insertMorePicksMovies(
         `INSERT INTO recommendation_movies (
             recommendation_id, movie_id, position, is_main_recommendation,
             ai_description, poster_url, localized_name, similarity,
-            from_tmdb, tmdb_id, tmdb_name, tmdb_year, tmdb_score_rating, tmdb_duration, tmdb_age_rating
-          ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)`,
+            from_tmdb, source, tmdb_id, tmdb_name, tmdb_year, tmdb_score_rating, tmdb_duration, tmdb_age_rating
+          ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`,
         [
           recommendationId,
           null, // all more-picks movies are TMDB-only; no local movie_id
@@ -1340,6 +1382,7 @@ export async function insertMorePicksMovies(
           m.localizedName ?? null,
           m.similarity ?? null,
           true,
+          m.source ?? 'tmdb-search',
           Math.abs(m.id),
           m.name,
           m.year,

--- a/apps/web/src/lib/jobQueue.ts
+++ b/apps/web/src/lib/jobQueue.ts
@@ -5,7 +5,11 @@ import logger from '@/lib/logger';
 import { redisOptionsFromUrl } from '@/lib/redisConnection';
 
 import type { SerializableTMDBEmbeddings, TMDBDiscoverMovie } from '@/features/recommendation/tmdb';
-import type { PersonFormData } from '@/features/recommendation/types';
+import type {
+  PersonFormData,
+  RecommendationExperienceMode,
+  RecommendationSourceStrategy,
+} from '@/features/recommendation/types';
 import type { Locale } from '@/lib/locale';
 import type { TraceCarrier } from '@/lib/tracing';
 
@@ -46,7 +50,9 @@ export type MovieSeedJobData = {
 export type RecommendationJobData = {
   recommendationId: string;
   quizData: PersonFormData | PersonFormData[];
+  experienceMode?: RecommendationExperienceMode;
   locale: Locale;
+  sourceStrategy?: RecommendationSourceStrategy;
   userId?: string;
   trace?: TraceCarrier;
 };

--- a/apps/web/src/lib/workers/recommendationWorker.ts
+++ b/apps/web/src/lib/workers/recommendationWorker.ts
@@ -7,6 +7,7 @@ import {
   markRecommendationProcessing,
 } from '@/features/recommendation/persistence';
 import { runRecommendationPipeline } from '@/features/recommendation/pipeline';
+import { resolveRecommendationSourceStrategy } from '@/features/recommendation/sourceStrategyPolicy';
 import {
   RECOMMENDATION_JOB_OPTIONS,
   RECOMMENDATION_QUEUE_NAME,
@@ -31,6 +32,14 @@ export function createRecommendationWorker(): Worker<RecommendationJobData> | nu
     RECOMMENDATION_QUEUE_NAME,
     async (job) => {
       const { recommendationId, quizData, locale, userId } = job.data;
+      const allPeopleData = Array.isArray(quizData) ? quizData : [quizData];
+      const experienceMode = job.data.experienceMode ?? 'normal-match';
+      const sourceStrategy =
+        job.data.sourceStrategy ??
+        resolveRecommendationSourceStrategy({
+          experienceMode,
+          people: allPeopleData,
+        }).id;
 
       await withTraceSpan(
         'recommendation.worker.process',
@@ -42,8 +51,10 @@ export function createRecommendationWorker(): Worker<RecommendationJobData> | nu
             'messaging.operation.name': 'process',
             'job.id': String(job.id ?? 'unknown'),
             'job.name': job.name,
+            'recommendation.experience_mode': experienceMode,
             'recommendation.id': recommendationId,
             'recommendation.mode': 'async_worker',
+            'recommendation.source_strategy': sourceStrategy,
           },
         },
         async () => {
@@ -55,14 +66,14 @@ export function createRecommendationWorker(): Worker<RecommendationJobData> | nu
           await markRecommendationProcessing(recommendationId);
 
           try {
-            const allPeopleData = Array.isArray(quizData) ? quizData : [quizData];
-
             // Run the full AI pipeline
             const result = await runRecommendationPipeline(allPeopleData, locale, {
               onStageChange: async (stage) => {
                 setActiveTraceAttributes({ 'recommendation.stage': stage });
                 await markRecommendationStage(recommendationId, stage);
               },
+              experienceMode,
+              sourceStrategy,
               userId,
             });
 

--- a/db/init/03_recommendations.sql
+++ b/db/init/03_recommendations.sql
@@ -17,7 +17,9 @@ CREATE TABLE IF NOT EXISTS recommendations (
   completed_at        timestamptz,
   used_broader_search boolean,
   db_movie_count      integer,
-  more_picks_status   text
+  more_picks_status   text,
+  source_strategy     text        NOT NULL DEFAULT 'hybrid-fast',
+  experience_mode     text        NOT NULL DEFAULT 'normal-match'
 );
 
 -- Idempotent column additions for databases created before slug / more_picks_status were added
@@ -25,6 +27,8 @@ ALTER TABLE recommendations ADD COLUMN IF NOT EXISTS slug             text;
 ALTER TABLE recommendations ADD COLUMN IF NOT EXISTS user_id          bigint REFERENCES users(id) ON DELETE SET NULL;
 ALTER TABLE recommendations ADD COLUMN IF NOT EXISTS more_picks_status text;
 ALTER TABLE recommendations ADD COLUMN IF NOT EXISTS stage             text;
+ALTER TABLE recommendations ADD COLUMN IF NOT EXISTS source_strategy   text;
+ALTER TABLE recommendations ADD COLUMN IF NOT EXISTS experience_mode   text;
 
 -- Back-fill slug for any legacy rows that pre-date the column
 UPDATE recommendations
@@ -35,10 +39,22 @@ UPDATE recommendations
    SET stage = 'queued'
  WHERE stage IS NULL;
 
+UPDATE recommendations
+   SET source_strategy = 'hybrid-fast'
+ WHERE source_strategy IS NULL;
+
+UPDATE recommendations
+   SET experience_mode = 'normal-match'
+ WHERE experience_mode IS NULL;
+
 -- Enforce NOT NULL now that every row has a value
 ALTER TABLE recommendations ALTER COLUMN slug SET NOT NULL;
 ALTER TABLE recommendations ALTER COLUMN stage SET DEFAULT 'queued';
 ALTER TABLE recommendations ALTER COLUMN stage SET NOT NULL;
+ALTER TABLE recommendations ALTER COLUMN source_strategy SET DEFAULT 'hybrid-fast';
+ALTER TABLE recommendations ALTER COLUMN source_strategy SET NOT NULL;
+ALTER TABLE recommendations ALTER COLUMN experience_mode SET DEFAULT 'normal-match';
+ALTER TABLE recommendations ALTER COLUMN experience_mode SET NOT NULL;
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_recommendations_slug
   ON recommendations (slug);
@@ -64,7 +80,8 @@ CREATE TABLE IF NOT EXISTS recommendation_movies (
   tmdb_year               integer,
   tmdb_score_rating       float,
   tmdb_duration           integer,
-  tmdb_age_rating         text
+  tmdb_age_rating         text,
+  source                  text       NOT NULL DEFAULT 'local-cache'
 );
 
 ALTER TABLE recommendation_movies
@@ -93,6 +110,19 @@ ALTER TABLE recommendation_movies
 
 ALTER TABLE recommendation_movies
   ADD COLUMN IF NOT EXISTS tmdb_age_rating text;
+
+ALTER TABLE recommendation_movies
+  ADD COLUMN IF NOT EXISTS source text;
+
+UPDATE recommendation_movies
+   SET source = CASE WHEN from_tmdb THEN 'tmdb-discover' ELSE 'local-cache' END
+ WHERE source IS NULL;
+
+ALTER TABLE recommendation_movies
+  ALTER COLUMN source SET DEFAULT 'local-cache';
+
+ALTER TABLE recommendation_movies
+  ALTER COLUMN source SET NOT NULL;
 
 CREATE INDEX IF NOT EXISTS idx_recommendation_movies_rec_id
   ON recommendation_movies (recommendation_id);

--- a/db/recommendations.sql
+++ b/db/recommendations.sql
@@ -13,7 +13,9 @@ CREATE TABLE IF NOT EXISTS recommendations (
   completed_at        timestamptz,
   used_broader_search boolean,
   db_movie_count      integer,
-  more_picks_status   text                                       -- null | pending | processing | completed | failed
+  more_picks_status   text,                                      -- null | pending | processing | completed | failed
+  source_strategy     text        NOT NULL DEFAULT 'hybrid-fast',
+  experience_mode     text        NOT NULL DEFAULT 'normal-match'
   -- future: rating smallint CHECK (rating BETWEEN 1 AND 5)
 );
 
@@ -29,15 +31,41 @@ ALTER TABLE recommendations
 ALTER TABLE recommendations
   ADD COLUMN IF NOT EXISTS stage text;
 
+ALTER TABLE recommendations
+  ADD COLUMN IF NOT EXISTS source_strategy text;
+
+ALTER TABLE recommendations
+  ADD COLUMN IF NOT EXISTS experience_mode text;
+
 UPDATE recommendations
    SET stage = 'queued'
  WHERE stage IS NULL;
+
+UPDATE recommendations
+   SET source_strategy = 'hybrid-fast'
+ WHERE source_strategy IS NULL;
+
+UPDATE recommendations
+   SET experience_mode = 'normal-match'
+ WHERE experience_mode IS NULL;
 
 ALTER TABLE recommendations
   ALTER COLUMN stage SET DEFAULT 'queued';
 
 ALTER TABLE recommendations
   ALTER COLUMN stage SET NOT NULL;
+
+ALTER TABLE recommendations
+  ALTER COLUMN source_strategy SET DEFAULT 'hybrid-fast';
+
+ALTER TABLE recommendations
+  ALTER COLUMN source_strategy SET NOT NULL;
+
+ALTER TABLE recommendations
+  ALTER COLUMN experience_mode SET DEFAULT 'normal-match';
+
+ALTER TABLE recommendations
+  ALTER COLUMN experience_mode SET NOT NULL;
 
 UPDATE recommendations
    SET slug = REPLACE(id::text, '-', '')
@@ -71,7 +99,8 @@ CREATE TABLE IF NOT EXISTS recommendation_movies (
   tmdb_year             integer,
   tmdb_score_rating     float,
   tmdb_duration         integer,
-  tmdb_age_rating       text
+  tmdb_age_rating       text,
+  source                text       NOT NULL DEFAULT 'local-cache'
 );
 
 ALTER TABLE recommendation_movies
@@ -100,6 +129,19 @@ ALTER TABLE recommendation_movies
 
 ALTER TABLE recommendation_movies
   ADD COLUMN IF NOT EXISTS tmdb_age_rating text;
+
+ALTER TABLE recommendation_movies
+  ADD COLUMN IF NOT EXISTS source text;
+
+UPDATE recommendation_movies
+   SET source = CASE WHEN from_tmdb THEN 'tmdb-discover' ELSE 'local-cache' END
+ WHERE source IS NULL;
+
+ALTER TABLE recommendation_movies
+  ALTER COLUMN source SET DEFAULT 'local-cache';
+
+ALTER TABLE recommendation_movies
+  ALTER COLUMN source SET NOT NULL;
 
 CREATE INDEX IF NOT EXISTS idx_recommendation_movies_rec_id
   ON recommendation_movies (recommendation_id);


### PR DESCRIPTION
Adds the recommendation source-strategy foundation: explicit source policy, candidate provenance through API/jobs/persistence/workers, and deterministic eval source-distribution scoring. Validation: targeted tests, format, lint, eval:recommendations 27/27, type-check, pre-push lint/server tests/build.