### PR TITLE
Improve backoffice test helper DX

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ npm run build:bull-board            # Build Bull Board runtime entrypoint
 npm run build:docs                  # Build the documentation site
 npm run build:backoffice            # Build the backoffice app
 npm run build:storybook             # Build static Storybook
+npm run check:backoffice            # Shared build + backoffice structure/type/test checks
 npm run start --workspace=apps/web  # Start production server (apps/web)
 cd apps/web && npm run start:workers # Start BullMQ workers (apps/web)
 cd apps/web && npm run bull-board    # Launch BullMQ dashboard (apps/web)

--- a/apps/backoffice/src/app/api/catalog-maintenance-queue/events/route.test.ts
+++ b/apps/backoffice/src/app/api/catalog-maintenance-queue/events/route.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { catalogMaintenanceQueueJobPage } from '../../../../test/backofficeFixtures';
+
 const mocks = vi.hoisted(() => ({
   createBackofficeQueueEventStream: vi.fn(),
   createServerSentEventResponse: vi.fn(),
@@ -42,26 +44,10 @@ describe('catalog maintenance queue events route', () => {
   });
 
   it('opens a snapshot-only stream when Redis is unavailable', async () => {
-    const jobPage = {
+    const jobPage = catalogMaintenanceQueueJobPage({
       available: false,
-      counts: {
-        active: 0,
-        completed: 0,
-        delayed: 0,
-        failed: 0,
-        prioritized: 0,
-        waiting: 0,
-        waitingChildren: 0,
-      },
-      jobs: [],
-      limit: 25,
-      offset: 0,
-      openJobs: 0,
-      queueName: 'catalog-maintenance',
-      state: 'waiting',
-      totalCount: 0,
       updatedAt: '2026-06-03T00:00:00.000Z',
-    };
+    });
     mocks.listCatalogMaintenanceQueueJobs.mockResolvedValue(jobPage);
 
     const response = await GET(

--- a/apps/backoffice/src/app/api/catalog-maintenance-queue/route.test.ts
+++ b/apps/backoffice/src/app/api/catalog-maintenance-queue/route.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { catalogMaintenanceQueueJobPage } from '../../../test/backofficeFixtures';
+
 const mocks = vi.hoisted(() => ({
   ensureBackofficeReady: vi.fn(),
   listCatalogMaintenanceQueueJobs: vi.fn(),
@@ -31,8 +33,7 @@ describe('catalog maintenance queue API route', () => {
   });
 
   it('returns a no-store queue page JSON response', async () => {
-    const jobPage = {
-      available: true,
+    const jobPage = catalogMaintenanceQueueJobPage({
       counts: {
         active: 0,
         completed: 0,
@@ -42,15 +43,10 @@ describe('catalog maintenance queue API route', () => {
         waiting: 1,
         waitingChildren: 0,
       },
-      jobs: [],
-      limit: 25,
-      offset: 0,
       openJobs: 1,
-      queueName: 'catalog-maintenance',
-      state: 'waiting',
       totalCount: 1,
       updatedAt: '2026-06-03T00:00:00.000Z',
-    };
+    });
     mocks.listCatalogMaintenanceQueueJobs.mockResolvedValue(jobPage);
 
     const response = await GET(

--- a/apps/backoffice/src/app/catalog-health/actions/route.test.ts
+++ b/apps/backoffice/src/app/catalog-health/actions/route.test.ts
@@ -48,13 +48,13 @@ function createRepairRequest({
 } = {}) {
   return createBackofficeFormRequest({
     accept,
+    fetch: requestedWith === 'fetch',
     fields: {
       action,
       issue_key: 'missing_poster_url',
       movie_id: '42',
       return_to: returnTo,
     },
-    requestedWith,
     url: 'https://backoffice.test/catalog-health/actions',
   });
 }

--- a/apps/backoffice/src/app/repair-batches/[id]/actions/route.test.ts
+++ b/apps/backoffice/src/app/repair-batches/[id]/actions/route.test.ts
@@ -29,13 +29,13 @@ import { POST } from './route';
 
 function createRetryRequest(fields: Record<string, string> = {}) {
   return createBackofficeFormRequest({
+    fetch: true,
     fields: {
       action: 'retry_item',
       item_id: 'item-1',
       return_to: '/repair-batches/batch-1?status=needs_review',
       ...fields,
     },
-    requestedWith: 'fetch',
     url: 'https://backoffice.test/repair-batches/batch-1/actions',
   });
 }

--- a/apps/backoffice/src/app/tmdb-reviews/[id]/actions/route.test.ts
+++ b/apps/backoffice/src/app/tmdb-reviews/[id]/actions/route.test.ts
@@ -40,11 +40,11 @@ function createReviewRequest({
 } = {}) {
   return createBackofficeFormRequest({
     accept,
+    fetch: requestedWith === 'fetch',
     fields: {
       action: 'apply_candidate',
       candidate_id: '12',
     },
-    requestedWith,
     url: 'https://backoffice.test/tmdb-reviews/review-1/actions',
   });
 }

--- a/apps/backoffice/src/components/catalog-health/issuePanel.test.tsx
+++ b/apps/backoffice/src/components/catalog-health/issuePanel.test.tsx
@@ -1,29 +1,20 @@
-import type { CatalogHealthIssue, CatalogMovieSample } from '@pop-choice/shared';
+import type { CatalogHealthIssue } from '@pop-choice/shared';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 
+import { catalogHealthIssue, catalogMovieSample } from '../../test/backofficeFixtures';
 import { CatalogIssuePanel, buildCatalogIssuePageHref, catalogIssueHint } from './issuePanel';
 
-const sampleMovie: CatalogMovieSample = {
+const sampleMovie = catalogMovieSample({
   age_rating: 'NR',
   duration: 0,
   id: '331',
-  localized_name: null,
   name: 'Mock Movie',
-  poster_url: null,
-  tmdb_id: null,
-  tmdb_matched_at: null,
   year: 2026,
-};
+});
 
 function issue(overrides: Partial<CatalogHealthIssue> = {}): CatalogHealthIssue {
-  return {
-    count: 42,
-    key: 'missing_poster_url',
-    label: 'Missing poster_url',
-    samples: [sampleMovie],
-    ...overrides,
-  };
+  return catalogHealthIssue({ samples: [sampleMovie], ...overrides });
 }
 
 describe('catalog health issue panel presentation', () => {

--- a/apps/backoffice/src/components/catalog-queue/helpers.test.ts
+++ b/apps/backoffice/src/components/catalog-queue/helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import type { CatalogMaintenanceQueueJobPage } from '../../catalogMaintenanceQueue';
 
+import { catalogMaintenanceQueueJobPage } from '../../test/backofficeFixtures';
 import {
   buildQueueHref,
   getLastQueueEvent,
@@ -14,26 +14,7 @@ import {
   queueRealtimeCopy,
 } from './helpers';
 
-const page: CatalogMaintenanceQueueJobPage = {
-  available: true,
-  counts: {
-    active: 0,
-    completed: 10,
-    delayed: 0,
-    failed: 0,
-    prioritized: 0,
-    waiting: 0,
-    waitingChildren: 0,
-  },
-  jobs: [],
-  limit: 25,
-  offset: 0,
-  openJobs: 0,
-  queueName: 'catalog-maintenance',
-  state: 'waiting',
-  totalCount: 0,
-  updatedAt: '2026-06-02T12:00:00Z',
-};
+const page = catalogMaintenanceQueueJobPage();
 
 describe('catalog queue helpers', () => {
   it('builds queue state links and state labels', () => {

--- a/apps/backoffice/src/components/repair-batches/detailSections.test.tsx
+++ b/apps/backoffice/src/components/repair-batches/detailSections.test.tsx
@@ -1,30 +1,8 @@
-import type { CatalogRepairBatchItem } from '@pop-choice/shared';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 
+import { catalogRepairBatchItem } from '../../test/backofficeFixtures';
 import { RepairBatchItemRows } from './detailSections';
-
-function batchItem(overrides: Partial<CatalogRepairBatchItem> = {}): CatalogRepairBatchItem {
-  return {
-    batchId: 'batch-1',
-    completedAt: null,
-    createdAt: '2026-06-02T12:00:00.000Z',
-    errorMessage: null,
-    id: 'item-1',
-    issueKey: 'missing_poster_url',
-    jobId: null,
-    jobName: null,
-    language: 'en',
-    movieId: '42',
-    movieSnapshot: { id: '42', name: 'Heat', year: 1995 },
-    queueName: null,
-    reason: 'missing_metadata',
-    result: {},
-    status: 'failed',
-    updatedAt: '2026-06-02T12:05:00.000Z',
-    ...overrides,
-  };
-}
 
 describe('repair batch detail sections', () => {
   it('shows retry actions only for failed, enqueue-failed, and unavailable items', () => {
@@ -33,9 +11,9 @@ describe('repair batch detail sections', () => {
         <tbody>
           <RepairBatchItemRows
             items={[
-              batchItem({ id: 'failed-item', status: 'failed' }),
-              batchItem({ id: 'unavailable-item', status: 'unavailable' }),
-              batchItem({ id: 'unresolved-item', status: 'completed_unresolved' }),
+              catalogRepairBatchItem({ id: 'failed-item', status: 'failed' }),
+              catalogRepairBatchItem({ id: 'unavailable-item', status: 'unavailable' }),
+              catalogRepairBatchItem({ id: 'unresolved-item', status: 'completed_unresolved' }),
             ]}
           />
         </tbody>

--- a/apps/backoffice/src/components/repair-batches/helpers.test.ts
+++ b/apps/backoffice/src/components/repair-batches/helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import type { CatalogRepairBatch } from '@pop-choice/shared';
 
+import { catalogRepairBatch } from '../../test/backofficeFixtures';
 import {
   buildRepairBatchItemPageHref,
   buildRepairBatchListHref,
@@ -14,30 +14,7 @@ import {
   truncateText,
 } from './helpers';
 
-const baseBatch: CatalogRepairBatch = {
-  action: 'bulk_enqueue_backfill',
-  actor: 'lexi',
-  attemptedCount: 10,
-  completedAt: null,
-  completedCount: 3,
-  createdAt: '2026-06-02T10:00:00Z',
-  dedupedCount: 2,
-  failedCount: 0,
-  id: '42',
-  issueKey: 'missing_poster_url',
-  note: null,
-  previousState: {},
-  requestedLimit: 10,
-  result: {},
-  skippedCount: 1,
-  status: 'completed',
-  targetId: 'missing_poster_url',
-  targetType: 'catalog_issue',
-  totalCandidates: 100,
-  unavailableCount: 0,
-  updatedAt: '2026-06-02T10:10:00Z',
-  queuedCount: 4,
-};
+const baseBatch = catalogRepairBatch({ actor: 'lexi', id: '42' });
 
 describe('repair batch helpers', () => {
   it('formats progress from terminal item counts', () => {

--- a/apps/backoffice/src/components/tmdb-reviews/detail.test.tsx
+++ b/apps/backoffice/src/components/tmdb-reviews/detail.test.tsx
@@ -1,58 +1,12 @@
-import type { TMDBMatchReview } from '@pop-choice/shared';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 
+import { tmdbMatchReview } from '../../test/backofficeFixtures';
 import { ReviewDetailPage } from './detail';
-
-function review(overrides: Partial<TMDBMatchReview> = {}): TMDBMatchReview {
-  return {
-    candidates: [
-      {
-        confidence: 0.62,
-        id: 42,
-        originalTitle: 'Heat',
-        raw: { id: 42, title: 'Heat' },
-        releaseYear: 1994,
-        title: 'Heat',
-      },
-      {
-        confidence: 0.59,
-        id: 43,
-        originalTitle: 'Heat',
-        raw: { id: 43, title: 'Heat' },
-        releaseYear: 1995,
-        title: 'Heat',
-      },
-    ],
-    createdAt: '2026-06-02T12:00:00.000Z',
-    currentMovie: {
-      age_rating: 'R',
-      duration: 170,
-      id: '7',
-      localized_name: null,
-      name: 'Heat',
-      poster_url: null,
-      tmdb_id: 41,
-      tmdb_match_confidence: 0.51,
-      tmdb_match_source: 'candidate',
-      tmdb_matched_at: '2026-06-01T12:00:00.000Z',
-      year: 1995,
-    },
-    id: 'review-1',
-    movieId: '7',
-    movieName: 'Heat',
-    movieYear: 1995,
-    notes: 'Runtime differs from current TMDB match.',
-    reason: 'runtime_mismatch',
-    status: 'open',
-    updatedAt: '2026-06-02T12:00:00.000Z',
-    ...overrides,
-  };
-}
 
 describe('TMDB review detail page', () => {
   it('renders risk summary, next-review navigation, and pending-capable action forms', () => {
-    const html = renderToStaticMarkup(<ReviewDetailPage review={review()} audit={[]} />);
+    const html = renderToStaticMarkup(<ReviewDetailPage review={tmdbMatchReview()} audit={[]} />);
 
     expect(html).toContain('Next open');
     expect(html).toContain('High review risk');

--- a/apps/backoffice/src/lib/catalogMaintenanceQueueLive.test.ts
+++ b/apps/backoffice/src/lib/catalogMaintenanceQueueLive.test.ts
@@ -1,13 +1,15 @@
 import { describe, expect, it } from 'vitest';
 
-import type { CatalogMaintenanceQueueJobPage } from '../catalogMaintenanceQueue';
+import {
+  catalogMaintenanceQueueJobPage,
+  catalogMaintenanceQueueJobSummary,
+} from '../test/backofficeFixtures';
 import {
   parseCatalogMaintenanceQueueConnectedMode,
   parseCatalogMaintenanceQueueSnapshotMessage,
 } from './catalogMaintenanceQueueLive';
 
-const jobPage: CatalogMaintenanceQueueJobPage = {
-  available: true,
+const jobPage = catalogMaintenanceQueueJobPage({
   counts: {
     active: 1,
     completed: 8,
@@ -17,31 +19,12 @@ const jobPage: CatalogMaintenanceQueueJobPage = {
     waiting: 2,
     waitingChildren: 0,
   },
-  jobs: [
-    {
-      attemptsConfigured: 4,
-      attemptsMade: 1,
-      createdAt: '2026-06-02T12:00:00.000Z',
-      failedReason: null,
-      finishedAt: null,
-      id: 'backfill-331',
-      movieId: '331',
-      name: 'backfill-movie',
-      payload: [{ label: 'Movie', value: '331' }],
-      processedAt: '2026-06-02T12:01:00.000Z',
-      repairBatchId: null,
-      repairBatchItemId: null,
-      state: 'active',
-    },
-  ],
-  limit: 25,
-  offset: 0,
+  jobs: [catalogMaintenanceQueueJobSummary({ id: 'backfill-331', movieId: '331' })],
   openJobs: 3,
-  queueName: 'catalog-maintenance',
   state: 'active',
   totalCount: 1,
   updatedAt: '2026-06-02T12:02:00.000Z',
-};
+});
 
 describe('catalog maintenance queue live snapshots', () => {
   it('parses streamed job pages for client-side queue updates', () => {

--- a/apps/backoffice/src/lib/catalogRepairBatchActions.test.ts
+++ b/apps/backoffice/src/lib/catalogRepairBatchActions.test.ts
@@ -1,5 +1,10 @@
-import type { CatalogMovieSample } from '@pop-choice/shared';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  catalogBackfillQueueJob,
+  catalogMovieSample,
+  catalogRepairBatchItem,
+} from '../test/backofficeFixtures';
 
 const mocks = vi.hoisted(() => ({
   createCatalogRepairBatchItem: vi.fn(),
@@ -42,20 +47,6 @@ import {
   retryCatalogRepairBatchItem,
 } from './catalogRepairBatchActions';
 
-function sampleMovie(id: string): CatalogMovieSample {
-  return {
-    age_rating: 'PG',
-    duration: 100,
-    id,
-    localized_name: null,
-    name: `Movie ${id}`,
-    poster_url: null,
-    tmdb_id: null,
-    tmdb_matched_at: null,
-    year: 2026,
-  };
-}
-
 describe('catalog repair batch actions', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -70,7 +61,10 @@ describe('catalog repair batch actions', () => {
   });
 
   it('continues processing when failure-status persistence fails', async () => {
-    const movies = [sampleMovie('1'), sampleMovie('2')];
+    const movies = [
+      catalogMovieSample({ id: '1', name: 'Movie 1', year: 2026 }),
+      catalogMovieSample({ id: '2', name: 'Movie 2', year: 2026 }),
+    ];
     const summary = createCatalogBulkRepairSummary({
       issueKey: 'missing_poster_url',
       limit: 2,
@@ -80,13 +74,7 @@ describe('catalog repair batch actions', () => {
 
     mocks.enqueueCatalogBackfillMovieFromBackoffice
       .mockRejectedValueOnce(new Error('queue failed'))
-      .mockResolvedValueOnce({
-        jobId: 'job-2',
-        jobName: 'backfill-movie',
-        language: 'en',
-        queueName: 'catalog-maintenance',
-        status: 'queued',
-      });
+      .mockResolvedValueOnce(catalogBackfillQueueJob({ jobId: 'job-2', language: 'en' }));
     mocks.updateCatalogRepairBatchItemEnqueueResult
       .mockRejectedValueOnce(new Error('persist failed'))
       .mockResolvedValueOnce(undefined);
@@ -118,31 +106,10 @@ describe('catalog repair batch actions', () => {
   });
 
   it('retries a failed repair batch item with the original batch item context', async () => {
-    const item = {
-      batchId: 'batch-1',
+    const item = catalogRepairBatchItem({
       completedAt: '2026-06-02T12:05:00.000Z',
-      createdAt: '2026-06-02T12:00:00.000Z',
-      errorMessage: 'worker failed',
-      id: 'item-1',
-      issueKey: 'missing_poster_url',
-      jobId: 'old-job',
-      jobName: 'backfill-movie',
-      language: 'en',
-      movieId: '42',
-      movieSnapshot: { id: '42', name: 'Heat' },
-      queueName: 'catalog-maintenance',
-      reason: 'missing_metadata',
-      result: { status: 'failed' },
-      status: 'failed',
-      updatedAt: '2026-06-02T12:05:00.000Z',
-    };
-    const job = {
-      jobId: 'job-42',
-      jobName: 'backfill-movie',
-      language: 'en-US',
-      queueName: 'catalog-maintenance',
-      status: 'queued',
-    };
+    });
+    const job = catalogBackfillQueueJob();
     const updatedItem = { ...item, completedAt: null, jobId: 'job-42', status: 'queued' };
     mocks.getCatalogRepairBatchItem.mockResolvedValue(item);
     mocks.enqueueCatalogBackfillMovieFromBackoffice.mockResolvedValue(job);
@@ -207,24 +174,17 @@ describe('catalog repair batch actions', () => {
   });
 
   it('marks retried items unavailable when the queue is disabled', async () => {
-    const item = {
-      batchId: 'batch-1',
+    const item = catalogRepairBatchItem({
       completedAt: '2026-06-02T12:05:00.000Z',
-      createdAt: '2026-06-02T12:00:00.000Z',
       errorMessage: 'redis missing',
-      id: 'item-1',
-      issueKey: 'missing_poster_url',
       jobId: null,
       jobName: null,
       language: null,
-      movieId: '42',
-      movieSnapshot: { id: '42', name: 'Heat' },
       queueName: null,
       reason: null,
       result: { status: 'queue_unavailable' },
       status: 'unavailable',
-      updatedAt: '2026-06-02T12:05:00.000Z',
-    };
+    });
     const updatedItem = { ...item, status: 'unavailable' };
     mocks.getCatalogRepairBatchItem.mockResolvedValue(item);
     mocks.enqueueCatalogBackfillMovieFromBackoffice.mockResolvedValue(null);
@@ -247,13 +207,11 @@ describe('catalog repair batch actions', () => {
   });
 
   it('rejects retry for completed-unresolved items', async () => {
-    mocks.getCatalogRepairBatchItem.mockResolvedValue({
-      batchId: 'batch-1',
-      id: 'item-1',
-      issueKey: 'missing_poster_url',
-      movieId: '42',
-      status: 'completed_unresolved',
-    });
+    mocks.getCatalogRepairBatchItem.mockResolvedValue(
+      catalogRepairBatchItem({
+        status: 'completed_unresolved',
+      }),
+    );
 
     const formData = new FormData();
     formData.set('action', 'retry_item');

--- a/apps/backoffice/src/test/backofficeActionRoute.ts
+++ b/apps/backoffice/src/test/backofficeActionRoute.ts
@@ -2,14 +2,18 @@ import { expect } from 'vitest';
 
 type FormRequestOptions = {
   accept?: string;
+  fetch?: boolean;
   fields?: Record<string, string>;
+  json?: boolean;
   requestedWith?: string;
   url: string;
 };
 
 export function createBackofficeFormRequest({
   accept,
+  fetch,
   fields,
+  json,
   requestedWith,
   url,
 }: FormRequestOptions): Request {
@@ -19,7 +23,9 @@ export function createBackofficeFormRequest({
   });
 
   const headers = new Headers();
+  if (json) headers.set('accept', 'application/json');
   if (accept) headers.set('accept', accept);
+  if (fetch) headers.set('x-requested-with', 'fetch');
   if (requestedWith) headers.set('x-requested-with', requestedWith);
 
   return new Request(url, {

--- a/apps/backoffice/src/test/backofficeFixtures.ts
+++ b/apps/backoffice/src/test/backofficeFixtures.ts
@@ -1,0 +1,202 @@
+import type {
+  CatalogHealthIssue,
+  CatalogMovieSample,
+  CatalogRepairBatch,
+  CatalogRepairBatchItem,
+  TMDBMatchReview,
+} from '@pop-choice/shared';
+
+import type {
+  CatalogMaintenanceQueueJobPage,
+  CatalogMaintenanceQueueJobSummary,
+  EnqueueCatalogBackfillMovieResult,
+} from '../catalogMaintenanceQueue';
+
+export function catalogMovieSample(
+  overrides: Partial<CatalogMovieSample> = {},
+): CatalogMovieSample {
+  return {
+    age_rating: 'PG',
+    duration: 100,
+    id: '42',
+    localized_name: null,
+    name: 'Heat',
+    poster_url: null,
+    tmdb_id: null,
+    tmdb_matched_at: null,
+    year: 1995,
+    ...overrides,
+  };
+}
+
+export function catalogHealthIssue(
+  overrides: Partial<CatalogHealthIssue> = {},
+): CatalogHealthIssue {
+  return {
+    count: 42,
+    key: 'missing_poster_url',
+    label: 'Missing poster_url',
+    samples: [catalogMovieSample()],
+    ...overrides,
+  };
+}
+
+export function catalogRepairBatchItem(
+  overrides: Partial<CatalogRepairBatchItem> = {},
+): CatalogRepairBatchItem {
+  return {
+    batchId: 'batch-1',
+    completedAt: null,
+    createdAt: '2026-06-02T12:00:00.000Z',
+    errorMessage: 'worker failed',
+    id: 'item-1',
+    issueKey: 'missing_poster_url',
+    jobId: 'old-job',
+    jobName: 'backfill-movie',
+    language: 'en',
+    movieId: '42',
+    movieSnapshot: { ...catalogMovieSample({ id: '42', name: 'Heat' }) },
+    queueName: 'catalog-maintenance',
+    reason: 'missing_metadata',
+    result: { status: 'failed' },
+    status: 'failed',
+    updatedAt: '2026-06-02T12:05:00.000Z',
+    ...overrides,
+  };
+}
+
+export function catalogRepairBatch(
+  overrides: Partial<CatalogRepairBatch> = {},
+): CatalogRepairBatch {
+  return {
+    action: 'bulk_enqueue_backfill',
+    actor: 'operator@example.test',
+    attemptedCount: 10,
+    completedAt: null,
+    completedCount: 3,
+    createdAt: '2026-06-02T10:00:00.000Z',
+    dedupedCount: 2,
+    failedCount: 0,
+    id: 'batch-1',
+    issueKey: 'missing_poster_url',
+    note: null,
+    previousState: {},
+    queuedCount: 4,
+    requestedLimit: 10,
+    result: {},
+    skippedCount: 1,
+    status: 'completed',
+    targetId: 'missing_poster_url',
+    targetType: 'catalog_issue',
+    totalCandidates: 100,
+    unavailableCount: 0,
+    updatedAt: '2026-06-02T10:10:00.000Z',
+    ...overrides,
+  };
+}
+
+export function catalogBackfillQueueJob(
+  overrides: Partial<EnqueueCatalogBackfillMovieResult> = {},
+): EnqueueCatalogBackfillMovieResult {
+  return {
+    jobId: 'job-42',
+    jobName: 'backfill-movie',
+    language: 'en-US',
+    queueName: 'catalog-maintenance',
+    status: 'queued',
+    ...overrides,
+  };
+}
+
+export function catalogMaintenanceQueueJobSummary(
+  overrides: Partial<CatalogMaintenanceQueueJobSummary> = {},
+): CatalogMaintenanceQueueJobSummary {
+  return {
+    attemptsConfigured: 4,
+    attemptsMade: 1,
+    createdAt: '2026-06-02T12:00:00.000Z',
+    failedReason: null,
+    finishedAt: null,
+    id: 'backfill-42',
+    movieId: '42',
+    name: 'backfill-movie',
+    payload: [{ label: 'Movie', value: '42' }],
+    processedAt: '2026-06-02T12:01:00.000Z',
+    repairBatchId: null,
+    repairBatchItemId: null,
+    state: 'active',
+    ...overrides,
+  };
+}
+
+export function catalogMaintenanceQueueJobPage(
+  overrides: Partial<CatalogMaintenanceQueueJobPage> = {},
+): CatalogMaintenanceQueueJobPage {
+  return {
+    available: true,
+    counts: {
+      active: 0,
+      completed: 10,
+      delayed: 0,
+      failed: 0,
+      prioritized: 0,
+      waiting: 0,
+      waitingChildren: 0,
+    },
+    jobs: [],
+    limit: 25,
+    offset: 0,
+    openJobs: 0,
+    queueName: 'catalog-maintenance',
+    state: 'waiting',
+    totalCount: 0,
+    updatedAt: '2026-06-02T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+export function tmdbMatchReview(overrides: Partial<TMDBMatchReview> = {}): TMDBMatchReview {
+  return {
+    candidates: [
+      {
+        confidence: 0.62,
+        id: 42,
+        originalTitle: 'Heat',
+        raw: { id: 42, title: 'Heat' },
+        releaseYear: 1994,
+        title: 'Heat',
+      },
+      {
+        confidence: 0.59,
+        id: 43,
+        originalTitle: 'Heat',
+        raw: { id: 43, title: 'Heat' },
+        releaseYear: 1995,
+        title: 'Heat',
+      },
+    ],
+    createdAt: '2026-06-02T12:00:00.000Z',
+    currentMovie: {
+      age_rating: 'R',
+      duration: 170,
+      id: '7',
+      localized_name: null,
+      name: 'Heat',
+      poster_url: null,
+      tmdb_id: 41,
+      tmdb_match_confidence: 0.51,
+      tmdb_match_source: 'candidate',
+      tmdb_matched_at: '2026-06-01T12:00:00.000Z',
+      year: 1995,
+    },
+    id: 'review-1',
+    movieId: '7',
+    movieName: 'Heat',
+    movieYear: 1995,
+    notes: 'Runtime differs from current TMDB match.',
+    reason: 'runtime_mismatch',
+    status: 'open',
+    updatedAt: '2026-06-02T12:00:00.000Z',
+    ...overrides,
+  };
+}

--- a/docs/BACKOFFICE.md
+++ b/docs/BACKOFFICE.md
@@ -144,6 +144,7 @@ Use workspace scripts that mirror the other apps:
 
 ```bash
 npm run dev:backoffice
+npm run check:backoffice
 npm run build:backoffice
 npm run start --workspace=apps/backoffice
 npm run quality:backoffice
@@ -153,9 +154,11 @@ npm run test:e2e:backoffice
 Run `npm run copy:env` after editing root `.env`; it copies values into
 `apps/backoffice/.env` for the local dev script. Local dev defaults to port
 `3004`; use `PORT=4030 npm run dev:backoffice` when you want a specific port.
-Use `npm run quality:backoffice` before publishing broad backoffice changes; it
-runs the module-size guard that keeps app routes, operator panels, and queue
-helpers split into reviewable files.
+Use `npm run check:backoffice` before publishing most backoffice changes; it
+builds `packages/shared`, runs the module-size guard, type-checks
+`apps/backoffice`, and runs the backoffice Vitest suite. Use
+`npm run quality:backoffice` for the faster structure-only guard that keeps app
+routes, operator panels, and queue helpers split into reviewable files.
 Use `npm run test:e2e:backoffice` when a change touches core operator browser
 flows such as catalog repair enqueueing, queue visibility, or TMDB review
 decisions. The script prepares the isolated e2e PostgreSQL/Redis services before

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -32,6 +32,8 @@ For docs ownership, navigation, and issue hygiene, use **[Documentation Governan
 - `npm run format:package` - Sort and format package.json
 - `npm run type-check` - Run TypeScript type checking
 - `npm run fix` - Run all fixes (lint, format, package.json)
+- `npm run check:backoffice` - Build shared code, run the backoffice structure
+  guard, type-check `apps/backoffice`, and run the backoffice Vitest suite
 - `npm run quality:backoffice` - Run the backoffice structural module-size
   guard used to keep operator UI/routes split into reviewable files
 - `$impeccable critique <target>` - Run before publishing UI PRs, then address
@@ -166,6 +168,12 @@ isolated database and Redis services:
 
 ```bash
 npm run test:e2e:backoffice
+```
+
+For local backoffice PR validation before browser e2e, run:
+
+```bash
+npm run check:backoffice
 ```
 
 Stop and remove the e2e services with:

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "catalog:backfill:enqueue": "npm run enqueue:catalog-maintenance --workspace=apps/web -- backfill",
     "catalog:discovery:enqueue": "npm run enqueue:catalog-maintenance --workspace=apps/web -- discovery",
     "catalog:health": "npm run catalog:health --workspace=movie-backfill",
+    "check:backoffice": "npm run build --workspace=packages/shared && npm run quality:backoffice && npm run type-check --workspace=apps/backoffice && npm run test --workspace=apps/backoffice",
     "cleanup:local-db": "bash scripts/cleanup-local-db.sh",
     "copy:env": "bash scripts/copy-env.sh",
     "dev": "npm run dev --workspace=apps/web",


### PR DESCRIPTION
## Summary

- Add explicit backoffice test fixture builders for catalog movies/issues, queue pages/jobs, repair batches/items, backfill queue jobs, and TMDB review records.
- Adopt the fixtures across queue, repair-batch, TMDB review, catalog-health, and action-route tests while keeping route contract assertions explicit.
- Add small `json`/`fetch` flags to the action-route request helper for common progressive-enhancement request modes.
- Add `npm run check:backoffice` and document the recommended local backoffice validation flow.

## Validation

- `npm run test --workspace=apps/backoffice -- --run src/lib/catalogRepairBatchActions.test.ts src/components/repair-batches/detailSections.test.tsx src/components/repair-batches/helpers.test.ts src/components/tmdb-reviews/detail.test.tsx src/components/catalog-queue/helpers.test.ts src/lib/catalogMaintenanceQueueLive.test.ts src/components/catalog-health/issuePanel.test.tsx src/app/api/catalog-maintenance-queue/route.test.ts src/app/api/catalog-maintenance-queue/events/route.test.ts src/app/catalog-health/actions/route.test.ts 'src/app/repair-batches/[id]/actions/route.test.ts' 'src/app/tmdb-reviews/[id]/actions/route.test.ts'`
- `npm run check:backoffice`
- `npm run build:backoffice`
- pre-push: `npm run lint:check`, `npm run test:server`, `npm run build`

Closes #668.
