### PR TITLE
Add metadata v1 recommendation quality layer

### DIFF
--- a/apps/web/e2e/available-movies.spec.ts
+++ b/apps/web/e2e/available-movies.spec.ts
@@ -16,7 +16,7 @@ test('renders seeded catalog data and filters it through the real movies API', a
   await page.goto('/available-movies');
 
   await expect(page.getByRole('heading', { name: 'Available Movies' })).toBeVisible();
-  await expect(page.getByText(/Showing 1.6 of 6 movies/)).toBeVisible();
+  await expect(page.getByText(/Showing 1.7 of 7 movies/)).toBeVisible();
   await expect(page.getByText('PopChoice E2E Space Opera')).toBeVisible();
   await expect(page.getByText('PopChoice E2E Short Comedy')).toBeVisible();
 
@@ -50,7 +50,7 @@ test('shows a useful empty state when catalog filters match nothing', async ({ p
   await page.goto('/available-movies');
 
   await expect(page.getByRole('heading', { name: 'Available Movies' })).toBeVisible();
-  await expect(page.getByText(/Showing 1.6 of 6 movies/)).toBeVisible();
+  await expect(page.getByText(/Showing 1.7 of 7 movies/)).toBeVisible();
 
   await page.getByPlaceholder('Title, actor, director, or genre').fill('No Such PopChoice Fixture');
   await page.getByRole('button', { name: 'Apply' }).click();
@@ -61,6 +61,6 @@ test('shows a useful empty state when catalog filters match nothing', async ({ p
 
   await page.locator('form').getByRole('button', { name: 'Clear' }).click();
 
-  await expect(page.getByText(/Showing 1.6 of 6 movies/)).toBeVisible();
+  await expect(page.getByText(/Showing 1.7 of 7 movies/)).toBeVisible();
   await expect(page.getByText('PopChoice E2E Space Opera')).toBeVisible();
 });

--- a/apps/web/src/features/catalogMaintenance/tmdb.test.ts
+++ b/apps/web/src/features/catalogMaintenance/tmdb.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractCatalogMetadata, extractUSCertification, getMetadataQualityScore } from './tmdb';
+
+import type { TMDBMovieDetails } from './tmdb';
+
+function makeDetails(overrides: Partial<TMDBMovieDetails> = {}): TMDBMovieDetails {
+  return {
+    id: 42,
+    title: 'Metadata Movie',
+    original_title: 'Metadata Movie Original',
+    original_language: 'en',
+    overview: 'A strong metadata fixture.',
+    release_date: '2024-05-01',
+    vote_average: 7.9,
+    vote_count: 1200,
+    popularity: 88,
+    runtime: 118,
+    poster_path: '/poster.jpg',
+    genres: [{ id: 878, name: 'Science Fiction' }],
+    credits: {
+      cast: [
+        {
+          credit_id: 'cast-1',
+          id: 1,
+          name: 'Lead Actor',
+          order: 0,
+          popularity: 50,
+        },
+      ],
+      crew: [
+        {
+          credit_id: 'crew-1',
+          department: 'Directing',
+          id: 2,
+          job: 'Director',
+          name: 'Main Director',
+        },
+      ],
+    },
+    keywords: { keywords: [{ id: 10, name: 'space travel' }] },
+    release_dates: {
+      results: [
+        {
+          iso_3166_1: 'US',
+          release_dates: [{ certification: 'PG-13', type: 3 }],
+        },
+      ],
+    },
+    spoken_languages: [{ english_name: 'English', iso_639_1: 'en', name: 'English' }],
+    production_countries: [{ iso_3166_1: 'US', name: 'United States of America' }],
+    'watch/providers': {
+      results: {
+        FI: {
+          flatrate: [
+            {
+              display_priority: 2,
+              logo_path: '/fi.png',
+              provider_id: 20,
+              provider_name: 'FI Stream',
+            },
+          ],
+          link: 'https://tmdb.example/fi',
+        },
+        RU: {
+          buy: [
+            {
+              display_priority: 3,
+              provider_id: 30,
+              provider_name: 'RU Buy',
+            },
+          ],
+          link: 'https://tmdb.example/ru',
+        },
+        US: {
+          rent: [
+            {
+              display_priority: 1,
+              logo_path: '/us.png',
+              provider_id: 10,
+              provider_name: 'US Rent',
+            },
+          ],
+          link: 'https://tmdb.example/us',
+        },
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('catalog TMDB metadata extraction', () => {
+  it('extracts pragmatic-core metadata including providers for configured regions', () => {
+    const metadata = extractCatalogMetadata(makeDetails());
+
+    expect(extractUSCertification(makeDetails())).toBe('PG-13');
+    expect(metadata.genres).toEqual([
+      expect.objectContaining({ name: 'Science Fiction', tmdbId: 878 }),
+    ]);
+    expect(metadata.keywords).toEqual([
+      expect.objectContaining({ name: 'space travel', tmdbId: 10 }),
+    ]);
+    expect(metadata.people.map((person) => person.role)).toEqual(['cast', 'director']);
+    expect(metadata.providers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          availabilityType: 'rent',
+          providerId: 10,
+          providerName: 'US Rent',
+          region: 'US',
+        }),
+        expect.objectContaining({
+          availabilityType: 'flatrate',
+          providerId: 20,
+          region: 'FI',
+        }),
+        expect.objectContaining({
+          availabilityType: 'buy',
+          providerId: 30,
+          region: 'RU',
+        }),
+      ]),
+    );
+    expect(metadata.snapshot).toMatchObject({
+      certification: 'PG-13',
+      metadata_quality_flags: [],
+      metadata_quality_score: 100,
+      original_language: 'en',
+      original_title: 'Metadata Movie Original',
+      popularity: 88,
+      vote_count: 1200,
+    });
+  });
+
+  it('scores missing metadata with actionable flags', () => {
+    const metadata = extractCatalogMetadata(
+      makeDetails({
+        credits: { cast: [], crew: [] },
+        genres: [],
+        keywords: { keywords: [] },
+        original_language: '',
+        popularity: 0,
+        poster_path: null,
+        release_dates: { results: [] },
+        runtime: 0,
+        vote_count: 0,
+        'watch/providers': { results: {} },
+      }),
+    );
+
+    expect(metadata.qualityFlags).toEqual(
+      expect.arrayContaining([
+        'missing_runtime',
+        'missing_certification',
+        'missing_poster',
+        'missing_original_language',
+        'missing_vote_count',
+        'missing_popularity',
+        'missing_genres',
+        'missing_keywords',
+        'missing_cast',
+        'missing_director',
+        'missing_provider_us',
+        'missing_provider_fi',
+        'missing_provider_ru',
+      ]),
+    );
+    expect(metadata.qualityScore).toBeLessThan(70);
+    expect(getMetadataQualityScore([])).toBe(100);
+  });
+});

--- a/apps/web/src/features/catalogMaintenance/tmdb.ts
+++ b/apps/web/src/features/catalogMaintenance/tmdb.ts
@@ -10,6 +10,8 @@ const TMDB_IMAGE_BASE_URL = 'https://image.tmdb.org/t/p';
 const TMDB_FETCH_TIMEOUT_MS = 8_000;
 const MAX_CAST_CREDITS = 12;
 const MAX_KEYWORDS = 20;
+const SUPPORTED_PROVIDER_REGIONS = ['US', 'FI', 'RU'] as const;
+const WATCH_PROVIDER_TYPES = ['flatrate', 'rent', 'buy', 'ads', 'free'] as const;
 
 type TMDBGenre = {
   id: number;
@@ -41,14 +43,38 @@ type TMDBKeyword = {
   name: string;
 };
 
+type TMDBWatchProvider = {
+  provider_id: number;
+  provider_name: string;
+  logo_path?: string | null;
+  display_priority?: number | null;
+};
+
+type TMDBWatchProviderRegion = {
+  link?: string | null;
+} & Partial<Record<(typeof WATCH_PROVIDER_TYPES)[number], TMDBWatchProvider[]>>;
+
 export type TMDBMovieDetails = {
   id: number;
   title: string;
+  original_title?: string | null;
+  original_language?: string | null;
   overview: string;
   release_date: string;
   vote_average: number;
+  vote_count?: number | null;
+  popularity?: number | null;
   runtime: number | null;
   poster_path: string | null;
+  spoken_languages?: Array<{
+    english_name?: string | null;
+    iso_639_1?: string | null;
+    name?: string | null;
+  }>;
+  production_countries?: Array<{
+    iso_3166_1?: string | null;
+    name?: string | null;
+  }>;
   genres?: TMDBGenre[];
   credits?: {
     cast?: TMDBCastCredit[];
@@ -65,6 +91,9 @@ export type TMDBMovieDetails = {
         type: number;
       }>;
     }>;
+  };
+  'watch/providers'?: {
+    results?: Record<string, TMDBWatchProviderRegion>;
   };
 };
 
@@ -92,6 +121,18 @@ export type TMDBCatalogMetadata = {
     name: string;
     rawMetadata: Record<string, unknown>;
   }>;
+  providers: Array<{
+    providerId: number;
+    providerName: string;
+    logoPath: string | null;
+    displayPriority: number | null;
+    region: string;
+    availabilityType: (typeof WATCH_PROVIDER_TYPES)[number];
+    link: string | null;
+    rawMetadata: Record<string, unknown>;
+  }>;
+  qualityFlags: string[];
+  qualityScore: number;
   snapshot: Record<string, unknown>;
 };
 
@@ -152,7 +193,7 @@ export async function fetchMovieDetails(
 ): Promise<TMDBMovieDetails | null> {
   try {
     const response = await tmdbGet(apiKey, `/movie/${movieId}`, {
-      append_to_response: 'release_dates,credits,keywords',
+      append_to_response: 'release_dates,credits,keywords,watch/providers',
       language,
     });
 
@@ -372,6 +413,87 @@ export function extractUSCertification(details: TMDBMovieDetails): string {
   return (theatrical ?? any)?.certification || 'NR';
 }
 
+function extractWatchProviders(details: TMDBMovieDetails): TMDBCatalogMetadata['providers'] {
+  const results = details['watch/providers']?.results ?? {};
+  return SUPPORTED_PROVIDER_REGIONS.flatMap((region) => {
+    const regionProviders = results[region];
+    if (!regionProviders) return [];
+    const link = regionProviders.link ?? null;
+
+    return WATCH_PROVIDER_TYPES.flatMap((availabilityType) =>
+      (regionProviders[availabilityType] ?? [])
+        .filter(
+          (provider) =>
+            Number.isFinite(provider.provider_id) && provider.provider_name.trim().length > 0,
+        )
+        .map((provider) => ({
+          availabilityType,
+          displayPriority: provider.display_priority ?? null,
+          link,
+          logoPath: provider.logo_path ?? null,
+          providerId: provider.provider_id,
+          providerName: provider.provider_name,
+          rawMetadata: provider as unknown as Record<string, unknown>,
+          region,
+        })),
+    );
+  });
+}
+
+function getMetadataQualityFlags(input: {
+  ageRating: string;
+  details: TMDBMovieDetails;
+  genres: TMDBCatalogMetadata['genres'];
+  keywords: TMDBCatalogMetadata['keywords'];
+  people: TMDBCatalogMetadata['people'];
+  providers: TMDBCatalogMetadata['providers'];
+}): string[] {
+  const flags: string[] = [];
+  if (!input.details.runtime || input.details.runtime <= 0) flags.push('missing_runtime');
+  if (!input.ageRating || input.ageRating === 'NR') flags.push('missing_certification');
+  if (!input.details.poster_path) flags.push('missing_poster');
+  if (!input.details.overview?.trim()) flags.push('missing_overview');
+  if (!input.details.original_language?.trim()) flags.push('missing_original_language');
+  if (!Number.isFinite(input.details.vote_count) || Number(input.details.vote_count ?? 0) <= 0) {
+    flags.push('missing_vote_count');
+  }
+  if (!Number.isFinite(input.details.popularity) || Number(input.details.popularity ?? 0) <= 0) {
+    flags.push('missing_popularity');
+  }
+  if (input.genres.length === 0) flags.push('missing_genres');
+  if (input.keywords.length === 0) flags.push('missing_keywords');
+  if (!input.people.some((person) => person.role === 'cast')) flags.push('missing_cast');
+  if (!input.people.some((person) => person.role === 'director')) flags.push('missing_director');
+  for (const region of SUPPORTED_PROVIDER_REGIONS) {
+    if (!input.providers.some((provider) => provider.region === region)) {
+      flags.push(`missing_provider_${region.toLowerCase()}`);
+    }
+  }
+  return flags;
+}
+
+export function getMetadataQualityScore(flags: string[]): number {
+  const penaltyByFlag: Record<string, number> = {
+    missing_runtime: 15,
+    missing_certification: 12,
+    missing_poster: 8,
+    missing_overview: 12,
+    missing_original_language: 4,
+    missing_vote_count: 8,
+    missing_popularity: 6,
+    missing_genres: 12,
+    missing_keywords: 8,
+    missing_cast: 6,
+    missing_director: 6,
+    missing_provider_us: 1,
+    missing_provider_fi: 1,
+    missing_provider_ru: 1,
+  };
+
+  const penalty = flags.reduce((sum, flag) => sum + (penaltyByFlag[flag] ?? 4), 0);
+  return Math.max(0, Math.min(100, 100 - penalty));
+}
+
 export function extractCatalogMetadata(details: TMDBMovieDetails): TMDBCatalogMetadata {
   const genres = (details.genres ?? [])
     .filter((genre) => Number.isFinite(genre.id) && genre.name)
@@ -429,18 +551,39 @@ export function extractCatalogMetadata(details: TMDBMovieDetails): TMDBCatalogMe
       name: keyword.name,
       rawMetadata: keyword as unknown as Record<string, unknown>,
     }));
-
-  return {
-    people: [...cast, ...directors],
+  const providers = extractWatchProviders(details);
+  const people = [...cast, ...directors];
+  const ageRating = extractUSCertification(details);
+  const qualityFlags = getMetadataQualityFlags({
+    ageRating,
+    details,
     genres,
     keywords,
+    people,
+    providers,
+  });
+
+  return {
+    people,
+    genres,
+    keywords,
+    providers,
+    qualityFlags,
+    qualityScore: getMetadataQualityScore(qualityFlags),
     snapshot: {
       id: details.id,
       title: details.title,
+      original_title: details.original_title ?? null,
+      original_language: details.original_language ?? null,
       release_date: details.release_date,
       runtime: details.runtime,
       vote_average: details.vote_average,
+      vote_count: details.vote_count ?? null,
+      popularity: details.popularity ?? null,
       poster_path: details.poster_path,
+      spoken_languages: details.spoken_languages ?? [],
+      production_countries: details.production_countries ?? [],
+      certification: ageRating,
       genres: genres.map(({ tmdbId, name }) => ({ id: tmdbId, name })),
       cast: cast.map(({ tmdbId, name, characterName, billingOrder }) => ({
         id: tmdbId,
@@ -450,6 +593,17 @@ export function extractCatalogMetadata(details: TMDBMovieDetails): TMDBCatalogMe
       })),
       directors: directors.map(({ tmdbId, name, job }) => ({ id: tmdbId, name, job })),
       keywords: keywords.map(({ tmdbId, name }) => ({ id: tmdbId, name })),
+      providers: providers.map(
+        ({ providerId, providerName, region, availabilityType, displayPriority }) => ({
+          id: providerId,
+          name: providerName,
+          region,
+          type: availabilityType,
+          display_priority: displayPriority,
+        }),
+      ),
+      metadata_quality_score: getMetadataQualityScore(qualityFlags),
+      metadata_quality_flags: qualityFlags,
     },
   };
 }

--- a/apps/web/src/features/recommendation/evals/fixtures.ts
+++ b/apps/web/src/features/recommendation/evals/fixtures.ts
@@ -239,6 +239,8 @@ function toSimilarMovie(
     year: candidate.year,
     ...details,
     fromTMDB,
+    metadataQualityFlags: [],
+    metadataQualityScore: 100,
     source,
     ...(isMainRecommendation ? { isMainRecommendation } : {}),
   };

--- a/apps/web/src/features/recommendation/evals/scoring.ts
+++ b/apps/web/src/features/recommendation/evals/scoring.ts
@@ -365,7 +365,9 @@ function getQualityThresholdResult(
         movie.year > 0 &&
         movie.duration > 0 &&
         movie.score_rating > 0 &&
-        movie.age_rating.trim().length > 0,
+        movie.age_rating.trim().length > 0 &&
+        typeof movie.metadataQualityScore === 'number' &&
+        movie.metadataQualityScore >= 70,
     ).length ?? 0;
   const metadataPassed = metadataCompleteCount >= minMetadataComplete;
 

--- a/apps/web/src/features/recommendation/pipeline.ts
+++ b/apps/web/src/features/recommendation/pipeline.ts
@@ -36,6 +36,7 @@ import {
 import { resolveRecommendationSourceStrategy } from './sourceStrategyPolicy';
 import {
   MAX_TOTAL_MOVIES,
+  enrichTMDBMatchesWithDetails,
   fetchTMDBDiscoverMovies,
   parseTMDBReleaseYear,
   scoreAndConvertTMDBMovies,
@@ -237,10 +238,10 @@ export async function runRecommendationPipeline(
           .slice(0, slotsRemaining);
         const newTMDBMatches = await scoreAndConvertTMDBMovies(filteredTMDBMovies, embedding);
         const tmdbEmbeddings = newTMDBMatches.embeddings;
-        const newTMDBMatchList = applyFeedbackToLocalMovies(
-          newTMDBMatches.matches,
-          feedbackSignals,
-        );
+        const enrichedTMDBMatches = prefersTMDBCandidates
+          ? await enrichTMDBMatchesWithDetails(newTMDBMatches.matches, tmdbApiKey, locale)
+          : newTMDBMatches.matches;
+        const newTMDBMatchList = applyFeedbackToLocalMovies(enrichedTMDBMatches, feedbackSignals);
 
         if (prefersTMDBCandidates) {
           similarMovies = [...newTMDBMatchList, ...localResultsForMerge]
@@ -417,7 +418,12 @@ export async function runRecommendationPipeline(
         posterURL: movie.posterURL,
         aiDescription: movie.aiDescription,
         localizedName: movie.localizedName,
+        metadataQualityScore: movie.metadataQualityScore,
+        metadataQualityFlags: movie.metadataQualityFlags,
+        originalLanguage: movie.originalLanguage,
+        voteCount: movie.voteCount,
         popularity: movie.popularity,
+        watchProviders: movie.watchProviders,
         isMainRecommendation: recommendedMovie ? movie.id === recommendedMovie.id : false,
         fromTMDB: Number(movie.id) < 0,
         source,

--- a/apps/web/src/features/recommendation/recommendation.ts
+++ b/apps/web/src/features/recommendation/recommendation.ts
@@ -59,10 +59,45 @@ IMPORTANT: The "title" field must be returned exactly as it appears in the provi
 
 const movieService = new MovieService();
 
+const MAX_LOCAL_METADATA_QUALITY_BOOST = 0.02;
+const LOW_LOCAL_METADATA_QUALITY_PENALTY = 0.02;
+
 type LocalMatchRow = EnhancedMovieMatch & {
   tmdb_id?: number | null;
   tmdb_match_source?: string | null;
+  original_language?: string | null;
+  vote_count?: number | null;
+  popularity?: number | null;
+  metadata_quality_score?: number | null;
+  metadata_quality_flags?: unknown;
 };
+
+function normalizeMetadataQualityFlags(flags: unknown): string[] | undefined {
+  if (!Array.isArray(flags)) {
+    return undefined;
+  }
+
+  return flags.filter((flag): flag is string => typeof flag === 'string');
+}
+
+function adjustLocalSimilarityForMetadata(movie: LocalMatchRow): number {
+  const score =
+    typeof movie.metadata_quality_score === 'number' &&
+    Number.isFinite(movie.metadata_quality_score)
+      ? Math.max(0, Math.min(100, movie.metadata_quality_score))
+      : null;
+  const base = Number.isFinite(movie.similarity) ? movie.similarity : 0;
+
+  if (score === null) {
+    return Number((base - LOW_LOCAL_METADATA_QUALITY_PENALTY).toFixed(6));
+  }
+
+  if (score < 50) {
+    return Number((base - LOW_LOCAL_METADATA_QUALITY_PENALTY).toFixed(6));
+  }
+
+  return Number((base + (score / 100) * MAX_LOCAL_METADATA_QUALITY_BOOST).toFixed(6));
+}
 
 // ---------------------------------------------------------------------------
 // Vector DB search
@@ -89,9 +124,18 @@ async function findNearestMatch(embedding: number[]): Promise<EnhancedMovieMatch
   return (data as LocalMatchRow[])
     .map((movie) => ({
       ...movie,
+      similarity: adjustLocalSimilarityForMetadata(movie),
       source: getLocalCandidateSource(movie.tmdb_match_source),
       tmdbId: movie.tmdb_id ?? movie.tmdbId ?? null,
       tmdbMatchSource: movie.tmdb_match_source ?? movie.tmdbMatchSource ?? null,
+      originalLanguage: movie.original_language ?? movie.originalLanguage ?? null,
+      voteCount: movie.vote_count ?? movie.voteCount ?? null,
+      popularity: movie.popularity ?? movie.popularity ?? null,
+      metadataQualityScore: movie.metadata_quality_score ?? movie.metadataQualityScore ?? 0,
+      metadataQualityFlags:
+        normalizeMetadataQualityFlags(movie.metadata_quality_flags) ??
+        movie.metadataQualityFlags ??
+        [],
     }))
     .sort((a, b) => b.similarity - a.similarity);
 }

--- a/apps/web/src/features/recommendation/tmdb.test.ts
+++ b/apps/web/src/features/recommendation/tmdb.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  buildTMDBDiscoverQueryShape,
+  enrichTMDBMatchesWithDetails,
+  fetchTMDBDiscoverMovies,
+} from './tmdb';
+
+import type { EnhancedMovieMatch, PersonFormData } from './types';
+
+const basePerson: PersonFormData = {
+  favoriteMovie: 'The Matrix',
+  favoriteMovieWhy: 'Smart genre momentum.',
+  moodPreference: ['Sci-Fi', 'Action'],
+  newVsClassic: 'Both new and classic',
+  tonePreference: 'Balanced',
+};
+
+function personWith(overrides: Partial<PersonFormData>): PersonFormData {
+  return { ...basePerson, ...overrides };
+}
+
+describe('buildTMDBDiscoverQueryShape', () => {
+  it('turns hard avoids and safe discovery appetite into bounded TMDB discover params', () => {
+    const shape = buildTMDBDiscoverQueryShape([
+      personWith({
+        favoriteMovieWhy: 'Avoid: horror, gore, long runtime. Discovery appetite: Safe hit.',
+        moodPreference: ['Horror', 'Sci-Fi', 'Action'],
+        tonePreference: 'Dark and intense',
+      }),
+    ]);
+
+    expect(shape.genreIds).toEqual([878, 28]);
+    expect(shape.withoutGenreIds).toEqual([27]);
+    expect(shape.voteCountGte).toBe(500);
+    expect(shape.with_runtime_lte).toBe(125);
+    expect(shape.sortBy).toBe('popularity.desc');
+  });
+
+  it('keeps surprise discovery broader while preserving serious tone sorting', () => {
+    const shape = buildTMDBDiscoverQueryShape([
+      personWith({
+        favoriteMovieWhy: 'Discovery appetite: Surprise me.',
+        tonePreference: 'Serious and thought-provoking',
+      }),
+    ]);
+
+    expect(shape.voteCountGte).toBe(50);
+    expect(shape.sortBy).toBe('vote_average.desc');
+  });
+});
+
+describe('fetchTMDBDiscoverMovies', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.clearAllMocks();
+  });
+
+  it('passes shaped hard-avoid and discovery params to TMDB discover', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          results: [
+            {
+              genre_ids: [878],
+              id: 100,
+              overview: 'A space adventure.',
+              poster_path: null,
+              release_date: '2020-01-01',
+              title: 'Space Adventure',
+              vote_average: 7.4,
+            },
+          ],
+        }),
+    } as Response);
+
+    await fetchTMDBDiscoverMovies(
+      [
+        personWith({
+          favoriteMovieWhy: 'Avoid: horror, long runtime. Discovery appetite: Safe hit.',
+          moodPreference: ['Horror', 'Sci-Fi'],
+        }),
+      ],
+      'test-token',
+    );
+
+    const [url] = vi.mocked(global.fetch).mock.calls[0] ?? [];
+    expect(typeof url).toBe('string');
+    const parsedUrl = new URL(String(url));
+    expect(parsedUrl.pathname).toBe('/3/discover/movie');
+    expect(parsedUrl.searchParams.get('with_genres')).toBe('878');
+    expect(parsedUrl.searchParams.get('without_genres')).toBe('27');
+    expect(parsedUrl.searchParams.get('vote_count.gte')).toBe('500');
+    expect(parsedUrl.searchParams.get('with_runtime.lte')).toBe('125');
+  });
+});
+
+describe('enrichTMDBMatchesWithDetails', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.clearAllMocks();
+  });
+
+  it('enriches bounded direct TMDB matches with pragmatic metadata', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          id: 100,
+          title: 'Space Adventure',
+          original_title: 'Space Adventure Original',
+          original_language: 'en',
+          overview: 'A richer details overview.',
+          release_date: '2021-02-03',
+          vote_average: 8.1,
+          vote_count: 1400,
+          popularity: 75,
+          runtime: 122,
+          poster_path: '/poster.jpg',
+          genres: [{ id: 878, name: 'Science Fiction' }],
+          credits: {
+            cast: [{ credit_id: 'cast-1', id: 1, name: 'Lead Actor', order: 0 }],
+            crew: [{ credit_id: 'crew-1', id: 2, job: 'Director', name: 'Director' }],
+          },
+          keywords: { keywords: [{ id: 3, name: 'space travel' }] },
+          release_dates: {
+            results: [
+              {
+                iso_3166_1: 'US',
+                release_dates: [{ certification: 'PG-13', type: 3 }],
+              },
+            ],
+          },
+          'watch/providers': {
+            results: {
+              US: {
+                flatrate: [{ provider_id: 10, provider_name: 'US Stream', display_priority: 1 }],
+              },
+            },
+          },
+        }),
+    } as Response);
+
+    const matches: EnhancedMovieMatch[] = [
+      {
+        age_rating: 'NR',
+        content: 'Space Adventure',
+        description: 'Short discover overview.',
+        duration: 0,
+        id: -100,
+        name: 'Space Adventure',
+        score_rating: 7.4,
+        similarity: 0.5,
+        tmdbId: 100,
+        year: 2020,
+      },
+    ];
+
+    const [enriched] = await enrichTMDBMatchesWithDetails(matches, 'token', 'en');
+
+    expect(enriched).toMatchObject({
+      age_rating: 'PG-13',
+      duration: 122,
+      metadataQualityScore: expect.any(Number),
+      originalLanguage: 'en',
+      popularity: 75,
+      posterURL: 'https://image.tmdb.org/t/p/w500/poster.jpg',
+      score_rating: 8.1,
+      voteCount: 1400,
+      watchProviders: [
+        expect.objectContaining({
+          availabilityType: 'flatrate',
+          providerId: 10,
+          providerName: 'US Stream',
+          region: 'US',
+        }),
+      ],
+      year: 2021,
+    });
+    expect(enriched?.similarity).toBeGreaterThan(0.5);
+  });
+});

--- a/apps/web/src/features/recommendation/tmdb.ts
+++ b/apps/web/src/features/recommendation/tmdb.ts
@@ -2,7 +2,14 @@ import z from 'zod';
 
 import { getDbClient } from '@/clients/dbClient';
 import { getOpenAIClient } from '@/clients/openaiClient';
+import {
+  extractCatalogMetadata,
+  extractUSCertification,
+  fetchMovieDetails,
+  getPosterUrl,
+} from '@/features/catalogMaintenance/tmdb';
 import { IMAGE_BASE_URL } from '@/integrations/tmdb';
+import { LOCALE_TO_TMDB_LANG } from '@/lib/locale';
 import logger from '@/lib/logger';
 import { recordOpenAIProviderError, recordTMDBProviderError } from '@/lib/metrics';
 import { MODELS } from '@/lib/models';
@@ -17,6 +24,8 @@ import {
 import { MAX_JIT_SEED_MOVIES, MAX_TOTAL_MOVIES } from './config';
 
 import type { EnhancedMovieMatch, PersonFormData } from './types';
+import type { TMDBMovieDetails } from '@/features/catalogMaintenance/tmdb';
+import type { Locale } from '@/lib/locale';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -29,6 +38,8 @@ const TMDB_API_BASE = 'https://api.themoviedb.org/3';
 
 /** Timeout for TMDB discover requests in the main recommendation route. */
 const TMDB_DISCOVER_FETCH_TIMEOUT_MS = 8_000;
+const MAX_TMDB_DETAILS_ENRICHMENT = 8;
+const MAX_METADATA_QUALITY_SIMILARITY_BOOST = 0.03;
 
 const tmdbDiscoverMovieSchema = z.object({
   id: z.number(),
@@ -36,6 +47,10 @@ const tmdbDiscoverMovieSchema = z.object({
   overview: z.string(),
   release_date: z.string(),
   vote_average: z.number(),
+  vote_count: z.number().optional(),
+  popularity: z.number().optional(),
+  original_language: z.string().optional(),
+  original_title: z.string().optional(),
   genre_ids: z.array(z.number()).optional(),
   poster_path: z.string().nullable(),
 });
@@ -325,6 +340,82 @@ export async function scoreAndConvertTMDBMovies(
   return { matches, embeddings: embeddingsMap };
 }
 
+export async function enrichTMDBMatchesWithDetails(
+  matches: EnhancedMovieMatch[],
+  tmdbApiKey: string,
+  locale: Locale,
+): Promise<EnhancedMovieMatch[]> {
+  const tmdbMatches = matches
+    .filter((movie) => movie.tmdbId && movie.id < 0)
+    .slice(0, MAX_TMDB_DETAILS_ENRICHMENT);
+  if (tmdbMatches.length === 0) return matches;
+
+  const language = LOCALE_TO_TMDB_LANG[locale] ?? 'en-US';
+  const detailsByTMDBId = new Map(
+    (
+      await Promise.all(
+        tmdbMatches.map(async (movie) => {
+          const tmdbId = movie.tmdbId;
+          if (!tmdbId) return null;
+          const details = await fetchMovieDetails(tmdbApiKey, tmdbId, language);
+          return details ? ([tmdbId, details] as const) : null;
+        }),
+      )
+    ).filter((entry): entry is readonly [number, TMDBMovieDetails] => entry !== null),
+  );
+
+  return matches.map((movie) => {
+    if (!movie.tmdbId || movie.id >= 0) return movie;
+    const details = detailsByTMDBId.get(movie.tmdbId);
+    if (!details) {
+      return {
+        ...movie,
+        metadataQualityFlags: [...(movie.metadataQualityFlags ?? []), 'missing_details'],
+        metadataQualityScore: movie.metadataQualityScore ?? 0,
+      };
+    }
+
+    const metadata = extractCatalogMetadata(details);
+    const ageRating = extractUSCertification(details);
+    const runtime = details.runtime ?? movie.duration;
+    const scoreRating = Number((details.vote_average ?? movie.score_rating ?? 0).toFixed(1));
+    const qualityBoost = (metadata.qualityScore / 100) * MAX_METADATA_QUALITY_SIMILARITY_BOOST;
+
+    return {
+      ...movie,
+      age_rating: ageRating,
+      content: [
+        `${details.title} (${parseTMDBReleaseYear(details.release_date)}) | ${ageRating}`,
+        `Duration: ${runtime || 'unknown'} min | TMDB Score: ${scoreRating}/10`,
+        details.overview || movie.description || '',
+      ]
+        .filter(Boolean)
+        .join('\n'),
+      description: details.overview || movie.description,
+      duration: runtime,
+      metadataQualityFlags: metadata.qualityFlags,
+      metadataQualityScore: metadata.qualityScore,
+      name: details.title || movie.name,
+      originalLanguage: details.original_language ?? null,
+      popularity: details.popularity ?? null,
+      posterURL: getPosterUrl(details.poster_path) ?? movie.posterURL,
+      score_rating: scoreRating,
+      similarity: Number((movie.similarity + qualityBoost).toFixed(6)),
+      voteCount: details.vote_count ?? null,
+      watchProviders: metadata.providers.map(
+        ({ availabilityType, displayPriority, providerId, providerName, region }) => ({
+          availabilityType,
+          displayPriority,
+          providerId,
+          providerName,
+          region,
+        }),
+      ),
+      year: parseTMDBReleaseYear(details.release_date) || movie.year,
+    };
+  });
+}
+
 /**
  * Convert a TMDB discover result to the EnhancedMovieMatch shape used by the rest of the route.
  * Uses a negative TMDB ID so it is distinct from positive local DB IDs.
@@ -354,8 +445,11 @@ function tmdbMovieToEnhancedMatch(
     year,
     similarity,
     content,
+    originalLanguage: movie.original_language ?? null,
+    popularity: movie.popularity ?? null,
     posterURL,
     source: 'tmdb-discover',
+    voteCount: movie.vote_count ?? null,
   };
 }
 

--- a/apps/web/src/features/recommendation/types.ts
+++ b/apps/web/src/features/recommendation/types.ts
@@ -154,7 +154,22 @@ export const apiResponseSchema = z.object({
         posterURL: z.string().url().optional(), // Added poster URL support
         aiDescription: z.string().optional(), // Added AI-generated description
         localizedName: z.string().optional(), // Localized title from TMDB
+        metadataQualityScore: z.number().optional(),
+        metadataQualityFlags: z.array(z.string()).optional(),
+        originalLanguage: z.string().nullable().optional(),
+        voteCount: z.number().nullable().optional(),
         popularity: z.number().nullable().optional(),
+        watchProviders: z
+          .array(
+            z.object({
+              providerId: z.number(),
+              providerName: z.string(),
+              region: z.string(),
+              availabilityType: z.enum(['flatrate', 'rent', 'buy', 'ads', 'free']),
+              displayPriority: z.number().nullable().optional(),
+            }),
+          )
+          .optional(),
         isMainRecommendation: z.boolean().optional(), // Mark main recommendation
         fromTMDB: z.boolean().optional(), // True for movies sourced from TMDB fallback
         source: candidateSourceSchema.optional(), // First-class candidate provenance
@@ -202,7 +217,18 @@ export type EnhancedMovieMatch = {
   posterURL?: string;
   source?: CandidateSource;
   tmdbMatchSource?: string | null;
+  metadataQualityScore?: number;
+  metadataQualityFlags?: string[];
+  originalLanguage?: string | null;
+  voteCount?: number | null;
   popularity?: number | null;
+  watchProviders?: Array<{
+    providerId: number;
+    providerName: string;
+    region: string;
+    availabilityType: 'flatrate' | 'rent' | 'buy' | 'ads' | 'free';
+    displayPriority?: number | null;
+  }>;
 };
 
 /** Minimal movie match returned from the vector DB RPC. */

--- a/apps/web/src/lib/workers/catalogMaintenanceWorker.ts
+++ b/apps/web/src/lib/workers/catalogMaintenanceWorker.ts
@@ -278,6 +278,7 @@ async function processSeedTMDBMovie(job: Job<CatalogSeedTMDBMovieJobData>): Prom
         people: metadata.people,
         genres: metadata.genres,
         keywords: metadata.keywords,
+        providers: metadata.providers,
       });
     }
     logger.debug({ jobId: job.id, tmdbId: movie.id }, 'Catalog seed skipped existing movie');
@@ -288,6 +289,7 @@ async function processSeedTMDBMovie(job: Job<CatalogSeedTMDBMovieJobData>): Prom
   const runtime = details?.runtime ?? 0;
   const description = details?.overview || movie.overview || 'No description available.';
   const scoreRating = Number((details?.vote_average ?? movie.vote_average ?? 0).toFixed(1));
+  const metadata = details ? extractCatalogMetadata(details) : null;
   let embedding = job.data.embedding;
 
   if (!embedding) {
@@ -321,6 +323,13 @@ async function processSeedTMDBMovie(job: Job<CatalogSeedTMDBMovieJobData>): Prom
     description,
     duration: runtime,
     score_rating: scoreRating,
+    original_title: details?.original_title ?? null,
+    original_language: details?.original_language ?? null,
+    release_date: details?.release_date ?? movie.release_date,
+    vote_count: details?.vote_count ?? movie.vote_count ?? null,
+    popularity: details?.popularity ?? null,
+    metadata_quality_score: metadata?.qualityScore ?? 0,
+    metadata_quality_flags: metadata?.qualityFlags ?? ['missing_details'],
     poster_url: getPosterUrl(details?.poster_path ?? movie.poster_path),
     localized_name: details?.title && details.title !== movie.title ? details.title : null,
     tmdb_id: movie.id,
@@ -336,14 +345,14 @@ async function processSeedTMDBMovie(job: Job<CatalogSeedTMDBMovieJobData>): Prom
     return;
   }
 
-  if (details) {
-    const metadata = extractCatalogMetadata(details);
+  if (details && metadata) {
     await upsertMovieCatalogMetadata({
       movieId: insertedMovie.id,
       tmdbMetadata: metadata.snapshot,
       people: metadata.people,
       genres: metadata.genres,
       keywords: metadata.keywords,
+      providers: metadata.providers,
     });
   }
 
@@ -661,6 +670,7 @@ async function processBackfillMovie(job: Job<CatalogBackfillMovieJobData>): Prom
 
   const runtime = details.runtime ?? movie.duration;
   const ageRating = extractUSCertification(details);
+  const metadata = extractCatalogMetadata(details);
   const embeddingText = movieToEmbeddingText({
     title: movie.name,
     year: movie.year,
@@ -685,8 +695,15 @@ async function processBackfillMovie(job: Job<CatalogBackfillMovieJobData>): Prom
             tmdb_matched_at = now(),
             poster_url = COALESCE($5, poster_url),
             localized_name = COALESCE($6, localized_name),
-            embedding = $7::vector
-      WHERE id = $8`,
+            embedding = $7::vector,
+            original_title = $8,
+            original_language = $9,
+            release_date = $10::date,
+            vote_count = $11,
+            popularity = $12,
+            metadata_quality_score = $13,
+            metadata_quality_flags = $14::jsonb
+      WHERE id = $15`,
     [
       runtime,
       ageRating,
@@ -695,17 +712,24 @@ async function processBackfillMovie(job: Job<CatalogBackfillMovieJobData>): Prom
       getPosterUrl(details.poster_path),
       details.title && details.title !== movie.name ? details.title : null,
       JSON.stringify(embedding),
+      details.original_title ?? null,
+      details.original_language ?? null,
+      details.release_date || null,
+      details.vote_count ?? null,
+      details.popularity ?? null,
+      metadata.qualityScore,
+      JSON.stringify(metadata.qualityFlags),
       movie.id,
     ],
   );
 
-  const metadata = extractCatalogMetadata(details);
   await upsertMovieCatalogMetadata({
     movieId: movie.id,
     tmdbMetadata: metadata.snapshot,
     people: metadata.people,
     genres: metadata.genres,
     keywords: metadata.keywords,
+    providers: metadata.providers,
   });
 
   logger.info(

--- a/db/createDB.sql
+++ b/db/createDB.sql
@@ -6,6 +6,13 @@
   duration integer not null,
   score_rating float not null,
   year int not null,
+  original_title text,
+  original_language text,
+  release_date date,
+  vote_count integer,
+  popularity float,
+  metadata_quality_score integer NOT NULL DEFAULT 0,
+  metadata_quality_flags jsonb NOT NULL DEFAULT '[]'::jsonb,
   tmdb_id bigint,
   poster_url text,
   localized_name text,
@@ -39,6 +46,27 @@ ALTER TABLE movies
 
 ALTER TABLE movies
   ADD COLUMN IF NOT EXISTS tmdb_metadata_refreshed_at timestamptz;
+
+ALTER TABLE movies
+  ADD COLUMN IF NOT EXISTS original_title text;
+
+ALTER TABLE movies
+  ADD COLUMN IF NOT EXISTS original_language text;
+
+ALTER TABLE movies
+  ADD COLUMN IF NOT EXISTS release_date date;
+
+ALTER TABLE movies
+  ADD COLUMN IF NOT EXISTS vote_count integer;
+
+ALTER TABLE movies
+  ADD COLUMN IF NOT EXISTS popularity float;
+
+ALTER TABLE movies
+  ADD COLUMN IF NOT EXISTS metadata_quality_score integer NOT NULL DEFAULT 0;
+
+ALTER TABLE movies
+  ADD COLUMN IF NOT EXISTS metadata_quality_flags jsonb NOT NULL DEFAULT '[]'::jsonb;
 
 ALTER TABLE movies
   DROP CONSTRAINT IF EXISTS movies_tmdb_match_source_check;
@@ -168,6 +196,45 @@ ALTER TABLE movie_keywords
 
 CREATE INDEX IF NOT EXISTS idx_movie_keywords_keyword_id
   ON movie_keywords (keyword_id);
+
+CREATE TABLE IF NOT EXISTS catalog_watch_providers (
+  id bigserial PRIMARY KEY,
+  tmdb_id int,
+  provider_name text NOT NULL,
+  logo_path text,
+  raw_metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS catalog_watch_providers_tmdb_id_unique
+  ON catalog_watch_providers (tmdb_id)
+  WHERE tmdb_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_catalog_watch_providers_name_lower
+  ON catalog_watch_providers (lower(provider_name));
+
+CREATE TABLE IF NOT EXISTS movie_watch_providers (
+  movie_id bigint NOT NULL REFERENCES movies(id) ON DELETE CASCADE,
+  provider_id bigint NOT NULL REFERENCES catalog_watch_providers(id) ON DELETE CASCADE,
+  region text NOT NULL,
+  availability_type text NOT NULL,
+  display_priority int,
+  link text,
+  raw_metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT movie_watch_providers_availability_type_check CHECK (
+    availability_type IN ('flatrate', 'rent', 'buy', 'ads', 'free')
+  ),
+  PRIMARY KEY (movie_id, provider_id, region, availability_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_movie_watch_providers_region_type
+  ON movie_watch_providers (region, availability_type);
+
+CREATE INDEX IF NOT EXISTS idx_movie_watch_providers_provider_id
+  ON movie_watch_providers (provider_id);
 
 CREATE TABLE IF NOT EXISTS tmdb_match_reviews (
   id bigserial PRIMARY KEY,

--- a/db/init/01_schema.sql
+++ b/db/init/01_schema.sql
@@ -11,6 +11,13 @@ CREATE TABLE IF NOT EXISTS movies (
   duration integer NOT NULL,
   score_rating float NOT NULL,
   year int NOT NULL,
+  original_title text,
+  original_language text,
+  release_date date,
+  vote_count integer,
+  popularity float,
+  metadata_quality_score integer NOT NULL DEFAULT 0,
+  metadata_quality_flags jsonb NOT NULL DEFAULT '[]'::jsonb,
   tmdb_id bigint,
   poster_url text,
   localized_name text,
@@ -44,6 +51,27 @@ ALTER TABLE movies
 
 ALTER TABLE movies
   ADD COLUMN IF NOT EXISTS tmdb_metadata_refreshed_at timestamptz;
+
+ALTER TABLE movies
+  ADD COLUMN IF NOT EXISTS original_title text;
+
+ALTER TABLE movies
+  ADD COLUMN IF NOT EXISTS original_language text;
+
+ALTER TABLE movies
+  ADD COLUMN IF NOT EXISTS release_date date;
+
+ALTER TABLE movies
+  ADD COLUMN IF NOT EXISTS vote_count integer;
+
+ALTER TABLE movies
+  ADD COLUMN IF NOT EXISTS popularity float;
+
+ALTER TABLE movies
+  ADD COLUMN IF NOT EXISTS metadata_quality_score integer NOT NULL DEFAULT 0;
+
+ALTER TABLE movies
+  ADD COLUMN IF NOT EXISTS metadata_quality_flags jsonb NOT NULL DEFAULT '[]'::jsonb;
 
 ALTER TABLE movies
   DROP CONSTRAINT IF EXISTS movies_tmdb_match_source_check;
@@ -173,6 +201,45 @@ ALTER TABLE movie_keywords
 
 CREATE INDEX IF NOT EXISTS idx_movie_keywords_keyword_id
   ON movie_keywords (keyword_id);
+
+CREATE TABLE IF NOT EXISTS catalog_watch_providers (
+  id bigserial PRIMARY KEY,
+  tmdb_id int,
+  provider_name text NOT NULL,
+  logo_path text,
+  raw_metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS catalog_watch_providers_tmdb_id_unique
+  ON catalog_watch_providers (tmdb_id)
+  WHERE tmdb_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_catalog_watch_providers_name_lower
+  ON catalog_watch_providers (lower(provider_name));
+
+CREATE TABLE IF NOT EXISTS movie_watch_providers (
+  movie_id bigint NOT NULL REFERENCES movies(id) ON DELETE CASCADE,
+  provider_id bigint NOT NULL REFERENCES catalog_watch_providers(id) ON DELETE CASCADE,
+  region text NOT NULL,
+  availability_type text NOT NULL,
+  display_priority int,
+  link text,
+  raw_metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT movie_watch_providers_availability_type_check CHECK (
+    availability_type IN ('flatrate', 'rent', 'buy', 'ads', 'free')
+  ),
+  PRIMARY KEY (movie_id, provider_id, region, availability_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_movie_watch_providers_region_type
+  ON movie_watch_providers (region, availability_type);
+
+CREATE INDEX IF NOT EXISTS idx_movie_watch_providers_provider_id
+  ON movie_watch_providers (provider_id);
 
 CREATE TABLE IF NOT EXISTS tmdb_match_reviews (
   id bigserial PRIMARY KEY,

--- a/db/init/02_match_movies.sql
+++ b/db/init/02_match_movies.sql
@@ -17,6 +17,12 @@ RETURNS TABLE (
   score_rating float,
   year int,
   tmdb_id bigint,
+  tmdb_match_source text,
+  original_language text,
+  vote_count integer,
+  popularity float,
+  metadata_quality_score integer,
+  metadata_quality_flags jsonb,
   similarity float,
   content text
 )
@@ -25,6 +31,12 @@ AS $$
   SELECT
     movies.id, movies.name, movies.age_rating, movies.description,
     movies.duration, movies.score_rating, movies.year, movies.tmdb_id,
+    movies.tmdb_match_source,
+    movies.original_language,
+    movies.vote_count,
+    movies.popularity,
+    movies.metadata_quality_score,
+    movies.metadata_quality_flags,
     1 - (movies.embedding <=> query_embedding) AS similarity,
     format(
       '%s (%s) | %s | Duration: %s min | Rating: %s/10%s%s',

--- a/db/match_movies.sql
+++ b/db/match_movies.sql
@@ -16,6 +16,12 @@ returns table (
   score_rating float,
   year int,
   tmdb_id bigint,
+  tmdb_match_source text,
+  original_language text,
+  vote_count integer,
+  popularity float,
+  metadata_quality_score integer,
+  metadata_quality_flags jsonb,
   similarity float,
   content text
 )
@@ -30,6 +36,12 @@ as $$
     movies.score_rating,
     movies.year,
     movies.tmdb_id,
+    movies.tmdb_match_source,
+    movies.original_language,
+    movies.vote_count,
+    movies.popularity,
+    movies.metadata_quality_score,
+    movies.metadata_quality_flags,
     1 - (movies.embedding <=> query_embedding) as similarity,
     -- Format content for API consumption
     format(

--- a/docs/RECOMMENDATION-ROADMAP.md
+++ b/docs/RECOMMENDATION-ROADMAP.md
@@ -85,20 +85,40 @@ Target behavior:
 
 This avoids pretending that a few hundred embedded titles can power a real app, while still preserving the value of local ranking, memory, and generated explanations.
 
+## Candidate Source Strategy
+
+Recommendation V2 should treat candidate source as a separate decision from audience size and match depth.
+
+| Strategy             | Primary use                                          | Candidate mix                                                              |
+| -------------------- | ---------------------------------------------------- | -------------------------------------------------------------------------- |
+| Curated showcase     | Demo/showcase surfaces and safe regression fixtures. | `curated` local seed records only.                                         |
+| Hybrid fast          | Fast Pick when latency matters.                      | `local-cache` first, then bounded `tmdb-discover` if local quality is low. |
+| Memory-aware local   | Signed-in fast/normal recommendations with history.  | `local-cache` plus memory exclusions/down-ranks.                           |
+| TMDB-first normal    | Normal Match and later Taste Swipe.                  | `tmdb-discover`/`tmdb-search`, enriched by local cache and JIT seeding.    |
+| Compromise group/duo | Duo and group results where overlap matters.         | Same source mix as selected depth, but scored against participant overlap. |
+
+[#612](https://github.com/shchilkin/PopChoice/issues/612) tracks carrying these source decisions through code, persistence, logs, eval reports, and optional UI badges.
+The current code now has a first policy module, persisted `experienceMode`, and route/job/pipeline metadata bridge for these defaults:
+
+- Curated showcase -> `curated-showcase`.
+- Fast Pick solo -> `hybrid-fast`.
+- Normal Match and Taste Swipe solo -> `tmdb-first`.
+- Duo and Group -> `compromise-hybrid`, regardless of fast/normal entry point.
+- Signed-in solo Fast Pick with existing memory can temporarily use `memory-aware-local` until TMDB-first memory reranking is implemented.
+
 ## Experience Modes
 
-### 1. Quick Pick
+### 1. Fast Pick
 
-Short guided mode for users who want a result fast.
+Short guided mode for users who want a result fast. The current flow asks for audience, intent, hard avoids, and discovery appetite, then sends `experienceMode: fast-pick` through the recommendation API.
 
-Possible questions:
+Target questions:
 
-- Who is watching: solo or group?
 - What kind of night is this: easy, funny, gripping, emotional, weird, cozy, dark?
 - What should PopChoice avoid: horror, gore, slow pacing, subtitles, long runtime, already-seen movies?
 - Discovery level: safe hit, balanced, surprise me?
 
-This should become the default replacement for the current long quiz.
+Duo/group Fast Pick reuses the same short question set per participant after audience-specific setup, then runs the same `hybrid-fast` source strategy.
 
 ### 2. Taste Swipe
 
@@ -198,6 +218,7 @@ This keeps the high-risk data and orchestration work ahead of visual polish. The
   - [x] [#471](https://github.com/shchilkin/PopChoice/issues/471) schema/model for cast, directors, genres, and keywords.
   - [x] [#472](https://github.com/shchilkin/PopChoice/issues/472) TMDB backfill and refresh for that metadata.
   - [x] [#473](https://github.com/shchilkin/PopChoice/issues/473) available-movies partial `ILIKE` search over titles, actors, directors, and genres, combined with exact/ranged catalog filters.
+  - [x] Metadata v1 quality contract: hot identity/quality/language columns, normalized watch providers for `US`, `FI`, and `RU`, bounded TMDB details enrichment for top direct TMDB candidates, and catalog-health/eval visibility for low-quality metadata.
 - Track TMDB API failures, timeout behavior, and fallback quality.
 - Keep [#493](https://github.com/shchilkin/PopChoice/issues/493) as the epic for admin/back-office review of ambiguous title matches and catalog-health issues.
 
@@ -205,9 +226,29 @@ This keeps the high-risk data and orchestration work ahead of visual polish. The
 
 - [x] [#474](https://github.com/shchilkin/PopChoice/issues/474): add a full Playwright e2e harness with an isolated migrated test database.
 - [x] [#475](https://github.com/shchilkin/PopChoice/issues/475): add product smoke flows for auth, catalog, quiz, recommendation, and feedback.
+- [x] Extend recommendation browser smoke coverage across current Normal/Fast and Solo/Duo/Group entry paths in `apps/web/e2e/recommendation.spec.ts`.
 - [x] [#476](https://github.com/shchilkin/PopChoice/issues/476): add recommendation eval fixtures and scoring so AI behavior can be changed with more control.
 - [x] [#490](https://github.com/shchilkin/PopChoice/issues/490): add scheduled or manually triggered real-data recommendation evals for seeded DB and catalog-retrieval changes. The backoffice can now queue mock and real-data evals, persist run summaries/results, and expose guarded live eval enqueueing for explicit operator checks.
 - Keep live-model evals optional. The default path should be deterministic, cheap, and safe for CI.
+
+### Stage 5.6: Backoffice eval operations
+
+The eval stack should be layered instead of treated as one overloaded "real data" command:
+
+| Eval layer                        | Purpose                                                                                                                                                             | Where it runs                                    |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| Deterministic fixture eval        | Prompt/output shape, repeat avoidance, explanation quality, and basic scenario scoring without external services.                                                   | Per-PR CI.                                       |
+| Seeded catalog retrieval eval     | Migrations, seeded catalog connectivity, fixture candidate availability, and catalog search.                                                                        | Scheduled/manual GitHub Actions.                 |
+| Environment retrieval/source eval | Current environment DB health for recommendation scenarios: candidate counts, source distribution, metadata quality/provider gaps, and hard-constraint feasibility. | Backoffice-triggered BullMQ job.                 |
+| Live provider eval                | Full provider-sensitive check with OpenAI/TMDB calls for intentional pre-launch validation.                                                                         | Manual, guarded, audited backoffice action only. |
+
+Implementation should be split in this order:
+
+1. [x] [#618](https://github.com/shchilkin/PopChoice/issues/618): classify and refactor the current seeded `--real-data` checks so the runner is importable by jobs and docs do not imply it is a full live recommendation eval.
+2. [x] [#616](https://github.com/shchilkin/PopChoice/issues/616): persist eval run and result history so reports are not trapped in CLI logs or GitHub artifacts.
+3. [x] [#617](https://github.com/shchilkin/PopChoice/issues/617): add bounded BullMQ jobs for environment retrieval and source-strategy evals against the configured DB.
+4. [x] [#619](https://github.com/shchilkin/PopChoice/issues/619): add a protected backoffice UI for safe eval runs, history, status, and report details.
+5. [x] [#620](https://github.com/shchilkin/PopChoice/issues/620): add a guarded live-provider eval action only after safe non-live backoffice evals exist.
 
 ### Stage 6: Long-term personalization
 
@@ -222,11 +263,29 @@ Good next PRs, in order:
 
 1. [x] [#484](https://github.com/shchilkin/PopChoice/issues/484): refactor the quiz submit/results handoff so navigation state is explicit and the quiz page does not need short-lived reset guards.
 2. [x] [#492](https://github.com/shchilkin/PopChoice/issues/492): move TMDB discovery/backfill/enrichment into a shared rate-limited BullMQ catalog worker before scaling catalog volume.
-3. Replace the current quiz copy and options with a more "tonight" oriented flow while preserving existing API shape.
-4. Add a small taste-swipe prototype behind a feature flag or alternate quiz entry path.
-5. Add TMDB-backed candidate-card sourcing for swipe mode.
-6. Add a `TasteSignal` domain model and adapters from quiz answers and swipe reactions.
-7. Add manual-review logging for ambiguous TMDB/local identity matches.
+3. [x] [#618](https://github.com/shchilkin/PopChoice/issues/618): classify/refactor current seeded real-data checks before adding backoffice eval execution.
+4. [x] [#616](https://github.com/shchilkin/PopChoice/issues/616): persist eval run/result history for backoffice and worker reports.
+5. [x] [#617](https://github.com/shchilkin/PopChoice/issues/617): add non-live environment retrieval/source-strategy eval jobs.
+6. [x] [#619](https://github.com/shchilkin/PopChoice/issues/619): expose recommendation eval runs in backoffice.
+7. Replace the current quiz copy and options with a more "tonight" oriented flow while preserving existing API shape.
+8. Add a small taste-swipe prototype behind a feature flag or alternate quiz entry path.
+9. Add TMDB-backed candidate-card sourcing for swipe mode.
+10. Add a `TasteSignal` domain model and adapters from quiz answers and swipe reactions.
+11. [x] [#620](https://github.com/shchilkin/PopChoice/issues/620): add guarded live-provider evals after safe backoffice evals exist.
+12. [x] Start [#612](https://github.com/shchilkin/PopChoice/issues/612) with first-class candidate source provenance, source-strategy policy, route/job/pipeline metadata, and eval assertions for curated showcase, hybrid fast, and TMDB-first behavior.
+13. [x] Connect [#612](https://github.com/shchilkin/PopChoice/issues/612) source strategy to initial retrieval behavior: `hybrid-fast` and `compromise-hybrid` use bounded TMDB fallback, while curated/local-only strategies block external lookup.
+14. [x] Add `experienceMode` request/job/pipeline metadata so `fast-pick` can select `hybrid-fast` while current requests default to `normal-match`.
+15. [x] Add a first Fast Pick quiz intro entry that sends the `fast-pick` wrapper into the existing recommendation API.
+16. [x] Add the first short solo Fast Pick guided flow for intent, hard avoids, and discovery appetite under [#609](https://github.com/shchilkin/PopChoice/issues/609).
+17. [x] Extend Fast Pick to Duo/Group by adding an audience layer before the short question flow.
+18. [x] Start [#608](https://github.com/shchilkin/PopChoice/issues/608) by adding an optional Normal-mode hard-avoids step and carrying those negative signals into the current recommendation payload.
+19. [x] Make Duo first-class in the guided UI: separate Normal/Fast audience entry, two-person setup copy, Duo result copy, and deterministic e2e coverage.
+20. [x] Connect the first `tmdb-first` retrieval slice: Normal solo now attempts TMDB discover as a primary candidate-discovery path, then score-ranks TMDB and strong local matches together.
+21. [x] Deepen the first `tmdb-first` query-shaping slice: Normal/Fast hard avoids and discovery appetite now shape TMDB discover params, and eval fixtures include source/metadata quality thresholds.
+22. [x] Deepen `tmdb-first` JIT enrichment before making it the Normal quality default: fetch richer TMDB details for strong direct candidates, persist/cache useful runtime/rating/provider metadata, and calibrate backoffice real-data thresholds.
+23. [#655](https://github.com/shchilkin/PopChoice/issues/655): add provider-aware result UI and user-facing availability copy once product behavior decides whether availability is informational, a soft preference, or a hard constraint.
+24. [#656](https://github.com/shchilkin/PopChoice/issues/656): evaluate a movie embedding text v2 contract before adding metadata such as genres, keywords, cast, director, language, popularity, or certification to retrieval embeddings.
+25. Add manual-review logging for ambiguous TMDB/local identity matches.
 
 ## Non-Goals For Now
 

--- a/docs/ROADMAP-ARCHITECTURE.md
+++ b/docs/ROADMAP-ARCHITECTURE.md
@@ -277,9 +277,15 @@ work implementation-sized:
 
 - [x] [#474](https://github.com/shchilkin/PopChoice/issues/474): add a Playwright e2e harness with an isolated migrated test database and deterministic seed fixtures.
 - [x] [#475](https://github.com/shchilkin/PopChoice/issues/475): cover auth, catalog, quiz, recommendation, and feedback smoke flows through product-level e2e tests.
+- [x] Cover the current recommendation entry matrix in browser smoke tests: Normal Solo, Normal Duo, Normal Group, Fast Pick Solo, Fast Pick Duo, and Fast Pick Group.
 - [x] [#476](https://github.com/shchilkin/PopChoice/issues/476): add an AI recommendation eval harness with deterministic fixtures by default and optional live model/provider runs.
 - [x] [#490](https://github.com/shchilkin/PopChoice/issues/490): add a scheduled or manually triggered real-data recommendation eval workflow with seeded database data and real catalog retrieval.
-- Add [#606](https://github.com/shchilkin/PopChoice/issues/606) deterministic recommendation scenarios for Solo/Fast, Solo/Normal, Duo/Fast, Duo/Normal, Group/Fast, and Group/Normal so the next recommendation UX/backend changes can be judged against meaningful-pick behavior, not only response shape.
+- Add [#606](https://github.com/shchilkin/PopChoice/issues/606) deterministic recommendation scenarios that validate audience behavior, match-depth behavior, source-strategy behavior, and meaningful-pick quality, not only response shape.
+- [x] [#618](https://github.com/shchilkin/PopChoice/issues/618): classify and refactor the current seeded `--real-data` checks so they are clearly catalog retrieval/candidate-availability evals and can be reused by worker jobs.
+- [x] [#616](https://github.com/shchilkin/PopChoice/issues/616): persist recommendation eval run/result history for backoffice and worker reports.
+- [x] [#617](https://github.com/shchilkin/PopChoice/issues/617): add bounded non-live BullMQ jobs for environment retrieval and source-strategy evals against the configured database.
+- [x] [#619](https://github.com/shchilkin/PopChoice/issues/619): add a protected backoffice recommendation eval UI for safe runs, status, history, and report details.
+- [x] [#620](https://github.com/shchilkin/PopChoice/issues/620): add guarded, audited live-provider evals only after safe backoffice evals exist.
 - Keep Storybook/component tests separate from full product e2e tests so UI component regressions and app-flow regressions fail with clear ownership.
 - Keep AI evals separate from normal e2e smoke tests because recommendation quality gates need fixture scoring, model controls, and optional API cost.
 
@@ -303,6 +309,7 @@ work implementation-sized:
 - Backfill TMDB ids for existing local movies using exact title/year matches first, then persist ambiguous or low-confidence matches for manual review.
 - Add cast, director, genre, and keyword metadata as first-class catalog data before implementing actor/director/genre search.
 - [x] Move TMDB discovery, backfill, and metadata refresh into shared rate-limited BullMQ catalog workers in [#492](https://github.com/shchilkin/PopChoice/issues/492) before growing catalog volume. The worker enforces one configurable TMDB request budget across catalog-maintenance jobs, honors `429` with backoff, dedupes jobs by stable `tmdbId`/`movieId` keys, and exposes queue depth/failures in Bull Board.
+- [x] Add the metadata v1 quality contract for recommendations: hot movie columns for identity/language/quality/popularity, normalized watch providers for `US`, `FI`, and `RU`, bounded TMDB details enrichment for top direct TMDB candidates, and catalog-health/eval checks for low-quality metadata.
 - Add a back-office review queue for ambiguous TMDB matches, missing posters, duplicate identities, and metadata conflicts in [#493](https://github.com/shchilkin/PopChoice/issues/493) before applying risky automatic merges.
 - Prefer TMDB ids for all cross-feature identity checks. Fall back to normalized title plus year only when TMDB identity is unavailable.
 - Design future discovery flows around dynamic TMDB candidate sets: "I have watched many films" deck mode, quiz-assisted mode, and later a preference/taste-training mode.
@@ -317,12 +324,15 @@ work implementation-sized:
 
 ### Recommendation Experience Track
 
-- Define Recommendation V2 in [#610](https://github.com/shchilkin/PopChoice/issues/610) around two explicit product axes: audience mode (Solo, Duo, Group) and effort mode (Fast, Normal).
+- Define Recommendation V2 in [#610](https://github.com/shchilkin/PopChoice/issues/610) around three independent axes: audience context, match depth, and candidate source strategy.
 - Treat quiz answers, swipe reactions, account memory, and result feedback as inputs into a shared taste-signal model.
 - Rework the guided quiz around "what do you want tonight?" instead of relying on a favorite movie, broad genre labels, and optional actor input.
-- Build [#609](https://github.com/shchilkin/PopChoice/issues/609) as the Fast Pick guided flow with minimal intent, hard avoids, and discovery appetite.
-- Build [#608](https://github.com/shchilkin/PopChoice/issues/608) as the Normal mode flow with richer positive/negative signals, optional reference movies, and first-class Duo compromise handling.
+- Build [#609](https://github.com/shchilkin/PopChoice/issues/609) as the Fast Pick guided flow with minimal intent, hard avoids, and discovery appetite. The current flow separates audience selection from match depth, supports Solo/Duo/Group, and sends `experienceMode: fast-pick`.
+- Build [#608](https://github.com/shchilkin/PopChoice/issues/608) as the Normal mode flow with richer positive/negative signals, optional reference movies, and first-class Duo compromise handling. The first slices add Normal-mode hard avoids, carry those negative signals through the existing recommendation payload, and expose Duo as a separate two-person entry/results path.
 - Add an alternate taste-swipe mode for users who have watched many films and prefer to react to concrete movie cards instead of answering abstract questions.
+- Start [#612](https://github.com/shchilkin/PopChoice/issues/612) by carrying candidate source provenance through recommendation results, persistence, logs, eval reports, a source-strategy policy, and route/job/pipeline metadata before changing retrieval defaults.
+- Connect [#612](https://github.com/shchilkin/PopChoice/issues/612) to retrieval behavior in stages: bounded `hybrid-fast`/`compromise-hybrid` fallback first, then `tmdb-first` generation with hard-avoid/discovery-aware TMDB query shaping and source/metadata eval thresholds before making it the Normal quality default.
+- Add `experienceMode` as the product-facing selector for this policy layer, defaulting existing traffic to `normal-match` while letting Fast Pick requests choose `fast-pick`.
 - Move toward TMDB-first candidate generation: use TMDB for broad discovery and keep the local database as a cache/enrichment/reranking layer rather than the whole movie universe.
 - Keep TMDB ids as the preferred movie identity and log ambiguous title/year matches for later admin/back-office review.
 - See [RECOMMENDATION-ROADMAP.md](/docs/RECOMMENDATION-ROADMAP) for the staged plan.

--- a/docs/SERVICES.md
+++ b/docs/SERVICES.md
@@ -90,7 +90,7 @@ Or via Docker Compose (workers.Dockerfile).
 `catalog-maintenance` is the shared BullMQ pacing layer for TMDB catalog work. It owns:
 
 - `discover-tmdb-source-page` jobs that fetch one TMDB source page and enqueue per-movie seed jobs.
-- `seed-tmdb-movie` jobs that fetch details, generate or reuse embeddings, insert new cached catalog rows, and upsert normalized cast/director/genre/keyword metadata.
+- `seed-tmdb-movie` jobs that fetch details, generate or reuse embeddings, insert new cached catalog rows, and upsert normalized cast/director/genre/keyword/provider metadata.
 - `backfill-movie` jobs that refresh an existing movie row by TMDB id or conservative title/year match.
 
 Jobs use deterministic BullMQ-safe ids such as `tmdb-discover-popular-1-en-US`,
@@ -308,9 +308,10 @@ visibility. The shared query logic lives in `packages/shared`, so the CLI report
 and `apps/backoffice` browser overview use the same `SELECT`-only semantics. It
 reports:
 
-- Missing `poster_url`, `localized_name`, `tmdb_id`, runtime, age rating, and TMDB match timestamps.
-- TMDB-backed rows whose `tmdb_matched_at` is older than the stale threshold.
-- Missing cast, director, genre, and keyword coverage for TMDB-backed rows.
+- Missing `poster_url`, `localized_name`, `tmdb_id`, runtime, age rating, original language, vote count, popularity, and TMDB match timestamps.
+- TMDB-backed rows whose `tmdb_metadata_refreshed_at` is older than the stale threshold.
+- Missing cast, director, genre, keyword, and `US`/`FI`/`RU` watch-provider coverage for TMDB-backed rows.
+- Low metadata-quality scores derived from the metadata v1 contract.
 - Likely duplicate identities by repeated `tmdb_id` and normalized title/year groups.
 - Sample movie rows for each issue so local or CI logs point at concrete records.
 

--- a/packages/shared/src/catalogHealth.test.ts
+++ b/packages/shared/src/catalogHealth.test.ts
@@ -93,6 +93,7 @@ describe('catalog health issue movie pages', () => {
     expect(poolMock.query.mock.calls[1][1]).toEqual([90, 25, 50]);
     expect(String(poolMock.query.mock.calls[1][0])).toContain('LIMIT $2');
     expect(String(poolMock.query.mock.calls[1][0])).toContain('OFFSET $3');
+    expect(String(poolMock.query.mock.calls[1][0])).toContain('tmdb_metadata_refreshed_at');
   });
 
   it('re-checks whether one movie still matches the original issue predicate', async () => {
@@ -125,11 +126,15 @@ describe('catalog health issue movie pages', () => {
     ).resolves.toBe(false);
 
     expect(String(poolMock.query.mock.calls[0][0])).toContain('WHERE id = $2');
+    expect(String(poolMock.query.mock.calls[0][0])).toContain('tmdb_metadata_refreshed_at');
     expect(poolMock.query.mock.calls[0][1]).toEqual([90, '334']);
   });
 
   it('rejects unknown issue keys before building SQL', async () => {
     expect(isCatalogHealthIssueKey('missing_poster_url')).toBe(true);
+    expect(isCatalogHealthIssueKey('missing_original_language')).toBe(true);
+    expect(isCatalogHealthIssueKey('missing_watch_provider_us')).toBe(true);
+    expect(isCatalogHealthIssueKey('low_metadata_quality')).toBe(true);
     expect(isCatalogHealthIssueKey('drop table movies')).toBe(false);
 
     await expect(

--- a/packages/shared/src/catalogHealth.ts
+++ b/packages/shared/src/catalogHealth.ts
@@ -62,6 +62,13 @@ interface SummaryRow {
   missing_age_rating: number;
   missing_tmdb_matched_at: number;
   stale_tmdb_metadata: number;
+  missing_original_language: number;
+  missing_vote_count: number;
+  missing_popularity: number;
+  low_metadata_quality: number;
+  missing_watch_provider_us: number;
+  missing_watch_provider_fi: number;
+  missing_watch_provider_ru: number;
   missing_cast_metadata: number;
   missing_director_metadata: number;
   missing_genre_metadata: number;
@@ -109,7 +116,52 @@ export const CATALOG_HEALTH_ISSUE_DEFINITIONS: CatalogHealthIssueDefinition[] = 
     key: 'stale_tmdb_metadata',
     label: 'Stale TMDB metadata',
     where: (staleAfterDaysParam) =>
-      `tmdb_id IS NOT NULL AND tmdb_matched_at < now() - (${staleAfterDaysParam}::int * interval '1 day')`,
+      `tmdb_id IS NOT NULL AND (
+      tmdb_metadata_refreshed_at IS NULL
+      OR tmdb_metadata_refreshed_at < now() - (${staleAfterDaysParam}::int * interval '1 day')
+    )`,
+  },
+  {
+    key: 'missing_original_language',
+    label: 'Missing original_language',
+    where: () =>
+      "tmdb_id IS NOT NULL AND (original_language IS NULL OR btrim(original_language) = '')",
+  },
+  {
+    key: 'missing_vote_count',
+    label: 'Missing vote_count',
+    where: () => 'tmdb_id IS NOT NULL AND (vote_count IS NULL OR vote_count <= 0)',
+  },
+  {
+    key: 'missing_popularity',
+    label: 'Missing popularity',
+    where: () => 'tmdb_id IS NOT NULL AND (popularity IS NULL OR popularity <= 0)',
+  },
+  {
+    key: 'low_metadata_quality',
+    label: 'Low metadata quality',
+    where: () => 'tmdb_id IS NOT NULL AND metadata_quality_score < 70',
+  },
+  {
+    key: 'missing_watch_provider_us',
+    label: 'Missing US watch providers',
+    where: () => `tmdb_id IS NOT NULL AND NOT EXISTS (
+      SELECT 1 FROM movie_watch_providers WHERE movie_watch_providers.movie_id = movies.id AND region = 'US'
+    )`,
+  },
+  {
+    key: 'missing_watch_provider_fi',
+    label: 'Missing FI watch providers',
+    where: () => `tmdb_id IS NOT NULL AND NOT EXISTS (
+      SELECT 1 FROM movie_watch_providers WHERE movie_watch_providers.movie_id = movies.id AND region = 'FI'
+    )`,
+  },
+  {
+    key: 'missing_watch_provider_ru',
+    label: 'Missing RU watch providers',
+    where: () => `tmdb_id IS NOT NULL AND NOT EXISTS (
+      SELECT 1 FROM movie_watch_providers WHERE movie_watch_providers.movie_id = movies.id AND region = 'RU'
+    )`,
   },
   {
     key: 'missing_cast_metadata',
@@ -314,8 +366,33 @@ async function getSummary(staleAfterDays: number): Promise<SummaryRow> {
         COUNT(*) FILTER (WHERE tmdb_id IS NOT NULL AND tmdb_matched_at IS NULL)::int AS missing_tmdb_matched_at,
         COUNT(*) FILTER (
           WHERE tmdb_id IS NOT NULL
-            AND tmdb_matched_at < now() - ($1::int * interval '1 day')
+            AND (
+              tmdb_metadata_refreshed_at IS NULL
+              OR tmdb_metadata_refreshed_at < now() - ($1::int * interval '1 day')
+            )
         )::int AS stale_tmdb_metadata,
+        COUNT(*) FILTER (WHERE tmdb_id IS NOT NULL AND (original_language IS NULL OR btrim(original_language) = ''))::int AS missing_original_language,
+        COUNT(*) FILTER (WHERE tmdb_id IS NOT NULL AND (vote_count IS NULL OR vote_count <= 0))::int AS missing_vote_count,
+        COUNT(*) FILTER (WHERE tmdb_id IS NOT NULL AND (popularity IS NULL OR popularity <= 0))::int AS missing_popularity,
+        COUNT(*) FILTER (WHERE tmdb_id IS NOT NULL AND metadata_quality_score < 70)::int AS low_metadata_quality,
+        COUNT(*) FILTER (
+          WHERE tmdb_id IS NOT NULL
+            AND NOT EXISTS (
+              SELECT 1 FROM movie_watch_providers WHERE movie_watch_providers.movie_id = movies.id AND region = 'US'
+            )
+        )::int AS missing_watch_provider_us,
+        COUNT(*) FILTER (
+          WHERE tmdb_id IS NOT NULL
+            AND NOT EXISTS (
+              SELECT 1 FROM movie_watch_providers WHERE movie_watch_providers.movie_id = movies.id AND region = 'FI'
+            )
+        )::int AS missing_watch_provider_fi,
+        COUNT(*) FILTER (
+          WHERE tmdb_id IS NOT NULL
+            AND NOT EXISTS (
+              SELECT 1 FROM movie_watch_providers WHERE movie_watch_providers.movie_id = movies.id AND region = 'RU'
+            )
+        )::int AS missing_watch_provider_ru,
         COUNT(*) FILTER (
           WHERE tmdb_id IS NOT NULL
             AND NOT EXISTS (
@@ -354,6 +431,13 @@ async function getSummary(staleAfterDays: number): Promise<SummaryRow> {
     missing_age_rating: toNumber(row?.missing_age_rating),
     missing_tmdb_matched_at: toNumber(row?.missing_tmdb_matched_at),
     stale_tmdb_metadata: toNumber(row?.stale_tmdb_metadata),
+    missing_original_language: toNumber(row?.missing_original_language),
+    missing_vote_count: toNumber(row?.missing_vote_count),
+    missing_popularity: toNumber(row?.missing_popularity),
+    low_metadata_quality: toNumber(row?.low_metadata_quality),
+    missing_watch_provider_us: toNumber(row?.missing_watch_provider_us),
+    missing_watch_provider_fi: toNumber(row?.missing_watch_provider_fi),
+    missing_watch_provider_ru: toNumber(row?.missing_watch_provider_ru),
     missing_cast_metadata: toNumber(row?.missing_cast_metadata),
     missing_director_metadata: toNumber(row?.missing_director_metadata),
     missing_genre_metadata: toNumber(row?.missing_genre_metadata),

--- a/packages/shared/src/db.ts
+++ b/packages/shared/src/db.ts
@@ -13,6 +13,13 @@ export interface MovieRecord {
   description: string;
   duration: number;
   score_rating: number;
+  original_title?: string | null;
+  original_language?: string | null;
+  release_date?: string | null;
+  vote_count?: number | null;
+  popularity?: number | null;
+  metadata_quality_score?: number | null;
+  metadata_quality_flags?: string[] | Record<string, unknown> | null;
   poster_url?: string | null;
   localized_name?: string | null;
   tmdb_id?: number | null;
@@ -82,6 +89,19 @@ export interface CatalogKeywordInput {
   rawMetadata?: Record<string, unknown>;
 }
 
+export type WatchProviderAvailabilityType = 'flatrate' | 'rent' | 'buy' | 'ads' | 'free';
+
+export interface MovieWatchProviderInput {
+  providerId: number;
+  providerName: string;
+  logoPath?: string | null;
+  displayPriority?: number | null;
+  region: string;
+  availabilityType: WatchProviderAvailabilityType;
+  link?: string | null;
+  rawMetadata?: Record<string, unknown>;
+}
+
 export interface MoviePersonCreditInput extends CatalogPersonInput {
   creditId: string;
   role: MoviePersonRole;
@@ -97,6 +117,7 @@ export interface MovieCatalogMetadataInput {
   people?: MoviePersonCreditInput[];
   genres?: CatalogGenreInput[];
   keywords?: CatalogKeywordInput[];
+  providers?: MovieWatchProviderInput[];
   source?: CatalogMetadataSource;
 }
 
@@ -126,6 +147,14 @@ export function getPool(): InstanceType<typeof Pool> {
 
 function getMovieKey(name: string, year: number): string {
   return `${name}\u0000${year}`;
+}
+
+function serializeMetadataQualityFlags(
+  flags: MovieRecord['metadata_quality_flags'],
+): Record<string, unknown> | string[] {
+  if (!flags) return [];
+  if (Array.isArray(flags)) return flags;
+  return flags;
 }
 
 async function getExistingMovieKeys(movies: MovieRecord[]): Promise<Set<string>> {
@@ -202,6 +231,13 @@ export async function ensureSchema(): Promise<void> {
       duration integer NOT NULL,
       score_rating float NOT NULL,
       year int NOT NULL,
+      original_title text,
+      original_language text,
+      release_date date,
+      vote_count integer,
+      popularity float,
+      metadata_quality_score integer NOT NULL DEFAULT 0,
+      metadata_quality_flags jsonb NOT NULL DEFAULT '[]'::jsonb,
       poster_url text,
       localized_name text,
       tmdb_id bigint,
@@ -237,6 +273,27 @@ export async function ensureSchema(): Promise<void> {
 
     ALTER TABLE movies
       ADD COLUMN IF NOT EXISTS tmdb_metadata_refreshed_at timestamptz;
+
+    ALTER TABLE movies
+      ADD COLUMN IF NOT EXISTS original_title text;
+
+    ALTER TABLE movies
+      ADD COLUMN IF NOT EXISTS original_language text;
+
+    ALTER TABLE movies
+      ADD COLUMN IF NOT EXISTS release_date date;
+
+    ALTER TABLE movies
+      ADD COLUMN IF NOT EXISTS vote_count integer;
+
+    ALTER TABLE movies
+      ADD COLUMN IF NOT EXISTS popularity float;
+
+    ALTER TABLE movies
+      ADD COLUMN IF NOT EXISTS metadata_quality_score integer NOT NULL DEFAULT 0;
+
+    ALTER TABLE movies
+      ADD COLUMN IF NOT EXISTS metadata_quality_flags jsonb NOT NULL DEFAULT '[]'::jsonb;
 
     ALTER TABLE movies
       DROP CONSTRAINT IF EXISTS movies_tmdb_match_source_check;
@@ -501,6 +558,12 @@ export async function ensureSchema(): Promise<void> {
       score_rating float,
       year int,
       tmdb_id bigint,
+      tmdb_match_source text,
+      original_language text,
+      vote_count integer,
+      popularity float,
+      metadata_quality_score integer,
+      metadata_quality_flags jsonb,
       similarity float,
       content text
     )
@@ -514,6 +577,12 @@ export async function ensureSchema(): Promise<void> {
         movies.score_rating,
         movies.year,
         movies.tmdb_id,
+        movies.tmdb_match_source,
+        movies.original_language,
+        movies.vote_count,
+        movies.popularity,
+        movies.metadata_quality_score,
+        movies.metadata_quality_flags,
         1 - (movies.embedding <=> query_embedding) AS similarity,
         format(
           '%s (%s) | %s | Duration: %s min | Rating: %s/10%s%s',
@@ -655,6 +724,45 @@ export async function ensureCatalogMetadataSchema(): Promise<void> {
 
     CREATE INDEX IF NOT EXISTS idx_movie_keywords_keyword_id
       ON movie_keywords (keyword_id);
+
+    CREATE TABLE IF NOT EXISTS catalog_watch_providers (
+      id bigserial PRIMARY KEY,
+      tmdb_id int,
+      provider_name text NOT NULL,
+      logo_path text,
+      raw_metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    );
+
+    CREATE UNIQUE INDEX IF NOT EXISTS catalog_watch_providers_tmdb_id_unique
+      ON catalog_watch_providers (tmdb_id)
+      WHERE tmdb_id IS NOT NULL;
+
+    CREATE INDEX IF NOT EXISTS idx_catalog_watch_providers_name_lower
+      ON catalog_watch_providers (lower(provider_name));
+
+    CREATE TABLE IF NOT EXISTS movie_watch_providers (
+      movie_id bigint NOT NULL REFERENCES movies(id) ON DELETE CASCADE,
+      provider_id bigint NOT NULL REFERENCES catalog_watch_providers(id) ON DELETE CASCADE,
+      region text NOT NULL,
+      availability_type text NOT NULL,
+      display_priority int,
+      link text,
+      raw_metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now(),
+      CONSTRAINT movie_watch_providers_availability_type_check CHECK (
+        availability_type IN ('flatrate', 'rent', 'buy', 'ads', 'free')
+      ),
+      PRIMARY KEY (movie_id, provider_id, region, availability_type)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_movie_watch_providers_region_type
+      ON movie_watch_providers (region, availability_type);
+
+    CREATE INDEX IF NOT EXISTS idx_movie_watch_providers_provider_id
+      ON movie_watch_providers (provider_id);
   `);
 }
 
@@ -670,9 +778,11 @@ export async function upsertMovieCatalogMetadata(input: MovieCatalogMetadataInpu
   const shouldRefreshPeople = input.people !== undefined;
   const shouldRefreshGenres = input.genres !== undefined;
   const shouldRefreshKeywords = input.keywords !== undefined;
+  const shouldRefreshProviders = input.providers !== undefined;
   const people = input.people ?? [];
   const genres = input.genres ?? [];
   const keywords = input.keywords ?? [];
+  const providers = input.providers ?? [];
 
   try {
     await client.query('BEGIN');
@@ -706,6 +816,9 @@ export async function upsertMovieCatalogMetadata(input: MovieCatalogMetadataInpu
         movieId,
         source,
       ]);
+    }
+    if (shouldRefreshProviders) {
+      await client.query(`DELETE FROM movie_watch_providers WHERE movie_id = $1`, [movieId]);
     }
 
     for (const person of shouldRefreshPeople ? people : []) {
@@ -807,6 +920,51 @@ export async function upsertMovieCatalogMetadata(input: MovieCatalogMetadataInpu
       );
     }
 
+    for (const provider of shouldRefreshProviders ? providers : []) {
+      const providerResult = await client.query<{ id: string }>(
+        `INSERT INTO catalog_watch_providers (
+           tmdb_id, provider_name, logo_path, raw_metadata, updated_at
+         )
+         VALUES ($1, $2, $3, $4::jsonb, now())
+         ON CONFLICT (tmdb_id) WHERE tmdb_id IS NOT NULL DO UPDATE
+           SET provider_name = EXCLUDED.provider_name,
+               logo_path = COALESCE(EXCLUDED.logo_path, catalog_watch_providers.logo_path),
+               raw_metadata = EXCLUDED.raw_metadata,
+               updated_at = now()
+         RETURNING id::text`,
+        [
+          provider.providerId,
+          provider.providerName,
+          provider.logoPath ?? null,
+          JSON.stringify(provider.rawMetadata ?? {}),
+        ],
+      );
+      const providerRowId = providerResult.rows[0]?.id;
+      if (!providerRowId) continue;
+
+      await client.query(
+        `INSERT INTO movie_watch_providers (
+           movie_id, provider_id, region, availability_type, display_priority,
+           link, raw_metadata, updated_at
+         )
+         VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, now())
+         ON CONFLICT (movie_id, provider_id, region, availability_type) DO UPDATE
+           SET display_priority = EXCLUDED.display_priority,
+               link = EXCLUDED.link,
+               raw_metadata = EXCLUDED.raw_metadata,
+               updated_at = now()`,
+        [
+          movieId,
+          providerRowId,
+          provider.region,
+          provider.availabilityType,
+          provider.displayPriority ?? null,
+          provider.link ?? null,
+          JSON.stringify(provider.rawMetadata ?? {}),
+        ],
+      );
+    }
+
     await client.query('COMMIT');
   } catch (error) {
     await client.query('ROLLBACK');
@@ -832,15 +990,20 @@ export async function insertMovies(
       const result = await getPool().query<InsertedMovieRecord>(
         `INSERT INTO movies (
            name, year, age_rating, description, duration, score_rating,
-           poster_url, localized_name, tmdb_id, tmdb_match_confidence,
-           tmdb_match_source, tmdb_matched_at, embedding
+           original_title, original_language, release_date, vote_count, popularity,
+           metadata_quality_score, metadata_quality_flags, poster_url, localized_name, tmdb_id,
+           tmdb_match_confidence, tmdb_match_source, tmdb_matched_at, embedding
          )
-         SELECT n, y, ar, d, du, sr, poster, localized, tid, conf, src,
+         SELECT n, y, ar, d, du, sr, original, lang, release_dt, votes, pop,
+                quality_score, quality_flags::jsonb, poster, localized, tid, conf, src,
                 CASE WHEN tid IS NULL THEN NULL ELSE now() END, e::vector
          FROM unnest(
            $1::text[], $2::int[], $3::text[], $4::text[], $5::int[], $6::float8[],
-           $7::text[], $8::text[], $9::bigint[], $10::float8[], $11::text[], $12::text[]
-         ) AS t(n, y, ar, d, du, sr, poster, localized, tid, conf, src, e)
+           $7::text[], $8::text[], $9::date[], $10::int[], $11::float8[], $12::int[],
+           $13::text[], $14::text[], $15::text[], $16::bigint[], $17::float8[],
+           $18::text[], $19::text[]
+         ) AS t(n, y, ar, d, du, sr, original, lang, release_dt, votes, pop, quality_score,
+                quality_flags, poster, localized, tid, conf, src, e)
          ON CONFLICT (name, year) DO NOTHING
          RETURNING id::text, tmdb_id`,
         [
@@ -850,6 +1013,13 @@ export async function insertMovies(
           batch.map((m) => m.description),
           batch.map((m) => m.duration),
           batch.map((m) => m.score_rating),
+          batch.map((m) => m.original_title ?? null),
+          batch.map((m) => m.original_language ?? null),
+          batch.map((m) => m.release_date ?? null),
+          batch.map((m) => m.vote_count ?? null),
+          batch.map((m) => m.popularity ?? null),
+          batch.map((m) => m.metadata_quality_score ?? 0),
+          batch.map((m) => JSON.stringify(serializeMetadataQualityFlags(m.metadata_quality_flags))),
           batch.map((m) => m.poster_url ?? null),
           batch.map((m) => m.localized_name ?? null),
           batch.map((m) => m.tmdb_id ?? null),
@@ -880,13 +1050,15 @@ export async function insertMovies(
           const result = await getPool().query<InsertedMovieRecord>(
             `INSERT INTO movies (
                name, year, age_rating, description, duration, score_rating,
-               poster_url, localized_name, tmdb_id, tmdb_match_confidence,
-               tmdb_match_source, tmdb_matched_at, embedding
+               original_title, original_language, release_date, vote_count, popularity,
+               metadata_quality_score, metadata_quality_flags, poster_url, localized_name, tmdb_id,
+               tmdb_match_confidence, tmdb_match_source, tmdb_matched_at, embedding
              )
              VALUES (
-               $1, $2, $3, $4, $5, $6, $7::text, $8::text, $9::bigint,
-               $10::float8, $11::text, CASE WHEN $9 IS NULL THEN NULL ELSE now() END,
-               $12::vector
+               $1, $2, $3, $4, $5, $6, $7::text, $8::text, $9::date, $10::int, $11::float8,
+               $12::int, $13::jsonb, $14::text, $15::text, $16::bigint,
+               $17::float8, $18::text, CASE WHEN $16 IS NULL THEN NULL ELSE now() END,
+               $19::vector
              )
              ON CONFLICT (name, year) DO NOTHING
              RETURNING id::text, tmdb_id`,
@@ -897,6 +1069,13 @@ export async function insertMovies(
               movie.description,
               movie.duration,
               movie.score_rating,
+              movie.original_title ?? null,
+              movie.original_language ?? null,
+              movie.release_date ?? null,
+              movie.vote_count ?? null,
+              movie.popularity ?? null,
+              movie.metadata_quality_score ?? 0,
+              JSON.stringify(serializeMetadataQualityFlags(movie.metadata_quality_flags)),
               movie.poster_url ?? null,
               movie.localized_name ?? null,
               movie.tmdb_id ?? null,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -24,7 +24,9 @@ export type {
   MoviePersonCreditInput,
   MoviePersonCreditRecord,
   MoviePersonRole,
+  MovieWatchProviderInput,
   MovieRecord,
+  WatchProviderAvailabilityType,
 } from './db.js';
 export { createEmbeddings } from './embeddings.js';
 export {

--- a/scripts/e2e/setup-db.mjs
+++ b/scripts/e2e/setup-db.mjs
@@ -64,7 +64,8 @@ async function seedDatabase(databaseUrl) {
           ($19, $20, $21, $22, $23, $24, $25, $26, $27),
           ($28, $29, $30, $31, $32, $33, $34, $35, $36),
           ($37, $38, $39, $40, $41, $42, $43, $44, $45),
-          ($46, $47, $48, $49, $50, $51, $52, $53, $54)
+          ($46, $47, $48, $49, $50, $51, $52, $53, $54),
+          ($55, $56, $57, $58, $59, $60, $61, $62, $63)
       `,
       [
         'PopChoice E2E Space Opera',
@@ -121,6 +122,15 @@ async function seedDatabase(databaseUrl) {
         900006,
         null,
         'PopChoice E2E Ensemble Comedy',
+        'PopChoice E2E Grounded Thriller',
+        'PG-13',
+        'A precise thriller fixture for focused recommendation eval candidate availability.',
+        112,
+        7.9,
+        2016,
+        900007,
+        null,
+        'PopChoice E2E Grounded Thriller',
       ],
     );
 


### PR DESCRIPTION
## Summary

Stacks on #658 and adds the metadata v1 quality layer for recommendation candidates.

- Adds movie hot metadata fields, provider storage, and provider/catalog health persistence helpers.
- Extends TMDB catalog/recommendation parsing for details, certifications, language/country, providers, and metadata quality scoring.
- Enriches final TMDB-first candidates with bounded details and fails open when details are unavailable.
- Adds metadata quality fields into recommendation responses and deterministic eval metadata completeness checks.
- Updates catalog health/docs/roadmap and e2e seed data for real-data eval coverage.

## Validation

- npm run test --workspace=apps/web -- src/features/catalogMaintenance/tmdb.test.ts src/features/recommendation/tmdb.test.ts src/features/recommendation/evals/scoring.test.ts
- npm run test --workspace=packages/shared -- src/catalogHealth.test.ts
- npm run format:check
- npm run lint:check
- npm run eval:recommendations -> 27/27 passed
- npm run type-check
- pre-push hook: lint, server tests (68 files / 742 tests), production build

## Notes

This PR is intentionally stacked on #658. Provider fields are informational metadata in v1; provider UI/filtering remains follow-up work.