### PR TITLE
Clean up service Fallow export surface

### DIFF
--- a/services/movie-backfill/src/catalog-health.ts
+++ b/services/movie-backfill/src/catalog-health.ts
@@ -1,15 +1,5 @@
 export {
   formatCatalogHealthReport,
   getCatalogHealthReport,
-  isCatalogHealthIssueKey,
-  listCatalogHealthIssueMoviePage,
 } from '@pop-choice/shared/catalogHealth';
-export type {
-  CatalogHealthIssue,
-  CatalogHealthIssueMoviePage,
-  CatalogHealthOptions,
-  CatalogHealthReport,
-  CatalogMovieSample,
-  DuplicateIdentityGroup,
-  DuplicateIdentityReport,
-} from '@pop-choice/shared/catalogHealth';
+export type { CatalogHealthReport } from '@pop-choice/shared/catalogHealth';

--- a/services/movie-backfill/src/database.ts
+++ b/services/movie-backfill/src/database.ts
@@ -9,7 +9,6 @@ import {
 } from '@pop-choice/shared';
 
 import type { TMDBSearchCandidate } from './tmdb.js';
-import type { MovieCatalogMetadataInput } from '@pop-choice/shared';
 
 export {
   initDatabase,
@@ -18,7 +17,6 @@ export {
   ensureCatalogMetadataSchema,
   upsertMovieCatalogMetadata,
 };
-export type { MovieCatalogMetadataInput };
 
 export interface IncompleteMovie {
   id: string;

--- a/services/movie-discovery/src/database.ts
+++ b/services/movie-discovery/src/database.ts
@@ -7,4 +7,4 @@ export {
   insertMovies,
   upsertMovieCatalogMetadata,
 } from '@pop-choice/shared';
-export type { MovieCatalogMetadataInput, MovieRecord } from '@pop-choice/shared';
+export type { MovieRecord } from '@pop-choice/shared';


### PR DESCRIPTION
## Summary
- remove unused private service facade re-exports reported by Fallow in movie-backfill and movie-discovery
- keep runtime imports and shared package public exports unchanged
- leave higher-risk duplication/complexity findings tracked under #698

## Validation
- npm run test:services
- npm run build:services
- npm run format:check
- npm run quality:fallow:audit -- --changed-since origin/development --format compact
- pre-push: lint, server tests, production build

Refs #698