### PR TITLE
Clean up backoffice and docs Fallow findings

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -5,6 +5,7 @@
     "**/.next/**",
     "**/dist/**",
     "**/coverage/**",
+    "**/e2e/**",
     "**/playwright-report/**",
     "**/test-results/**",
     ".turbo/**",
@@ -16,6 +17,7 @@
     "@pop-choice/shared",
     "pino-pretty",
   ],
+  "ignoreUnresolvedImports": ["collections/server"],
   "duplicates": {
     "mode": "mild",
     "minTokens": 50,

--- a/apps/backoffice/package.json
+++ b/apps/backoffice/package.json
@@ -24,6 +24,7 @@
     "@types/node": "25.9.1",
     "@types/react": "19.2.16",
     "@types/react-dom": "^19",
+    "playwright": "^1.60.0",
     "typescript": "6.0.3",
     "vitest": "^4.1.8"
   },

--- a/apps/backoffice/src/catalogMaintenanceQueue.ts
+++ b/apps/backoffice/src/catalogMaintenanceQueue.ts
@@ -9,7 +9,6 @@ import {
   CATALOG_BACKFILL_MOVIE_JOB_NAME,
   CATALOG_ENQUEUE_REPAIR_BATCH_JOB_NAME,
   CATALOG_MAINTENANCE_JOB_OPTIONS,
-  CATALOG_MAINTENANCE_QUEUE_JOB_STATES,
   EMPTY_CATALOG_MAINTENANCE_QUEUE_COUNTS,
   compactJobValue,
   getCatalogBackfillMovieJobId,
@@ -28,7 +27,6 @@ import {
 export const CATALOG_MAINTENANCE_QUEUE_NAME = 'catalog-maintenance';
 
 export {
-  CATALOG_MAINTENANCE_QUEUE_JOB_STATES,
   getCatalogBackfillMovieJobId,
   getCatalogRepairBatchJobId,
   isCatalogMaintenanceQueueJobState,

--- a/apps/backoffice/src/catalogMaintenanceQueueHelpers.ts
+++ b/apps/backoffice/src/catalogMaintenanceQueueHelpers.ts
@@ -2,7 +2,7 @@ const DEFAULT_TMDB_LANGUAGE = 'en-US';
 
 export const CATALOG_BACKFILL_MOVIE_JOB_NAME = 'backfill-movie';
 export const CATALOG_ENQUEUE_REPAIR_BATCH_JOB_NAME = 'enqueue-catalog-repair-batch';
-export const CATALOG_MAINTENANCE_QUEUE_JOB_STATES = [
+const CATALOG_MAINTENANCE_QUEUE_JOB_STATES = [
   'waiting',
   'active',
   'delayed',

--- a/apps/backoffice/src/components/backoffice-layout/index.tsx
+++ b/apps/backoffice/src/components/backoffice-layout/index.tsx
@@ -75,8 +75,6 @@ export function BackofficeLayout({
   );
 }
 
-export const BackofficeShell = BackofficeLayout;
-
 export function BackofficeLoadingPage({
   active = 'health',
   title = 'Loading backoffice',

--- a/apps/backoffice/src/components/backoffice.tsx
+++ b/apps/backoffice/src/components/backoffice.tsx
@@ -1,9 +1,4 @@
-export {
-  BackofficeErrorPage,
-  BackofficeLayout,
-  BackofficeLoadingPage,
-  BackofficeShell,
-} from './backoffice-layout';
+export { BackofficeErrorPage, BackofficeLoadingPage } from './backoffice-layout';
 export { CatalogHealthPage } from './catalog-health';
 export { CatalogMaintenanceQueuePage } from './catalog-queue';
 export { CatalogMovieDetailPage, CatalogMovieNotFoundPage } from './movie-detail';
@@ -18,4 +13,3 @@ export {
   RecommendationEvalNotFoundPage,
 } from './recommendation-evals';
 export { ReviewDetailPage, ReviewListPage } from './tmdb-reviews';
-export type { BackofficeSection } from './backoffice-layout';

--- a/apps/backoffice/src/components/catalog-queue/helpers.ts
+++ b/apps/backoffice/src/components/catalog-queue/helpers.ts
@@ -6,7 +6,7 @@ import type {
 import { formatLiveSyncTime } from '../liveRefreshTime';
 
 export const QUEUE_REALTIME_FALLBACK_INTERVAL_SECONDS = 30;
-export const QUEUE_REALTIME_STALE_AFTER_MS = 120_000;
+const QUEUE_REALTIME_STALE_AFTER_MS = 120_000;
 
 export const QUEUE_STATES = [
   'waiting',

--- a/apps/backoffice/src/components/catalog-repair-audit/index.tsx
+++ b/apps/backoffice/src/components/catalog-repair-audit/index.tsx
@@ -7,7 +7,7 @@ export function humanizeBackofficeIdentifier(value: string): string {
   return value.replace(/_/g, ' ').replace(/\b\w/g, (letter) => letter.toUpperCase());
 }
 
-export function formatCompactBackofficeDateTime(value: string): string {
+function formatCompactBackofficeDateTime(value: string): string {
   const formatted = formatBackofficeDateTime(value);
   return formatted.replace(/,\s*/g, ' ').replace(/\sUTC$/, ' UTC');
 }

--- a/apps/backoffice/src/lib/backofficeEventStream.ts
+++ b/apps/backoffice/src/lib/backofficeEventStream.ts
@@ -3,8 +3,8 @@ import { Redis } from 'ioredis';
 
 import { recordBackofficeSseLifecycle } from './backofficeMetrics';
 
-export const BACKOFFICE_STREAM_HEARTBEAT_INTERVAL_MS = 25_000;
-export const BACKOFFICE_STREAM_SNAPSHOT_DEBOUNCE_MS = 350;
+const BACKOFFICE_STREAM_HEARTBEAT_INTERVAL_MS = 25_000;
+const BACKOFFICE_STREAM_SNAPSHOT_DEBOUNCE_MS = 350;
 
 export type QueueEventPayload = Record<string, unknown> | string | number | null | undefined;
 export type SnapshotQueueEvent = { payload: Record<string, unknown>; type: string };

--- a/apps/backoffice/src/lib/backofficeParams.ts
+++ b/apps/backoffice/src/lib/backofficeParams.ts
@@ -31,13 +31,13 @@ export const DEFAULT_ASYNC_BULK_REPAIR_CHUNK_SIZE = DEFAULT_BULK_REPAIR_LIMIT;
 export const DEFAULT_REPAIR_BATCH_PAGE_SIZE = 25;
 export const DEFAULT_REPAIR_BATCH_ITEM_PAGE_SIZE = 100;
 export const MAX_REPAIR_BATCH_PAGE_SIZE = 100;
-export const MAX_REPAIR_BATCH_PAGE_NUMBER = 4_001;
+const MAX_REPAIR_BATCH_PAGE_NUMBER = 4_001;
 export const DEFAULT_QUEUE_JOB_PAGE_SIZE = 25;
 export const MAX_QUEUE_JOB_PAGE_SIZE = 50;
-export const MAX_QUEUE_JOB_PAGE_NUMBER = 4_001;
+const MAX_QUEUE_JOB_PAGE_NUMBER = 4_001;
 export const DEFAULT_RECOMMENDATION_EVAL_PAGE_SIZE = 25;
 export const MAX_RECOMMENDATION_EVAL_PAGE_SIZE = 100;
-export const MAX_RECOMMENDATION_EVAL_PAGE_NUMBER = 4_001;
+const MAX_RECOMMENDATION_EVAL_PAGE_NUMBER = 4_001;
 
 const REPAIR_BATCH_STATUS_FILTERS = new Set<CatalogRepairBatchStatusFilter>([
   'all',
@@ -101,7 +101,7 @@ export function parsePositiveIntParam(
   return Math.min(parsed, max);
 }
 
-export function firstSearchParam(value: string | string[] | undefined): string | null {
+function firstSearchParam(value: string | string[] | undefined): string | null {
   if (Array.isArray(value)) return value[0] ?? null;
   return value ?? null;
 }

--- a/apps/backoffice/src/lib/backofficeRuntime.ts
+++ b/apps/backoffice/src/lib/backofficeRuntime.ts
@@ -38,7 +38,7 @@ export function backofficeActionError(
   return error;
 }
 
-export function getBackofficeConfig(): BackofficeRuntimeConfig {
+function getBackofficeConfig(): BackofficeRuntimeConfig {
   cachedConfig ??= readBackofficeRuntimeConfig();
   return cachedConfig;
 }

--- a/apps/backoffice/src/lib/recommendationEvalActions.ts
+++ b/apps/backoffice/src/lib/recommendationEvalActions.ts
@@ -19,13 +19,6 @@ import type { RecommendationEvalRunMode } from '@pop-choice/shared';
 
 const LIVE_RECOMMENDATION_EVAL_CONFIRMATION = 'RUN LIVE RECOMMENDATION EVAL';
 
-export function parseSafeRecommendationEvalMode(
-  value: FormDataEntryValue | string | null,
-): BackofficeRecommendationEvalMode {
-  if (value === 'mock' || value === 'real-data') return value;
-  throw backofficeActionError('Unsupported recommendation eval mode.');
-}
-
 export function parseRecommendationEvalMode(formData: FormData): BackofficeRecommendationEvalMode {
   const value = formData.get('mode');
   if (value === 'mock' || value === 'real-data') return value;

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -84,6 +84,7 @@ The `fallow-audit` PR job runs `npm run quality:fallow:audit -- --changed-since 
 It is intentionally advisory during the first rollout (`continue-on-error: true`) and is not included in the required
 `PR Validation` aggregate yet. This lets reviewers see newly introduced unused-code, duplication, and complexity
 findings while the project tunes false positives and turns high-confidence baseline findings into focused cleanup work.
+The audit runs from the repository root, so findings can come from any npm workspace, not only `apps/web`.
 
 ### Google Fonts Build Reliability
 

--- a/docs/QUALITY.md
+++ b/docs/QUALITY.md
@@ -16,6 +16,9 @@ Run these from the repository root:
 ```bash
 npm run quality:fallow:workspaces
 npm run quality:fallow:dead-code -- --workspace @pop-choice/web --summary
+npm run quality:fallow:dead-code -- --workspace @pop-choice/backoffice --summary
+npm run quality:fallow:dead-code -- --workspace @pop-choice/docs --summary
+npm run quality:fallow:health -- --workspace @pop-choice/shared --summary
 npm run quality:fallow:dupes -- --workspace @pop-choice/web --summary
 npm run quality:fallow:health -- --workspace @pop-choice/web --summary
 npm run quality:fallow:audit -- --changed-since origin/development
@@ -47,3 +50,24 @@ recommended adoption path is:
 2. Convert high-confidence findings into focused cleanup tickets.
 3. Add baselines or suppressions only when a finding is intentionally kept.
 4. Make the PR audit blocking once new-only failures are consistently low-noise.
+
+## Monorepo Follow-ups
+
+Fallow is configured at the repository root and sees all npm workspaces:
+`apps/backoffice`, `apps/bull-board`, `apps/docs`, `apps/web`,
+`packages/shared`, and the service workspaces. PR audit should therefore be
+read as a monorepo gate, even when a cleanup issue focuses on one workspace.
+
+Current focused follow-ups:
+
+- [#697](https://github.com/shchilkin/PopChoice/issues/697): backoffice/docs
+  findings, including generated docs imports, Playwright e2e reachability, and
+  backoffice export-surface cleanup.
+- [#698](https://github.com/shchilkin/PopChoice/issues/698): shared/services
+  findings, including package-level health hotspots and service-local unused
+  exports/types.
+
+The root config intentionally ignores `**/e2e/**` for dead-code reachability and
+`collections/server` as a generated Fumadocs import. Keep those ignores narrow:
+e2e behavior is covered by Playwright jobs, and docs type-check runs
+`fumadocs-mdx` before `tsc`.

--- a/docs/ROADMAP-ARCHITECTURE.md
+++ b/docs/ROADMAP-ARCHITECTURE.md
@@ -142,6 +142,7 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 - Reuse config packages where duplication exists across app/services.
 - Align CI checks to the new boundaries and ownership model.
 - Adopt Fallow code-quality analysis in [#684](https://github.com/shchilkin/PopChoice/issues/684), starting advisory with PR-local findings before making it a required gate.
+- Extend Fallow cleanup beyond `apps/web` through [#697](https://github.com/shchilkin/PopChoice/issues/697) for backoffice/docs and [#698](https://github.com/shchilkin/PopChoice/issues/698) for shared/services.
 
 ### CI/CD and Deployment Track
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "@types/node": "25.9.1",
         "@types/react": "19.2.16",
         "@types/react-dom": "^19",
+        "playwright": "^1.60.0",
         "typescript": "6.0.3",
         "vitest": "^4.1.8"
       },


### PR DESCRIPTION
## Summary
- tune root Fallow config for monorepo-generated docs imports and e2e test reachability
- add explicit Playwright devDependency for apps/backoffice
- remove unused backoffice export surface without changing runtime behavior
- document monorepo Fallow follow-ups and link #697/#698

Closes #697
Refs #684
Refs #698

## Validation
- npm run quality:fallow:audit -- --changed-since origin/development --format compact
- npm run type-check
- npm run test:backoffice
- npm run format:check
- npm run quality:fallow:dead-code -- --workspace @pop-choice/backoffice --summary
- npm run quality:fallow:dead-code -- --workspace @pop-choice/docs --summary