### PR TITLE
Stabilize backoffice repair action e2e

### DIFF
--- a/apps/backoffice/e2e/tmdb-review-flow.spec.ts
+++ b/apps/backoffice/e2e/tmdb-review-flow.spec.ts
@@ -18,6 +18,7 @@ test('operator queues a catalog repair and sees the queued job and audit row', a
 
   await expect(page.getByRole('heading', { name: 'Catalog Health' })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'Missing poster_url' })).toBeVisible();
+  await expect(page.locator('html')).toHaveAttribute('data-catalog-repair-enhanced', 'true');
   await expect(
     page
       .locator('#issue-missing_poster_url')
@@ -63,7 +64,7 @@ test('operator queues a catalog repair and sees the queued job and audit row', a
   await expect(auditRow).toBeVisible();
   await expect(auditRow).toContainText('e2e-operator');
   await expect(auditRow).toContainText('Missing Poster Url');
-  await expect(auditRow).toContainText('Accepted');
+  await expect(auditRow).toContainText(/Accepted|Already queued/);
 });
 
 test('operator applies a seeded TMDB review candidate from queue to audit history', async ({

--- a/apps/backoffice/src/app/catalog-health/actions/route.test.ts
+++ b/apps/backoffice/src/app/catalog-health/actions/route.test.ts
@@ -128,6 +128,31 @@ describe('catalog health repair action route', () => {
     );
   });
 
+  it('returns an ok JSON contract for already queued single repairs', async () => {
+    mocks.performCatalogRepairAction.mockResolvedValue({
+      issueKey: 'missing_poster_url',
+      job: { jobId: 'backfill-42', status: 'deduped' },
+      mode: 'single',
+      movieId: '42',
+      status: 'deduped',
+    });
+
+    const response = await POST(createRepairRequest({ requestedWith: 'fetch' }) as never);
+
+    await expectBackofficeActionJson(response, {
+      body: {
+        issueKey: 'missing_poster_url',
+        job: { jobId: 'backfill-42', status: 'deduped' },
+        message: 'message:deduped',
+        mode: 'single',
+        movieId: '42',
+        ok: true,
+        status: 'deduped',
+      },
+      status: 200,
+    });
+  });
+
   it('returns a partial JSON status for partially queued bulk repairs', async () => {
     const summary = {
       attempted: 25,

--- a/apps/backoffice/src/app/catalog-health/actions/route.ts
+++ b/apps/backoffice/src/app/catalog-health/actions/route.ts
@@ -15,6 +15,7 @@ export const dynamic = 'force-dynamic';
 
 function repairRedirectStatus(result: Awaited<ReturnType<typeof performCatalogRepairAction>>) {
   if (result.status === 'queued') return result.mode === 'bulk' ? 'bulk-queued' : 'queued';
+  if (result.status === 'deduped') return 'deduped';
   if (result.status === 'orchestration_queued') return 'bulk-orchestration-queued';
   if (result.status === 'partial') return 'bulk-partial';
   if (result.status === 'empty') return 'empty';
@@ -53,7 +54,10 @@ export async function POST(request: NextRequest) {
     const result = await performCatalogRepairAction(formData, request.headers);
 
     if (wantsBackofficeJsonResponse(request)) {
-      const ok = result.status === 'queued' || result.status === 'orchestration_queued';
+      const ok =
+        result.status === 'queued' ||
+        result.status === 'deduped' ||
+        result.status === 'orchestration_queued';
       return NextResponse.json(
         {
           ok,

--- a/apps/backoffice/src/components/catalog-health/index.tsx
+++ b/apps/backoffice/src/components/catalog-health/index.tsx
@@ -26,6 +26,15 @@ function RepairFlash({ repairStatus }: { repairStatus: string | null }) {
     );
   }
 
+  if (repairStatus === 'deduped') {
+    return (
+      <div className="notice neutral">
+        Catalog backfill work was already queued. Workers will process the existing job through the
+        rate-limited TMDB path.
+      </div>
+    );
+  }
+
   if (repairStatus === 'bulk-queued') {
     return (
       <div className="notice neutral">

--- a/apps/backoffice/src/components/catalogRepairEnhancement.tsx
+++ b/apps/backoffice/src/components/catalogRepairEnhancement.tsx
@@ -151,15 +151,18 @@ export function CatalogRepairEnhancement() {
             };
           } | null;
 
-          if (response.ok && payload?.status === 'queued') {
+          if (response.ok && (payload?.status === 'queued' || payload?.status === 'deduped')) {
             requestCatalogHealthRefresh();
             row?.classList.remove('repair-pending');
             row?.classList.add('repair-accepted');
-            setButton(form, 'Accepted', true);
+            const deduped = payload.status === 'deduped';
+            setButton(form, deduped ? 'Already queued' : 'Accepted', true);
             const bulkSummary = payload.mode === 'bulk' ? payload.summary : null;
             const bulkMessage = bulkSummary
               ? `Accepted ${bulkSummary.queued ?? 0}, already queued ${bulkSummary.deduped ?? 0}`
-              : 'Accepted for worker';
+              : deduped
+                ? 'Already queued for worker'
+                : 'Accepted for worker';
             setMessage(form, bulkMessage, 'accepted');
 
             if (row) {
@@ -216,7 +219,10 @@ export function CatalogRepairEnhancement() {
       cleanups.push(() => form.removeEventListener('submit', submit));
     });
 
+    document.documentElement.dataset.catalogRepairEnhanced = 'true';
+
     return () => {
+      delete document.documentElement.dataset.catalogRepairEnhanced;
       cleanups.forEach((cleanup) => cleanup());
       timeouts.forEach((timeoutId) => window.clearTimeout(timeoutId));
     };

--- a/apps/backoffice/src/components/movie-detail/helpers.ts
+++ b/apps/backoffice/src/components/movie-detail/helpers.ts
@@ -15,6 +15,7 @@ export function normalizeRepairFlashStatus(
 
   if (
     repairStatus === 'queued' ||
+    repairStatus === 'deduped' ||
     repairStatus === 'unavailable' ||
     repairStatus === 'failed' ||
     repairStatus === 'empty' ||
@@ -34,7 +35,11 @@ export function repairFlashMessage(repairStatus: string | null): string | null {
 
 export function repairFlashTone(repairStatus: string | null): 'accepted' | 'warn' {
   const mappedStatus = normalizeRepairFlashStatus(repairStatus);
-  return mappedStatus === 'queued' || mappedStatus === 'orchestration_queued' ? 'accepted' : 'warn';
+  return mappedStatus === 'queued' ||
+    mappedStatus === 'deduped' ||
+    mappedStatus === 'orchestration_queued'
+    ? 'accepted'
+    : 'warn';
 }
 
 export function repairableHealthFlags(flags: CatalogMovieDetailHealthFlag[]) {

--- a/apps/backoffice/src/lib/catalogRepairActionHelpers.ts
+++ b/apps/backoffice/src/lib/catalogRepairActionHelpers.ts
@@ -24,6 +24,7 @@ export const REPAIRABLE_CATALOG_ISSUE_KEYS = new Set([
 
 export type CatalogRepairActionStatus =
   | 'queued'
+  | 'deduped'
   | 'orchestration_queued'
   | 'partial'
   | 'failed'
@@ -71,6 +72,9 @@ export function catalogRepairMessage(status: CatalogRepairActionStatus): string 
   }
   if (status === 'queued') {
     return 'Catalog backfill job queued. Workers will process it through the existing rate-limited TMDB path.';
+  }
+  if (status === 'deduped') {
+    return 'Catalog backfill job is already queued. Workers will process the existing job.';
   }
   if (status === 'empty') {
     return 'No affected movies are currently available for this repair action.';

--- a/apps/backoffice/src/lib/catalogRepairActions.test.ts
+++ b/apps/backoffice/src/lib/catalogRepairActions.test.ts
@@ -23,6 +23,7 @@ describe('catalog repair actions', () => {
   it('maps repair result statuses to operator-facing messages', () => {
     expect(catalogRepairMessage('orchestration_queued')).toContain('orchestration accepted');
     expect(catalogRepairMessage('queued')).toContain('backfill job queued');
+    expect(catalogRepairMessage('deduped')).toContain('already queued');
     expect(catalogRepairMessage('empty')).toContain('No affected movies');
     expect(catalogRepairMessage('partial')).toContain('partially queued');
     expect(catalogRepairMessage('failed')).toContain('failed to enqueue');

--- a/apps/backoffice/src/lib/catalogRepairActions.ts
+++ b/apps/backoffice/src/lib/catalogRepairActions.ts
@@ -38,7 +38,7 @@ export { catalogRepairMessage, REPAIRABLE_CATALOG_ISSUE_KEYS };
 export type CatalogRepairActionResult =
   | {
       mode: 'single';
-      status: 'queued' | 'unavailable';
+      status: 'queued' | 'deduped' | 'unavailable';
       issueKey: string;
       movieId: string;
       job: Awaited<ReturnType<typeof enqueueCatalogBackfillMovieFromBackoffice>>;
@@ -49,6 +49,38 @@ export type CatalogRepairActionResult =
       issueKey: string;
       summary: CatalogBulkRepairSummary;
     };
+
+interface AsyncBulkRepairBatchInput {
+  actor: string;
+  issueKey: string;
+  note: string | undefined;
+  requestedLimit: number;
+  totalCandidates: number;
+}
+
+function asyncBulkRepairPreviousState(input: AsyncBulkRepairBatchInput) {
+  return {
+    async: true,
+    issueKey: input.issueKey,
+    requestedLimit: input.requestedLimit,
+    totalCandidates: input.totalCandidates,
+  };
+}
+
+async function createAsyncBulkRepairBatch(input: AsyncBulkRepairBatchInput) {
+  return createCatalogRepairBatch({
+    action: 'bulk_enqueue_backfill',
+    actor: input.actor,
+    issueKey: input.issueKey,
+    targetType: 'catalog_issue',
+    targetId: input.issueKey,
+    requestedLimit: input.requestedLimit,
+    totalCandidates: input.totalCandidates,
+    attemptedCount: 0,
+    note: input.note,
+    previousState: asyncBulkRepairPreviousState(input),
+  });
+}
 
 async function performAsyncBulkCatalogRepairAction(
   formData: FormData,
@@ -66,6 +98,14 @@ async function performAsyncBulkCatalogRepairAction(
   });
   const limit = parseAsyncBulkRepairLimit(formData.get('batch_limit'), countPage.totalCount);
   const requestedLimit = Math.min(limit, countPage.totalCount);
+  const batchInput = {
+    actor,
+    issueKey,
+    note,
+    requestedLimit,
+    totalCandidates: countPage.totalCount,
+  };
+  const previousState = asyncBulkRepairPreviousState(batchInput);
   const summary = createCatalogBulkRepairSummary({
     issueKey,
     totalCandidates: countPage.totalCount,
@@ -73,23 +113,7 @@ async function performAsyncBulkCatalogRepairAction(
   });
 
   if (requestedLimit === 0) {
-    const batch = await createCatalogRepairBatch({
-      action: 'bulk_enqueue_backfill',
-      actor,
-      issueKey,
-      targetType: 'catalog_issue',
-      targetId: issueKey,
-      requestedLimit,
-      totalCandidates: countPage.totalCount,
-      attemptedCount: 0,
-      note,
-      previousState: {
-        async: true,
-        issueKey,
-        requestedLimit,
-        totalCandidates: countPage.totalCount,
-      },
-    });
+    const batch = await createAsyncBulkRepairBatch(batchInput);
     summary.batchId = batch.id;
     await recordCatalogRepairAction({
       action: 'bulk_enqueue_backfill',
@@ -98,12 +122,7 @@ async function performAsyncBulkCatalogRepairAction(
       targetType: 'catalog_issue',
       targetId: issueKey,
       note,
-      previousState: {
-        async: true,
-        issueKey,
-        requestedLimit,
-        totalCandidates: countPage.totalCount,
-      },
+      previousState,
       result: {
         ...summary,
         status: 'empty',
@@ -119,23 +138,7 @@ async function performAsyncBulkCatalogRepairAction(
     };
   }
 
-  const batch = await createCatalogRepairBatch({
-    action: 'bulk_enqueue_backfill',
-    actor,
-    issueKey,
-    targetType: 'catalog_issue',
-    targetId: issueKey,
-    requestedLimit,
-    totalCandidates: countPage.totalCount,
-    attemptedCount: 0,
-    note,
-    previousState: {
-      async: true,
-      issueKey,
-      requestedLimit,
-      totalCandidates: countPage.totalCount,
-    },
-  });
+  const batch = await createAsyncBulkRepairBatch(batchInput);
   summary.batchId = batch.id;
 
   const orchestrationJob = await enqueueCatalogRepairBatchFromBackoffice(

--- a/apps/backoffice/src/lib/catalogSingleRepairAction.ts
+++ b/apps/backoffice/src/lib/catalogSingleRepairAction.ts
@@ -52,7 +52,7 @@ export async function performSingleCatalogRepairAction({
 
   return {
     mode: 'single',
-    status: job ? 'queued' : 'unavailable',
+    status: job?.status ?? 'unavailable',
     issueKey,
     movieId,
     job,


### PR DESCRIPTION
## Summary
- Treat single catalog repair dedupe as a successful idempotent outcome in the backoffice action contract.
- Mark catalog repair forms once the client enhancer has attached so Playwright does not submit before hydration.
- Allow the backoffice e2e audit assertion to pass for either newly accepted or already queued repair jobs.
- Remove changed-file duplication in async bulk repair batch creation.

## Verification
- npm run test --workspace=apps/backoffice -- catalogRepairActions catalog-health/actions catalogRepairEnhancement
- npm run type-check --workspace=apps/backoffice
- npm run test:e2e:backoffice
- npm run test:e2e:down
- npm run test:backoffice
- npm run quality:fallow:dupes -- --changed-since origin/development --top 20 --format json --quiet 2>/dev/null || true
- npm run quality:fallow:dead-code -- --changed-since origin/development --format json --quiet 2>/dev/null || true

Note: local Fallow audit still hits the known temp worktree error for origin/development (exit_code 2); CI should run the audit in a clean checkout.