### PR TITLE
Share TMDB search matching helpers

### DIFF
--- a/apps/web/src/features/catalogMaintenance/tmdb.ts
+++ b/apps/web/src/features/catalogMaintenance/tmdb.ts
@@ -1,4 +1,9 @@
-import { extractTMDBCatalogMetadataCore, extractTMDBUSCertification } from '@pop-choice/shared';
+import {
+  extractTMDBCatalogMetadataCore,
+  extractTMDBUSCertification,
+  resolveTMDBSearchMatch,
+  scoreTMDBTitleMatch,
+} from '@pop-choice/shared';
 import z from 'zod';
 
 import logger from '@/lib/logger';
@@ -245,34 +250,12 @@ export async function fetchTMDBSourcePage(input: {
   }));
 }
 
-function normalizeTitle(title: string): string {
-  return title
-    .normalize('NFKD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .replace(/&/g, ' and ')
-    .replace(/[^\p{Letter}\p{Number}]+/gu, ' ')
-    .trim()
-    .toLowerCase()
-    .replace(/^(the|a|an)\s+/, '')
-    .replace(/\s+/g, ' ');
-}
-
-function titleConfidence(candidate: TMDBSearchResult, targetTitle: string): number {
-  const target = normalizeTitle(targetTitle);
-  const title = normalizeTitle(candidate.title);
-  const originalTitle = candidate.original_title ? normalizeTitle(candidate.original_title) : '';
-
-  if (!target || (!title && !originalTitle)) return 0;
-  if (target === title || target === originalTitle) return 0.75;
-  return 0;
-}
-
 function scoreSearchCandidate(candidate: TMDBSearchResult, title: string, year: number): number {
   const releaseYear = parseTMDBYear(candidate.release_date);
   const yearScore =
     year <= 0 ? 0.1 : releaseYear === 0 ? 0 : Math.abs(releaseYear - year) <= 1 ? 0.25 : -0.5;
 
-  return titleConfidence(candidate, title) + yearScore;
+  return scoreTMDBTitleMatch(candidate, title) + yearScore;
 }
 
 async function tmdbSearch(
@@ -307,40 +290,29 @@ export async function searchMovieMatch(
   title: string,
   year: number,
 ): Promise<TMDBMovieSearchResult> {
-  const collected = new Map<number, TMDBSearchResult>();
-  const scopedResults = year > 0 ? await tmdbSearch(apiKey, title, year) : [];
-  for (const result of scopedResults) collected.set(result.id, result);
-
-  const broadResults = await tmdbSearch(apiKey, title, null);
-  for (const result of broadResults) collected.set(result.id, result);
-
-  const candidates = Array.from(collected.values())
-    .map((candidate) => ({
+  const threshold = year > 0 ? 0.9 : 0.82;
+  const match = await resolveTMDBSearchMatch({
+    title,
+    year,
+    search: (query, searchYear) => tmdbSearch(apiKey, query, searchYear),
+    toCandidate: (candidate) => ({
       id: candidate.id,
       title: candidate.title,
       releaseYear: parseTMDBYear(candidate.release_date) || null,
       confidence: scoreSearchCandidate(candidate, title, year),
-    }))
-    .filter((candidate) => candidate.confidence > 0)
-    .sort((a, b) => b.confidence - a.confidence)
-    .slice(0, 5);
+    }),
+    matchThreshold: threshold,
+    ambiguousRunnerUpThreshold: 0.82,
+    ambiguousScoreGap: 0.08,
+  });
 
-  const best = candidates[0];
-  if (!best) return { status: 'not_found', candidates };
-
-  const runnerUp = candidates[1];
-  if (runnerUp && runnerUp.confidence >= 0.82 && best.confidence - runnerUp.confidence <= 0.08) {
-    return { status: 'ambiguous', candidates };
-  }
-
-  const threshold = year > 0 ? 0.9 : 0.82;
-  if (best.confidence < threshold) return { status: 'not_found', candidates };
+  if (match.status !== 'matched') return { status: match.status, candidates: match.candidates };
 
   return {
     status: 'matched',
-    tmdbId: best.id,
-    confidence: best.confidence,
-    candidates,
+    tmdbId: match.best.id,
+    confidence: match.best.confidence,
+    candidates: match.candidates,
   };
 }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -33,6 +33,20 @@ export {
   extractTMDBCatalogMetadataCore,
   extractTMDBUSCertification,
 } from './tmdbCatalogMetadata.js';
+export {
+  collectTMDBSearchResults,
+  decideTMDBSearchMatch,
+  normalizeTMDBTitle,
+  rankTMDBSearchCandidates,
+  resolveTMDBSearchMatch,
+  scoreTMDBTitleMatch,
+} from './tmdbSearchMatching.js';
+export type {
+  TMDBScoredSearchCandidate,
+  TMDBSearchMatchDecision,
+  TMDBSearchMatchResult,
+  TMDBTitleMatchCandidate,
+} from './tmdbSearchMatching.js';
 export type {
   ExtractTMDBCatalogMetadataOptions,
   TMDBCatalogCastCreditSource,

--- a/packages/shared/src/tmdbSearchMatching.test.ts
+++ b/packages/shared/src/tmdbSearchMatching.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  collectTMDBSearchResults,
+  decideTMDBSearchMatch,
+  normalizeTMDBTitle,
+  rankTMDBSearchCandidates,
+  resolveTMDBSearchMatch,
+  scoreTMDBTitleMatch,
+} from './tmdbSearchMatching.js';
+
+describe('TMDB search matching', () => {
+  it('normalizes punctuation, articles, accents, ampersands, and spacing', () => {
+    expect(normalizeTMDBTitle('  The Am\u00e9lie & Friends: Part II  ')).toBe(
+      'amelie and friends part ii',
+    );
+  });
+
+  it('scores exact normalized title and original title matches', () => {
+    expect(scoreTMDBTitleMatch({ title: 'The Matrix' }, 'Matrix')).toBe(0.75);
+    expect(scoreTMDBTitleMatch({ title: 'Solaris', original_title: 'Solyaris' }, 'Solyaris')).toBe(
+      0.75,
+    );
+  });
+
+  it('deduplicates year-scoped and broad TMDB search results by id', async () => {
+    const results = await collectTMDBSearchResults({
+      title: 'Movie',
+      year: 2024,
+      search: async (_title, year) =>
+        year === 2024
+          ? [{ id: 1, title: 'Movie' }]
+          : [
+              { id: 1, title: 'Movie duplicate' },
+              { id: 2, title: 'Movie broad' },
+            ],
+    });
+
+    expect(results).toEqual([
+      { id: 1, title: 'Movie duplicate' },
+      { id: 2, title: 'Movie broad' },
+    ]);
+  });
+
+  it('ranks positive-confidence candidates and decides match status', () => {
+    const candidates = rankTMDBSearchCandidates(
+      [
+        { id: 1, confidence: 0 },
+        { id: 2, confidence: 0.95 },
+        { id: 3, confidence: 0.7 },
+      ],
+      (candidate) => candidate,
+    );
+
+    expect(candidates.map((candidate) => candidate.id)).toEqual([2, 3]);
+    expect(
+      decideTMDBSearchMatch(candidates, {
+        matchThreshold: 0.9,
+        ambiguousRunnerUpThreshold: 0.82,
+        ambiguousScoreGap: 0.08,
+      }),
+    ).toEqual({ status: 'matched', best: { id: 2, confidence: 0.95 } });
+  });
+
+  it('returns ambiguous and not_found decisions for weak top candidates', () => {
+    expect(
+      decideTMDBSearchMatch([{ confidence: 0.9 }, { confidence: 0.85 }], {
+        matchThreshold: 0.9,
+        ambiguousRunnerUpThreshold: 0.82,
+        ambiguousScoreGap: 0.08,
+      }).status,
+    ).toBe('ambiguous');
+
+    expect(
+      decideTMDBSearchMatch([{ confidence: 0.7 }], {
+        matchThreshold: 0.9,
+        ambiguousRunnerUpThreshold: 0.82,
+        ambiguousScoreGap: 0.08,
+      }).status,
+    ).toBe('not_found');
+  });
+
+  it('resolves a complete search match from raw results', async () => {
+    const match = await resolveTMDBSearchMatch({
+      title: 'Movie',
+      year: 2024,
+      search: async () => [
+        { id: 1, title: 'Movie', release_date: '2024-01-01' },
+        { id: 2, title: 'Other', release_date: '2024-01-01' },
+      ],
+      toCandidate: (result) => ({
+        id: result.id,
+        confidence: scoreTMDBTitleMatch(result, 'Movie') + 0.25,
+      }),
+      matchThreshold: 0.9,
+      ambiguousRunnerUpThreshold: 0.82,
+      ambiguousScoreGap: 0.08,
+    });
+
+    expect(match).toEqual({
+      status: 'matched',
+      best: { id: 1, confidence: 1 },
+      candidates: [
+        { id: 1, confidence: 1 },
+        { id: 2, confidence: 0.25 },
+      ],
+    });
+  });
+});

--- a/packages/shared/src/tmdbSearchMatching.ts
+++ b/packages/shared/src/tmdbSearchMatching.ts
@@ -1,0 +1,140 @@
+export type TMDBTitleMatchCandidate = {
+  title: string;
+  original_title?: string | null;
+};
+
+export type TMDBScoredSearchCandidate = {
+  confidence: number;
+};
+
+export type TMDBSearchMatchDecision<TCandidate extends TMDBScoredSearchCandidate> =
+  | {
+      status: 'matched' | 'ambiguous';
+      best: TCandidate;
+    }
+  | {
+      status: 'not_found';
+      best: TCandidate | null;
+    };
+
+export type TMDBSearchMatchResult<TCandidate extends TMDBScoredSearchCandidate> =
+  | {
+      status: 'matched';
+      best: TCandidate;
+      candidates: TCandidate[];
+    }
+  | {
+      status: 'ambiguous' | 'not_found';
+      candidates: TCandidate[];
+    };
+
+const EXACT_TITLE_MATCH_SCORE = 0.75;
+
+export function normalizeTMDBTitle(title: string): string {
+  return title
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/&/g, ' and ')
+    .replace(/[^\p{Letter}\p{Number}]+/gu, ' ')
+    .trim()
+    .toLowerCase()
+    .replace(/^(the|a|an)\s+/, '')
+    .replace(/\s+/g, ' ');
+}
+
+export function scoreTMDBTitleMatch(
+  candidate: TMDBTitleMatchCandidate,
+  targetTitle: string,
+): number {
+  const target = normalizeTMDBTitle(targetTitle);
+  const title = normalizeTMDBTitle(candidate.title);
+  const originalTitle = candidate.original_title
+    ? normalizeTMDBTitle(candidate.original_title)
+    : '';
+
+  if (!target || (!title && !originalTitle)) return 0;
+  if (target === title || target === originalTitle) return EXACT_TITLE_MATCH_SCORE;
+  return 0;
+}
+
+export async function collectTMDBSearchResults<TResult extends { id: number }>(input: {
+  title: string;
+  year: number;
+  search: (title: string, year: number | null) => Promise<TResult[]>;
+}): Promise<TResult[]> {
+  const collected = new Map<number, TResult>();
+
+  if (input.year > 0) {
+    const scopedResults = await input.search(input.title, input.year);
+    for (const result of scopedResults) collected.set(result.id, result);
+  }
+
+  const broadResults = await input.search(input.title, null);
+  for (const result of broadResults) collected.set(result.id, result);
+
+  return Array.from(collected.values());
+}
+
+export function rankTMDBSearchCandidates<TResult, TCandidate extends TMDBScoredSearchCandidate>(
+  results: TResult[],
+  toCandidate: (result: TResult) => TCandidate,
+): TCandidate[] {
+  return results
+    .map(toCandidate)
+    .filter((candidate) => candidate.confidence > 0)
+    .sort((a, b) => b.confidence - a.confidence)
+    .slice(0, 5);
+}
+
+export function decideTMDBSearchMatch<TCandidate extends TMDBScoredSearchCandidate>(
+  candidates: readonly TCandidate[],
+  options: {
+    matchThreshold: number;
+    ambiguousRunnerUpThreshold: number;
+    ambiguousScoreGap: number;
+  },
+): TMDBSearchMatchDecision<TCandidate> {
+  const best = candidates[0];
+  if (!best) return { status: 'not_found', best: null };
+
+  const runnerUp = candidates[1];
+  const isAmbiguous =
+    runnerUp &&
+    runnerUp.confidence >= options.ambiguousRunnerUpThreshold &&
+    best.confidence - runnerUp.confidence <= options.ambiguousScoreGap;
+
+  if (isAmbiguous) return { status: 'ambiguous', best };
+  if (best.confidence < options.matchThreshold) return { status: 'not_found', best };
+  return { status: 'matched', best };
+}
+
+export async function resolveTMDBSearchMatch<
+  TResult extends { id: number },
+  TCandidate extends TMDBScoredSearchCandidate,
+>(input: {
+  title: string;
+  year: number;
+  search: (title: string, year: number | null) => Promise<TResult[]>;
+  toCandidate: (result: TResult) => TCandidate;
+  matchThreshold: number;
+  ambiguousRunnerUpThreshold: number;
+  ambiguousScoreGap: number;
+}): Promise<TMDBSearchMatchResult<TCandidate>> {
+  const searchResults = await collectTMDBSearchResults({
+    title: input.title,
+    year: input.year,
+    search: input.search,
+  });
+  const candidates = rankTMDBSearchCandidates(searchResults, input.toCandidate);
+  const decision = decideTMDBSearchMatch(candidates, {
+    matchThreshold: input.matchThreshold,
+    ambiguousRunnerUpThreshold: input.ambiguousRunnerUpThreshold,
+    ambiguousScoreGap: input.ambiguousScoreGap,
+  });
+
+  if (decision.status === 'matched') {
+    return { status: 'matched', best: decision.best, candidates };
+  }
+
+  return { status: decision.status, candidates };
+}

--- a/services/movie-backfill/src/tmdb.ts
+++ b/services/movie-backfill/src/tmdb.ts
@@ -1,5 +1,10 @@
 import { logger } from './logger.js';
-import { extractTMDBCatalogMetadataCore, extractTMDBUSCertification } from '@pop-choice/shared';
+import {
+  extractTMDBCatalogMetadataCore,
+  extractTMDBUSCertification,
+  resolveTMDBSearchMatch,
+  scoreTMDBTitleMatch,
+} from '@pop-choice/shared';
 import z from 'zod';
 
 import type { TMDBCatalogMetadataCore, TMDBCatalogMovieDetails } from '@pop-choice/shared';
@@ -80,28 +85,6 @@ function parseReleaseYear(releaseDate: string): number | null {
   return Number.isFinite(year) ? year : null;
 }
 
-function normalizeTitle(title: string): string {
-  return title
-    .normalize('NFKD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .replace(/&/g, ' and ')
-    .replace(/[^\p{Letter}\p{Number}]+/gu, ' ')
-    .trim()
-    .toLowerCase()
-    .replace(/^(the|a|an)\s+/, '')
-    .replace(/\s+/g, ' ');
-}
-
-function titleConfidence(candidate: TMDBSearchResult, targetTitle: string): number {
-  const target = normalizeTitle(targetTitle);
-  const title = normalizeTitle(candidate.title);
-  const originalTitle = candidate.original_title ? normalizeTitle(candidate.original_title) : '';
-
-  if (!target || (!title && !originalTitle)) return 0;
-  if (target === title || target === originalTitle) return 0.75;
-  return 0;
-}
-
 function yearConfidence(candidateYear: number | null, targetYear: number): number {
   if (targetYear <= 0) return 0.1;
   if (candidateYear === null) return 0;
@@ -118,7 +101,7 @@ function scoreCandidate(
   targetYear: number,
 ): number {
   const releaseYear = parseReleaseYear(candidate.release_date);
-  return titleConfidence(candidate, targetTitle) + yearConfidence(releaseYear, targetYear);
+  return scoreTMDBTitleMatch(candidate, targetTitle) + yearConfidence(releaseYear, targetYear);
 }
 
 function toCandidate(
@@ -212,50 +195,26 @@ export async function searchMovieMatch(
   title: string,
   year: number,
 ): Promise<TMDBMovieSearchResult> {
-  const collected = new Map<number, TMDBSearchResult>();
-
-  if (year > 0) {
-    const scopedResults = await tmdbSearch(apiKey, title, year);
-    for (const result of scopedResults) collected.set(result.id, result);
-
-    const broadResults = await tmdbSearch(apiKey, title, null);
-    for (const result of broadResults) collected.set(result.id, result);
-  } else {
-    const results = await tmdbSearch(apiKey, title, null);
-    for (const result of results) collected.set(result.id, result);
-  }
-
-  const candidates = Array.from(collected.values())
-    .map((candidate) => toCandidate(candidate, title, year))
-    .filter((candidate) => candidate.confidence > 0)
-    .sort((a, b) => b.confidence - a.confidence)
-    .slice(0, 5);
-
-  const best = candidates[0];
-  if (!best) return { status: 'not_found', candidates };
-
   const threshold = year > 0 ? CONFIDENT_MATCH_THRESHOLD : LOW_YEAR_CONFIDENT_MATCH_THRESHOLD;
-  const runnerUp = candidates[1];
-  const isAmbiguous =
-    runnerUp &&
-    runnerUp.confidence >= LOW_YEAR_CONFIDENT_MATCH_THRESHOLD &&
-    best.confidence - runnerUp.confidence <= AMBIGUOUS_SCORE_GAP;
+  const match = await resolveTMDBSearchMatch({
+    title,
+    year,
+    search: (query, searchYear) => tmdbSearch(apiKey, query, searchYear),
+    toCandidate: (candidate) => toCandidate(candidate, title, year),
+    matchThreshold: threshold,
+    ambiguousRunnerUpThreshold: LOW_YEAR_CONFIDENT_MATCH_THRESHOLD,
+    ambiguousScoreGap: AMBIGUOUS_SCORE_GAP,
+  });
 
-  if (isAmbiguous) {
-    return { status: 'ambiguous', candidates };
-  }
-
-  if (best.confidence < threshold) {
-    return { status: 'not_found', candidates };
-  }
+  if (match.status !== 'matched') return { status: match.status, candidates: match.candidates };
 
   return {
     status: 'matched',
-    tmdbId: best.id,
-    confidence: best.confidence,
-    title: best.title,
-    releaseYear: best.releaseYear,
-    candidates,
+    tmdbId: match.best.id,
+    confidence: match.best.confidence,
+    title: match.best.title,
+    releaseYear: match.best.releaseYear,
+    candidates: match.candidates,
   };
 }
 


### PR DESCRIPTION
## Summary
- add shared TMDB search matching utilities for title normalization, scoring, result collection, ranking, and match decisions
- update web catalog maintenance and movie-backfill TMDB search flows to use the shared matcher
- add shared unit coverage for normalization, scoring, dedupe, ranking, decisions, and full match resolution

## Verification
- npm run build --workspace=packages/shared
- npm run test --workspace=packages/shared -- src/tmdbSearchMatching.test.ts
- npm run test --workspace=apps/web -- src/features/catalogMaintenance/tmdb.test.ts
- npm run test --workspace=movie-backfill -- src/tmdb.test.ts
- npm run type-check --workspace=apps/web
- npm run build --workspace=movie-backfill
- npm run lint:check
- npm run quality:fallow:dupes -- --changed-since origin/development --top 20 --format json --quiet
- npm run quality:fallow:dead-code -- --changed-since origin/development --format json --quiet
- pre-push: lint, server tests, production build

Note: local fallow audit could not create a temporary worktree for the base ref in this linked worktree; CI Fallow Audit should run on the PR.