### PR TITLE
Consolidate TMDB catalog metadata extraction

### DIFF
--- a/apps/web/playwright.e2e.config.ts
+++ b/apps/web/playwright.e2e.config.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from 'node:url';
+
 import { defineConfig, devices } from 'playwright/test';
 
 const e2ePort = Number.parseInt(process.env.E2E_PORT ?? '3100', 10);
@@ -5,6 +7,7 @@ const baseURL = process.env.E2E_BASE_URL ?? `http://127.0.0.1:${e2ePort}`;
 const databaseUrl =
   process.env.E2E_DATABASE_URL ?? 'postgresql://popchoice_e2e@127.0.0.1:55432/popchoice_e2e';
 const redisUrl = process.env.E2E_REDIS_URL ?? 'redis://127.0.0.1:56379';
+const repoRoot = fileURLToPath(new URL('../../', import.meta.url));
 
 export default defineConfig({
   testDir: './e2e',
@@ -23,7 +26,8 @@ export default defineConfig({
     screenshot: 'only-on-failure',
   },
   webServer: {
-    command: `npm run dev -- --hostname 127.0.0.1 --port ${e2ePort}`,
+    command: `npm run build --workspace=packages/shared && npm run dev --workspace=apps/web -- --hostname 127.0.0.1 --port ${e2ePort}`,
+    cwd: repoRoot,
     url: baseURL,
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,

--- a/apps/web/src/features/catalogMaintenance/tmdb.ts
+++ b/apps/web/src/features/catalogMaintenance/tmdb.ts
@@ -1,47 +1,17 @@
+import { extractTMDBCatalogMetadataCore, extractTMDBUSCertification } from '@pop-choice/shared';
 import z from 'zod';
 
 import logger from '@/lib/logger';
 import { recordTMDBProviderError } from '@/lib/metrics';
 
 import type { TMDBCatalogCandidate, TMDBDiscoverySource } from '@/lib/jobQueue';
+import type { TMDBCatalogMetadataCore, TMDBCatalogMovieDetails } from '@pop-choice/shared';
 
 const TMDB_BASE_URL = 'https://api.themoviedb.org/3';
 const TMDB_IMAGE_BASE_URL = 'https://image.tmdb.org/t/p';
 const TMDB_FETCH_TIMEOUT_MS = 8_000;
-const MAX_CAST_CREDITS = 12;
-const MAX_KEYWORDS = 20;
 const SUPPORTED_PROVIDER_REGIONS = ['US', 'FI', 'RU'] as const;
 const WATCH_PROVIDER_TYPES = ['flatrate', 'rent', 'buy', 'ads', 'free'] as const;
-
-type TMDBGenre = {
-  id: number;
-  name: string;
-};
-
-type TMDBCastCredit = {
-  id: number;
-  name: string;
-  character?: string | null;
-  order?: number | null;
-  profile_path?: string | null;
-  popularity?: number | null;
-  credit_id?: string | null;
-};
-
-type TMDBCrewCredit = {
-  id: number;
-  name: string;
-  job?: string | null;
-  department?: string | null;
-  profile_path?: string | null;
-  popularity?: number | null;
-  credit_id?: string | null;
-};
-
-type TMDBKeyword = {
-  id: number;
-  name: string;
-};
 
 type TMDBWatchProvider = {
   provider_id: number;
@@ -54,17 +24,12 @@ type TMDBWatchProviderRegion = {
   link?: string | null;
 } & Partial<Record<(typeof WATCH_PROVIDER_TYPES)[number], TMDBWatchProvider[]>>;
 
-export type TMDBMovieDetails = {
-  id: number;
-  title: string;
+export type TMDBMovieDetails = TMDBCatalogMovieDetails & {
   original_title?: string | null;
   original_language?: string | null;
   overview: string;
-  release_date: string;
-  vote_average: number;
   vote_count?: number | null;
   popularity?: number | null;
-  runtime: number | null;
   poster_path: string | null;
   spoken_languages?: Array<{
     english_name?: string | null;
@@ -75,52 +40,12 @@ export type TMDBMovieDetails = {
     iso_3166_1?: string | null;
     name?: string | null;
   }>;
-  genres?: TMDBGenre[];
-  credits?: {
-    cast?: TMDBCastCredit[];
-    crew?: TMDBCrewCredit[];
-  };
-  keywords?: {
-    keywords?: TMDBKeyword[];
-  };
-  release_dates?: {
-    results?: Array<{
-      iso_3166_1: string;
-      release_dates: Array<{
-        certification: string;
-        type: number;
-      }>;
-    }>;
-  };
   'watch/providers'?: {
     results?: Record<string, TMDBWatchProviderRegion>;
   };
 };
 
-export type TMDBCatalogMetadata = {
-  people: Array<{
-    tmdbId: number;
-    name: string;
-    profilePath: string | null;
-    popularity: number | null;
-    creditId: string;
-    role: 'cast' | 'director';
-    characterName: string | null;
-    job: string | null;
-    department: string | null;
-    billingOrder: number | null;
-    rawMetadata: Record<string, unknown>;
-  }>;
-  genres: Array<{
-    tmdbId: number;
-    name: string;
-    rawMetadata: Record<string, unknown>;
-  }>;
-  keywords: Array<{
-    tmdbId: number;
-    name: string;
-    rawMetadata: Record<string, unknown>;
-  }>;
+export type TMDBCatalogMetadata = Omit<TMDBCatalogMetadataCore, 'snapshot'> & {
   providers: Array<{
     providerId: number;
     providerName: string;
@@ -133,7 +58,24 @@ export type TMDBCatalogMetadata = {
   }>;
   qualityFlags: string[];
   qualityScore: number;
-  snapshot: Record<string, unknown>;
+  snapshot: TMDBCatalogMetadataCore['snapshot'] & {
+    original_title: string | null;
+    original_language: string | null;
+    vote_count: number | null;
+    popularity: number | null;
+    spoken_languages: TMDBMovieDetails['spoken_languages'];
+    production_countries: TMDBMovieDetails['production_countries'];
+    certification: string;
+    providers: Array<{
+      id: number;
+      name: string;
+      region: string;
+      type: (typeof WATCH_PROVIDER_TYPES)[number];
+      display_priority: number | null;
+    }>;
+    metadata_quality_score: number;
+    metadata_quality_flags: string[];
+  };
 };
 
 export class TMDBRateLimitError extends Error {
@@ -403,14 +345,7 @@ export async function searchMovieMatch(
 }
 
 export function extractUSCertification(details: TMDBMovieDetails): string {
-  const usEntry = details.release_dates?.results?.find((entry) => entry.iso_3166_1 === 'US');
-  if (!usEntry) return 'NR';
-
-  const theatrical = usEntry.release_dates.find(
-    (release) => release.type === 3 && release.certification,
-  );
-  const any = usEntry.release_dates.find((release) => release.certification);
-  return (theatrical ?? any)?.certification || 'NR';
+  return extractTMDBUSCertification(details);
 }
 
 function extractWatchProviders(details: TMDBMovieDetails): TMDBCatalogMetadata['providers'] {
@@ -495,64 +430,9 @@ export function getMetadataQualityScore(flags: string[]): number {
 }
 
 export function extractCatalogMetadata(details: TMDBMovieDetails): TMDBCatalogMetadata {
-  const genres = (details.genres ?? [])
-    .filter((genre) => Number.isFinite(genre.id) && genre.name)
-    .map((genre) => ({
-      tmdbId: genre.id,
-      name: genre.name,
-      rawMetadata: genre as unknown as Record<string, unknown>,
-    }));
-
-  const cast = (details.credits?.cast ?? [])
-    .filter((credit) => Number.isFinite(credit.id) && credit.name && credit.credit_id)
-    .sort((a, b) => (a.order ?? Number.MAX_SAFE_INTEGER) - (b.order ?? Number.MAX_SAFE_INTEGER))
-    .slice(0, MAX_CAST_CREDITS)
-    .map((credit) => ({
-      tmdbId: credit.id,
-      name: credit.name,
-      profilePath: credit.profile_path ?? null,
-      popularity: credit.popularity ?? null,
-      creditId: credit.credit_id as string,
-      role: 'cast' as const,
-      characterName: credit.character ?? null,
-      job: null,
-      department: null,
-      billingOrder: credit.order ?? null,
-      rawMetadata: credit as unknown as Record<string, unknown>,
-    }));
-
-  const directors = (details.credits?.crew ?? [])
-    .filter(
-      (credit) =>
-        Number.isFinite(credit.id) &&
-        credit.name &&
-        credit.credit_id &&
-        credit.job?.toLowerCase() === 'director',
-    )
-    .map((credit) => ({
-      tmdbId: credit.id,
-      name: credit.name,
-      profilePath: credit.profile_path ?? null,
-      popularity: credit.popularity ?? null,
-      creditId: credit.credit_id as string,
-      role: 'director' as const,
-      characterName: null,
-      job: credit.job ?? null,
-      department: credit.department ?? null,
-      billingOrder: null,
-      rawMetadata: credit as unknown as Record<string, unknown>,
-    }));
-
-  const keywords = (details.keywords?.keywords ?? [])
-    .filter((keyword) => Number.isFinite(keyword.id) && keyword.name)
-    .slice(0, MAX_KEYWORDS)
-    .map((keyword) => ({
-      tmdbId: keyword.id,
-      name: keyword.name,
-      rawMetadata: keyword as unknown as Record<string, unknown>,
-    }));
+  const coreMetadata = extractTMDBCatalogMetadataCore(details);
+  const { genres, keywords, people } = coreMetadata;
   const providers = extractWatchProviders(details);
-  const people = [...cast, ...directors];
   const ageRating = extractUSCertification(details);
   const qualityFlags = getMetadataQualityFlags({
     ageRating,
@@ -564,6 +444,7 @@ export function extractCatalogMetadata(details: TMDBMovieDetails): TMDBCatalogMe
   });
 
   return {
+    ...coreMetadata,
     people,
     genres,
     keywords,
@@ -571,28 +452,14 @@ export function extractCatalogMetadata(details: TMDBMovieDetails): TMDBCatalogMe
     qualityFlags,
     qualityScore: getMetadataQualityScore(qualityFlags),
     snapshot: {
-      id: details.id,
-      title: details.title,
+      ...coreMetadata.snapshot,
       original_title: details.original_title ?? null,
       original_language: details.original_language ?? null,
-      release_date: details.release_date,
-      runtime: details.runtime,
-      vote_average: details.vote_average,
       vote_count: details.vote_count ?? null,
       popularity: details.popularity ?? null,
-      poster_path: details.poster_path,
       spoken_languages: details.spoken_languages ?? [],
       production_countries: details.production_countries ?? [],
       certification: ageRating,
-      genres: genres.map(({ tmdbId, name }) => ({ id: tmdbId, name })),
-      cast: cast.map(({ tmdbId, name, characterName, billingOrder }) => ({
-        id: tmdbId,
-        name,
-        character: characterName,
-        order: billingOrder,
-      })),
-      directors: directors.map(({ tmdbId, name, job }) => ({ id: tmdbId, name, job })),
-      keywords: keywords.map(({ tmdbId, name }) => ({ id: tmdbId, name })),
       providers: providers.map(
         ({ providerId, providerName, region, availabilityType, displayPriority }) => ({
           id: providerId,

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(dirname, './src'),
+      '@pop-choice/shared': path.resolve(dirname, '../../packages/shared/src/index.ts'),
     },
   },
   test: {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -30,6 +30,22 @@ export type {
 } from './db.js';
 export { createEmbeddings } from './embeddings.js';
 export {
+  extractTMDBCatalogMetadataCore,
+  extractTMDBUSCertification,
+} from './tmdbCatalogMetadata.js';
+export type {
+  ExtractTMDBCatalogMetadataOptions,
+  TMDBCatalogCastCreditSource,
+  TMDBCatalogCrewCreditSource,
+  TMDBCatalogGenreMetadata,
+  TMDBCatalogGenreSource,
+  TMDBCatalogKeywordMetadata,
+  TMDBCatalogKeywordSource,
+  TMDBCatalogMetadataCore,
+  TMDBCatalogMovieDetails,
+  TMDBCatalogPersonMetadata,
+} from './tmdbCatalogMetadata.js';
+export {
   parsePositiveInt,
   parseNonNegativeInt,
   parsePositiveFloat,

--- a/packages/shared/src/tmdbCatalogMetadata.test.ts
+++ b/packages/shared/src/tmdbCatalogMetadata.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  extractTMDBCatalogMetadataCore,
+  extractTMDBUSCertification,
+} from './tmdbCatalogMetadata.js';
+
+import type { TMDBCatalogMovieDetails } from './tmdbCatalogMetadata.js';
+
+function makeDetails(overrides: Partial<TMDBCatalogMovieDetails> = {}): TMDBCatalogMovieDetails {
+  return {
+    id: 42,
+    title: 'Shared Metadata Movie',
+    release_date: '2024-05-01',
+    vote_average: 7.9,
+    runtime: 118,
+    poster_path: '/poster.jpg',
+    release_dates: {
+      results: [
+        {
+          iso_3166_1: 'US',
+          release_dates: [{ certification: 'PG-13', type: 3 }],
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+describe('extractTMDBUSCertification', () => {
+  it('prefers theatrical US certification and falls back to any non-empty US certification', () => {
+    expect(
+      extractTMDBUSCertification(
+        makeDetails({
+          release_dates: {
+            results: [
+              {
+                iso_3166_1: 'US',
+                release_dates: [
+                  { certification: '', type: 3 },
+                  { certification: 'R', type: 5 },
+                ],
+              },
+            ],
+          },
+        }),
+      ),
+    ).toBe('R');
+  });
+
+  it('returns NR when US release certification is unavailable', () => {
+    expect(
+      extractTMDBUSCertification(
+        makeDetails({
+          release_dates: {
+            results: [{ iso_3166_1: 'GB', release_dates: [{ certification: '15', type: 3 }] }],
+          },
+        }),
+      ),
+    ).toBe('NR');
+  });
+});
+
+describe('extractTMDBCatalogMetadataCore', () => {
+  it('normalizes cast, directors, genres, keywords, and snapshot fields', () => {
+    const metadata = extractTMDBCatalogMetadataCore(
+      makeDetails({
+        genres: [{ id: 878, name: 'Science Fiction' }],
+        credits: {
+          cast: [
+            { id: 3, name: 'Late Cast', order: 3, credit_id: 'cast-3' },
+            { id: 1, name: 'Lead Cast', character: 'Lead', order: 0, credit_id: 'cast-1' },
+            { id: 2, name: 'Missing Credit Id', order: 1 },
+          ],
+          crew: [
+            { id: 10, name: 'Director', job: 'Director', credit_id: 'crew-10' },
+            { id: 11, name: 'Producer', job: 'Producer', credit_id: 'crew-11' },
+          ],
+        },
+        keywords: { keywords: [{ id: 7, name: 'space travel' }] },
+      }),
+      { maxCastCredits: 1 },
+    );
+
+    expect(metadata.people).toEqual([
+      expect.objectContaining({
+        tmdbId: 1,
+        role: 'cast',
+        characterName: 'Lead',
+        creditId: 'cast-1',
+      }),
+      expect.objectContaining({
+        tmdbId: 10,
+        role: 'director',
+        job: 'Director',
+        creditId: 'crew-10',
+      }),
+    ]);
+    expect(metadata.genres).toEqual([
+      expect.objectContaining({ tmdbId: 878, name: 'Science Fiction' }),
+    ]);
+    expect(metadata.keywords).toEqual([
+      expect.objectContaining({ tmdbId: 7, name: 'space travel' }),
+    ]);
+    expect(metadata.snapshot).toMatchObject({
+      id: 42,
+      title: 'Shared Metadata Movie',
+      poster_path: '/poster.jpg',
+      cast: [{ id: 1, name: 'Lead Cast', character: 'Lead', order: 0 }],
+      directors: [{ id: 10, name: 'Director', job: 'Director' }],
+    });
+  });
+});

--- a/packages/shared/src/tmdbCatalogMetadata.ts
+++ b/packages/shared/src/tmdbCatalogMetadata.ts
@@ -1,0 +1,206 @@
+const DEFAULT_MAX_CAST_CREDITS = 12;
+const DEFAULT_MAX_KEYWORDS = 20;
+
+export interface TMDBCatalogGenreSource {
+  id: number;
+  name: string;
+}
+
+export interface TMDBCatalogCastCreditSource {
+  id: number;
+  name: string;
+  character?: string | null;
+  order?: number | null;
+  profile_path?: string | null;
+  popularity?: number | null;
+  credit_id?: string | null;
+}
+
+export interface TMDBCatalogCrewCreditSource {
+  id: number;
+  name: string;
+  job?: string | null;
+  department?: string | null;
+  profile_path?: string | null;
+  popularity?: number | null;
+  credit_id?: string | null;
+}
+
+export interface TMDBCatalogKeywordSource {
+  id: number;
+  name: string;
+}
+
+export interface TMDBCatalogMovieDetails {
+  id: number;
+  title: string;
+  release_date: string;
+  vote_average: number;
+  runtime: number | null;
+  poster_path?: string | null;
+  genres?: TMDBCatalogGenreSource[];
+  credits?: {
+    cast?: TMDBCatalogCastCreditSource[];
+    crew?: TMDBCatalogCrewCreditSource[];
+  };
+  keywords?: {
+    keywords?: TMDBCatalogKeywordSource[];
+  };
+  release_dates?: {
+    results?: Array<{
+      iso_3166_1: string;
+      release_dates: Array<{
+        certification: string;
+        type: number;
+      }>;
+    }>;
+  };
+}
+
+export interface TMDBCatalogPersonMetadata {
+  tmdbId: number;
+  name: string;
+  profilePath: string | null;
+  popularity: number | null;
+  creditId: string;
+  role: 'cast' | 'director';
+  characterName: string | null;
+  job: string | null;
+  department: string | null;
+  billingOrder: number | null;
+  rawMetadata: Record<string, unknown>;
+}
+
+export interface TMDBCatalogGenreMetadata {
+  tmdbId: number;
+  name: string;
+  rawMetadata: Record<string, unknown>;
+}
+
+export interface TMDBCatalogKeywordMetadata {
+  tmdbId: number;
+  name: string;
+  rawMetadata: Record<string, unknown>;
+}
+
+export interface TMDBCatalogMetadataCore {
+  people: TMDBCatalogPersonMetadata[];
+  genres: TMDBCatalogGenreMetadata[];
+  keywords: TMDBCatalogKeywordMetadata[];
+  snapshot: {
+    id: number;
+    title: string;
+    release_date: string;
+    runtime: number | null;
+    vote_average: number;
+    poster_path: string | null;
+    genres: Array<{ id: number; name: string }>;
+    cast: Array<{ id: number; name: string; character: string | null; order: number | null }>;
+    directors: Array<{ id: number; name: string; job: string | null }>;
+    keywords: Array<{ id: number; name: string }>;
+  };
+}
+
+export interface ExtractTMDBCatalogMetadataOptions {
+  maxCastCredits?: number;
+  maxKeywords?: number;
+}
+
+export function extractTMDBUSCertification(details: TMDBCatalogMovieDetails): string {
+  const usEntry = details.release_dates?.results?.find((entry) => entry.iso_3166_1 === 'US');
+  if (!usEntry) return 'NR';
+
+  const theatrical = usEntry.release_dates.find(
+    (release) => release.type === 3 && release.certification,
+  );
+  const any = usEntry.release_dates.find((release) => release.certification);
+  return (theatrical ?? any)?.certification || 'NR';
+}
+
+export function extractTMDBCatalogMetadataCore(
+  details: TMDBCatalogMovieDetails,
+  options: ExtractTMDBCatalogMetadataOptions = {},
+): TMDBCatalogMetadataCore {
+  const maxCastCredits = options.maxCastCredits ?? DEFAULT_MAX_CAST_CREDITS;
+  const maxKeywords = options.maxKeywords ?? DEFAULT_MAX_KEYWORDS;
+
+  const genres = (details.genres ?? [])
+    .filter((genre) => Number.isFinite(genre.id) && genre.name)
+    .map((genre) => ({
+      tmdbId: genre.id,
+      name: genre.name,
+      rawMetadata: genre as unknown as Record<string, unknown>,
+    }));
+
+  const cast = (details.credits?.cast ?? [])
+    .filter((credit) => Number.isFinite(credit.id) && credit.name && credit.credit_id)
+    .sort((a, b) => (a.order ?? Number.MAX_SAFE_INTEGER) - (b.order ?? Number.MAX_SAFE_INTEGER))
+    .slice(0, maxCastCredits)
+    .map((credit) => ({
+      tmdbId: credit.id,
+      name: credit.name,
+      profilePath: credit.profile_path ?? null,
+      popularity: credit.popularity ?? null,
+      creditId: credit.credit_id as string,
+      role: 'cast' as const,
+      characterName: credit.character ?? null,
+      job: null,
+      department: null,
+      billingOrder: credit.order ?? null,
+      rawMetadata: credit as unknown as Record<string, unknown>,
+    }));
+
+  const directors = (details.credits?.crew ?? [])
+    .filter(
+      (credit) =>
+        Number.isFinite(credit.id) &&
+        credit.name &&
+        credit.credit_id &&
+        credit.job?.toLowerCase() === 'director',
+    )
+    .map((credit) => ({
+      tmdbId: credit.id,
+      name: credit.name,
+      profilePath: credit.profile_path ?? null,
+      popularity: credit.popularity ?? null,
+      creditId: credit.credit_id as string,
+      role: 'director' as const,
+      characterName: null,
+      job: credit.job ?? null,
+      department: credit.department ?? null,
+      billingOrder: null,
+      rawMetadata: credit as unknown as Record<string, unknown>,
+    }));
+
+  const keywords = (details.keywords?.keywords ?? [])
+    .filter((keyword) => Number.isFinite(keyword.id) && keyword.name)
+    .slice(0, maxKeywords)
+    .map((keyword) => ({
+      tmdbId: keyword.id,
+      name: keyword.name,
+      rawMetadata: keyword as unknown as Record<string, unknown>,
+    }));
+
+  return {
+    people: [...cast, ...directors],
+    genres,
+    keywords,
+    snapshot: {
+      id: details.id,
+      title: details.title,
+      release_date: details.release_date,
+      runtime: details.runtime,
+      vote_average: details.vote_average,
+      poster_path: details.poster_path ?? null,
+      genres: genres.map(({ tmdbId, name }) => ({ id: tmdbId, name })),
+      cast: cast.map(({ tmdbId, name, characterName, billingOrder }) => ({
+        id: tmdbId,
+        name,
+        character: characterName,
+        order: billingOrder,
+      })),
+      directors: directors.map(({ tmdbId, name, job }) => ({ id: tmdbId, name, job })),
+      keywords: keywords.map(({ tmdbId, name }) => ({ id: tmdbId, name })),
+    },
+  };
+}

--- a/services/movie-backfill/src/tmdb.ts
+++ b/services/movie-backfill/src/tmdb.ts
@@ -1,59 +1,17 @@
 import { logger } from './logger.js';
+import { extractTMDBCatalogMetadataCore, extractTMDBUSCertification } from '@pop-choice/shared';
 import z from 'zod';
+
+import type { TMDBCatalogMetadataCore, TMDBCatalogMovieDetails } from '@pop-choice/shared';
 
 const TMDB_BASE_URL = 'https://api.themoviedb.org/3';
 const TMDB_IMAGE_BASE_URL = 'https://image.tmdb.org/t/p';
 const TMDB_SEARCH_FETCH_TIMEOUT_MS = 8_000;
 const TMDB_MOVIE_DETAILS_FETCH_TIMEOUT_MS = 8_000;
-const MAX_CAST_CREDITS = 12;
-const MAX_KEYWORDS = 20;
 
-interface TMDBGenre {
-  id: number;
-  name: string;
-}
-
-interface TMDBCastCredit {
-  id: number;
-  name: string;
-  character?: string | null;
-  order?: number | null;
-  profile_path?: string | null;
-  popularity?: number | null;
-  credit_id?: string | null;
-}
-
-interface TMDBCrewCredit {
-  id: number;
-  name: string;
-  job?: string | null;
-  department?: string | null;
-  profile_path?: string | null;
-  popularity?: number | null;
-  credit_id?: string | null;
-}
-
-interface TMDBKeyword {
-  id: number;
-  name: string;
-}
-
-export interface TMDBMovieDetails {
-  id: number;
-  title: string;
+export type TMDBMovieDetails = TMDBCatalogMovieDetails & {
   overview: string;
-  release_date: string;
-  vote_average: number;
-  runtime: number | null;
   poster_path: string | null;
-  genres?: TMDBGenre[];
-  credits?: {
-    cast?: TMDBCastCredit[];
-    crew?: TMDBCrewCredit[];
-  };
-  keywords?: {
-    keywords?: TMDBKeyword[];
-  };
   release_dates: {
     results: Array<{
       iso_3166_1: string;
@@ -63,34 +21,9 @@ export interface TMDBMovieDetails {
       }>;
     }>;
   };
-}
+};
 
-export interface TMDBCatalogMetadata {
-  people: Array<{
-    tmdbId: number;
-    name: string;
-    profilePath: string | null;
-    popularity: number | null;
-    creditId: string;
-    role: 'cast' | 'director';
-    characterName: string | null;
-    job: string | null;
-    department: string | null;
-    billingOrder: number | null;
-    rawMetadata: Record<string, unknown>;
-  }>;
-  genres: Array<{
-    tmdbId: number;
-    name: string;
-    rawMetadata: Record<string, unknown>;
-  }>;
-  keywords: Array<{
-    tmdbId: number;
-    name: string;
-    rawMetadata: Record<string, unknown>;
-  }>;
-  snapshot: Record<string, unknown>;
-}
+export type TMDBCatalogMetadata = TMDBCatalogMetadataCore;
 
 export function getPosterUrl(posterPath: string | null | undefined): string | null {
   return posterPath ? `${TMDB_IMAGE_BASE_URL}/w500${posterPath}` : null;
@@ -369,102 +302,13 @@ export async function fetchMovieDetails(
   return (await response.json()) as TMDBMovieDetails;
 }
 
-export function extractCatalogMetadata(details: TMDBMovieDetails): TMDBCatalogMetadata {
-  const genres = (details.genres ?? [])
-    .filter((genre) => Number.isFinite(genre.id) && genre.name)
-    .map((genre) => ({
-      tmdbId: genre.id,
-      name: genre.name,
-      rawMetadata: genre as unknown as Record<string, unknown>,
-    }));
-
-  const cast = (details.credits?.cast ?? [])
-    .filter((credit) => Number.isFinite(credit.id) && credit.name && credit.credit_id)
-    .sort((a, b) => (a.order ?? Number.MAX_SAFE_INTEGER) - (b.order ?? Number.MAX_SAFE_INTEGER))
-    .slice(0, MAX_CAST_CREDITS)
-    .map((credit) => ({
-      tmdbId: credit.id,
-      name: credit.name,
-      profilePath: credit.profile_path ?? null,
-      popularity: credit.popularity ?? null,
-      creditId: credit.credit_id as string,
-      role: 'cast' as const,
-      characterName: credit.character ?? null,
-      job: null,
-      department: null,
-      billingOrder: credit.order ?? null,
-      rawMetadata: credit as unknown as Record<string, unknown>,
-    }));
-
-  const directors = (details.credits?.crew ?? [])
-    .filter(
-      (credit) =>
-        Number.isFinite(credit.id) &&
-        credit.name &&
-        credit.credit_id &&
-        credit.job?.toLowerCase() === 'director',
-    )
-    .map((credit) => ({
-      tmdbId: credit.id,
-      name: credit.name,
-      profilePath: credit.profile_path ?? null,
-      popularity: credit.popularity ?? null,
-      creditId: credit.credit_id as string,
-      role: 'director' as const,
-      characterName: null,
-      job: credit.job ?? null,
-      department: credit.department ?? null,
-      billingOrder: null,
-      rawMetadata: credit as unknown as Record<string, unknown>,
-    }));
-
-  const keywords = (details.keywords?.keywords ?? [])
-    .filter((keyword) => Number.isFinite(keyword.id) && keyword.name)
-    .slice(0, MAX_KEYWORDS)
-    .map((keyword) => ({
-      tmdbId: keyword.id,
-      name: keyword.name,
-      rawMetadata: keyword as unknown as Record<string, unknown>,
-    }));
-
-  return {
-    people: [...cast, ...directors],
-    genres,
-    keywords,
-    snapshot: {
-      id: details.id,
-      title: details.title,
-      release_date: details.release_date,
-      runtime: details.runtime,
-      vote_average: details.vote_average,
-      poster_path: details.poster_path,
-      genres: genres.map(({ tmdbId, name }) => ({ id: tmdbId, name })),
-      cast: cast.map(({ tmdbId, name, characterName, billingOrder }) => ({
-        id: tmdbId,
-        name,
-        character: characterName,
-        order: billingOrder,
-      })),
-      directors: directors.map(({ tmdbId, name, job }) => ({ id: tmdbId, name, job })),
-      keywords: keywords.map(({ tmdbId, name }) => ({ id: tmdbId, name })),
-    },
-  };
-}
+export const extractCatalogMetadata = extractTMDBCatalogMetadataCore;
 
 /**
  * Extract the US certification from movie details.
  * Falls back to 'NR' if not found.
  */
-export function extractUSCertification(details: TMDBMovieDetails): string {
-  const usEntry = details.release_dates?.results?.find((r) => r.iso_3166_1 === 'US');
-  if (!usEntry) return 'NR';
-
-  // Type 3 = Theatrical, prefer that; otherwise take the first with a certification
-  const theatrical = usEntry.release_dates.find((rd) => rd.type === 3 && rd.certification);
-  const any = usEntry.release_dates.find((rd) => rd.certification);
-  const cert = (theatrical ?? any)?.certification ?? '';
-  return cert || 'NR';
-}
+export const extractUSCertification = extractTMDBUSCertification;
 
 /**
  * Convert movie data into a text description suitable for embedding.

--- a/services/movie-discovery/src/tmdb.ts
+++ b/services/movie-discovery/src/tmdb.ts
@@ -1,39 +1,10 @@
 import { logger } from './logger.js';
 import type { TMDBSource } from './config.js';
+import { extractTMDBCatalogMetadataCore, extractTMDBUSCertification } from '@pop-choice/shared';
+
+import type { TMDBCatalogMetadataCore, TMDBCatalogMovieDetails } from '@pop-choice/shared';
 
 const TMDB_BASE_URL = 'https://api.themoviedb.org/3';
-const MAX_CAST_CREDITS = 12;
-const MAX_KEYWORDS = 20;
-
-interface TMDBGenre {
-  id: number;
-  name: string;
-}
-
-interface TMDBCastCredit {
-  id: number;
-  name: string;
-  character?: string | null;
-  order?: number | null;
-  profile_path?: string | null;
-  popularity?: number | null;
-  credit_id?: string | null;
-}
-
-interface TMDBCrewCredit {
-  id: number;
-  name: string;
-  job?: string | null;
-  department?: string | null;
-  profile_path?: string | null;
-  popularity?: number | null;
-  credit_id?: string | null;
-}
-
-interface TMDBKeyword {
-  id: number;
-  name: string;
-}
 
 export interface TMDBMovie {
   id: number;
@@ -50,23 +21,9 @@ export interface TMDBMovie {
   backdrop_path: string | null;
 }
 
-export interface TMDBMovieDetails {
-  id: number;
-  title: string;
+export type TMDBMovieDetails = TMDBCatalogMovieDetails & {
   overview: string;
-  release_date: string;
-  vote_average: number;
   vote_count: number;
-  runtime: number | null;
-  poster_path?: string | null;
-  genres?: TMDBGenre[];
-  credits?: {
-    cast?: TMDBCastCredit[];
-    crew?: TMDBCrewCredit[];
-  };
-  keywords?: {
-    keywords?: TMDBKeyword[];
-  };
   release_dates: {
     results: Array<{
       iso_3166_1: string;
@@ -76,34 +33,9 @@ export interface TMDBMovieDetails {
       }>;
     }>;
   };
-}
+};
 
-export interface TMDBCatalogMetadata {
-  people: Array<{
-    tmdbId: number;
-    name: string;
-    profilePath: string | null;
-    popularity: number | null;
-    creditId: string;
-    role: 'cast' | 'director';
-    characterName: string | null;
-    job: string | null;
-    department: string | null;
-    billingOrder: number | null;
-    rawMetadata: Record<string, unknown>;
-  }>;
-  genres: Array<{
-    tmdbId: number;
-    name: string;
-    rawMetadata: Record<string, unknown>;
-  }>;
-  keywords: Array<{
-    tmdbId: number;
-    name: string;
-    rawMetadata: Record<string, unknown>;
-  }>;
-  snapshot: Record<string, unknown>;
-}
+export type TMDBCatalogMetadata = TMDBCatalogMetadataCore;
 
 interface TMDBListResponse {
   page: number;
@@ -214,102 +146,13 @@ export async function fetchMovieDetails(
   return (await response.json()) as TMDBMovieDetails;
 }
 
-export function extractCatalogMetadata(details: TMDBMovieDetails): TMDBCatalogMetadata {
-  const genres = (details.genres ?? [])
-    .filter((genre) => Number.isFinite(genre.id) && genre.name)
-    .map((genre) => ({
-      tmdbId: genre.id,
-      name: genre.name,
-      rawMetadata: genre as unknown as Record<string, unknown>,
-    }));
-
-  const cast = (details.credits?.cast ?? [])
-    .filter((credit) => Number.isFinite(credit.id) && credit.name && credit.credit_id)
-    .sort((a, b) => (a.order ?? Number.MAX_SAFE_INTEGER) - (b.order ?? Number.MAX_SAFE_INTEGER))
-    .slice(0, MAX_CAST_CREDITS)
-    .map((credit) => ({
-      tmdbId: credit.id,
-      name: credit.name,
-      profilePath: credit.profile_path ?? null,
-      popularity: credit.popularity ?? null,
-      creditId: credit.credit_id as string,
-      role: 'cast' as const,
-      characterName: credit.character ?? null,
-      job: null,
-      department: null,
-      billingOrder: credit.order ?? null,
-      rawMetadata: credit as unknown as Record<string, unknown>,
-    }));
-
-  const directors = (details.credits?.crew ?? [])
-    .filter(
-      (credit) =>
-        Number.isFinite(credit.id) &&
-        credit.name &&
-        credit.credit_id &&
-        credit.job?.toLowerCase() === 'director',
-    )
-    .map((credit) => ({
-      tmdbId: credit.id,
-      name: credit.name,
-      profilePath: credit.profile_path ?? null,
-      popularity: credit.popularity ?? null,
-      creditId: credit.credit_id as string,
-      role: 'director' as const,
-      characterName: null,
-      job: credit.job ?? null,
-      department: credit.department ?? null,
-      billingOrder: null,
-      rawMetadata: credit as unknown as Record<string, unknown>,
-    }));
-
-  const keywords = (details.keywords?.keywords ?? [])
-    .filter((keyword) => Number.isFinite(keyword.id) && keyword.name)
-    .slice(0, MAX_KEYWORDS)
-    .map((keyword) => ({
-      tmdbId: keyword.id,
-      name: keyword.name,
-      rawMetadata: keyword as unknown as Record<string, unknown>,
-    }));
-
-  return {
-    people: [...cast, ...directors],
-    genres,
-    keywords,
-    snapshot: {
-      id: details.id,
-      title: details.title,
-      release_date: details.release_date,
-      runtime: details.runtime,
-      vote_average: details.vote_average,
-      poster_path: details.poster_path ?? null,
-      genres: genres.map(({ tmdbId, name }) => ({ id: tmdbId, name })),
-      cast: cast.map(({ tmdbId, name, characterName, billingOrder }) => ({
-        id: tmdbId,
-        name,
-        character: characterName,
-        order: billingOrder,
-      })),
-      directors: directors.map(({ tmdbId, name, job }) => ({ id: tmdbId, name, job })),
-      keywords: keywords.map(({ tmdbId, name }) => ({ id: tmdbId, name })),
-    },
-  };
-}
+export const extractCatalogMetadata = extractTMDBCatalogMetadataCore;
 
 /**
  * Extract the US certification from movie details.
  * Falls back to 'NR' if not found.
  */
-export function extractUSCertification(details: TMDBMovieDetails): string {
-  const usEntry = details.release_dates?.results?.find((r) => r.iso_3166_1 === 'US');
-  if (!usEntry) return 'NR';
-
-  // Type 3 = Theatrical, prefer that; otherwise take the first with a certification
-  const theatrical = usEntry.release_dates.find((rd) => rd.type === 3 && rd.certification);
-  const any = usEntry.release_dates.find((rd) => rd.certification);
-  const cert = (theatrical ?? any)?.certification ?? '';
-  return cert || 'NR';
-}
+export const extractUSCertification = extractTMDBUSCertification;
 
 /**
  * Convert a TMDB movie into a text description suitable for embedding.


### PR DESCRIPTION
## Summary
- Add a shared TMDB catalog metadata core extractor and US certification helper in packages/shared.
- Route web catalog maintenance, movie-backfill, and movie-discovery through the shared core while preserving web-specific providers/quality snapshot fields and service fetch/error behavior.
- Add shared unit coverage for certification fallback and metadata normalization.

Closes #701
Refs #698

## Validation
- npm run format:check
- npm run lint:check
- npm run type-check
- npm run test:services
- npm run build:services
- npm run test:server --workspace=apps/web -- src/features/catalogMaintenance/tmdb.test.ts
- npm run build
- npm run quality:fallow:audit -- --changed-since origin/development --format compact
- npx fallow dead-code --workspace @pop-choice/shared --format json --quiet
- npx fallow dead-code --workspace movie-backfill --format json --quiet
- npx fallow dead-code --workspace movie-discovery --format json --quiet
- npx fallow dupes --workspace movie-backfill --format json --quiet --top 8
- npx fallow dupes --workspace movie-discovery --format json --quiet --top 8

## Fallow notes
- movie-backfill duplication now reports 5 clone groups / 129 duplicated lines.
- movie-discovery duplication now reports 2 clone groups / 36 duplicated lines.
- Remaining clones are search scoring / service entrypoint follow-ups tracked under the umbrella.