### PR TITLE
Complete TMDB review workflow follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ npm run build:bull-board            # Build Bull Board runtime entrypoint
 npm run build:docs                  # Build the documentation site
 npm run build:backoffice            # Build the backoffice app
 npm run build:storybook             # Build static Storybook
+npm run check:backoffice            # Shared build + backoffice structure/type/test checks
 npm run start --workspace=apps/web  # Start production server (apps/web)
 cd apps/web && npm run start:workers # Start BullMQ workers (apps/web)
 cd apps/web && npm run bull-board    # Launch BullMQ dashboard (apps/web)

--- a/apps/backoffice/src/app/api/catalog-maintenance-queue/events/route.test.ts
+++ b/apps/backoffice/src/app/api/catalog-maintenance-queue/events/route.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { catalogMaintenanceQueueJobPage } from '../../../../test/backofficeFixtures';
+
 const mocks = vi.hoisted(() => ({
   createBackofficeQueueEventStream: vi.fn(),
   createServerSentEventResponse: vi.fn(),
@@ -42,26 +44,10 @@ describe('catalog maintenance queue events route', () => {
   });
 
   it('opens a snapshot-only stream when Redis is unavailable', async () => {
-    const jobPage = {
+    const jobPage = catalogMaintenanceQueueJobPage({
       available: false,
-      counts: {
-        active: 0,
-        completed: 0,
-        delayed: 0,
-        failed: 0,
-        prioritized: 0,
-        waiting: 0,
-        waitingChildren: 0,
-      },
-      jobs: [],
-      limit: 25,
-      offset: 0,
-      openJobs: 0,
-      queueName: 'catalog-maintenance',
-      state: 'waiting',
-      totalCount: 0,
       updatedAt: '2026-06-03T00:00:00.000Z',
-    };
+    });
     mocks.listCatalogMaintenanceQueueJobs.mockResolvedValue(jobPage);
 
     const response = await GET(

--- a/apps/backoffice/src/app/api/catalog-maintenance-queue/route.test.ts
+++ b/apps/backoffice/src/app/api/catalog-maintenance-queue/route.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { catalogMaintenanceQueueJobPage } from '../../../test/backofficeFixtures';
+
 const mocks = vi.hoisted(() => ({
   ensureBackofficeReady: vi.fn(),
   listCatalogMaintenanceQueueJobs: vi.fn(),
@@ -31,8 +33,7 @@ describe('catalog maintenance queue API route', () => {
   });
 
   it('returns a no-store queue page JSON response', async () => {
-    const jobPage = {
-      available: true,
+    const jobPage = catalogMaintenanceQueueJobPage({
       counts: {
         active: 0,
         completed: 0,
@@ -42,15 +43,10 @@ describe('catalog maintenance queue API route', () => {
         waiting: 1,
         waitingChildren: 0,
       },
-      jobs: [],
-      limit: 25,
-      offset: 0,
       openJobs: 1,
-      queueName: 'catalog-maintenance',
-      state: 'waiting',
       totalCount: 1,
       updatedAt: '2026-06-03T00:00:00.000Z',
-    };
+    });
     mocks.listCatalogMaintenanceQueueJobs.mockResolvedValue(jobPage);
 
     const response = await GET(

--- a/apps/backoffice/src/app/catalog-health/actions/route.test.ts
+++ b/apps/backoffice/src/app/catalog-health/actions/route.test.ts
@@ -48,13 +48,13 @@ function createRepairRequest({
 } = {}) {
   return createBackofficeFormRequest({
     accept,
+    fetch: requestedWith === 'fetch',
     fields: {
       action,
       issue_key: 'missing_poster_url',
       movie_id: '42',
       return_to: returnTo,
     },
-    requestedWith,
     url: 'https://backoffice.test/catalog-health/actions',
   });
 }

--- a/apps/backoffice/src/app/globals.css
+++ b/apps/backoffice/src/app/globals.css
@@ -1474,6 +1474,21 @@ input:disabled {
   border-top: 1px solid var(--border);
   background: rgba(255, 255, 255, 0.018);
 }
+.review-risk.medium,
+.review-risk.high {
+  border-color: color-mix(in srgb, var(--warn), var(--border) 48%);
+}
+.review-risk.high {
+  border-color: color-mix(in srgb, var(--bad), var(--border) 48%);
+}
+.evidence-list {
+  margin: 0;
+  padding: 14px 18px 14px 28px;
+  display: grid;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 13px;
+}
 .facts,
 .candidate dl {
   margin: 0;

--- a/apps/backoffice/src/app/repair-batches/[id]/actions/route.test.ts
+++ b/apps/backoffice/src/app/repair-batches/[id]/actions/route.test.ts
@@ -29,13 +29,13 @@ import { POST } from './route';
 
 function createRetryRequest(fields: Record<string, string> = {}) {
   return createBackofficeFormRequest({
+    fetch: true,
     fields: {
       action: 'retry_item',
       item_id: 'item-1',
       return_to: '/repair-batches/batch-1?status=needs_review',
       ...fields,
     },
-    requestedWith: 'fetch',
     url: 'https://backoffice.test/repair-batches/batch-1/actions',
   });
 }

--- a/apps/backoffice/src/app/tmdb-reviews/[id]/actions/route.test.ts
+++ b/apps/backoffice/src/app/tmdb-reviews/[id]/actions/route.test.ts
@@ -40,11 +40,11 @@ function createReviewRequest({
 } = {}) {
   return createBackofficeFormRequest({
     accept,
+    fetch: requestedWith === 'fetch',
     fields: {
       action: 'apply_candidate',
       candidate_id: '12',
     },
-    requestedWith,
     url: 'https://backoffice.test/tmdb-reviews/review-1/actions',
   });
 }

--- a/apps/backoffice/src/app/tmdb-reviews/[id]/actions/route.test.ts
+++ b/apps/backoffice/src/app/tmdb-reviews/[id]/actions/route.test.ts
@@ -52,6 +52,11 @@ function createReviewRequest({
 describe('TMDB review action route', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.applyTMDBReviewFormAction.mockResolvedValue({
+      action: 'apply_candidate',
+      redirectTo: '/tmdb-reviews/review-1',
+      review: { id: 'review-1' },
+    });
     mocks.getBackofficeErrorStatus.mockReturnValue(500);
     mocks.isSameOriginRequest.mockReturnValue(true);
     mocks.wantsBackofficeJsonResponse.mockImplementation((request: Request) => {
@@ -124,6 +129,7 @@ describe('TMDB review action route', () => {
         ok: true,
         status: 'applied',
         message: 'Review action applied.',
+        action: 'apply_candidate',
         reviewId: 'review-1',
         redirectTo: '/tmdb-reviews/review-1',
       },

--- a/apps/backoffice/src/app/tmdb-reviews/[id]/actions/route.ts
+++ b/apps/backoffice/src/app/tmdb-reviews/[id]/actions/route.ts
@@ -18,7 +18,6 @@ type ReviewActionContext = {
 
 export async function POST(request: NextRequest, context: ReviewActionContext) {
   const { id } = await context.params;
-  const reviewPath = `/tmdb-reviews/${encodeURIComponent(id)}`;
 
   try {
     if (!isSameOriginRequest(request)) {
@@ -35,7 +34,7 @@ export async function POST(request: NextRequest, context: ReviewActionContext) {
     }
 
     const formData = await request.formData();
-    await applyTMDBReviewFormAction(id, formData, request.headers);
+    const result = await applyTMDBReviewFormAction(id, formData, request.headers);
 
     if (wantsBackofficeJsonResponse(request)) {
       return NextResponse.json({
@@ -43,11 +42,12 @@ export async function POST(request: NextRequest, context: ReviewActionContext) {
         status: 'applied',
         message: 'Review action applied.',
         reviewId: id,
-        redirectTo: reviewPath,
+        action: result.action,
+        redirectTo: result.redirectTo,
       });
     }
 
-    return NextResponse.redirect(new URL(reviewPath, request.url), 303);
+    return NextResponse.redirect(new URL(result.redirectTo, request.url), 303);
   } catch (error) {
     logBackofficeError('Failed to apply TMDB match review action', error);
     const status = getBackofficeErrorStatus(error);

--- a/apps/backoffice/src/components/catalog-health/issuePanel.test.tsx
+++ b/apps/backoffice/src/components/catalog-health/issuePanel.test.tsx
@@ -1,29 +1,20 @@
-import type { CatalogHealthIssue, CatalogMovieSample } from '@pop-choice/shared';
+import type { CatalogHealthIssue } from '@pop-choice/shared';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 
+import { catalogHealthIssue, catalogMovieSample } from '../../test/backofficeFixtures';
 import { CatalogIssuePanel, buildCatalogIssuePageHref, catalogIssueHint } from './issuePanel';
 
-const sampleMovie: CatalogMovieSample = {
+const sampleMovie = catalogMovieSample({
   age_rating: 'NR',
   duration: 0,
   id: '331',
-  localized_name: null,
   name: 'Mock Movie',
-  poster_url: null,
-  tmdb_id: null,
-  tmdb_matched_at: null,
   year: 2026,
-};
+});
 
 function issue(overrides: Partial<CatalogHealthIssue> = {}): CatalogHealthIssue {
-  return {
-    count: 42,
-    key: 'missing_poster_url',
-    label: 'Missing poster_url',
-    samples: [sampleMovie],
-    ...overrides,
-  };
+  return catalogHealthIssue({ samples: [sampleMovie], ...overrides });
 }
 
 describe('catalog health issue panel presentation', () => {

--- a/apps/backoffice/src/components/catalog-queue/helpers.test.ts
+++ b/apps/backoffice/src/components/catalog-queue/helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import type { CatalogMaintenanceQueueJobPage } from '../../catalogMaintenanceQueue';
 
+import { catalogMaintenanceQueueJobPage } from '../../test/backofficeFixtures';
 import {
   buildQueueHref,
   getLastQueueEvent,
@@ -14,26 +14,7 @@ import {
   queueRealtimeCopy,
 } from './helpers';
 
-const page: CatalogMaintenanceQueueJobPage = {
-  available: true,
-  counts: {
-    active: 0,
-    completed: 10,
-    delayed: 0,
-    failed: 0,
-    prioritized: 0,
-    waiting: 0,
-    waitingChildren: 0,
-  },
-  jobs: [],
-  limit: 25,
-  offset: 0,
-  openJobs: 0,
-  queueName: 'catalog-maintenance',
-  state: 'waiting',
-  totalCount: 0,
-  updatedAt: '2026-06-02T12:00:00Z',
-};
+const page = catalogMaintenanceQueueJobPage();
 
 describe('catalog queue helpers', () => {
   it('builds queue state links and state labels', () => {

--- a/apps/backoffice/src/components/repair-batches/detailSections.test.tsx
+++ b/apps/backoffice/src/components/repair-batches/detailSections.test.tsx
@@ -1,30 +1,8 @@
-import type { CatalogRepairBatchItem } from '@pop-choice/shared';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 
+import { catalogRepairBatchItem } from '../../test/backofficeFixtures';
 import { RepairBatchItemRows } from './detailSections';
-
-function batchItem(overrides: Partial<CatalogRepairBatchItem> = {}): CatalogRepairBatchItem {
-  return {
-    batchId: 'batch-1',
-    completedAt: null,
-    createdAt: '2026-06-02T12:00:00.000Z',
-    errorMessage: null,
-    id: 'item-1',
-    issueKey: 'missing_poster_url',
-    jobId: null,
-    jobName: null,
-    language: 'en',
-    movieId: '42',
-    movieSnapshot: { id: '42', name: 'Heat', year: 1995 },
-    queueName: null,
-    reason: 'missing_metadata',
-    result: {},
-    status: 'failed',
-    updatedAt: '2026-06-02T12:05:00.000Z',
-    ...overrides,
-  };
-}
 
 describe('repair batch detail sections', () => {
   it('shows retry actions only for failed, enqueue-failed, and unavailable items', () => {
@@ -33,9 +11,9 @@ describe('repair batch detail sections', () => {
         <tbody>
           <RepairBatchItemRows
             items={[
-              batchItem({ id: 'failed-item', status: 'failed' }),
-              batchItem({ id: 'unavailable-item', status: 'unavailable' }),
-              batchItem({ id: 'unresolved-item', status: 'completed_unresolved' }),
+              catalogRepairBatchItem({ id: 'failed-item', status: 'failed' }),
+              catalogRepairBatchItem({ id: 'unavailable-item', status: 'unavailable' }),
+              catalogRepairBatchItem({ id: 'unresolved-item', status: 'completed_unresolved' }),
             ]}
           />
         </tbody>

--- a/apps/backoffice/src/components/repair-batches/helpers.test.ts
+++ b/apps/backoffice/src/components/repair-batches/helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import type { CatalogRepairBatch } from '@pop-choice/shared';
 
+import { catalogRepairBatch } from '../../test/backofficeFixtures';
 import {
   buildRepairBatchItemPageHref,
   buildRepairBatchListHref,
@@ -14,30 +14,7 @@ import {
   truncateText,
 } from './helpers';
 
-const baseBatch: CatalogRepairBatch = {
-  action: 'bulk_enqueue_backfill',
-  actor: 'lexi',
-  attemptedCount: 10,
-  completedAt: null,
-  completedCount: 3,
-  createdAt: '2026-06-02T10:00:00Z',
-  dedupedCount: 2,
-  failedCount: 0,
-  id: '42',
-  issueKey: 'missing_poster_url',
-  note: null,
-  previousState: {},
-  requestedLimit: 10,
-  result: {},
-  skippedCount: 1,
-  status: 'completed',
-  targetId: 'missing_poster_url',
-  targetType: 'catalog_issue',
-  totalCandidates: 100,
-  unavailableCount: 0,
-  updatedAt: '2026-06-02T10:10:00Z',
-  queuedCount: 4,
-};
+const baseBatch = catalogRepairBatch({ actor: 'lexi', id: '42' });
 
 describe('repair batch helpers', () => {
   it('formats progress from terminal item counts', () => {

--- a/apps/backoffice/src/components/tmdb-reviews/actionSubmitButton.tsx
+++ b/apps/backoffice/src/components/tmdb-reviews/actionSubmitButton.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useFormStatus } from 'react-dom';
+
+export function ReviewActionSubmitButton({
+  buttonClass,
+  disabled = false,
+  label,
+  name,
+  pendingLabel,
+  value,
+}: {
+  buttonClass: string;
+  disabled?: boolean;
+  label: string;
+  name?: string;
+  pendingLabel: string;
+  value?: string;
+}) {
+  const { pending } = useFormStatus();
+  const isDisabled = disabled || pending;
+
+  return (
+    <button
+      className={`button ${buttonClass}`}
+      disabled={isDisabled}
+      name={name}
+      type="submit"
+      value={value}
+    >
+      {pending ? pendingLabel : label}
+    </button>
+  );
+}

--- a/apps/backoffice/src/components/tmdb-reviews/auditRows.tsx
+++ b/apps/backoffice/src/components/tmdb-reviews/auditRows.tsx
@@ -1,0 +1,44 @@
+import type { TMDBMatchReviewActionAudit } from '@pop-choice/shared';
+
+import { formatBackofficeDateTime } from '../../lib/backoffice';
+import { StatusBadge } from './reviewPresentation';
+
+export function AuditRows({ audit }: { audit: TMDBMatchReviewActionAudit[] }) {
+  if (audit.length === 0) return <p className="empty">No decisions have been recorded yet.</p>;
+
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>When</th>
+          <th>Actor</th>
+          <th>Action</th>
+          <th>Status</th>
+          <th>Candidate</th>
+          <th>Note</th>
+        </tr>
+      </thead>
+      <tbody>
+        {audit.map((entry) => (
+          <tr key={entry.id}>
+            <td>{formatBackofficeDateTime(entry.createdAt)}</td>
+            <td>{entry.actor}</td>
+            <td>{entry.action.replaceAll('_', ' ')}</td>
+            <td>
+              {entry.previousStatus ? (
+                <StatusBadge status={entry.previousStatus} />
+              ) : (
+                <span className="data-pill neutral">-</span>
+              )}{' '}
+              <StatusBadge status={entry.newStatus} />
+            </td>
+            <td>
+              {entry.candidate?.id ?? '-'} {entry.candidate ? entry.candidate.title : ''}
+            </td>
+            <td>{entry.note ?? '-'}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/apps/backoffice/src/components/tmdb-reviews/detail.test.tsx
+++ b/apps/backoffice/src/components/tmdb-reviews/detail.test.tsx
@@ -1,58 +1,12 @@
-import type { TMDBMatchReview } from '@pop-choice/shared';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 
+import { tmdbMatchReview } from '../../test/backofficeFixtures';
 import { ReviewDetailPage } from './detail';
-
-function review(overrides: Partial<TMDBMatchReview> = {}): TMDBMatchReview {
-  return {
-    candidates: [
-      {
-        confidence: 0.62,
-        id: 42,
-        originalTitle: 'Heat',
-        raw: { id: 42, title: 'Heat' },
-        releaseYear: 1994,
-        title: 'Heat',
-      },
-      {
-        confidence: 0.59,
-        id: 43,
-        originalTitle: 'Heat',
-        raw: { id: 43, title: 'Heat' },
-        releaseYear: 1995,
-        title: 'Heat',
-      },
-    ],
-    createdAt: '2026-06-02T12:00:00.000Z',
-    currentMovie: {
-      age_rating: 'R',
-      duration: 170,
-      id: '7',
-      localized_name: null,
-      name: 'Heat',
-      poster_url: null,
-      tmdb_id: 41,
-      tmdb_match_confidence: 0.51,
-      tmdb_match_source: 'candidate',
-      tmdb_matched_at: '2026-06-01T12:00:00.000Z',
-      year: 1995,
-    },
-    id: 'review-1',
-    movieId: '7',
-    movieName: 'Heat',
-    movieYear: 1995,
-    notes: 'Runtime differs from current TMDB match.',
-    reason: 'runtime_mismatch',
-    status: 'open',
-    updatedAt: '2026-06-02T12:00:00.000Z',
-    ...overrides,
-  };
-}
 
 describe('TMDB review detail page', () => {
   it('renders risk summary, next-review navigation, and pending-capable action forms', () => {
-    const html = renderToStaticMarkup(<ReviewDetailPage review={review()} audit={[]} />);
+    const html = renderToStaticMarkup(<ReviewDetailPage review={tmdbMatchReview()} audit={[]} />);
 
     expect(html).toContain('Next open');
     expect(html).toContain('High review risk');

--- a/apps/backoffice/src/components/tmdb-reviews/detail.test.tsx
+++ b/apps/backoffice/src/components/tmdb-reviews/detail.test.tsx
@@ -1,0 +1,64 @@
+import type { TMDBMatchReview } from '@pop-choice/shared';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { ReviewDetailPage } from './detail';
+
+function review(overrides: Partial<TMDBMatchReview> = {}): TMDBMatchReview {
+  return {
+    candidates: [
+      {
+        confidence: 0.62,
+        id: 42,
+        originalTitle: 'Heat',
+        raw: { id: 42, title: 'Heat' },
+        releaseYear: 1994,
+        title: 'Heat',
+      },
+      {
+        confidence: 0.59,
+        id: 43,
+        originalTitle: 'Heat',
+        raw: { id: 43, title: 'Heat' },
+        releaseYear: 1995,
+        title: 'Heat',
+      },
+    ],
+    createdAt: '2026-06-02T12:00:00.000Z',
+    currentMovie: {
+      age_rating: 'R',
+      duration: 170,
+      id: '7',
+      localized_name: null,
+      name: 'Heat',
+      poster_url: null,
+      tmdb_id: 41,
+      tmdb_match_confidence: 0.51,
+      tmdb_match_source: 'candidate',
+      tmdb_matched_at: '2026-06-01T12:00:00.000Z',
+      year: 1995,
+    },
+    id: 'review-1',
+    movieId: '7',
+    movieName: 'Heat',
+    movieYear: 1995,
+    notes: 'Runtime differs from current TMDB match.',
+    reason: 'runtime_mismatch',
+    status: 'open',
+    updatedAt: '2026-06-02T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('TMDB review detail page', () => {
+  it('renders risk summary, next-review navigation, and pending-capable action forms', () => {
+    const html = renderToStaticMarkup(<ReviewDetailPage review={review()} audit={[]} />);
+
+    expect(html).toContain('Next open');
+    expect(html).toContain('High review risk');
+    expect(html).toContain('Current catalog TMDB id is 41');
+    expect(html.match(/name="next_review"/g)).toHaveLength(4);
+    expect(html).toContain('Apply candidate');
+    expect(html).toContain('Apply + next');
+  });
+});

--- a/apps/backoffice/src/components/tmdb-reviews/detail.tsx
+++ b/apps/backoffice/src/components/tmdb-reviews/detail.tsx
@@ -8,7 +8,15 @@ import type {
 import { formatBackofficeDateTime } from '../../lib/backoffice';
 import { BackofficeLayout } from '../backoffice-layout';
 import { formatPercent } from '../shared';
-import { canApplyCandidate, getCandidateWarning, isCurrentCandidate } from './helpers';
+import { ReviewActionSubmitButton } from './actionSubmitButton';
+import { AuditRows } from './auditRows';
+import {
+  buildReviewPageHref,
+  canApplyCandidate,
+  getCandidateWarning,
+  getReviewRiskSummary,
+  isCurrentCandidate,
+} from './helpers';
 import {
   ConfidenceMeter,
   CurrentTMDBValue,
@@ -75,54 +83,23 @@ function CandidateCard({
             Decision note
             <input name="note" maxLength={500} placeholder="Why this candidate is correct" />
           </label>
-          <button className="button success" type="submit">
-            Apply candidate
-          </button>
+          <ReviewActionSubmitButton
+            buttonClass="success"
+            label="Apply candidate"
+            pendingLabel="Applying..."
+          />
+          <ReviewActionSubmitButton
+            buttonClass="secondary"
+            label="Apply + next"
+            name="next_review"
+            pendingLabel="Applying..."
+            value="1"
+          />
         </form>
       ) : (
         <p className="muted">This candidate cannot be applied from the current review state.</p>
       )}
     </article>
-  );
-}
-
-function AuditRows({ audit }: { audit: TMDBMatchReviewActionAudit[] }) {
-  if (audit.length === 0) return <p className="empty">No decisions have been recorded yet.</p>;
-
-  return (
-    <table>
-      <thead>
-        <tr>
-          <th>When</th>
-          <th>Actor</th>
-          <th>Action</th>
-          <th>Status</th>
-          <th>Candidate</th>
-          <th>Note</th>
-        </tr>
-      </thead>
-      <tbody>
-        {audit.map((entry) => (
-          <tr key={entry.id}>
-            <td>{formatBackofficeDateTime(entry.createdAt)}</td>
-            <td>{entry.actor}</td>
-            <td>{entry.action.replaceAll('_', ' ')}</td>
-            <td>
-              {entry.previousStatus ? (
-                <StatusBadge status={entry.previousStatus} />
-              ) : (
-                <span className="data-pill neutral">-</span>
-              )}{' '}
-              <StatusBadge status={entry.newStatus} />
-            </td>
-            <td>
-              {entry.candidate?.id ?? '-'} {entry.candidate ? entry.candidate.title : ''}
-            </td>
-            <td>{entry.note ?? '-'}</td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
   );
 }
 
@@ -174,9 +151,22 @@ function StatusActionForm({
           Decision note
           <input name="note" maxLength={500} placeholder="Optional rationale" disabled={disabled} />
         </label>
-        <button className={`button ${details.buttonClass}`} type="submit" disabled={disabled}>
-          {label}
-        </button>
+        <ReviewActionSubmitButton
+          buttonClass={details.buttonClass}
+          disabled={disabled}
+          label={label}
+          pendingLabel="Saving..."
+        />
+        {action === 'reopen' ? null : (
+          <ReviewActionSubmitButton
+            buttonClass="secondary"
+            disabled={disabled}
+            label={`${label} + next`}
+            name="next_review"
+            pendingLabel="Saving..."
+            value="1"
+          />
+        )}
       </form>
     </article>
   );
@@ -189,6 +179,13 @@ export function ReviewDetailPage({
   review: TMDBMatchReview;
   audit: TMDBMatchReviewActionAudit[];
 }) {
+  const riskSummary = getReviewRiskSummary(review);
+  const openQueueHref = buildReviewPageHref({
+    filters: { reason: 'all', sort: 'highest_risk', status: 'open' },
+    page: 1,
+    pageSize: 25,
+  });
+
   return (
     <BackofficeLayout
       active="reviews"
@@ -202,9 +199,14 @@ export function ReviewDetailPage({
         </div>
       }
       actions={
-        <a className="button" href="/tmdb-reviews">
-          Back to queue
-        </a>
+        <>
+          <a className="button" href={openQueueHref}>
+            Next open
+          </a>
+          <a className="button quiet" href="/tmdb-reviews">
+            Back to queue
+          </a>
+        </>
       }
     >
       <section className="detail-grid">
@@ -267,6 +269,22 @@ export function ReviewDetailPage({
               refreshes.
             </p>
           </div>
+        </article>
+        <article className={`panel review-risk ${riskSummary.level}`}>
+          <div className="panel-header">
+            <div>
+              <h2>{riskSummary.title}</h2>
+              <div className="issue-hint">Decision context before changing TMDB identity.</div>
+            </div>
+            <span className={`pill ${riskSummary.level === 'low' ? 'good' : 'warning'}`}>
+              {riskSummary.level}
+            </span>
+          </div>
+          <ul className="evidence-list">
+            {riskSummary.items.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
         </article>
       </section>
       <section className="panel">

--- a/apps/backoffice/src/components/tmdb-reviews/helpers.test.ts
+++ b/apps/backoffice/src/components/tmdb-reviews/helpers.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import {
   buildReviewPageHref,
+  buildReviewDetailHref,
   canApplyCandidate,
   candidateConfidenceGap,
   getCandidateWarning,
+  getReviewRiskSummary,
   isCurrentCandidate,
 } from './helpers';
 
@@ -17,6 +19,7 @@ describe('tmdb review helpers', () => {
         pageSize: 50,
       }),
     ).toBe('/tmdb-reviews?status=open&reason=runtime_mismatch&sort=oldest&page=2&pageSize=50');
+    expect(buildReviewDetailHref('review:42')).toBe('/tmdb-reviews/review%3A42');
   });
 
   it('calculates confidence gap only when the top two candidates have scores', () => {
@@ -70,5 +73,34 @@ describe('tmdb review helpers', () => {
         review: { currentMovie: { tmdb_id: 42 } as never },
       }),
     ).toBe(true);
+  });
+
+  it('summarizes review risk from reason, candidates, and current TMDB identity', () => {
+    expect(
+      getReviewRiskSummary({
+        candidates: [{ confidence: 0.94, id: 42, releaseYear: 2024 } as never],
+        currentMovie: null,
+        movieYear: 2024,
+        reason: 'ambiguous_match',
+      } as never),
+    ).toMatchObject({
+      level: 'low',
+      title: 'Low review risk',
+    });
+
+    const highRisk = getReviewRiskSummary({
+      candidates: [
+        { confidence: 0.62, id: 42, releaseYear: 2023 } as never,
+        { confidence: 0.59, id: 43, releaseYear: 2024 } as never,
+      ],
+      currentMovie: { tmdb_id: 41 },
+      movieYear: 2024,
+      reason: 'runtime_mismatch',
+    } as never);
+
+    expect(highRisk.level).toBe('high');
+    expect(highRisk.items.join(' ')).toContain('Runtime mismatch');
+    expect(highRisk.items.join(' ')).toContain('Current catalog TMDB id is 41');
+    expect(highRisk.items.join(' ')).toContain('Top candidates are close');
   });
 });

--- a/apps/backoffice/src/components/tmdb-reviews/helpers.ts
+++ b/apps/backoffice/src/components/tmdb-reviews/helpers.ts
@@ -12,6 +12,12 @@ export type ReviewFilters = {
   sort: TMDBMatchReviewSort;
 };
 
+export type ReviewRiskSummary = {
+  level: 'low' | 'medium' | 'high';
+  items: string[];
+  title: string;
+};
+
 export function buildReviewPageHref({
   filters,
   page,
@@ -39,6 +45,10 @@ export function candidateConfidenceGap(candidates: TMDBReviewCandidate[]): numbe
     runnerUp?.confidence !== undefined
     ? best.confidence - runnerUp.confidence
     : null;
+}
+
+export function buildReviewDetailHref(reviewId: string): string {
+  return `/tmdb-reviews/${encodeURIComponent(reviewId)}`;
 }
 
 export function getCandidateWarning({
@@ -77,4 +87,52 @@ export function isCurrentCandidate({
   review: Pick<TMDBMatchReview, 'currentMovie'>;
 }): boolean {
   return candidate.id !== null && candidate.id === review.currentMovie?.tmdb_id;
+}
+
+export function getReviewRiskSummary(review: TMDBMatchReview): ReviewRiskSummary {
+  const items: string[] = [];
+  const bestCandidate = review.candidates[0];
+  const confidenceGap = candidateConfidenceGap(review.candidates);
+  const candidateWarnings = review.candidates
+    .map((candidate) => getCandidateWarning({ candidate, review }))
+    .filter((warning): warning is string => Boolean(warning));
+
+  if (review.reason === 'runtime_mismatch') {
+    items.push('Runtime mismatch can indicate a wrong TMDB identity even when title/year match.');
+  }
+  if (review.currentMovie?.tmdb_id) {
+    items.push(`Current catalog TMDB id is ${review.currentMovie.tmdb_id}; applying changes it.`);
+  }
+  if (bestCandidate?.id === null || bestCandidate === undefined) {
+    items.push('No applyable TMDB candidate is available from captured metadata.');
+  }
+  if (bestCandidate?.confidence !== null && bestCandidate?.confidence !== undefined) {
+    if (bestCandidate.confidence < 0.7) {
+      items.push('Best candidate confidence is below the normal manual-apply threshold.');
+    }
+  } else {
+    items.push('Best candidate confidence is unavailable.');
+  }
+  if (confidenceGap !== null && confidenceGap < 0.1) {
+    items.push('Top candidates are close together; compare title, year, and runtime carefully.');
+  }
+  for (const warning of candidateWarnings.slice(0, 2)) {
+    if (!items.includes(warning)) items.push(warning);
+  }
+
+  if (items.length === 0) {
+    return {
+      level: 'low',
+      title: 'Low review risk',
+      items: ['Top candidate looks consistent with the local movie snapshot.'],
+    };
+  }
+
+  const level = review.reason === 'runtime_mismatch' || items.length >= 3 ? 'high' : 'medium';
+
+  return {
+    level,
+    title: level === 'high' ? 'High review risk' : 'Medium review risk',
+    items,
+  };
 }

--- a/apps/backoffice/src/lib/backoffice.ts
+++ b/apps/backoffice/src/lib/backoffice.ts
@@ -1,5 +1,7 @@
 export * from './backofficeParams';
 export * from './backofficeActionResponse';
+export * from './backofficeActionLog';
+export * from './backofficeMetrics';
 export * from './backofficeRuntime';
 export * from './catalogRepairActions';
 export * from './catalogRepairBatchActions';

--- a/apps/backoffice/src/lib/backofficeActionLog.test.ts
+++ b/apps/backoffice/src/lib/backofficeActionLog.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { sanitizeBackofficeActionLog } from './backofficeActionLog';
+
+describe('backoffice action logging', () => {
+  it('keeps operator action logs low-cardinality and secret-safe', () => {
+    const payload = sanitizeBackofficeActionLog({
+      action: 'enqueue_backfill',
+      actor: 'operator@example.test',
+      durationMs: 12.7,
+      issueKey: 'missing_poster_url',
+      mode: 'single',
+      repairBatchId: 'batch-1',
+      repairBatchItemId: 'item-1',
+      requestId: 'request-1',
+      resultStatus: 'queued',
+      targetId: '42',
+      targetType: 'movie',
+      // Extra properties are intentionally ignored by the sanitizer.
+      authorization: 'Basic secret',
+      databaseUrl: 'postgres://secret',
+      note: 'private operator note',
+      redisUrl: 'redis://secret',
+    } as never);
+
+    expect(payload).toEqual({
+      action: 'enqueue_backfill',
+      actor: 'operator@example.test',
+      durationMs: 13,
+      issueKey: 'missing_poster_url',
+      mode: 'single',
+      repairBatchId: 'batch-1',
+      repairBatchItemId: 'item-1',
+      requestId: 'request-1',
+      resultStatus: 'queued',
+      targetId: '42',
+      targetType: 'movie',
+    });
+    expect(JSON.stringify(payload)).not.toContain('secret');
+    expect(JSON.stringify(payload)).not.toContain('private operator note');
+  });
+});

--- a/apps/backoffice/src/lib/backofficeActionLog.ts
+++ b/apps/backoffice/src/lib/backofficeActionLog.ts
@@ -1,0 +1,57 @@
+import { logger } from '@pop-choice/shared';
+
+type OptionalString = string | number | null | undefined;
+
+export type BackofficeActionLogInput = {
+  action: string;
+  actor: string;
+  durationMs: number;
+  issueKey?: OptionalString;
+  mode?: OptionalString;
+  repairBatchId?: OptionalString;
+  repairBatchItemId?: OptionalString;
+  requestId?: OptionalString;
+  resultStatus: string;
+  reviewId?: OptionalString;
+  targetId?: OptionalString;
+  targetType: string;
+};
+
+const STRING_FIELDS = [
+  'action',
+  'actor',
+  'issueKey',
+  'mode',
+  'repairBatchId',
+  'repairBatchItemId',
+  'requestId',
+  'resultStatus',
+  'reviewId',
+  'targetId',
+  'targetType',
+] as const;
+
+function compactString(value: OptionalString): string | undefined {
+  if (value === null || value === undefined) return undefined;
+  const compacted = String(value).trim();
+  return compacted === '' ? undefined : compacted;
+}
+
+export function sanitizeBackofficeActionLog(
+  input: BackofficeActionLogInput,
+): Record<string, number | string> {
+  const payload: Record<string, number | string> = {
+    durationMs: Math.max(Math.round(input.durationMs), 0),
+  };
+
+  for (const field of STRING_FIELDS) {
+    const value = compactString(input[field]);
+    if (value !== undefined) payload[field] = value;
+  }
+
+  return payload;
+}
+
+export function logBackofficeAction(input: BackofficeActionLogInput): void {
+  logger.info('Backoffice operator action', sanitizeBackofficeActionLog(input));
+}

--- a/apps/backoffice/src/lib/backofficeEventStream.test.ts
+++ b/apps/backoffice/src/lib/backofficeEventStream.test.ts
@@ -1,8 +1,10 @@
 import type { QueueEvents } from 'bullmq';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { readBackofficeCounterSnapshot, resetBackofficeMetricsForTest } from './backofficeMetrics';
 import {
   bindCatalogMaintenanceQueueEvents,
+  createBackofficeQueueEventStream,
   createServerSentEventResponse,
   encodeServerSentEvent,
   getSearchParamsRecord,
@@ -11,6 +13,10 @@ import {
 } from './backofficeEventStream';
 
 describe('backoffice event stream helpers', () => {
+  afterEach(() => {
+    resetBackofficeMetricsForTest();
+  });
+
   it('encodes server-sent events with JSON payloads', () => {
     const encoded = new TextDecoder().decode(encodeServerSentEvent('snapshot', { ok: true }));
 
@@ -55,6 +61,39 @@ describe('backoffice event stream helpers', () => {
     expect(response.headers.get('Cache-Control')).toBe('no-cache');
     expect(response.headers.get('Connection')).toBe('keep-alive');
     expect(response.headers.get('X-Accel-Buffering')).toBe('no');
+  });
+
+  it('records lifecycle metrics for snapshot-only SSE streams', async () => {
+    const stream = createBackofficeQueueEventStream({
+      errorEvent: 'stream-error',
+      logError: vi.fn(),
+      logOpenErrorMessage: 'open failed',
+      logQueueErrorMessage: 'queue failed',
+      logRedisErrorMessage: 'redis failed',
+      logSnapshotErrorMessage: 'snapshot failed',
+      queueName: 'catalog-maintenance',
+      readSnapshot: vi.fn(),
+      redisUrl: null,
+      request: new Request('https://backoffice.test/events'),
+      streamOpenErrorMessage: 'open failed',
+      streamQueueErrorMessage: 'queue failed',
+      streamRedisErrorMessage: 'redis failed',
+      streamSnapshotErrorMessage: 'snapshot failed',
+    });
+
+    const reader = stream.getReader();
+    await reader.read();
+    await reader.cancel();
+
+    expect(readBackofficeCounterSnapshot()).toEqual(
+      expect.arrayContaining([
+        {
+          labels: { event: 'connected_snapshot_only', queue: 'catalog-maintenance' },
+          name: 'backoffice_sse_lifecycle_total',
+          value: 1,
+        },
+      ]),
+    );
   });
 
   it('binds and cleans up catalog maintenance queue event listeners', () => {

--- a/apps/backoffice/src/lib/backofficeEventStream.ts
+++ b/apps/backoffice/src/lib/backofficeEventStream.ts
@@ -1,6 +1,8 @@
 import { QueueEvents } from 'bullmq';
 import { Redis } from 'ioredis';
 
+import { recordBackofficeSseLifecycle } from './backofficeMetrics';
+
 export const BACKOFFICE_STREAM_HEARTBEAT_INTERVAL_MS = 25_000;
 export const BACKOFFICE_STREAM_SNAPSHOT_DEBOUNCE_MS = 350;
 
@@ -179,6 +181,7 @@ export function createBackofficeQueueEventStream({
         try {
           send('snapshot', await readSnapshot({ queueEvent, trigger }));
         } catch (error) {
+          recordBackofficeSseLifecycle({ event: 'snapshot_error', queueName });
           logError(logSnapshotErrorMessage, error);
           send(errorEvent, { message: streamSnapshotErrorMessage });
         } finally {
@@ -211,6 +214,7 @@ export function createBackofficeQueueEventStream({
       const cleanup = async () => {
         if (closed) return;
         closed = true;
+        recordBackofficeSseLifecycle({ event: 'closed', queueName });
         cleanupStream = null;
         if (snapshotTimer !== null) {
           clearTimeout(snapshotTimer);
@@ -243,6 +247,7 @@ export function createBackofficeQueueEventStream({
       );
 
       if (!connection || !queueEvents) {
+        recordBackofficeSseLifecycle({ event: 'connected_snapshot_only', queueName });
         send('connected', connectedPayload('snapshot-only'));
         if (sendSnapshotWhenRedisUnavailable) {
           scheduleSnapshot('redis-unavailable');
@@ -252,6 +257,7 @@ export function createBackofficeQueueEventStream({
 
       const forward = (type: string) => (rawPayload: QueueEventPayload) => {
         const payload = normalizeQueueEventPayload(rawPayload);
+        recordBackofficeSseLifecycle({ event: 'queue_event', queueName });
         if (onQueueEvent) {
           onQueueEvent({ payload, scheduleSnapshot, send, type });
           return;
@@ -264,6 +270,7 @@ export function createBackofficeQueueEventStream({
       connection.on('error', (error) => {
         if (suppressDuplicateRedisErrors && hasEmittedRedisError) return;
         hasEmittedRedisError = true;
+        recordBackofficeSseLifecycle({ event: 'redis_error', queueName });
         logError(logRedisErrorMessage, error);
         send(errorEvent, { message: streamRedisErrorMessage });
       });
@@ -273,15 +280,18 @@ export function createBackofficeQueueEventStream({
 
       cleanupQueueEventListeners = bindCatalogMaintenanceQueueEvents(queueEvents, forward);
       queueEvents.on('error', (error) => {
+        recordBackofficeSseLifecycle({ event: 'queue_error', queueName });
         logError(logQueueErrorMessage, error);
         send(errorEvent, { message: streamQueueErrorMessage });
       });
 
       try {
         await queueEvents.waitUntilReady();
+        recordBackofficeSseLifecycle({ event: 'connected_live', queueName });
         send('connected', connectedPayload('live'));
         scheduleSnapshot('connected');
       } catch (error) {
+        recordBackofficeSseLifecycle({ event: 'open_error', queueName });
         logError(logOpenErrorMessage, error);
         send(errorEvent, { message: streamOpenErrorMessage });
         await cleanup();

--- a/apps/backoffice/src/lib/backofficeMetrics.test.ts
+++ b/apps/backoffice/src/lib/backofficeMetrics.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  normalizeBackofficeRepairEnqueueStatus,
+  readBackofficeCounterSnapshot,
+  recordBackofficeRepairEnqueue,
+  recordBackofficeSseLifecycle,
+  resetBackofficeMetricsForTest,
+} from './backofficeMetrics';
+
+describe('backoffice metrics', () => {
+  afterEach(() => {
+    resetBackofficeMetricsForTest();
+  });
+
+  it('records low-cardinality repair enqueue counters', () => {
+    recordBackofficeRepairEnqueue({ mode: 'single', status: 'queued' });
+    recordBackofficeRepairEnqueue({ mode: 'single', status: 'queued' });
+    recordBackofficeRepairEnqueue({ mode: 'bulk', status: 'queue_unavailable' });
+    recordBackofficeRepairEnqueue({ count: 3, mode: 'bulk', status: 'failed' });
+
+    expect(readBackofficeCounterSnapshot()).toEqual(
+      expect.arrayContaining([
+        {
+          labels: { mode: 'single', status: 'queued' },
+          name: 'backoffice_repair_enqueue_total',
+          value: 2,
+        },
+        {
+          labels: { mode: 'bulk', status: 'unavailable' },
+          name: 'backoffice_repair_enqueue_total',
+          value: 1,
+        },
+        {
+          labels: { mode: 'bulk', status: 'failed' },
+          name: 'backoffice_repair_enqueue_total',
+          value: 3,
+        },
+      ]),
+    );
+  });
+
+  it('normalizes repair statuses for metrics', () => {
+    expect(normalizeBackofficeRepairEnqueueStatus('queued')).toBe('queued');
+    expect(normalizeBackofficeRepairEnqueueStatus('orchestration_queued')).toBe('queued');
+    expect(normalizeBackofficeRepairEnqueueStatus('unavailable')).toBe('unavailable');
+    expect(normalizeBackofficeRepairEnqueueStatus('queue_unavailable')).toBe('unavailable');
+    expect(normalizeBackofficeRepairEnqueueStatus('enqueue_failed')).toBe('failed');
+  });
+
+  it('records SSE lifecycle counters without payload data', () => {
+    recordBackofficeSseLifecycle({
+      event: 'connected_snapshot_only',
+      queueName: 'catalog-maintenance',
+    });
+    recordBackofficeSseLifecycle({
+      event: 'redis_error',
+      queueName: 'catalog-maintenance',
+    });
+
+    expect(readBackofficeCounterSnapshot()).toEqual(
+      expect.arrayContaining([
+        {
+          labels: { event: 'connected_snapshot_only', queue: 'catalog-maintenance' },
+          name: 'backoffice_sse_lifecycle_total',
+          value: 1,
+        },
+        {
+          labels: { event: 'redis_error', queue: 'catalog-maintenance' },
+          name: 'backoffice_sse_lifecycle_total',
+          value: 1,
+        },
+      ]),
+    );
+  });
+});

--- a/apps/backoffice/src/lib/backofficeMetrics.ts
+++ b/apps/backoffice/src/lib/backofficeMetrics.ts
@@ -1,0 +1,110 @@
+type BackofficeMetricLabels = Record<string, string>;
+
+export type BackofficeCounterSnapshot = {
+  labels: BackofficeMetricLabels;
+  name: string;
+  value: number;
+};
+
+export type BackofficeRepairEnqueueStatus = 'failed' | 'queued' | 'unavailable';
+export type BackofficeSseLifecycleEvent =
+  | 'closed'
+  | 'connected_live'
+  | 'connected_snapshot_only'
+  | 'open_error'
+  | 'queue_error'
+  | 'queue_event'
+  | 'redis_error'
+  | 'snapshot_error';
+
+const GLOBAL_METRICS_KEY = Symbol.for('popchoice.backofficeMetrics');
+const MAX_LABEL_LENGTH = 80;
+
+function getCounterStore(): Map<string, BackofficeCounterSnapshot> {
+  const globalWithMetrics = globalThis as typeof globalThis & {
+    [GLOBAL_METRICS_KEY]?: Map<string, BackofficeCounterSnapshot>;
+  };
+
+  globalWithMetrics[GLOBAL_METRICS_KEY] ??= new Map();
+  return globalWithMetrics[GLOBAL_METRICS_KEY];
+}
+
+function normalizeLabelValue(value: string): string {
+  const compacted = value.trim();
+  if (!compacted) return 'unknown';
+  return compacted.slice(0, MAX_LABEL_LENGTH);
+}
+
+function serializeLabels(labels: BackofficeMetricLabels): string {
+  return Object.keys(labels)
+    .sort()
+    .map((key) => `${key}=${labels[key]}`)
+    .join(',');
+}
+
+function incrementBackofficeCounter(
+  name: string,
+  labels: BackofficeMetricLabels,
+  amount = 1,
+): void {
+  if (!Number.isFinite(amount) || amount <= 0) return;
+
+  const normalizedLabels = Object.fromEntries(
+    Object.entries(labels).map(([key, value]) => [key, normalizeLabelValue(value)]),
+  );
+  const store = getCounterStore();
+  const key = `${name}{${serializeLabels(normalizedLabels)}}`;
+  const existing = store.get(key);
+
+  if (existing) {
+    existing.value += amount;
+    return;
+  }
+
+  store.set(key, { labels: normalizedLabels, name, value: amount });
+}
+
+export function normalizeBackofficeRepairEnqueueStatus(
+  status: string,
+): BackofficeRepairEnqueueStatus {
+  if (status === 'queued' || status === 'orchestration_queued') return 'queued';
+  if (status === 'unavailable' || status === 'queue_unavailable') return 'unavailable';
+  return 'failed';
+}
+
+export function recordBackofficeRepairEnqueue(input: {
+  count?: number;
+  mode: 'bulk' | 'single';
+  status: BackofficeRepairEnqueueStatus | string;
+}): void {
+  incrementBackofficeCounter(
+    'backoffice_repair_enqueue_total',
+    {
+      mode: input.mode,
+      status: normalizeBackofficeRepairEnqueueStatus(input.status),
+    },
+    input.count,
+  );
+}
+
+export function recordBackofficeSseLifecycle(input: {
+  event: BackofficeSseLifecycleEvent;
+  queueName: string;
+}): void {
+  incrementBackofficeCounter('backoffice_sse_lifecycle_total', {
+    event: input.event,
+    queue: input.queueName,
+  });
+}
+
+export function readBackofficeCounterSnapshot(): BackofficeCounterSnapshot[] {
+  return [...getCounterStore().values()].map((counter) => ({
+    labels: { ...counter.labels },
+    name: counter.name,
+    value: counter.value,
+  }));
+}
+
+export function resetBackofficeMetricsForTest(): void {
+  getCounterStore().clear();
+}

--- a/apps/backoffice/src/lib/catalogMaintenanceQueueLive.test.ts
+++ b/apps/backoffice/src/lib/catalogMaintenanceQueueLive.test.ts
@@ -1,13 +1,15 @@
 import { describe, expect, it } from 'vitest';
 
-import type { CatalogMaintenanceQueueJobPage } from '../catalogMaintenanceQueue';
+import {
+  catalogMaintenanceQueueJobPage,
+  catalogMaintenanceQueueJobSummary,
+} from '../test/backofficeFixtures';
 import {
   parseCatalogMaintenanceQueueConnectedMode,
   parseCatalogMaintenanceQueueSnapshotMessage,
 } from './catalogMaintenanceQueueLive';
 
-const jobPage: CatalogMaintenanceQueueJobPage = {
-  available: true,
+const jobPage = catalogMaintenanceQueueJobPage({
   counts: {
     active: 1,
     completed: 8,
@@ -17,31 +19,12 @@ const jobPage: CatalogMaintenanceQueueJobPage = {
     waiting: 2,
     waitingChildren: 0,
   },
-  jobs: [
-    {
-      attemptsConfigured: 4,
-      attemptsMade: 1,
-      createdAt: '2026-06-02T12:00:00.000Z',
-      failedReason: null,
-      finishedAt: null,
-      id: 'backfill-331',
-      movieId: '331',
-      name: 'backfill-movie',
-      payload: [{ label: 'Movie', value: '331' }],
-      processedAt: '2026-06-02T12:01:00.000Z',
-      repairBatchId: null,
-      repairBatchItemId: null,
-      state: 'active',
-    },
-  ],
-  limit: 25,
-  offset: 0,
+  jobs: [catalogMaintenanceQueueJobSummary({ id: 'backfill-331', movieId: '331' })],
   openJobs: 3,
-  queueName: 'catalog-maintenance',
   state: 'active',
   totalCount: 1,
   updatedAt: '2026-06-02T12:02:00.000Z',
-};
+});
 
 describe('catalog maintenance queue live snapshots', () => {
   it('parses streamed job pages for client-side queue updates', () => {

--- a/apps/backoffice/src/lib/catalogRepairActionLog.test.ts
+++ b/apps/backoffice/src/lib/catalogRepairActionLog.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  loggerInfo: vi.fn(),
+}));
+
+vi.mock('@pop-choice/shared', () => ({
+  logger: { info: mocks.loggerInfo },
+}));
+
+import { readBackofficeCounterSnapshot, resetBackofficeMetricsForTest } from './backofficeMetrics';
+import { logCatalogRepairActionResult } from './catalogRepairActionLog';
+
+describe('catalog repair action logging', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    resetBackofficeMetricsForTest();
+  });
+
+  it('records bulk repair enqueue counters from item outcome counts', () => {
+    logCatalogRepairActionResult({
+      action: 'bulk_enqueue_backfill',
+      actor: 'operator@example.test',
+      durationMs: 25,
+      result: {
+        issueKey: 'missing_poster_url',
+        mode: 'bulk',
+        status: 'partial',
+        summary: {
+          attempted: 6,
+          batchId: 'batch-1',
+          deduped: 1,
+          failed: 2,
+          issueKey: 'missing_poster_url',
+          jobs: [],
+          limit: 6,
+          movieIds: [],
+          queued: 3,
+          totalCandidates: 6,
+          unavailable: 1,
+        },
+      },
+    });
+
+    expect(readBackofficeCounterSnapshot()).toEqual(
+      expect.arrayContaining([
+        {
+          labels: { mode: 'bulk', status: 'queued' },
+          name: 'backoffice_repair_enqueue_total',
+          value: 4,
+        },
+        {
+          labels: { mode: 'bulk', status: 'failed' },
+          name: 'backoffice_repair_enqueue_total',
+          value: 2,
+        },
+        {
+          labels: { mode: 'bulk', status: 'unavailable' },
+          name: 'backoffice_repair_enqueue_total',
+          value: 1,
+        },
+      ]),
+    );
+    expect(mocks.loggerInfo).toHaveBeenCalledWith(
+      'Backoffice operator action',
+      expect.objectContaining({
+        action: 'bulk_enqueue_backfill',
+        mode: 'bulk',
+        repairBatchId: 'batch-1',
+        resultStatus: 'partial',
+      }),
+    );
+  });
+});

--- a/apps/backoffice/src/lib/catalogRepairActionLog.ts
+++ b/apps/backoffice/src/lib/catalogRepairActionLog.ts
@@ -1,0 +1,76 @@
+import type { CatalogRepairActionResult } from './catalogRepairActions';
+import { logBackofficeAction } from './backofficeActionLog';
+import { recordBackofficeRepairEnqueue } from './backofficeMetrics';
+
+function recordBulkRepairEnqueueMetrics(
+  result: Extract<CatalogRepairActionResult, { mode: 'bulk' }>,
+) {
+  const itemOutcomeCount =
+    result.summary.queued +
+    result.summary.deduped +
+    result.summary.failed +
+    result.summary.unavailable;
+
+  if (itemOutcomeCount === 0) {
+    if (result.status !== 'empty') {
+      recordBackofficeRepairEnqueue({ mode: result.mode, status: result.status });
+    }
+    return;
+  }
+
+  recordBackofficeRepairEnqueue({
+    count: result.summary.queued + result.summary.deduped,
+    mode: result.mode,
+    status: 'queued',
+  });
+  recordBackofficeRepairEnqueue({
+    count: result.summary.failed,
+    mode: result.mode,
+    status: 'failed',
+  });
+  recordBackofficeRepairEnqueue({
+    count: result.summary.unavailable,
+    mode: result.mode,
+    status: 'unavailable',
+  });
+}
+
+export function logCatalogRepairActionResult({
+  action,
+  actor,
+  durationMs,
+  result,
+}: {
+  action: string;
+  actor: string;
+  durationMs: number;
+  result: CatalogRepairActionResult;
+}) {
+  if (result.mode === 'single') {
+    recordBackofficeRepairEnqueue({ mode: result.mode, status: result.status });
+    logBackofficeAction({
+      action,
+      actor,
+      durationMs,
+      issueKey: result.issueKey,
+      mode: result.mode,
+      resultStatus: result.status,
+      targetId: result.movieId,
+      targetType: 'movie',
+    });
+    return;
+  }
+
+  recordBulkRepairEnqueueMetrics(result);
+  logBackofficeAction({
+    action,
+    actor,
+    durationMs,
+    issueKey: result.issueKey,
+    mode: result.mode,
+    repairBatchId: result.summary.batchId,
+    resultStatus: result.status,
+    targetId: result.issueKey,
+    targetType: 'catalog_issue',
+  });
+}

--- a/apps/backoffice/src/lib/catalogRepairActions.ts
+++ b/apps/backoffice/src/lib/catalogRepairActions.ts
@@ -1,6 +1,5 @@
 import {
   createCatalogRepairBatch,
-  getCatalogRepairMovieSnapshot,
   listCatalogHealthIssueMoviePage,
   recordCatalogRepairAction,
   refreshCatalogRepairBatchCounts,
@@ -14,12 +13,10 @@ import {
 import {
   catalogRepairMessage,
   getAsyncBulkRepairPageSize,
-  getBackfillReasonForIssue,
   getBulkRepairStatus,
   parseAsyncBulkRepairLimit,
   parseBulkRepairLimit,
   parseCatalogIssueKey,
-  parseMovieId,
   REPAIRABLE_CATALOG_ISSUE_KEYS,
   type CatalogRepairActionStatus,
 } from './catalogRepairActionHelpers';
@@ -33,6 +30,8 @@ import {
   ensureBackofficeReady,
   parseOperatorActor,
 } from './backofficeRuntime';
+import { logCatalogRepairActionResult } from './catalogRepairActionLog';
+import { performSingleCatalogRepairAction } from './catalogSingleRepairAction';
 
 export { catalogRepairMessage, REPAIRABLE_CATALOG_ISSUE_KEYS };
 
@@ -297,52 +296,44 @@ export async function performCatalogRepairAction(
   headers: Headers,
 ): Promise<CatalogRepairActionResult> {
   const config = await ensureBackofficeReady();
+  const actor = parseOperatorActor(headers);
+  const startedAt = Date.now();
+  const requestedAction =
+    typeof formData.get('action') === 'string' ? String(formData.get('action')) : 'unknown';
 
   if (formData.get('action') === 'bulk_enqueue_backfill') {
-    return performBulkCatalogRepairAction(formData, headers);
+    const result = await performBulkCatalogRepairAction(formData, headers);
+    logCatalogRepairActionResult({
+      action: requestedAction,
+      actor,
+      durationMs: Date.now() - startedAt,
+      result,
+    });
+    return result;
   }
 
   if (formData.get('action') === 'bulk_enqueue_backfill_async') {
-    return performAsyncBulkCatalogRepairAction(formData, headers);
+    const result = await performAsyncBulkCatalogRepairAction(formData, headers);
+    logCatalogRepairActionResult({
+      action: requestedAction,
+      actor,
+      durationMs: Date.now() - startedAt,
+      result,
+    });
+    return result;
   }
 
   if (formData.get('action') !== 'enqueue_backfill') {
     throw backofficeActionError('Unsupported catalog-health action.');
   }
 
-  const movieId = parseMovieId(formData.get('movie_id'));
-  const issueKey = parseCatalogIssueKey(formData.get('issue_key'));
-  const snapshot = await getCatalogRepairMovieSnapshot(movieId);
-
-  if (!snapshot) {
-    throw backofficeActionError('Movie not found.', 404);
-  }
-
-  const job = await enqueueCatalogBackfillMovieFromBackoffice(
-    {
-      movieId,
-      reason: getBackfillReasonForIssue(issueKey),
-      language: config.tmdbLanguage,
-    },
-    config.redisUrl,
-  );
-
-  await recordCatalogRepairAction({
-    action: 'enqueue_backfill',
-    actor: parseOperatorActor(headers),
-    issueKey,
-    targetType: 'movie',
-    targetId: movieId,
-    note: typeof formData.get('note') === 'string' ? String(formData.get('note')) : undefined,
-    previousState: { ...snapshot },
-    result: job ? { ...job } : { status: 'queue_unavailable', queueName: 'catalog-maintenance' },
+  const result = await performSingleCatalogRepairAction({ config, formData, headers });
+  logCatalogRepairActionResult({
+    action: requestedAction,
+    actor,
+    durationMs: Date.now() - startedAt,
+    result,
   });
 
-  return {
-    mode: 'single',
-    status: job ? 'queued' : 'unavailable',
-    issueKey,
-    movieId,
-    job,
-  };
+  return result;
 }

--- a/apps/backoffice/src/lib/catalogRepairBatchActions.test.ts
+++ b/apps/backoffice/src/lib/catalogRepairBatchActions.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   ensureBackofficeReady: vi.fn(),
   getCatalogRepairBatchItem: vi.fn(),
   loggerError: vi.fn(),
+  loggerInfo: vi.fn(),
   parseOperatorActor: vi.fn(),
   recordCatalogRepairAction: vi.fn(),
   refreshCatalogRepairBatchCounts: vi.fn(),
@@ -16,7 +17,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock('@pop-choice/shared', () => ({
   createCatalogRepairBatchItem: mocks.createCatalogRepairBatchItem,
   getCatalogRepairBatchItem: mocks.getCatalogRepairBatchItem,
-  logger: { error: mocks.loggerError },
+  logger: { error: mocks.loggerError, info: mocks.loggerInfo },
   recordCatalogRepairAction: mocks.recordCatalogRepairAction,
   refreshCatalogRepairBatchCounts: mocks.refreshCatalogRepairBatchCounts,
   updateCatalogRepairBatchItemEnqueueResult: mocks.updateCatalogRepairBatchItemEnqueueResult,
@@ -192,6 +193,17 @@ describe('catalog repair batch actions', () => {
         targetType: 'movie',
       }),
     );
+    expect(mocks.loggerInfo).toHaveBeenCalledWith('Backoffice operator action', {
+      action: 'retry_item',
+      actor: 'operator@example.test',
+      durationMs: expect.any(Number),
+      issueKey: 'missing_poster_url',
+      repairBatchId: 'batch-1',
+      repairBatchItemId: 'item-1',
+      resultStatus: 'queued',
+      targetId: '42',
+      targetType: 'movie',
+    });
   });
 
   it('marks retried items unavailable when the queue is disabled', async () => {

--- a/apps/backoffice/src/lib/catalogRepairBatchActions.test.ts
+++ b/apps/backoffice/src/lib/catalogRepairBatchActions.test.ts
@@ -1,5 +1,10 @@
-import type { CatalogMovieSample } from '@pop-choice/shared';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  catalogBackfillQueueJob,
+  catalogMovieSample,
+  catalogRepairBatchItem,
+} from '../test/backofficeFixtures';
 
 const mocks = vi.hoisted(() => ({
   createCatalogRepairBatchItem: vi.fn(),
@@ -42,20 +47,6 @@ import {
   retryCatalogRepairBatchItem,
 } from './catalogRepairBatchActions';
 
-function sampleMovie(id: string): CatalogMovieSample {
-  return {
-    age_rating: 'PG',
-    duration: 100,
-    id,
-    localized_name: null,
-    name: `Movie ${id}`,
-    poster_url: null,
-    tmdb_id: null,
-    tmdb_matched_at: null,
-    year: 2026,
-  };
-}
-
 describe('catalog repair batch actions', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -70,7 +61,10 @@ describe('catalog repair batch actions', () => {
   });
 
   it('continues processing when failure-status persistence fails', async () => {
-    const movies = [sampleMovie('1'), sampleMovie('2')];
+    const movies = [
+      catalogMovieSample({ id: '1', name: 'Movie 1', year: 2026 }),
+      catalogMovieSample({ id: '2', name: 'Movie 2', year: 2026 }),
+    ];
     const summary = createCatalogBulkRepairSummary({
       issueKey: 'missing_poster_url',
       limit: 2,
@@ -80,13 +74,7 @@ describe('catalog repair batch actions', () => {
 
     mocks.enqueueCatalogBackfillMovieFromBackoffice
       .mockRejectedValueOnce(new Error('queue failed'))
-      .mockResolvedValueOnce({
-        jobId: 'job-2',
-        jobName: 'backfill-movie',
-        language: 'en',
-        queueName: 'catalog-maintenance',
-        status: 'queued',
-      });
+      .mockResolvedValueOnce(catalogBackfillQueueJob({ jobId: 'job-2', language: 'en' }));
     mocks.updateCatalogRepairBatchItemEnqueueResult
       .mockRejectedValueOnce(new Error('persist failed'))
       .mockResolvedValueOnce(undefined);
@@ -118,31 +106,10 @@ describe('catalog repair batch actions', () => {
   });
 
   it('retries a failed repair batch item with the original batch item context', async () => {
-    const item = {
-      batchId: 'batch-1',
+    const item = catalogRepairBatchItem({
       completedAt: '2026-06-02T12:05:00.000Z',
-      createdAt: '2026-06-02T12:00:00.000Z',
-      errorMessage: 'worker failed',
-      id: 'item-1',
-      issueKey: 'missing_poster_url',
-      jobId: 'old-job',
-      jobName: 'backfill-movie',
-      language: 'en',
-      movieId: '42',
-      movieSnapshot: { id: '42', name: 'Heat' },
-      queueName: 'catalog-maintenance',
-      reason: 'missing_metadata',
-      result: { status: 'failed' },
-      status: 'failed',
-      updatedAt: '2026-06-02T12:05:00.000Z',
-    };
-    const job = {
-      jobId: 'job-42',
-      jobName: 'backfill-movie',
-      language: 'en-US',
-      queueName: 'catalog-maintenance',
-      status: 'queued',
-    };
+    });
+    const job = catalogBackfillQueueJob();
     const updatedItem = { ...item, completedAt: null, jobId: 'job-42', status: 'queued' };
     mocks.getCatalogRepairBatchItem.mockResolvedValue(item);
     mocks.enqueueCatalogBackfillMovieFromBackoffice.mockResolvedValue(job);
@@ -207,24 +174,17 @@ describe('catalog repair batch actions', () => {
   });
 
   it('marks retried items unavailable when the queue is disabled', async () => {
-    const item = {
-      batchId: 'batch-1',
+    const item = catalogRepairBatchItem({
       completedAt: '2026-06-02T12:05:00.000Z',
-      createdAt: '2026-06-02T12:00:00.000Z',
       errorMessage: 'redis missing',
-      id: 'item-1',
-      issueKey: 'missing_poster_url',
       jobId: null,
       jobName: null,
       language: null,
-      movieId: '42',
-      movieSnapshot: { id: '42', name: 'Heat' },
       queueName: null,
       reason: null,
       result: { status: 'queue_unavailable' },
       status: 'unavailable',
-      updatedAt: '2026-06-02T12:05:00.000Z',
-    };
+    });
     const updatedItem = { ...item, status: 'unavailable' };
     mocks.getCatalogRepairBatchItem.mockResolvedValue(item);
     mocks.enqueueCatalogBackfillMovieFromBackoffice.mockResolvedValue(null);
@@ -247,13 +207,11 @@ describe('catalog repair batch actions', () => {
   });
 
   it('rejects retry for completed-unresolved items', async () => {
-    mocks.getCatalogRepairBatchItem.mockResolvedValue({
-      batchId: 'batch-1',
-      id: 'item-1',
-      issueKey: 'missing_poster_url',
-      movieId: '42',
-      status: 'completed_unresolved',
-    });
+    mocks.getCatalogRepairBatchItem.mockResolvedValue(
+      catalogRepairBatchItem({
+        status: 'completed_unresolved',
+      }),
+    );
 
     const formData = new FormData();
     formData.set('action', 'retry_item');

--- a/apps/backoffice/src/lib/catalogRepairBatchActions.ts
+++ b/apps/backoffice/src/lib/catalogRepairBatchActions.ts
@@ -10,6 +10,8 @@ import {
 } from '@pop-choice/shared';
 
 import { enqueueCatalogBackfillMovieFromBackoffice } from '../catalogMaintenanceQueue';
+import { logBackofficeAction } from './backofficeActionLog';
+import { recordBackofficeRepairEnqueue } from './backofficeMetrics';
 import { getBackfillReasonForIssue } from './catalogRepairActionHelpers';
 import {
   backofficeActionError,
@@ -192,6 +194,7 @@ export async function retryCatalogRepairBatchItem(
   headers: Headers,
 ): Promise<CatalogRepairBatchItemRetryResult> {
   const config = await ensureBackofficeReady();
+  const startedAt = Date.now();
   if (formData.get('action') !== 'retry_item') {
     throw backofficeActionError('Unsupported repair batch action.');
   }
@@ -264,6 +267,21 @@ export async function retryCatalogRepairBatchItem(
       repairBatchId: item.batchId,
       repairBatchItemId: item.id,
     });
+    logBackofficeAction({
+      action: 'retry_item',
+      actor,
+      durationMs: Date.now() - startedAt,
+      issueKey: item.issueKey,
+      repairBatchId: item.batchId,
+      repairBatchItemId: item.id,
+      resultStatus: job ? job.status : 'unavailable',
+      targetId: item.movieId,
+      targetType: 'movie',
+    });
+    recordBackofficeRepairEnqueue({
+      mode: 'single',
+      status: job ? job.status : 'unavailable',
+    });
 
     return {
       batchId: item.batchId,
@@ -301,6 +319,18 @@ export async function retryCatalogRepairBatchItem(
       issueKey: item.issueKey,
       movieId: item.movieId,
     });
+    logBackofficeAction({
+      action: 'retry_item',
+      actor,
+      durationMs: Date.now() - startedAt,
+      issueKey: item.issueKey,
+      repairBatchId: item.batchId,
+      repairBatchItemId: item.id,
+      resultStatus: 'failed',
+      targetId: item.movieId,
+      targetType: 'movie',
+    });
+    recordBackofficeRepairEnqueue({ mode: 'single', status: 'failed' });
 
     return {
       batchId: item.batchId,

--- a/apps/backoffice/src/lib/catalogSingleRepairAction.ts
+++ b/apps/backoffice/src/lib/catalogSingleRepairAction.ts
@@ -1,0 +1,60 @@
+import {
+  getCatalogRepairMovieSnapshot,
+  recordCatalogRepairAction,
+  type BackofficeRuntimeConfig,
+} from '@pop-choice/shared';
+
+import { enqueueCatalogBackfillMovieFromBackoffice } from '../catalogMaintenanceQueue';
+import {
+  getBackfillReasonForIssue,
+  parseCatalogIssueKey,
+  parseMovieId,
+} from './catalogRepairActionHelpers';
+import { backofficeActionError, parseOperatorActor } from './backofficeRuntime';
+import type { CatalogRepairActionResult } from './catalogRepairActions';
+
+export async function performSingleCatalogRepairAction({
+  config,
+  formData,
+  headers,
+}: {
+  config: BackofficeRuntimeConfig;
+  formData: FormData;
+  headers: Headers;
+}): Promise<CatalogRepairActionResult> {
+  const movieId = parseMovieId(formData.get('movie_id'));
+  const issueKey = parseCatalogIssueKey(formData.get('issue_key'));
+  const snapshot = await getCatalogRepairMovieSnapshot(movieId);
+
+  if (!snapshot) {
+    throw backofficeActionError('Movie not found.', 404);
+  }
+
+  const job = await enqueueCatalogBackfillMovieFromBackoffice(
+    {
+      movieId,
+      reason: getBackfillReasonForIssue(issueKey),
+      language: config.tmdbLanguage,
+    },
+    config.redisUrl,
+  );
+
+  await recordCatalogRepairAction({
+    action: 'enqueue_backfill',
+    actor: parseOperatorActor(headers),
+    issueKey,
+    targetType: 'movie',
+    targetId: movieId,
+    note: typeof formData.get('note') === 'string' ? String(formData.get('note')) : undefined,
+    previousState: { ...snapshot },
+    result: job ? { ...job } : { status: 'queue_unavailable', queueName: 'catalog-maintenance' },
+  });
+
+  return {
+    mode: 'single',
+    status: job ? 'queued' : 'unavailable',
+    issueKey,
+    movieId,
+    job,
+  };
+}

--- a/apps/backoffice/src/lib/tmdbReviewActions.test.ts
+++ b/apps/backoffice/src/lib/tmdbReviewActions.test.ts
@@ -1,14 +1,55 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { assertCandidateIdForAction, parseAction, parseCandidateId } from './tmdbReviewActions';
+const mocks = vi.hoisted(() => ({
+  applyTMDBMatchReviewAction: vi.fn(),
+  ensureBackofficeReady: vi.fn(),
+  listTMDBMatchReviewPage: vi.fn(),
+  parseOperatorActor: vi.fn(),
+}));
+
+vi.mock('@pop-choice/shared', () => ({
+  applyTMDBMatchReviewAction: mocks.applyTMDBMatchReviewAction,
+  listTMDBMatchReviewPage: mocks.listTMDBMatchReviewPage,
+}));
+
+vi.mock('./backofficeRuntime', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./backofficeRuntime')>();
+  return {
+    ...actual,
+    ensureBackofficeReady: mocks.ensureBackofficeReady,
+    parseOperatorActor: mocks.parseOperatorActor,
+  };
+});
+
+import {
+  applyTMDBReviewFormAction,
+  assertCandidateIdForAction,
+  getNextOpenReviewPath,
+  isNextReviewRequested,
+  openReviewQueuePath,
+  parseAction,
+  parseCandidateId,
+  reviewDetailPath,
+} from './tmdbReviewActions';
 
 describe('tmdb review action helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.ensureBackofficeReady.mockResolvedValue(undefined);
+    mocks.parseOperatorActor.mockReturnValue('operator@example.test');
+  });
+
   it('parses supported action names and candidate ids', () => {
     expect(parseAction('apply_candidate')).toBe('apply_candidate');
     expect(parseAction('reject')).toBe('reject');
     expect(parseCandidateId('42')).toBe(42);
     expect(parseCandidateId('')).toBeUndefined();
     expect(parseCandidateId(null)).toBeUndefined();
+    expect(isNextReviewRequested('1')).toBe(true);
+    expect(isNextReviewRequested('true')).toBe(true);
+    expect(isNextReviewRequested(null)).toBe(false);
+    expect(reviewDetailPath('review:42')).toBe('/tmdb-reviews/review%3A42');
+    expect(openReviewQueuePath()).toContain('status=open');
   });
 
   it('requires candidate id only when applying a TMDB candidate', () => {
@@ -23,5 +64,54 @@ describe('tmdb review action helpers', () => {
     expect(() => parseCandidateId('abc')).toThrow('Candidate id must be numeric');
     expect(() => parseCandidateId('-1')).toThrow('Candidate id must be numeric');
     expect(() => parseCandidateId('0')).toThrow('positive safe integer');
+  });
+
+  it('returns the next open review path while skipping the current review', async () => {
+    mocks.listTMDBMatchReviewPage.mockResolvedValue({
+      limit: 2,
+      offset: 0,
+      reviews: [{ id: 'review-1' }, { id: 'review-2' }],
+      totalCount: 2,
+    });
+
+    await expect(getNextOpenReviewPath('review-1')).resolves.toBe('/tmdb-reviews/review-2');
+    expect(mocks.listTMDBMatchReviewPage).toHaveBeenCalledWith({
+      limit: 2,
+      offset: 0,
+      reason: 'all',
+      sort: 'highest_risk',
+      status: 'open',
+    });
+  });
+
+  it('applies review actions and returns a next-review redirect when requested', async () => {
+    const updatedReview = { id: 'review-1', status: 'resolved' };
+    mocks.applyTMDBMatchReviewAction.mockResolvedValue(updatedReview);
+    mocks.listTMDBMatchReviewPage.mockResolvedValue({
+      limit: 2,
+      offset: 0,
+      reviews: [{ id: 'review-2' }],
+      totalCount: 1,
+    });
+    const formData = new FormData();
+    formData.set('action', 'apply_candidate');
+    formData.set('candidate_id', '42');
+    formData.set('next_review', '1');
+    formData.set('note', 'Looks right');
+
+    const result = await applyTMDBReviewFormAction('review-1', formData, new Headers());
+
+    expect(result).toEqual({
+      action: 'apply_candidate',
+      redirectTo: '/tmdb-reviews/review-2',
+      review: updatedReview,
+    });
+    expect(mocks.applyTMDBMatchReviewAction).toHaveBeenCalledWith({
+      action: 'apply_candidate',
+      actor: 'operator@example.test',
+      candidateId: 42,
+      note: 'Looks right',
+      reviewId: 'review-1',
+    });
   });
 });

--- a/apps/backoffice/src/lib/tmdbReviewActions.test.ts
+++ b/apps/backoffice/src/lib/tmdbReviewActions.test.ts
@@ -3,12 +3,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   applyTMDBMatchReviewAction: vi.fn(),
   ensureBackofficeReady: vi.fn(),
+  loggerInfo: vi.fn(),
   listTMDBMatchReviewPage: vi.fn(),
   parseOperatorActor: vi.fn(),
 }));
 
 vi.mock('@pop-choice/shared', () => ({
   applyTMDBMatchReviewAction: mocks.applyTMDBMatchReviewAction,
+  logger: { info: mocks.loggerInfo },
   listTMDBMatchReviewPage: mocks.listTMDBMatchReviewPage,
 }));
 
@@ -112,6 +114,15 @@ describe('tmdb review action helpers', () => {
       candidateId: 42,
       note: 'Looks right',
       reviewId: 'review-1',
+    });
+    expect(mocks.loggerInfo).toHaveBeenCalledWith('Backoffice operator action', {
+      action: 'apply_candidate',
+      actor: 'operator@example.test',
+      durationMs: expect.any(Number),
+      resultStatus: 'resolved',
+      reviewId: 'review-1',
+      targetId: 'review-1',
+      targetType: 'tmdb_match_review',
     });
   });
 });

--- a/apps/backoffice/src/lib/tmdbReviewActions.ts
+++ b/apps/backoffice/src/lib/tmdbReviewActions.ts
@@ -6,6 +6,7 @@ import {
   ensureBackofficeReady,
   parseOperatorActor,
 } from './backofficeRuntime';
+import { logBackofficeAction } from './backofficeActionLog';
 
 export type TMDBReviewFormActionResult = {
   action: TMDBMatchReviewAction;
@@ -88,6 +89,8 @@ export async function applyTMDBReviewFormAction(
   headers: Headers,
 ): Promise<TMDBReviewFormActionResult> {
   await ensureBackofficeReady();
+  const startedAt = Date.now();
+  const actor = parseOperatorActor(headers);
 
   const action = parseAction(formData.get('action'));
   const candidateId = parseCandidateId(formData.get('candidate_id'));
@@ -98,9 +101,18 @@ export async function applyTMDBReviewFormAction(
   const review = await applyTMDBMatchReviewAction({
     reviewId,
     action,
-    actor: parseOperatorActor(headers),
+    actor,
     candidateId,
     note: typeof note === 'string' ? note : undefined,
+  });
+  logBackofficeAction({
+    action,
+    actor,
+    durationMs: Date.now() - startedAt,
+    resultStatus: review.status,
+    reviewId,
+    targetId: reviewId,
+    targetType: 'tmdb_match_review',
   });
   const redirectTo = isNextReviewRequested(formData.get('next_review'))
     ? await getNextOpenReviewPath(review.id)

--- a/apps/backoffice/src/lib/tmdbReviewActions.ts
+++ b/apps/backoffice/src/lib/tmdbReviewActions.ts
@@ -1,11 +1,17 @@
-import { applyTMDBMatchReviewAction } from '@pop-choice/shared';
-import type { TMDBMatchReviewAction } from '@pop-choice/shared';
+import { applyTMDBMatchReviewAction, listTMDBMatchReviewPage } from '@pop-choice/shared';
+import type { TMDBMatchReview, TMDBMatchReviewAction } from '@pop-choice/shared';
 
 import {
   backofficeActionError,
   ensureBackofficeReady,
   parseOperatorActor,
 } from './backofficeRuntime';
+
+export type TMDBReviewFormActionResult = {
+  action: TMDBMatchReviewAction;
+  redirectTo: string;
+  review: TMDBMatchReview;
+};
 
 export function parseAction(value: FormDataEntryValue | null): TMDBMatchReviewAction {
   if (
@@ -51,11 +57,36 @@ export function assertCandidateIdForAction(
   }
 }
 
+export function isNextReviewRequested(value: FormDataEntryValue | null): boolean {
+  return value === '1' || value === 'true' || value === 'on';
+}
+
+export function reviewDetailPath(reviewId: string): string {
+  return `/tmdb-reviews/${encodeURIComponent(reviewId)}`;
+}
+
+export function openReviewQueuePath(): string {
+  return '/tmdb-reviews?status=open&reason=all&sort=highest_risk&page=1&pageSize=25';
+}
+
+export async function getNextOpenReviewPath(currentReviewId: string): Promise<string> {
+  const page = await listTMDBMatchReviewPage({
+    limit: 2,
+    offset: 0,
+    reason: 'all',
+    sort: 'highest_risk',
+    status: 'open',
+  });
+  const nextReview = page.reviews.find((review) => review.id !== currentReviewId);
+
+  return nextReview ? reviewDetailPath(nextReview.id) : openReviewQueuePath();
+}
+
 export async function applyTMDBReviewFormAction(
   reviewId: string,
   formData: FormData,
   headers: Headers,
-): Promise<void> {
+): Promise<TMDBReviewFormActionResult> {
   await ensureBackofficeReady();
 
   const action = parseAction(formData.get('action'));
@@ -64,11 +95,16 @@ export async function applyTMDBReviewFormAction(
 
   assertCandidateIdForAction(action, candidateId);
 
-  await applyTMDBMatchReviewAction({
+  const review = await applyTMDBMatchReviewAction({
     reviewId,
     action,
     actor: parseOperatorActor(headers),
     candidateId,
     note: typeof note === 'string' ? note : undefined,
   });
+  const redirectTo = isNextReviewRequested(formData.get('next_review'))
+    ? await getNextOpenReviewPath(review.id)
+    : reviewDetailPath(review.id);
+
+  return { action, redirectTo, review };
 }

--- a/apps/backoffice/src/proxy.test.ts
+++ b/apps/backoffice/src/proxy.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { proxy } from './proxy';
+
+type ProxyRequest = Parameters<typeof proxy>[0];
+
+const ORIGINAL_ENV = {
+  OPERATOR_AUTH_PASSWORD: process.env.OPERATOR_AUTH_PASSWORD,
+  OPERATOR_AUTH_RATE_LIMIT_MAX: process.env.OPERATOR_AUTH_RATE_LIMIT_MAX,
+  OPERATOR_AUTH_REALM: process.env.OPERATOR_AUTH_REALM,
+  OPERATOR_AUTH_REQUIRED: process.env.OPERATOR_AUTH_REQUIRED,
+  OPERATOR_AUTH_USERNAME: process.env.OPERATOR_AUTH_USERNAME,
+};
+
+function restoreEnv(): void {
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+function request(path: string): ProxyRequest {
+  return {
+    headers: new Headers({ 'x-real-ip': `198.51.100.${path.length}` }),
+    url: `https://backoffice.test${path}`,
+  } as ProxyRequest;
+}
+
+describe('backoffice proxy auth coverage', () => {
+  beforeEach(() => {
+    process.env.OPERATOR_AUTH_USERNAME = 'operator';
+    process.env.OPERATOR_AUTH_PASSWORD = 'secret';
+    process.env.OPERATOR_AUTH_REALM = 'PopChoice Operators';
+    process.env.OPERATOR_AUTH_REQUIRED = 'true';
+    process.env.OPERATOR_AUTH_RATE_LIMIT_MAX = '1000';
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  it.each([
+    '/catalog-health/actions',
+    '/repair-batches/batch-1/actions',
+    '/tmdb-reviews/review-1/actions',
+  ])('requires operator auth for mutation URL %s', (path) => {
+    const response = proxy(request(path));
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get('www-authenticate')).toContain('PopChoice Operators');
+  });
+});

--- a/apps/backoffice/src/test/backofficeActionRoute.ts
+++ b/apps/backoffice/src/test/backofficeActionRoute.ts
@@ -2,14 +2,18 @@ import { expect } from 'vitest';
 
 type FormRequestOptions = {
   accept?: string;
+  fetch?: boolean;
   fields?: Record<string, string>;
+  json?: boolean;
   requestedWith?: string;
   url: string;
 };
 
 export function createBackofficeFormRequest({
   accept,
+  fetch,
   fields,
+  json,
   requestedWith,
   url,
 }: FormRequestOptions): Request {
@@ -19,7 +23,9 @@ export function createBackofficeFormRequest({
   });
 
   const headers = new Headers();
+  if (json) headers.set('accept', 'application/json');
   if (accept) headers.set('accept', accept);
+  if (fetch) headers.set('x-requested-with', 'fetch');
   if (requestedWith) headers.set('x-requested-with', requestedWith);
 
   return new Request(url, {

--- a/apps/backoffice/src/test/backofficeFixtures.ts
+++ b/apps/backoffice/src/test/backofficeFixtures.ts
@@ -1,0 +1,202 @@
+import type {
+  CatalogHealthIssue,
+  CatalogMovieSample,
+  CatalogRepairBatch,
+  CatalogRepairBatchItem,
+  TMDBMatchReview,
+} from '@pop-choice/shared';
+
+import type {
+  CatalogMaintenanceQueueJobPage,
+  CatalogMaintenanceQueueJobSummary,
+  EnqueueCatalogBackfillMovieResult,
+} from '../catalogMaintenanceQueue';
+
+export function catalogMovieSample(
+  overrides: Partial<CatalogMovieSample> = {},
+): CatalogMovieSample {
+  return {
+    age_rating: 'PG',
+    duration: 100,
+    id: '42',
+    localized_name: null,
+    name: 'Heat',
+    poster_url: null,
+    tmdb_id: null,
+    tmdb_matched_at: null,
+    year: 1995,
+    ...overrides,
+  };
+}
+
+export function catalogHealthIssue(
+  overrides: Partial<CatalogHealthIssue> = {},
+): CatalogHealthIssue {
+  return {
+    count: 42,
+    key: 'missing_poster_url',
+    label: 'Missing poster_url',
+    samples: [catalogMovieSample()],
+    ...overrides,
+  };
+}
+
+export function catalogRepairBatchItem(
+  overrides: Partial<CatalogRepairBatchItem> = {},
+): CatalogRepairBatchItem {
+  return {
+    batchId: 'batch-1',
+    completedAt: null,
+    createdAt: '2026-06-02T12:00:00.000Z',
+    errorMessage: 'worker failed',
+    id: 'item-1',
+    issueKey: 'missing_poster_url',
+    jobId: 'old-job',
+    jobName: 'backfill-movie',
+    language: 'en',
+    movieId: '42',
+    movieSnapshot: { ...catalogMovieSample({ id: '42', name: 'Heat' }) },
+    queueName: 'catalog-maintenance',
+    reason: 'missing_metadata',
+    result: { status: 'failed' },
+    status: 'failed',
+    updatedAt: '2026-06-02T12:05:00.000Z',
+    ...overrides,
+  };
+}
+
+export function catalogRepairBatch(
+  overrides: Partial<CatalogRepairBatch> = {},
+): CatalogRepairBatch {
+  return {
+    action: 'bulk_enqueue_backfill',
+    actor: 'operator@example.test',
+    attemptedCount: 10,
+    completedAt: null,
+    completedCount: 3,
+    createdAt: '2026-06-02T10:00:00.000Z',
+    dedupedCount: 2,
+    failedCount: 0,
+    id: 'batch-1',
+    issueKey: 'missing_poster_url',
+    note: null,
+    previousState: {},
+    queuedCount: 4,
+    requestedLimit: 10,
+    result: {},
+    skippedCount: 1,
+    status: 'completed',
+    targetId: 'missing_poster_url',
+    targetType: 'catalog_issue',
+    totalCandidates: 100,
+    unavailableCount: 0,
+    updatedAt: '2026-06-02T10:10:00.000Z',
+    ...overrides,
+  };
+}
+
+export function catalogBackfillQueueJob(
+  overrides: Partial<EnqueueCatalogBackfillMovieResult> = {},
+): EnqueueCatalogBackfillMovieResult {
+  return {
+    jobId: 'job-42',
+    jobName: 'backfill-movie',
+    language: 'en-US',
+    queueName: 'catalog-maintenance',
+    status: 'queued',
+    ...overrides,
+  };
+}
+
+export function catalogMaintenanceQueueJobSummary(
+  overrides: Partial<CatalogMaintenanceQueueJobSummary> = {},
+): CatalogMaintenanceQueueJobSummary {
+  return {
+    attemptsConfigured: 4,
+    attemptsMade: 1,
+    createdAt: '2026-06-02T12:00:00.000Z',
+    failedReason: null,
+    finishedAt: null,
+    id: 'backfill-42',
+    movieId: '42',
+    name: 'backfill-movie',
+    payload: [{ label: 'Movie', value: '42' }],
+    processedAt: '2026-06-02T12:01:00.000Z',
+    repairBatchId: null,
+    repairBatchItemId: null,
+    state: 'active',
+    ...overrides,
+  };
+}
+
+export function catalogMaintenanceQueueJobPage(
+  overrides: Partial<CatalogMaintenanceQueueJobPage> = {},
+): CatalogMaintenanceQueueJobPage {
+  return {
+    available: true,
+    counts: {
+      active: 0,
+      completed: 10,
+      delayed: 0,
+      failed: 0,
+      prioritized: 0,
+      waiting: 0,
+      waitingChildren: 0,
+    },
+    jobs: [],
+    limit: 25,
+    offset: 0,
+    openJobs: 0,
+    queueName: 'catalog-maintenance',
+    state: 'waiting',
+    totalCount: 0,
+    updatedAt: '2026-06-02T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+export function tmdbMatchReview(overrides: Partial<TMDBMatchReview> = {}): TMDBMatchReview {
+  return {
+    candidates: [
+      {
+        confidence: 0.62,
+        id: 42,
+        originalTitle: 'Heat',
+        raw: { id: 42, title: 'Heat' },
+        releaseYear: 1994,
+        title: 'Heat',
+      },
+      {
+        confidence: 0.59,
+        id: 43,
+        originalTitle: 'Heat',
+        raw: { id: 43, title: 'Heat' },
+        releaseYear: 1995,
+        title: 'Heat',
+      },
+    ],
+    createdAt: '2026-06-02T12:00:00.000Z',
+    currentMovie: {
+      age_rating: 'R',
+      duration: 170,
+      id: '7',
+      localized_name: null,
+      name: 'Heat',
+      poster_url: null,
+      tmdb_id: 41,
+      tmdb_match_confidence: 0.51,
+      tmdb_match_source: 'candidate',
+      tmdb_matched_at: '2026-06-01T12:00:00.000Z',
+      year: 1995,
+    },
+    id: 'review-1',
+    movieId: '7',
+    movieName: 'Heat',
+    movieYear: 1995,
+    notes: 'Runtime differs from current TMDB match.',
+    reason: 'runtime_mismatch',
+    status: 'open',
+    updatedAt: '2026-06-02T12:00:00.000Z',
+    ...overrides,
+  };
+}

--- a/docs/BACKOFFICE.md
+++ b/docs/BACKOFFICE.md
@@ -144,6 +144,7 @@ Use workspace scripts that mirror the other apps:
 
 ```bash
 npm run dev:backoffice
+npm run check:backoffice
 npm run build:backoffice
 npm run start --workspace=apps/backoffice
 npm run quality:backoffice
@@ -153,9 +154,11 @@ npm run test:e2e:backoffice
 Run `npm run copy:env` after editing root `.env`; it copies values into
 `apps/backoffice/.env` for the local dev script. Local dev defaults to port
 `3004`; use `PORT=4030 npm run dev:backoffice` when you want a specific port.
-Use `npm run quality:backoffice` before publishing broad backoffice changes; it
-runs the module-size guard that keeps app routes, operator panels, and queue
-helpers split into reviewable files.
+Use `npm run check:backoffice` before publishing most backoffice changes; it
+builds `packages/shared`, runs the module-size guard, type-checks
+`apps/backoffice`, and runs the backoffice Vitest suite. Use
+`npm run quality:backoffice` for the faster structure-only guard that keeps app
+routes, operator panels, and queue helpers split into reviewable files.
 Use `npm run test:e2e:backoffice` when a change touches core operator browser
 flows such as catalog repair enqueueing, queue visibility, or TMDB review
 decisions. The script prepares the isolated e2e PostgreSQL/Redis services before

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -32,6 +32,8 @@ For docs ownership, navigation, and issue hygiene, use **[Documentation Governan
 - `npm run format:package` - Sort and format package.json
 - `npm run type-check` - Run TypeScript type checking
 - `npm run fix` - Run all fixes (lint, format, package.json)
+- `npm run check:backoffice` - Build shared code, run the backoffice structure
+  guard, type-check `apps/backoffice`, and run the backoffice Vitest suite
 - `npm run quality:backoffice` - Run the backoffice structural module-size
   guard used to keep operator UI/routes split into reviewable files
 - `$impeccable critique <target>` - Run before publishing UI PRs, then address
@@ -166,6 +168,12 @@ isolated database and Redis services:
 
 ```bash
 npm run test:e2e:backoffice
+```
+
+For local backoffice PR validation before browser e2e, run:
+
+```bash
+npm run check:backoffice
 ```
 
 Stop and remove the e2e services with:

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "catalog:backfill:enqueue": "npm run enqueue:catalog-maintenance --workspace=apps/web -- backfill",
     "catalog:discovery:enqueue": "npm run enqueue:catalog-maintenance --workspace=apps/web -- discovery",
     "catalog:health": "npm run catalog:health --workspace=movie-backfill",
+    "check:backoffice": "npm run build --workspace=packages/shared && npm run quality:backoffice && npm run type-check --workspace=apps/backoffice && npm run test --workspace=apps/backoffice",
     "cleanup:local-db": "bash scripts/cleanup-local-db.sh",
     "copy:env": "bash scripts/copy-env.sh",
     "dev": "npm run dev --workspace=apps/web",


### PR DESCRIPTION
## Summary
- add explicit Apply/Reject/Defer + next actions so operators can continue through open TMDB review work without losing context
- add review detail risk summaries from reason, current TMDB identity, confidence gaps, and candidate warnings
- add pending/disabled submit buttons for slow review actions and split audit rows out of the detail component to stay within structure limits

## Verification
- npm run test --workspace=apps/backoffice -- --run src/components/tmdb-reviews/helpers.test.ts src/lib/tmdbReviewActions.test.ts 'src/app/tmdb-reviews/[id]/actions/route.test.ts' src/components/tmdb-reviews/detail.test.tsx
- npm run test:backoffice
- npm run type-check --workspace=apps/backoffice
- npm run build:backoffice
- npm run test:e2e:backoffice
- npm run test:e2e:down
- pre-push: lint, server tests, production build

Closes #666

Stacked on #673.