### PR TITLE
[codex] Add advisory Fallow quality audit

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json",
+  "ignorePatterns": [
+    "**/node_modules/**",
+    "**/.next/**",
+    "**/dist/**",
+    "**/coverage/**",
+    "**/playwright-report/**",
+    "**/test-results/**",
+    ".turbo/**",
+  ],
+  "duplicates": {
+    "mode": "mild",
+    "minTokens": 50,
+    "minLines": 5,
+    "ignoreImports": true,
+    "ignore": ["**/*.stories.*", "**/*.test.*", "**/*.spec.*", "**/e2e/**"],
+  },
+  "health": {
+    "maxCyclomatic": 20,
+    "maxCognitive": 15,
+    "maxCrap": 30,
+    "ignore": ["**/*.stories.*", "**/*.test.*", "**/*.spec.*", "**/e2e/**"],
+  },
+  "audit": {
+    "gate": "new-only",
+  },
+}

--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -9,6 +9,13 @@
     "**/test-results/**",
     ".turbo/**",
   ],
+  "entry": ["apps/web/scripts/coolify-runtime-env.cjs"],
+  "ignoreDependencies": [
+    "@opentelemetry/instrumentation",
+    "@opentelemetry/semantic-conventions",
+    "@pop-choice/shared",
+    "pino-pretty",
+  ],
   "duplicates": {
     "mode": "mild",
     "minTokens": 50,

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -88,6 +88,32 @@ jobs:
       - name: Type check
         run: npm run type-check
 
+  fallow-audit:
+    name: Fallow Audit
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run advisory Fallow audit
+        run: npm run quality:fallow:audit -- --changed-since origin/development --format compact
+
   server-tests:
     name: Server Tests
     needs: changes

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This is a solo project for the **Embeddings and Vector Databases** chapter from 
 - **Validation:** Zod
 - **Logging:** Pino
 - **Testing:** Vitest, Storybook 10, Playwright, MSW (Mock Service Worker)
+- **Code Quality:** ESLint, Prettier, Fallow, CodeQL, dependency review
 - **Development:** ESLint, Prettier, Husky, lint-staged
 
 ## 🚀 Quick Start
@@ -185,6 +186,17 @@ npm run eval:recommendations -- --live
 ```
 
 Live runs require configured provider/database environment variables and are intended for manual checks before larger recommendation changes.
+
+### Static code quality
+
+Fallow provides advisory unused-code, duplication, complexity, and PR audit checks:
+
+```bash
+npm run quality:fallow:audit -- --changed-since origin/development
+npm run quality:fallow:health -- --workspace @pop-choice/web --summary
+```
+
+See [Code Quality Checks](docs/QUALITY.md) for adoption notes and current baseline context.
 
 ### Optional — Bull Board queue dashboard
 

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -24,6 +24,7 @@ The PR validation workflows run automatically on pull requests targeting the `de
 | ------------------------------------ | -------------------------------- | ------------------------------------------------------------------------------- |
 | `pr.yml`                             | `changes`                        | Classifies PR as docs-only vs code-changing                                     |
 | `pr.yml`                             | `lint`                           | ESLint code quality + Prettier formatting                                       |
+| `pr.yml`                             | `fallow-audit`                   | Advisory new-only Fallow audit for changed TypeScript/JavaScript quality risks  |
 | `pr.yml`                             | `type-check`                     | TypeScript type safety (`tsc --noEmit`)                                         |
 | `pr.yml`                             | `server-tests`                   | Vitest server tests with coverage collection and artifact upload                |
 | `pr.yml`                             | `recommendation-evals`           | Deterministic recommendation quality fixtures and scoring                       |
@@ -76,6 +77,13 @@ Agents and reviewers should explicitly consider these layers when a PR changes r
 ### Code Coverage
 
 Server tests run with `--coverage` via `@vitest/coverage-v8`. Coverage reports (HTML, JSON, LCOV) are uploaded as a GitHub Actions artifact named `coverage-report` and retained for 30 days. Coverage is configured in `vitest.config.ts`.
+
+### Fallow Code Quality Audit
+
+The `fallow-audit` PR job runs `npm run quality:fallow:audit -- --changed-since origin/development --format compact`.
+It is intentionally advisory during the first rollout (`continue-on-error: true`) and is not included in the required
+`PR Validation` aggregate yet. This lets reviewers see newly introduced unused-code, duplication, and complexity
+findings while the project tunes false positives and turns high-confidence baseline findings into focused cleanup work.
 
 ### Google Fonts Build Reliability
 

--- a/docs/QUALITY.md
+++ b/docs/QUALITY.md
@@ -1,0 +1,49 @@
+---
+title: 'Code Quality Checks'
+---
+
+# Code Quality Checks
+
+PopChoice uses Fallow for advisory static analysis across the TypeScript/JavaScript
+monorepo. Fallow complements ESLint, TypeScript, tests, CodeQL, and dependency
+review by finding unused code, duplicate code, complexity hotspots, and
+PR-local regressions.
+
+## Local Commands
+
+Run these from the repository root:
+
+```bash
+npm run quality:fallow:workspaces
+npm run quality:fallow:dead-code -- --workspace @pop-choice/web --summary
+npm run quality:fallow:dupes -- --workspace @pop-choice/web --summary
+npm run quality:fallow:health -- --workspace @pop-choice/web --summary
+npm run quality:fallow:audit -- --changed-since origin/development
+```
+
+The first rollout is intentionally advisory. Current `development` still has
+legacy findings, so PR review should focus on findings introduced by a changeset
+and on obvious cleanup candidates. Use `fallow audit` for PR-shaped feedback and
+the focused commands when planning cleanup work.
+
+## Initial Baseline Notes
+
+The first scoped pass on `@pop-choice/web` found useful signal:
+
+- `dead-code`: 103 findings in 148ms, including unused files/exports, dependency
+  hygiene issues, and duplicate exported type names.
+- `dupes`: 194 clone groups in 83ms. Many initial findings are test, e2e, and
+  app/service config similarities, so duplicate cleanup should be selective.
+- `health`: 169 complexity findings in 514ms. Top hotspots included
+  `apps/web/src/app/quiz/page.tsx`, `apps/web/src/app/results/[id]/ResultsIdClient.tsx`,
+  `apps/web/src/lib/db/recommendations.ts`, and
+  `apps/web/src/app/api/movies/route.ts`.
+
+Treat these numbers as orientation, not a target to clear in one PR. Track the
+rollout in [#684](https://github.com/shchilkin/PopChoice/issues/684). The
+recommended adoption path is:
+
+1. Keep the PR audit advisory while tuning false positives.
+2. Convert high-confidence findings into focused cleanup tickets.
+3. Add baselines or suppressions only when a finding is intentionally kept.
+4. Make the PR audit blocking once new-only failures are consistently low-noise.

--- a/docs/ROADMAP-ARCHITECTURE.md
+++ b/docs/ROADMAP-ARCHITECTURE.md
@@ -141,6 +141,7 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 - Consolidate shared TypeScript, lint, formatting, and test conventions.
 - Reuse config packages where duplication exists across app/services.
 - Align CI checks to the new boundaries and ownership model.
+- Adopt Fallow code-quality analysis in [#684](https://github.com/shchilkin/PopChoice/issues/684), starting advisory with PR-local findings before making it a required gate.
 
 ### CI/CD and Deployment Track
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "services/*"
       ],
       "devDependencies": {
+        "fallow": "2.88.2",
         "husky": "^9.1.7",
         "lint-staged": "^17.0.7",
         "prettier": "3.8.3",
@@ -297,7 +298,8 @@
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
       "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -341,7 +343,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -631,7 +632,6 @@
       "resolved": "https://registry.npmjs.org/@bull-board/ui/-/ui-7.1.5.tgz",
       "integrity": "sha512-2IkatKwNRx/1M9/lAZIptcxS1FPNq6icpp2M46Upwd4olVxs/ujF9Kvs+Ff9ExtIO/OgYfwx7mG2IprGZ+nQCg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bull-board/api": "7.1.5"
       }
@@ -667,6 +667,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -678,12 +679,12 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -695,12 +696,12 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -712,12 +713,12 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -729,12 +730,12 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -744,12 +745,12 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -761,12 +762,12 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -778,12 +779,12 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -795,12 +796,12 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -812,12 +813,12 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -829,12 +830,12 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -846,12 +847,12 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -863,12 +864,12 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -880,12 +881,12 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -897,12 +898,12 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -914,12 +915,12 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -931,12 +932,12 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -948,12 +949,12 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -965,12 +966,12 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -982,12 +983,12 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -999,12 +1000,12 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1016,12 +1017,12 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1033,12 +1034,12 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1050,12 +1051,12 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1067,12 +1068,12 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1084,12 +1085,12 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1101,12 +1102,12 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1231,6 +1232,118 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@fallow-cli/darwin-arm64": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/darwin-arm64/-/darwin-arm64-2.88.2.tgz",
+      "integrity": "sha512-NeOEdICMEiWcoeh0XvsRYIt6fncb/PH+ucmLQh9prsSF1Jgj5fK3O2B7PAfNiEWOM0I0o6oxgeTuWorgDt5NVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@fallow-cli/darwin-x64": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/darwin-x64/-/darwin-x64-2.88.2.tgz",
+      "integrity": "sha512-ml38maL3kTDcrqeF+PNsoxWPE/rbMSBbSXaTvJ5WEuiUndR2ogO7Y9xIKvqZAp8mgpw4Nd7+n5QaD3ffnRyvzg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@fallow-cli/linux-arm64-gnu": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-arm64-gnu/-/linux-arm64-gnu-2.88.2.tgz",
+      "integrity": "sha512-M2Q9zBUyknVYCTewamKqpWPaX5QWVfMmoGsL5QuZ/Nwla1aw/wAMxGsZnnT8I/795hnBKXNBe2a52HKm76dPVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@fallow-cli/linux-arm64-musl": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-arm64-musl/-/linux-arm64-musl-2.88.2.tgz",
+      "integrity": "sha512-TexUWUG8MQkYObMY2tONNHTaOKy6O55T5G68KakAMUhKWcQcrwM3cd/O/RLB5U0D8hjb26rV1O/5Kvf9Wa50jg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@fallow-cli/linux-x64-gnu": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-x64-gnu/-/linux-x64-gnu-2.88.2.tgz",
+      "integrity": "sha512-kQbG9ovmBwNv4IvVLrIgJz+RxcL66Au3snAAQn9108CSBdG6vCqk9RrqY57p1Cv9fF1GfPJrS0ddvUuEG4Zdkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@fallow-cli/linux-x64-musl": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/linux-x64-musl/-/linux-x64-musl-2.88.2.tgz",
+      "integrity": "sha512-9x9XPq5Qpnud2CpVfEB8IytvLUebSpAebK3TMdZlbMKNwmE+yq79EmVOD97FN/PGp8FtKAe4YTX3FHnpvZjaCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@fallow-cli/win32-arm64-msvc": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/win32-arm64-msvc/-/win32-arm64-msvc-2.88.2.tgz",
+      "integrity": "sha512-Xdiv5uKL6P8YgrBZKS6yKAowU2BeAivFbIyjTdWI53puBFb+WMZcY5M+yE5lHFt8SDxoirWys5OHZTpp1KfABA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@fallow-cli/win32-x64-msvc": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/@fallow-cli/win32-x64-msvc/-/win32-x64-msvc-2.88.2.tgz",
+      "integrity": "sha512-FugfOmcLsWUIn9wb0odQm9mTMXUoPgaaJpxdrtcqe82/W8zUx5TEgsAgNuvKNZu3gu49kcneBQ3FBD+NjvAzcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",
@@ -1948,7 +2061,7 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1966,7 +2079,7 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1976,7 +2089,7 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -1985,12 +2098,12 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -2196,7 +2309,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
       "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2430,7 +2542,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2674,7 +2785,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.218.0.tgz",
       "integrity": "sha512-r1Msf8SNLRmwh9J6XQ5uh82D7CdDWMNHnPB7LAVHjzut0TkSeKc5KcIvr4SvHvfk/xwN5gxC+VLKQ1k0o8PSPw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.7.1",
         "@opentelemetry/otlp-exporter-base": "0.218.0",
@@ -2994,7 +3104,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
       "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.7.1",
         "@opentelemetry/resources": "2.7.1",
@@ -3070,6 +3179,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3087,6 +3197,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3104,6 +3215,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3121,6 +3233,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3138,6 +3251,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3155,6 +3269,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3172,6 +3287,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3189,6 +3305,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3206,6 +3323,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3223,6 +3341,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3240,6 +3359,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3257,6 +3377,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3274,6 +3395,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3291,6 +3413,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3308,6 +3431,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3325,6 +3449,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3339,6 +3464,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.9.2",
         "@emnapi/runtime": "1.9.2",
@@ -3355,6 +3481,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -3367,6 +3494,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -3384,6 +3512,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3401,6 +3530,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3418,6 +3548,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -3428,6 +3559,7 @@
       "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
@@ -3444,7 +3576,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@oxc-resolver/binding-android-arm64": {
       "version": "11.20.0",
@@ -3458,7 +3591,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@oxc-resolver/binding-darwin-arm64": {
       "version": "11.20.0",
@@ -3472,7 +3606,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@oxc-resolver/binding-darwin-x64": {
       "version": "11.20.0",
@@ -3486,7 +3621,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@oxc-resolver/binding-freebsd-x64": {
       "version": "11.20.0",
@@ -3500,7 +3636,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
       "version": "11.20.0",
@@ -3514,7 +3651,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
       "version": "11.20.0",
@@ -3528,7 +3666,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
       "version": "11.20.0",
@@ -3542,7 +3681,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@oxc-resolver/binding-linux-arm64-musl": {
       "version": "11.20.0",
@@ -3556,7 +3696,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
       "version": "11.20.0",
@@ -3570,7 +3711,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
       "version": "11.20.0",
@@ -3584,7 +3726,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
       "version": "11.20.0",
@@ -3598,7 +3741,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
       "version": "11.20.0",
@@ -3612,7 +3756,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@oxc-resolver/binding-linux-x64-gnu": {
       "version": "11.20.0",
@@ -3626,7 +3771,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@oxc-resolver/binding-linux-x64-musl": {
       "version": "11.20.0",
@@ -3640,7 +3786,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@oxc-resolver/binding-openharmony-arm64": {
       "version": "11.20.0",
@@ -3654,7 +3801,8 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@oxc-resolver/binding-wasm32-wasi": {
       "version": "11.20.0",
@@ -3666,6 +3814,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.10.0",
         "@emnapi/runtime": "1.10.0",
@@ -3687,7 +3836,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@oxc-resolver/binding-win32-x64-msvc": {
       "version": "11.20.0",
@@ -3701,7 +3851,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
@@ -4619,7 +4770,6 @@
     "node_modules/@redis/client": {
       "version": "5.12.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -4676,7 +4826,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4693,7 +4842,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4710,7 +4858,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4727,7 +4874,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4744,7 +4890,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4761,7 +4906,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4778,7 +4922,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4795,7 +4938,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4812,7 +4954,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4829,7 +4970,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4846,7 +4986,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4863,7 +5002,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4880,7 +5018,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4899,7 +5036,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4916,7 +5052,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5392,7 +5527,6 @@
       "integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 20"
       },
@@ -5418,7 +5552,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5435,7 +5568,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5452,7 +5584,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5469,7 +5600,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5486,7 +5616,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5503,7 +5632,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5520,7 +5648,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5537,7 +5664,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5554,7 +5680,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5579,7 +5704,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5596,7 +5720,6 @@
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -5606,7 +5729,6 @@
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -5624,7 +5746,6 @@
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -5634,7 +5755,6 @@
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
       "version": "2.8.1",
-      "dev": true,
       "inBundle": true,
       "license": "0BSD",
       "optional": true
@@ -5646,7 +5766,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5663,7 +5782,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5717,7 +5835,6 @@
       "version": "10.4.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -5736,6 +5853,7 @@
       "version": "6.9.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@adobe/css-tools": "^4.4.0",
         "aria-query": "^5.0.0",
@@ -5753,12 +5871,14 @@
     "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
       "version": "0.6.3",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@testing-library/user-event": {
       "version": "14.6.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12",
         "npm": ">=6"
@@ -5853,7 +5973,6 @@
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -6024,15 +6143,13 @@
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
       "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "*"
       }
     },
     "node_modules/@types/mdx": {
       "version": "2.0.13",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -6188,7 +6305,6 @@
       "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.1",
         "@typescript-eslint/types": "8.60.1",
@@ -6818,6 +6934,7 @@
       "version": "3.2.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/spy": "3.2.4",
@@ -6878,6 +6995,7 @@
       "version": "3.2.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tinyrainbow": "^2.0.0"
       },
@@ -6891,7 +7009,6 @@
       "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.8",
         "pathe": "^2.0.3"
@@ -6996,6 +7113,7 @@
       "version": "3.2.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tinyspy": "^4.0.3"
       },
@@ -7007,6 +7125,7 @@
       "version": "3.2.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/pretty-format": "3.2.4",
         "loupe": "^3.1.4",
@@ -7180,7 +7299,8 @@
     "node_modules/@webcontainer/env": {
       "version": "1.1.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@xstate/graph": {
       "version": "3.0.4",
@@ -7260,7 +7380,6 @@
     "node_modules/acorn": {
       "version": "8.16.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7632,6 +7751,7 @@
       "version": "0.16.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.0.1"
       },
@@ -7886,7 +8006,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -7905,7 +8024,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/bullmq": {
@@ -7937,6 +8056,7 @@
       "version": "4.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "run-applescript": "^7.0.0"
       },
@@ -8046,6 +8166,7 @@
       "version": "5.3.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "assertion-error": "^2.0.1",
         "check-error": "^2.1.1",
@@ -8128,6 +8249,7 @@
       "version": "2.1.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 16"
       }
@@ -8520,7 +8642,8 @@
     "node_modules/css.escape": {
       "version": "1.5.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -8624,6 +8747,7 @@
       "version": "5.0.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -8644,6 +8768,7 @@
       "version": "5.5.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bundle-name": "^4.1.0",
         "default-browser-id": "^5.0.0"
@@ -8659,6 +8784,7 @@
       "version": "5.0.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -8686,6 +8812,7 @@
       "version": "3.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9099,7 +9226,7 @@
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "peer": true,
@@ -9164,7 +9291,6 @@
       "version": "9.32.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9375,7 +9501,6 @@
       "version": "2.32.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -9709,6 +9834,7 @@
       "version": "4.0.1",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -10048,6 +10174,34 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fallow": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/fallow/-/fallow-2.88.2.tgz",
+      "integrity": "sha512-yMi8qYC2ftkAV0wFfSCU4htACMdbfc8o3h+OFzyVPI76savgLaMSdfjMJWXxeO3mHSUzoCf7ggY7GLA4z+TqDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "2.1.2"
+      },
+      "bin": {
+        "fallow": "bin/fallow",
+        "fallow-lsp": "bin/fallow-lsp",
+        "fallow-mcp": "bin/fallow-mcp"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@fallow-cli/darwin-arm64": "2.88.2",
+        "@fallow-cli/darwin-x64": "2.88.2",
+        "@fallow-cli/linux-arm64-gnu": "2.88.2",
+        "@fallow-cli/linux-arm64-musl": "2.88.2",
+        "@fallow-cli/linux-x64-gnu": "2.88.2",
+        "@fallow-cli/linux-x64-musl": "2.88.2",
+        "@fallow-cli/win32-arm64-msvc": "2.88.2",
+        "@fallow-cli/win32-x64-msvc": "2.88.2"
+      }
+    },
     "node_modules/fast-copy": {
       "version": "4.0.3",
       "dev": true,
@@ -10308,7 +10462,6 @@
       "resolved": "https://registry.npmjs.org/fumadocs-core/-/fumadocs-core-16.9.1.tgz",
       "integrity": "sha512-8VW4aD1iG5SrCChRq84QpNyjKY69i5WfUFFgtx/LSUuX1RewWb0qps7DhKLSjOWraemhZatzsZ7iceivJmYRTg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@orama/orama": "^3.1.18",
         "estree-util-value-to-estree": "^3.5.0",
@@ -11690,6 +11843,7 @@
       "version": "4.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -12016,6 +12170,7 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-docker": "^3.0.0"
       },
@@ -12033,6 +12188,7 @@
       "version": "3.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "is-docker": "cli.js"
       },
@@ -12359,7 +12515,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -12561,7 +12717,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12580,7 +12735,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12601,7 +12755,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12622,7 +12775,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12643,7 +12795,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12664,7 +12815,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12685,7 +12835,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12706,7 +12855,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12727,7 +12875,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12748,7 +12895,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12769,7 +12915,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13033,7 +13178,8 @@
     "node_modules/loupe": {
       "version": "3.2.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lru-cache": {
       "version": "11.5.0",
@@ -13050,7 +13196,6 @@
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.16.0.tgz",
       "integrity": "sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==",
       "license": "ISC",
-      "peer": true,
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -14240,6 +14385,7 @@
       "version": "1.0.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -14385,7 +14531,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^6.0.11",
         "@mswjs/interceptors": "^0.41.3",
@@ -14513,7 +14658,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.7.tgz",
       "integrity": "sha512-eMJxgjRzBaj3olkP4cBamHDXL79A8FC6u1GcsO1D1Tsx8bw/LLXUJCaoajVxtnhD3A1IJqIT8IcRJjgBIPJq4w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "16.2.7",
         "@swc/helpers": "0.5.15",
@@ -14850,6 +14994,7 @@
       "version": "10.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "default-browser": "^5.2.1",
         "define-lazy-prop": "^3.0.0",
@@ -14868,7 +15013,6 @@
       "resolved": "https://registry.npmjs.org/openai/-/openai-6.41.0.tgz",
       "integrity": "sha512-IGWPopZq6Rjoynjfb3NSLf/z2MTw7UiOsm9TAjPGAjUESH7Uq41Trg4QWehBEn58p74i+m7uoRPV2vXcpPXhyA==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "ws": "^8.18.0",
         "zod": "^3.25 || ^4.0"
@@ -14925,6 +15069,7 @@
       "integrity": "sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "^0.127.0"
       },
@@ -14963,6 +15108,7 @@
       "integrity": "sha512-CblytBiV/a/ZXY34dsVU2NxhIOxMXst8CvDCtyBelVITgd7PLrKzbEbA6oKLdPjvDKDzCiW48qzmzZ+mYaqn+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       },
@@ -15125,6 +15271,7 @@
       "version": "2.0.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 14.16"
       }
@@ -15134,7 +15281,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
       "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.13.0",
         "pg-pool": "^3.14.0",
@@ -15298,7 +15444,6 @@
       "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright-core": "1.60.0"
       },
@@ -15413,7 +15558,6 @@
       "version": "3.8.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -15637,7 +15781,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15703,7 +15846,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15809,6 +15951,7 @@
       "version": "0.23.11",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ast-types": "^0.16.1",
         "esprima": "~4.0.0",
@@ -15891,6 +16034,7 @@
       "version": "3.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
@@ -15903,6 +16047,7 @@
       "version": "3.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "min-indent": "^1.0.0"
       },
@@ -15913,7 +16058,6 @@
     "node_modules/redis": {
       "version": "5.12.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@redis/bloom": "5.12.1",
         "@redis/client": "5.12.1",
@@ -16270,7 +16414,6 @@
       "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.132.0",
         "@rolldown/pluginutils": "^1.0.0"
@@ -16335,6 +16478,7 @@
       "version": "7.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -16474,7 +16618,6 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -16984,7 +17127,7 @@
     },
     "node_modules/source-map": {
       "version": "0.6.1",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -17001,7 +17144,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -17402,8 +17545,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
       "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.3",
@@ -17432,7 +17574,7 @@
       "version": "5.48.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
       "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -17512,7 +17654,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/thread-stream": {
@@ -17536,7 +17678,8 @@
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -17570,6 +17713,7 @@
       "version": "2.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -17578,6 +17722,7 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -18349,7 +18494,6 @@
       "version": "6.0.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18756,7 +18900,6 @@
       "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -18893,7 +19036,6 @@
     },
     "node_modules/vite/node_modules/fsevents": {
       "version": "2.3.3",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -18909,7 +19051,6 @@
       "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.8",
         "@vitest/mocker": "4.1.8",
@@ -19100,7 +19241,6 @@
       "integrity": "sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",
@@ -19348,7 +19488,6 @@
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -19369,6 +19508,7 @@
       "version": "0.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-wsl": "^3.1.0"
       },
@@ -19383,6 +19523,7 @@
       "version": "3.1.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-inside-container": "^1.0.0"
       },
@@ -19398,7 +19539,6 @@
       "resolved": "https://registry.npmjs.org/xstate/-/xstate-5.31.1.tgz",
       "integrity": "sha512-3P7t7GQ61BvLu+8Cj6Zq7rcS34vecL9pvfN2ucUWmIFIUG+rAREviOs4Xy4OO3BuJHSz6RLU8eqDXxSbVotjDQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/xstate"
@@ -19501,7 +19641,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,12 @@
     "populate-db": "npm run dev --workspace=services/movie-seed",
     "prepare": "husky || true",
     "quality:backoffice": "npm run quality:structure --workspace=apps/backoffice",
+    "quality:fallow": "fallow",
+    "quality:fallow:audit": "fallow audit",
+    "quality:fallow:dead-code": "fallow dead-code",
+    "quality:fallow:dupes": "fallow dupes",
+    "quality:fallow:health": "fallow health",
+    "quality:fallow:workspaces": "fallow workspaces",
     "setup:local-db": "bash scripts/setup-local-db.sh",
     "start:storybook": "npm run start:storybook --workspace=apps/web",
     "storybook": "npm run storybook --workspace=apps/web",
@@ -56,6 +62,7 @@
     "type-check:docs": "npm run type-check --workspace=apps/docs"
   },
   "devDependencies": {
+    "fallow": "2.88.2",
     "husky": "^9.1.7",
     "lint-staged": "^17.0.7",
     "prettier": "3.8.3",


### PR DESCRIPTION
## Summary
- add Fallow 2.88.2 as a pinned root dev dependency
- add `.fallowrc.jsonc` and root `quality:fallow:*` scripts
- document local usage, adoption baseline, and roadmap tracking
- add an advisory `fallow-audit` PR job with `continue-on-error: true`

Closes #685
Refs #684

## Validation
- `npx prettier --check .fallowrc.jsonc README.md docs/QUALITY.md docs/CI-CD.md docs/ROADMAP-ARCHITECTURE.md .github/workflows/pr.yml package.json`
- `npm run quality:fallow:workspaces -- --format json`
- `npm run quality:fallow:audit -- --changed-since origin/development --format compact`
- commit hook: `npm run type-check`
- pre-push hook: lint, server tests, production build

## Notes
The Fallow PR job is intentionally advisory for the first rollout. The initial audit still reports inherited dependency/dead-code findings, but the new-only gate passes for this branch.