### PR TITLE
Refactor web auth request guards

### DIFF
--- a/apps/web/src/app/api/account/movie-memory/route.ts
+++ b/apps/web/src/app/api/account/movie-memory/route.ts
@@ -15,18 +15,16 @@ import {
   searchMovieMemoryCatalog,
   searchMovieMemorySchema,
 } from '@/features/movie-memory/service';
+import { hasValidSameOriginCsrfPair } from '@/lib/auth/csrf';
 import { getSessionFromRequest } from '@/lib/auth/session';
 import { parseLocaleFromRequest, type Locale } from '@/lib/locale';
 import logger from '@/lib/logger';
 import { applyRateLimit } from '@/lib/rateLimit';
-import { isSameOriginBrowserRequest } from '@/lib/withAuth';
 
 const privateResponseHeaders = {
   'Cache-Control': 'no-store',
   Vary: 'Cookie',
 };
-
-const CSRF_COOKIE = '__csrf';
 
 function elapsedMs(startedAt: number): number {
   return Date.now() - startedAt;
@@ -34,14 +32,6 @@ function elapsedMs(startedAt: number): number {
 
 function movieMemoryJson(body: unknown, status: number): Response {
   return NextResponse.json(body, { status, headers: privateResponseHeaders });
-}
-
-function hasValidCsrf(req: NextRequest): boolean {
-  const csrfHeader = req.headers.get('x-csrf-token');
-  const csrfCookie = req.cookies.get(CSRF_COOKIE)?.value;
-  return Boolean(
-    csrfHeader && csrfCookie && csrfHeader === csrfCookie && isSameOriginBrowserRequest(req),
-  );
 }
 
 function parseRequestedLocale(req: NextRequest): Locale {
@@ -226,7 +216,7 @@ export async function POST(req: NextRequest): Promise<Response> {
     return rateLimitResponse;
   }
 
-  if (!hasValidCsrf(req)) {
+  if (!hasValidSameOriginCsrfPair(req)) {
     logger.warn(
       { userId: session.sub, durationMs: elapsedMs(startedAt) },
       'Movie memory creation rejected: CSRF check failed',
@@ -333,7 +323,7 @@ export async function DELETE(req: NextRequest): Promise<Response> {
   const rateLimitResponse = await applyRateLimit(req);
   if (rateLimitResponse) return rateLimitResponse;
 
-  if (!hasValidCsrf(req)) {
+  if (!hasValidSameOriginCsrfPair(req)) {
     logger.warn({ userId: session.sub }, 'Movie memory deletion rejected: CSRF check failed');
     return movieMemoryJson({ error: 'Forbidden' }, 403);
   }

--- a/apps/web/src/app/api/auth/delete-account/route.ts
+++ b/apps/web/src/app/api/auth/delete-account/route.ts
@@ -1,58 +1,22 @@
 import { NextRequest, NextResponse } from 'next/server';
-import z from 'zod';
 
 import { getDbClient } from '@/clients/dbClient';
 import { verifyPassword } from '@/lib/auth/password';
+import { readEmailPasswordAuthRequest } from '@/lib/auth/request';
 import { clearSessionCookie } from '@/lib/auth/session';
 import logger from '@/lib/logger';
-import { applyRateLimit } from '@/lib/rateLimit';
-import { isSameOriginBrowserRequest } from '@/lib/withAuth';
-
-// ---------------------------------------------------------------------------
-// Input schema
-// ---------------------------------------------------------------------------
-
-const deleteAccountSchema = z.object({
-  email: z.string().email().max(254),
-  password: z.string().min(1).max(128),
-});
 
 // ---------------------------------------------------------------------------
 // POST handler
 // ---------------------------------------------------------------------------
 
-// Auth endpoints are expensive (scrypt) — use a tighter limit than the default.
-const AUTH_RATE_LIMIT = { limit: 5, windowSeconds: 15 * 60 };
-const CSRF_COOKIE = '__csrf';
-
 export async function POST(req: NextRequest): Promise<Response> {
-  const rateLimitResponse = await applyRateLimit(req, AUTH_RATE_LIMIT);
-  if (rateLimitResponse) return rateLimitResponse;
+  const request = await readEmailPasswordAuthRequest(req, {
+    csrfFailureLogMessage: 'Account deletion rejected: CSRF check failed',
+  });
+  if (request.response) return request.response;
 
-  const csrfHeader = req.headers.get('x-csrf-token');
-  const csrfCookie = req.cookies.get(CSRF_COOKIE)?.value;
-  if (!csrfHeader || !csrfCookie || csrfHeader !== csrfCookie || !isSameOriginBrowserRequest(req)) {
-    logger.warn('Account deletion rejected: CSRF check failed');
-    return NextResponse.json({ error: 'Forbidden.' }, { status: 403 });
-  }
-
-  let body: unknown;
-  try {
-    body = await req.json();
-  } catch {
-    return NextResponse.json({ error: 'Invalid JSON body.' }, { status: 400 });
-  }
-
-  const parsed = deleteAccountSchema.safeParse(body);
-  if (!parsed.success) {
-    return NextResponse.json(
-      { error: 'Validation failed.', details: parsed.error.flatten().fieldErrors },
-      { status: 422 },
-    );
-  }
-
-  const { email, password } = parsed.data;
-  const normalizedEmail = email.toLowerCase().trim();
+  const { normalizedEmail, password } = request.data;
 
   const db = getDbClient();
   if (!db.isConfigured()) {

--- a/apps/web/src/app/api/auth/forgot-password/route.ts
+++ b/apps/web/src/app/api/auth/forgot-password/route.ts
@@ -10,9 +10,8 @@ import {
   sendPasswordResetEmail,
   shouldExposePasswordResetUrl,
 } from '@/lib/auth/passwordReset';
+import { readAuthJsonRequest } from '@/lib/auth/request';
 import logger from '@/lib/logger';
-import { applyRateLimit } from '@/lib/rateLimit';
-import { isSameOriginBrowserRequest } from '@/lib/withAuth';
 
 const forgotPasswordSchema = z.object({
   email: z.preprocess(
@@ -21,36 +20,13 @@ const forgotPasswordSchema = z.object({
   ),
 });
 
-const AUTH_RATE_LIMIT = { limit: 5, windowSeconds: 15 * 60 };
-const CSRF_COOKIE = '__csrf';
-
 export async function POST(req: NextRequest): Promise<Response> {
-  const rateLimitResponse = await applyRateLimit(req, AUTH_RATE_LIMIT);
-  if (rateLimitResponse) return rateLimitResponse;
+  const request = await readAuthJsonRequest(req, forgotPasswordSchema, {
+    csrfFailureLogMessage: 'Password reset request rejected: CSRF check failed',
+  });
+  if (request.response) return request.response;
 
-  const csrfHeader = req.headers.get('x-csrf-token');
-  const csrfCookie = req.cookies.get(CSRF_COOKIE)?.value;
-  if (!csrfHeader || !csrfCookie || csrfHeader !== csrfCookie || !isSameOriginBrowserRequest(req)) {
-    logger.warn('Password reset request rejected: CSRF check failed');
-    return NextResponse.json({ error: 'Forbidden.' }, { status: 403 });
-  }
-
-  let body: unknown;
-  try {
-    body = await req.json();
-  } catch {
-    return NextResponse.json({ error: 'Invalid JSON body.' }, { status: 400 });
-  }
-
-  const parsed = forgotPasswordSchema.safeParse(body);
-  if (!parsed.success) {
-    return NextResponse.json(
-      { error: 'Validation failed.', details: parsed.error.flatten().fieldErrors },
-      { status: 422 },
-    );
-  }
-
-  const normalizedEmail = parsed.data.email.toLowerCase().trim();
+  const normalizedEmail = request.data.email.toLowerCase().trim();
   const db = getDbClient();
   if (!db.isConfigured()) {
     logger.error('Database not configured — cannot create password reset token.');

--- a/apps/web/src/app/api/auth/login/route.ts
+++ b/apps/web/src/app/api/auth/login/route.ts
@@ -1,59 +1,22 @@
 import { NextRequest, NextResponse } from 'next/server';
-import z from 'zod';
 
 import { getDbClient } from '@/clients/dbClient';
 import { verifyPassword } from '@/lib/auth/password';
+import { readEmailPasswordAuthRequest } from '@/lib/auth/request';
 import { createSessionToken, setSessionCookie } from '@/lib/auth/session';
 import logger from '@/lib/logger';
-import { applyRateLimit } from '@/lib/rateLimit';
-import { isSameOriginBrowserRequest } from '@/lib/withAuth';
-
-// ---------------------------------------------------------------------------
-// Input schema
-// ---------------------------------------------------------------------------
-
-const loginSchema = z.object({
-  email: z.string().email().max(254),
-  password: z.string().min(1).max(128),
-});
 
 // ---------------------------------------------------------------------------
 // POST handler
 // ---------------------------------------------------------------------------
 
-// Auth endpoints are expensive (scrypt) — use a tighter limit than the default.
-const AUTH_RATE_LIMIT = { limit: 5, windowSeconds: 15 * 60 };
-const CSRF_COOKIE = '__csrf';
-
 export async function POST(req: NextRequest): Promise<Response> {
-  const rateLimitResponse = await applyRateLimit(req, AUTH_RATE_LIMIT);
-  if (rateLimitResponse) return rateLimitResponse;
+  const request = await readEmailPasswordAuthRequest(req, {
+    csrfFailureLogMessage: 'Login attempt rejected: CSRF check failed',
+  });
+  if (request.response) return request.response;
 
-  // Require a valid same-origin CSRF pair to prevent login CSRF attacks.
-  const csrfHeader = req.headers.get('x-csrf-token');
-  const csrfCookie = req.cookies.get(CSRF_COOKIE)?.value;
-  if (!csrfHeader || !csrfCookie || csrfHeader !== csrfCookie || !isSameOriginBrowserRequest(req)) {
-    logger.warn('Login attempt rejected: CSRF check failed');
-    return NextResponse.json({ error: 'Forbidden.' }, { status: 403 });
-  }
-
-  let body: unknown;
-  try {
-    body = await req.json();
-  } catch {
-    return NextResponse.json({ error: 'Invalid JSON body.' }, { status: 400 });
-  }
-
-  const parsed = loginSchema.safeParse(body);
-  if (!parsed.success) {
-    return NextResponse.json(
-      { error: 'Validation failed.', details: parsed.error.flatten().fieldErrors },
-      { status: 422 },
-    );
-  }
-
-  const { email, password } = parsed.data;
-  const normalizedEmail = email.toLowerCase().trim();
+  const { normalizedEmail, password } = request.data;
 
   const db = getDbClient();
   if (!db.isConfigured()) {

--- a/apps/web/src/app/api/auth/register/route.ts
+++ b/apps/web/src/app/api/auth/register/route.ts
@@ -1,38 +1,20 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { RegisterUserError, registerSchema, registerUser } from '@/features/auth/register';
+import { readAuthJsonRequest } from '@/lib/auth/request';
 import { createSessionToken, setSessionCookie } from '@/lib/auth/session';
 import logger from '@/lib/logger';
-import { applyRateLimit } from '@/lib/rateLimit';
 
 // ---------------------------------------------------------------------------
 // POST handler
 // ---------------------------------------------------------------------------
 
-// Auth endpoints are expensive (scrypt) — use a tighter limit than the default.
-const AUTH_RATE_LIMIT = { limit: 5, windowSeconds: 15 * 60 };
-
 export async function POST(req: NextRequest): Promise<Response> {
-  const rateLimitResponse = await applyRateLimit(req, AUTH_RATE_LIMIT);
-  if (rateLimitResponse) return rateLimitResponse;
-
-  let body: unknown;
-  try {
-    body = await req.json();
-  } catch {
-    return NextResponse.json({ error: 'Invalid JSON body.' }, { status: 400 });
-  }
-
-  const parsed = registerSchema.safeParse(body);
-  if (!parsed.success) {
-    return NextResponse.json(
-      { error: 'Validation failed.', details: parsed.error.flatten().fieldErrors },
-      { status: 422 },
-    );
-  }
+  const request = await readAuthJsonRequest(req, registerSchema, { requireCsrf: false });
+  if (request.response) return request.response;
 
   try {
-    const userId = await registerUser(parsed.data);
+    const userId = await registerUser(request.data);
     const sessionToken = createSessionToken(userId);
     if (!sessionToken) {
       logger.error({ userId }, 'Session secret is not configured — cannot sign in new user.');

--- a/apps/web/src/app/api/auth/reset-password/route.ts
+++ b/apps/web/src/app/api/auth/reset-password/route.ts
@@ -4,43 +4,19 @@ import z from 'zod';
 import { getDbClient } from '@/clients/dbClient';
 import { hashPassword } from '@/lib/auth/password';
 import { createAccountRecoveryTokenDigest } from '@/lib/auth/passwordReset';
+import { readAuthJsonRequest } from '@/lib/auth/request';
 import logger from '@/lib/logger';
-import { applyRateLimit } from '@/lib/rateLimit';
-import { isSameOriginBrowserRequest } from '@/lib/withAuth';
 
 const resetPasswordSchema = z.object({
   token: z.string().min(20).max(512),
   password: z.string().min(8).max(128),
 });
 
-const AUTH_RATE_LIMIT = { limit: 5, windowSeconds: 15 * 60 };
-const CSRF_COOKIE = '__csrf';
-
 export async function POST(req: NextRequest): Promise<Response> {
-  const rateLimitResponse = await applyRateLimit(req, AUTH_RATE_LIMIT);
-  if (rateLimitResponse) return rateLimitResponse;
-
-  const csrfHeader = req.headers.get('x-csrf-token');
-  const csrfCookie = req.cookies.get(CSRF_COOKIE)?.value;
-  if (!csrfHeader || !csrfCookie || csrfHeader !== csrfCookie || !isSameOriginBrowserRequest(req)) {
-    logger.warn('Password reset confirmation rejected: CSRF check failed');
-    return NextResponse.json({ error: 'Forbidden.' }, { status: 403 });
-  }
-
-  let body: unknown;
-  try {
-    body = await req.json();
-  } catch {
-    return NextResponse.json({ error: 'Invalid JSON body.' }, { status: 400 });
-  }
-
-  const parsed = resetPasswordSchema.safeParse(body);
-  if (!parsed.success) {
-    return NextResponse.json(
-      { error: 'Validation failed.', details: parsed.error.flatten().fieldErrors },
-      { status: 422 },
-    );
-  }
+  const request = await readAuthJsonRequest(req, resetPasswordSchema, {
+    csrfFailureLogMessage: 'Password reset confirmation rejected: CSRF check failed',
+  });
+  if (request.response) return request.response;
 
   const db = getDbClient();
   if (!db.isConfigured()) {
@@ -48,8 +24,8 @@ export async function POST(req: NextRequest): Promise<Response> {
     return NextResponse.json({ error: 'Service unavailable.' }, { status: 503 });
   }
 
-  const newPasswordHash = await hashPassword(parsed.data.password);
-  const tokenHash = createAccountRecoveryTokenDigest(parsed.data.token);
+  const newPasswordHash = await hashPassword(request.data.password);
+  const tokenHash = createAccountRecoveryTokenDigest(request.data.token);
 
   const result = await db.rpc('consume_password_reset_token', {
     p_token_hash: tokenHash,

--- a/apps/web/src/lib/auth/csrf.ts
+++ b/apps/web/src/lib/auth/csrf.ts
@@ -1,0 +1,13 @@
+import { isSameOriginBrowserRequest } from '@/lib/withAuth';
+
+import type { NextRequest } from 'next/server';
+
+const CSRF_COOKIE = '__csrf';
+
+export function hasValidSameOriginCsrfPair(req: NextRequest): boolean {
+  const csrfHeader = req.headers.get('x-csrf-token');
+  const csrfCookie = req.cookies.get(CSRF_COOKIE)?.value;
+  return Boolean(
+    csrfHeader && csrfCookie && csrfHeader === csrfCookie && isSameOriginBrowserRequest(req),
+  );
+}

--- a/apps/web/src/lib/auth/request.ts
+++ b/apps/web/src/lib/auth/request.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from 'next/server';
+import z, { type ZodType } from 'zod';
+
+import { hasValidSameOriginCsrfPair } from '@/lib/auth/csrf';
+import logger from '@/lib/logger';
+import { applyRateLimit } from '@/lib/rateLimit';
+
+// Auth endpoints are expensive (scrypt) — use a tighter limit than the default.
+const AUTH_RATE_LIMIT = { limit: 5, windowSeconds: 15 * 60 };
+
+type AuthJsonRequestResult<T> =
+  | { data: T; response?: never }
+  | { data?: never; response: Response };
+type AuthJsonRequestOptions = {
+  csrfFailureLogMessage?: string;
+  requireCsrf?: boolean;
+};
+
+const emailPasswordAuthSchema = z.object({
+  email: z.string().email().max(254),
+  password: z.string().min(1).max(128),
+});
+
+type EmailPasswordAuthData = z.infer<typeof emailPasswordAuthSchema> & {
+  normalizedEmail: string;
+};
+
+export async function readAuthJsonRequest<T>(
+  req: NextRequest,
+  schema: ZodType<T>,
+  { csrfFailureLogMessage, requireCsrf = true }: AuthJsonRequestOptions = {},
+): Promise<AuthJsonRequestResult<T>> {
+  const rateLimitResponse = await applyRateLimit(req, AUTH_RATE_LIMIT);
+  if (rateLimitResponse) return { response: rateLimitResponse };
+
+  if (requireCsrf && !hasValidSameOriginCsrfPair(req)) {
+    if (csrfFailureLogMessage) {
+      logger.warn(csrfFailureLogMessage);
+    }
+    return { response: NextResponse.json({ error: 'Forbidden.' }, { status: 403 }) };
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return { response: NextResponse.json({ error: 'Invalid JSON body.' }, { status: 400 }) };
+  }
+
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    return {
+      response: NextResponse.json(
+        { error: 'Validation failed.', details: parsed.error.flatten().fieldErrors },
+        { status: 422 },
+      ),
+    };
+  }
+
+  return { data: parsed.data };
+}
+
+export function readEmailPasswordAuthRequest(
+  req: NextRequest,
+  options: AuthJsonRequestOptions = {},
+): Promise<AuthJsonRequestResult<EmailPasswordAuthData>> {
+  return readAuthJsonRequest(req, emailPasswordAuthSchema, options).then((result) => {
+    if (result.response) return result;
+    return {
+      data: {
+        ...result.data,
+        normalizedEmail: result.data.email.toLowerCase().trim(),
+      },
+    };
+  });
+}


### PR DESCRIPTION
## Summary
- Add shared auth request helpers for rate limiting, JSON parsing, validation responses, and same-origin CSRF checks.
- Reuse the auth guards across login, register, forgot/reset password, and delete-account routes while preserving register's existing no-CSRF behavior.
- Reuse the same-origin CSRF pair helper in movie-memory mutations.

## Fallow notes
- Dead-code remains clean: 0 issues.
- Changed-since duplication for this branch is clean: 0 duplicated lines / 0 clone groups.
- Full-repo dupes still include broader page/form UI duplication and backoffice table headers; those are separate refactor surfaces.

## Verification
- npm run quality:fallow:dead-code -- --format json --quiet => 0 issues
- npm run quality:fallow:dupes -- --changed-since origin/development --top 20 --format json --quiet => 0 clone groups
- npm run test --workspace=apps/web -- auth/login auth/register auth/forgot-password auth/reset-password auth/delete-account account/movie-memory => 6 files, 72 tests
- npm run type-check --workspace=apps/web
- npm run lint:check
- git diff --check
- pre-push hook: lint, server tests, production build; Storybook skipped because there were no Storybook-relevant changes

Note: local fallow audit --changed-since still could not create Fallow's temporary base worktree, so I used changed-since dupes plus dead-code as the local Fallow fallback.