### PR TITLE
Refactor backoffice catalog health duplication

### DIFF
--- a/apps/backoffice/src/app/page.tsx
+++ b/apps/backoffice/src/app/page.tsx
@@ -1,23 +1,6 @@
-import {
-  getCatalogHealthReport,
-  isCatalogHealthIssueKey,
-  listCatalogHealthIssueMoviePage,
-  listCatalogRepairAuditPage,
-  MAX_CATALOG_HEALTH_ISSUE_PAGE_SIZE,
-} from '@pop-choice/shared';
-
 import { BackofficeErrorPage, CatalogHealthPage } from '../components/backoffice';
-import { getCatalogMaintenanceQueueSnapshot } from '../catalogMaintenanceQueue';
-import {
-  DEFAULT_CATALOG_ISSUE_PAGE_SIZE,
-  DEFAULT_REPAIR_AUDIT_LIMIT,
-  ensureBackofficeReady,
-  logBackofficeError,
-  MAX_CATALOG_ISSUE_PAGE_NUMBER,
-  MAX_REPAIR_AUDIT_PAGE_NUMBER,
-  parsePositiveIntParam,
-} from '../lib/backoffice';
-import { toCatalogHealthLiveData } from '../lib/catalogHealthLive';
+import { ensureBackofficeReady, logBackofficeError } from '../lib/backoffice';
+import { readCatalogHealthPageData } from '../lib/catalogHealthLiveServer';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
@@ -36,54 +19,16 @@ export default async function HomePage({ searchParams }: HomePageProps) {
     const config = await ensureBackofficeReady();
     const params = (await searchParams) ?? {};
     const repairStatus = getParamValue(params.repair)?.trim() ?? null;
-    const selectedIssueKey = getParamValue(params.issue)?.trim() ?? null;
-    const issuePageSize = parsePositiveIntParam(
-      getParamValue(params.issuePageSize),
-      DEFAULT_CATALOG_ISSUE_PAGE_SIZE,
-      { max: MAX_CATALOG_HEALTH_ISSUE_PAGE_SIZE },
-    );
-    const issuePageNumber = parsePositiveIntParam(getParamValue(params.issuePage), 1, {
-      max: MAX_CATALOG_ISSUE_PAGE_NUMBER,
+    const { auditPage, issueMoviePage, liveData, report } = await readCatalogHealthPageData({
+      config,
+      searchParams: params,
     });
-    const auditPageSize = parsePositiveIntParam(
-      getParamValue(params.auditPageSize),
-      DEFAULT_REPAIR_AUDIT_LIMIT,
-      { max: 100 },
-    );
-    const auditPageNumber = parsePositiveIntParam(getParamValue(params.auditPage), 1, {
-      max: MAX_REPAIR_AUDIT_PAGE_NUMBER,
-    });
-
-    const [report, auditPage, issueMoviePage, queueSnapshot] = await Promise.all([
-      getCatalogHealthReport({
-        sampleLimit: config.catalogHealthSampleLimit,
-        staleAfterDays: config.catalogHealthStaleDays,
-      }),
-      listCatalogRepairAuditPage({
-        limit: auditPageSize,
-        offset: (auditPageNumber - 1) * auditPageSize,
-      }),
-      selectedIssueKey && isCatalogHealthIssueKey(selectedIssueKey)
-        ? listCatalogHealthIssueMoviePage({
-            issueKey: selectedIssueKey,
-            limit: issuePageSize,
-            offset: (issuePageNumber - 1) * issuePageSize,
-            staleAfterDays: config.catalogHealthStaleDays,
-          })
-        : Promise.resolve(null),
-      getCatalogMaintenanceQueueSnapshot(config.redisUrl),
-    ]);
 
     return (
       <CatalogHealthPage
         report={report}
         auditPage={auditPage}
-        initialLiveData={toCatalogHealthLiveData({
-          auditPage,
-          issueMoviePage,
-          queueSnapshot,
-          report,
-        })}
+        initialLiveData={liveData}
         issueMoviePage={issueMoviePage}
         bullBoardUrl={config.bullBoardUrl}
         repairStatus={repairStatus}

--- a/apps/backoffice/src/components/catalog-health/index.tsx
+++ b/apps/backoffice/src/components/catalog-health/index.tsx
@@ -13,14 +13,8 @@ import { CatalogHealthRealtimeOverview } from '../catalogHealthRealtimeOverview'
 import { CatalogRepairEnhancement } from '../catalogRepairEnhancement';
 import { formatLiveSyncTime } from '../liveRefreshTime';
 import { CountPill, SimplePaginationControls } from '../shared';
+import { buildRepairAuditPageHref } from '../shared/hrefs';
 import { CatalogIssuePanel } from './issuePanel';
-
-function buildRepairAuditPageHref({ page, pageSize }: { page: number; pageSize: number }) {
-  const params = new URLSearchParams();
-  params.set('auditPage', String(page));
-  params.set('auditPageSize', String(pageSize));
-  return `/?${params.toString()}#repair-audit`;
-}
 
 function RepairFlash({ repairStatus }: { repairStatus: string | null }) {
   if (repairStatus === 'queued') {

--- a/apps/backoffice/src/components/catalog-health/issuePanel.tsx
+++ b/apps/backoffice/src/components/catalog-health/issuePanel.tsx
@@ -16,6 +16,7 @@ import {
   OptionalCatalogValue,
   SimplePaginationControls,
 } from '../shared';
+import { buildCatalogIssuePageHref } from '../shared/hrefs';
 
 export function catalogIssueHint(issueKey: string): string {
   const hints: Record<string, string> = {
@@ -35,21 +36,7 @@ export function catalogIssueHint(issueKey: string): string {
   return hints[issueKey] ?? 'Review affected catalog records.';
 }
 
-export function buildCatalogIssuePageHref({
-  issueKey,
-  page,
-  pageSize,
-}: {
-  issueKey: string;
-  page: number;
-  pageSize: number;
-}) {
-  const params = new URLSearchParams();
-  params.set('issue', issueKey);
-  params.set('issuePage', String(page));
-  params.set('issuePageSize', String(pageSize));
-  return `/?${params.toString()}#issue-${encodeURIComponent(issueKey)}`;
-}
+export { buildCatalogIssuePageHref };
 
 function SampleRows({
   emptyLabel = 'No sample records returned.',
@@ -181,6 +168,34 @@ function BulkRepairForm({ issue }: { issue: CatalogHealthIssue }) {
   );
 }
 
+function CatalogIssuePagination({
+  ariaLabel,
+  issue,
+  page,
+}: {
+  ariaLabel: string;
+  issue: CatalogHealthIssue;
+  page: CatalogHealthIssueMoviePage;
+}) {
+  return (
+    <SimplePaginationControls
+      ariaLabel={ariaLabel}
+      emptyLabel="No affected movies"
+      itemLabel="affected movies"
+      limit={page.limit}
+      offset={page.offset}
+      totalCount={page.totalCount}
+      hrefForPage={(nextPage) =>
+        buildCatalogIssuePageHref({
+          issueKey: issue.key,
+          page: nextPage,
+          pageSize: page.limit,
+        })
+      }
+    />
+  );
+}
+
 export function CatalogIssuePanel({
   issue,
   issuePage,
@@ -233,20 +248,10 @@ export function CatalogIssuePanel({
       ) : (
         <>
           {activePage ? (
-            <SimplePaginationControls
+            <CatalogIssuePagination
               ariaLabel={`${issue.label} affected movie pagination`}
-              emptyLabel="No affected movies"
-              itemLabel="affected movies"
-              limit={activePage.limit}
-              offset={activePage.offset}
-              totalCount={activePage.totalCount}
-              hrefForPage={(page) =>
-                buildCatalogIssuePageHref({
-                  issueKey: issue.key,
-                  page,
-                  pageSize: activePage.limit,
-                })
-              }
+              issue={issue}
+              page={activePage}
             />
           ) : null}
           <SampleRows
@@ -255,20 +260,10 @@ export function CatalogIssuePanel({
             emptyLabel={activePage ? 'No affected movies on this page.' : undefined}
           />
           {activePage ? (
-            <SimplePaginationControls
+            <CatalogIssuePagination
               ariaLabel={`${issue.label} affected movie pagination bottom`}
-              emptyLabel="No affected movies"
-              itemLabel="affected movies"
-              limit={activePage.limit}
-              offset={activePage.offset}
-              totalCount={activePage.totalCount}
-              hrefForPage={(page) =>
-                buildCatalogIssuePageHref({
-                  issueKey: issue.key,
-                  page,
-                  pageSize: activePage.limit,
-                })
-              }
+              issue={issue}
+              page={activePage}
             />
           ) : issue.count > issue.samples.length ? (
             <div className="panel-footer">

--- a/apps/backoffice/src/components/shared/hrefs.ts
+++ b/apps/backoffice/src/components/shared/hrefs.ts
@@ -1,0 +1,22 @@
+export function buildCatalogIssuePageHref({
+  issueKey,
+  page,
+  pageSize,
+}: {
+  issueKey: string;
+  page: number;
+  pageSize: number;
+}) {
+  const params = new URLSearchParams();
+  params.set('issue', issueKey);
+  params.set('issuePage', String(page));
+  params.set('issuePageSize', String(pageSize));
+  return `/?${params.toString()}#issue-${encodeURIComponent(issueKey)}`;
+}
+
+export function buildRepairAuditPageHref({ page, pageSize }: { page: number; pageSize: number }) {
+  const params = new URLSearchParams();
+  params.set('auditPage', String(page));
+  params.set('auditPageSize', String(pageSize));
+  return `/?${params.toString()}#repair-audit`;
+}

--- a/apps/backoffice/src/components/shared/index.tsx
+++ b/apps/backoffice/src/components/shared/index.tsx
@@ -81,29 +81,6 @@ export function CountPill({
   return <span className={state ? `count ${state}` : 'count'}>{count}</span>;
 }
 
-function buildCatalogIssuePageHref({
-  issueKey,
-  page,
-  pageSize,
-}: {
-  issueKey: string;
-  page: number;
-  pageSize: number;
-}) {
-  const params = new URLSearchParams();
-  params.set('issue', issueKey);
-  params.set('issuePage', String(page));
-  params.set('issuePageSize', String(pageSize));
-  return `/?${params.toString()}#issue-${encodeURIComponent(issueKey)}`;
-}
-
-function buildRepairAuditPageHref({ page, pageSize }: { page: number; pageSize: number }) {
-  const params = new URLSearchParams();
-  params.set('auditPage', String(page));
-  params.set('auditPageSize', String(pageSize));
-  return `/?${params.toString()}#repair-audit`;
-}
-
 export function SimplePaginationControls({
   ariaLabel,
   emptyLabel,

--- a/apps/backoffice/src/lib/catalogHealthLiveServer.ts
+++ b/apps/backoffice/src/lib/catalogHealthLiveServer.ts
@@ -17,16 +17,20 @@ import {
 } from './backoffice';
 import { toCatalogHealthLiveData } from './catalogHealthLive';
 
-function getSearchParamValue(params: URLSearchParams, key: string): string | null {
-  return params.get(key)?.trim() ?? null;
+type CatalogHealthSearchParams = URLSearchParams | Record<string, string | string[] | undefined>;
+
+function getSearchParamValue(params: CatalogHealthSearchParams, key: string): string | null {
+  const value = params instanceof URLSearchParams ? params.get(key) : params[key];
+  const firstValue = Array.isArray(value) ? value[0] : value;
+  return firstValue?.trim() ?? null;
 }
 
-export async function readCatalogHealthLiveData({
+export async function readCatalogHealthPageData({
   config,
   searchParams,
 }: {
   config: BackofficeRuntimeConfig;
-  searchParams: URLSearchParams;
+  searchParams: CatalogHealthSearchParams;
 }) {
   const selectedIssueKey = getSearchParamValue(searchParams, 'issue');
   const issuePageSize = parsePositiveIntParam(
@@ -66,5 +70,22 @@ export async function readCatalogHealthLiveData({
     getCatalogMaintenanceQueueSnapshot(config.redisUrl),
   ]);
 
-  return toCatalogHealthLiveData({ auditPage, issueMoviePage, queueSnapshot, report });
+  return {
+    auditPage,
+    issueMoviePage,
+    liveData: toCatalogHealthLiveData({ auditPage, issueMoviePage, queueSnapshot, report }),
+    queueSnapshot,
+    report,
+  };
+}
+
+export async function readCatalogHealthLiveData({
+  config,
+  searchParams,
+}: {
+  config: BackofficeRuntimeConfig;
+  searchParams: CatalogHealthSearchParams;
+}) {
+  const { liveData } = await readCatalogHealthPageData({ config, searchParams });
+  return liveData;
 }


### PR DESCRIPTION
## Summary
- Share the catalog-health data reader between the backoffice page and live/API snapshots.
- Move catalog-health and repair-audit href builders into a small shared helper.
- Extract the repeated catalog issue pagination rendering inside the issue panel.

## Fallow notes
- Dead-code remains clean: 0 issues.
- Full dupes improved from the post-cleanup baseline to 2393 duplicated lines / 4.27% in the latest local run.
- Remaining top findings are broader web auth/form duplication and generic backoffice table headers; I left those for separate PRs because they are separate UI/API refactors.

## Verification
- npm run quality:fallow:dead-code -- --format json --quiet => 0 issues
- npm run quality:fallow:dupes -- --top 5 --format json --quiet
- npm run quality:fallow:dupes -- --changed-since origin/development --top 20 --format json --quiet
- npm run type-check --workspace=apps/backoffice
- npm run test --workspace=apps/backoffice => 35 files, 138 tests
- npm run quality:structure --workspace=apps/backoffice
- npm run build --workspace=apps/backoffice
- npm run lint:check
- pre-push hook: lint, server tests, production build; Storybook skipped because there were no Storybook-relevant changes