### PR TITLE
Refactor TMDB discover parameter helpers

### DIFF
--- a/apps/web/src/features/recommendation/morePicksPipeline.ts
+++ b/apps/web/src/features/recommendation/morePicksPipeline.ts
@@ -13,15 +13,11 @@ import { LOCALE_LANGUAGE, LOCALE_TO_TMDB_LANG } from '@/lib/locale';
 import logger from '@/lib/logger';
 import { MODELS } from '@/lib/models';
 import { OPENAI_TIMEOUTS_MS, openAIRequestOptions } from '@/lib/openaiTimeout';
-import {
-  GENRE_LABEL_TO_TMDB_ID,
-  cosineSimilarity,
-  normalizeGenreLabel,
-  parseTMDBReleaseYear,
-} from '@/lib/tmdb';
+import { cosineSimilarity, parseTMDBReleaseYear } from '@/lib/tmdb';
 import { getTraceCarrier, withTraceSpan } from '@/lib/tracing';
 
 import { morePicksPersonFormDataSchema } from './morePicksSchemas';
+import { formatTMDBMovieEmbeddingText, getTopTMDBGenreIds } from './tmdbDiscoverHelpers';
 
 import type { MorePicksPersonFormData } from './morePicksSchemas';
 import type { TMDBDiscoverMovie } from './tmdb';
@@ -65,66 +61,72 @@ const tmdbMovieDetailSchema = z.object({
 // Helpers (exported for unit testing; callers should prefer runMorePicksPipeline)
 // ---------------------------------------------------------------------------
 
-export function extractTMDBParams(allPeopleData: MorePicksPersonFormData[]) {
-  const moodCounts: Record<string, number> = {};
-  allPeopleData.forEach((p) => {
-    p.moodPreference.forEach((mood) => {
-      const key = normalizeGenreLabel(mood);
-      moodCounts[key] = (moodCounts[key] ?? 0) + 1;
-    });
-  });
+type MorePicksEraPreference = 'new' | 'classic' | 'both';
+type MorePicksTonePreference = 'serious' | 'dark' | 'balanced' | 'light';
 
-  const genre_ids = Object.entries(moodCounts)
-    .sort(([, a], [, b]) => b - a)
-    .slice(0, 3)
-    .map(([key]) => GENRE_LABEL_TO_TMDB_ID[key])
-    .filter((id): id is number => id !== undefined);
+function getDominantValue<TValue extends string>(values: TValue[], fallback: TValue): TValue {
+  const counts = new Map<TValue, number>();
+  for (const value of values) counts.set(value, (counts.get(value) ?? 0) + 1);
+  return Array.from(counts.entries()).sort(([, a], [, b]) => b - a)[0]?.[0] ?? fallback;
+}
 
-  const eraCounts: Record<string, number> = {};
-  allPeopleData.forEach((p) => {
-    const era = p.newVsClassic.toLowerCase();
-    let key: string;
-    if (era.includes('both')) {
-      key = 'both';
-    } else if (era.includes('classic')) {
-      key = 'classic';
-    } else if (era.includes('new')) {
-      key = 'new';
-    } else {
-      key = 'both';
-    }
-    eraCounts[key] = (eraCounts[key] ?? 0) + 1;
-  });
-  const dominantEra = Object.entries(eraCounts).sort(([, a], [, b]) => b - a)[0]?.[0] ?? 'both';
+function getTopGenreIds(allPeopleData: MorePicksPersonFormData[]): number[] {
+  return getTopTMDBGenreIds(allPeopleData.flatMap((person) => person.moodPreference));
+}
+
+function normalizeEraPreference(value: string): MorePicksEraPreference {
+  const era = value.toLowerCase();
+  if (era.includes('both')) return 'both';
+  if (era.includes('classic')) return 'classic';
+  if (era.includes('new')) return 'new';
+  return 'both';
+}
+
+function getReleaseDateFilters(dominantEra: MorePicksEraPreference): {
+  primary_release_date_gte?: string;
+  primary_release_date_lte?: string;
+} {
   const currentYear = new Date().getFullYear();
-  let primary_release_date_gte: string | undefined;
-  let primary_release_date_lte: string | undefined;
   if (dominantEra === 'new') {
-    primary_release_date_gte = `${currentYear - 10}-01-01`;
-  } else if (dominantEra === 'classic') {
-    primary_release_date_lte = `${currentYear - 20}-12-31`;
+    return { primary_release_date_gte: `${currentYear - 10}-01-01` };
   }
 
-  const toneCounts: Record<string, number> = {};
-  allPeopleData.forEach((p) => {
-    const tone = p.tonePreference.toLowerCase();
-    let key: string;
-    if (tone.includes('serious')) {
-      key = 'serious';
-    } else if (tone.includes('dark')) {
-      key = 'dark';
-    } else if (tone.includes('balanced')) {
-      key = 'balanced';
-    } else {
-      key = 'light';
-    }
-    toneCounts[key] = (toneCounts[key] ?? 0) + 1;
-  });
-  const dominantTone = Object.entries(toneCounts).sort(([, a], [, b]) => b - a)[0]?.[0] ?? 'light';
-  const sort_by =
-    dominantTone === 'serious' || dominantTone === 'dark' ? 'vote_average.desc' : 'popularity.desc';
+  if (dominantEra === 'classic') {
+    return { primary_release_date_lte: `${currentYear - 20}-12-31` };
+  }
 
-  return { genre_ids, sort_by, primary_release_date_gte, primary_release_date_lte };
+  return {};
+}
+
+function normalizeTonePreference(value: string): MorePicksTonePreference {
+  const tone = value.toLowerCase();
+  if (tone.includes('serious')) return 'serious';
+  if (tone.includes('dark')) return 'dark';
+  if (tone.includes('balanced')) return 'balanced';
+  return 'light';
+}
+
+function getSortBy(dominantTone: MorePicksTonePreference): string {
+  return dominantTone === 'serious' || dominantTone === 'dark'
+    ? 'vote_average.desc'
+    : 'popularity.desc';
+}
+
+export function extractTMDBParams(allPeopleData: MorePicksPersonFormData[]) {
+  const dominantEra = getDominantValue(
+    allPeopleData.map((person) => normalizeEraPreference(person.newVsClassic)),
+    'both',
+  );
+  const dominantTone = getDominantValue(
+    allPeopleData.map((person) => normalizeTonePreference(person.tonePreference)),
+    'light',
+  );
+
+  return {
+    genre_ids: getTopGenreIds(allPeopleData),
+    sort_by: getSortBy(dominantTone),
+    ...getReleaseDateFilters(dominantEra),
+  };
 }
 
 function combineAllPeopleDataToString(allPeopleData: MorePicksPersonFormData[]): string {
@@ -267,13 +269,7 @@ export async function runMorePicksPipeline(
 
   // Compute cosine similarity scores
   const queryText = combineAllPeopleDataToString(allPeopleData);
-  const candidateTexts = candidates.map((m) => {
-    const year = parseTMDBReleaseYear(m.release_date);
-    const score = Number(m.vote_average?.toFixed(1)) || 0;
-    return [`${m.title} (${year}) | TMDB Score: ${score}/10`, m.overview || '']
-      .filter(Boolean)
-      .join('\n');
-  });
+  const candidateTexts = candidates.map(formatTMDBMovieEmbeddingText);
 
   const similarityMap = new Map<number, number>();
   try {

--- a/apps/web/src/features/recommendation/morePicksPipeline.ts
+++ b/apps/web/src/features/recommendation/morePicksPipeline.ts
@@ -32,6 +32,8 @@ export type { MorePicksPersonFormData } from './morePicksSchemas';
 
 const TMDB_API_BASE = 'https://api.themoviedb.org/3';
 const MORE_PICKS_PAGE_SIZE = 6;
+const MORE_PICKS_BATCH_SIZE = 2;
+const MORE_PICKS_BATCH_DELAY_MS = 200;
 const TMDB_DISCOVER_FETCH_TIMEOUT_MS = 8_000;
 const TMDB_MOVIE_DETAILS_FETCH_TIMEOUT_MS = 5_000;
 
@@ -46,6 +48,8 @@ const tmdbMovieSchema = z.object({
   popularity: z.number().optional(),
   poster_path: z.string().nullable(),
 });
+
+type MorePicksTMDBMovie = z.infer<typeof tmdbMovieSchema>;
 
 const tmdbDiscoverResponseSchema = z.object({
   results: z.array(tmdbMovieSchema).optional(),
@@ -149,6 +153,300 @@ function combineAllPeopleDataToString(allPeopleData: MorePicksPersonFormData[]):
   return combined.trim();
 }
 
+function parseMorePicksQuizData(quizData: unknown): MorePicksPersonFormData[] {
+  const parsed = z
+    .union([morePicksPersonFormDataSchema, z.array(morePicksPersonFormDataSchema).min(1)])
+    .safeParse(quizData);
+
+  if (!parsed.success) throw new Error('Invalid quiz data in recommendation');
+  return Array.isArray(parsed.data) ? parsed.data : [parsed.data];
+}
+
+function buildTMDBDiscoverUrl(params: ReturnType<typeof extractTMDBParams>, page: number): URL {
+  const url = new URL(`${TMDB_API_BASE}/discover/movie`);
+  if (params.genre_ids.length > 0) {
+    url.searchParams.set('with_genres', params.genre_ids.join('|'));
+  }
+  url.searchParams.set('sort_by', params.sort_by);
+  url.searchParams.set('vote_count.gte', '100');
+  url.searchParams.set('include_adult', 'false');
+  url.searchParams.set('page', String(page));
+  if (params.primary_release_date_gte) {
+    url.searchParams.set('primary_release_date.gte', params.primary_release_date_gte);
+  }
+  if (params.primary_release_date_lte) {
+    url.searchParams.set('primary_release_date.lte', params.primary_release_date_lte);
+  }
+  return url;
+}
+
+async function fetchMorePicksCandidates(input: {
+  tmdbApiKey: string;
+  params: ReturnType<typeof extractTMDBParams>;
+  page: number;
+  excludeIds: number[];
+}): Promise<MorePicksTMDBMovie[]> {
+  const url = buildTMDBDiscoverUrl(input.params, input.page);
+  const tmdbResponse = await fetch(url.toString(), {
+    headers: { Authorization: `Bearer ${input.tmdbApiKey}`, Accept: 'application/json' },
+    signal: AbortSignal.timeout(TMDB_DISCOVER_FETCH_TIMEOUT_MS),
+  });
+
+  if (!tmdbResponse.ok) {
+    throw new Error(`TMDB discover failed with status ${tmdbResponse.status}`);
+  }
+
+  const parsedDiscover = tmdbDiscoverResponseSchema.safeParse(await tmdbResponse.json());
+  if (!parsedDiscover.success) {
+    logger.error(
+      { err: parsedDiscover.error },
+      'more-picks pipeline: Invalid TMDB discover response',
+    );
+    throw new Error('TMDB discover response validation failed');
+  }
+
+  const excludedTmdbIds = new Set(input.excludeIds.map((id) => -id));
+  return (parsedDiscover.data.results ?? [])
+    .filter((movie) => !excludedTmdbIds.has(movie.id))
+    .slice(0, MORE_PICKS_PAGE_SIZE);
+}
+
+function toTMDBSeedMovie(movie: MorePicksTMDBMovie): TMDBDiscoverMovie {
+  return {
+    id: movie.id,
+    title: movie.title,
+    overview: movie.overview,
+    release_date: movie.release_date,
+    vote_average: movie.vote_average,
+    vote_count: movie.vote_count ?? 100,
+    genre_ids: movie.genre_ids ?? [],
+    popularity: movie.popularity ?? 0,
+    poster_path: movie.poster_path,
+  };
+}
+
+async function enqueueMorePicksSeedJob(candidates: MorePicksTMDBMovie[]): Promise<void> {
+  if (!seedQueue) return;
+
+  const queue = seedQueue;
+  const tmdbMoviesForSeeding = candidates.map(toTMDBSeedMovie);
+  await withTraceSpan(
+    'movie_seed.enqueue',
+    {
+      attributes: {
+        'messaging.system': 'bullmq',
+        'messaging.destination.name': 'movie-seed',
+        'messaging.operation.name': 'enqueue',
+        'movie.count': tmdbMoviesForSeeding.length,
+      },
+    },
+    async (span) => {
+      const job = await queue.add(
+        'seed-movies',
+        { tmdbMovies: tmdbMoviesForSeeding, localKeys: [], trace: getTraceCarrier() },
+        MOVIE_SEED_JOB_OPTIONS,
+      );
+      span.setAttribute('job.id', String(job.id ?? 'unknown'));
+    },
+  )
+    .then(() =>
+      logger.info({ queuedMovies: candidates.length }, 'more-picks pipeline: Queued seeding job'),
+    )
+    .catch((err) => logger.warn({ err }, 'more-picks pipeline: Failed to enqueue seeding job'));
+}
+
+async function computeMorePicksSimilarityMap(
+  allPeopleData: MorePicksPersonFormData[],
+  candidates: MorePicksTMDBMovie[],
+): Promise<Map<number, number>> {
+  const similarityMap = new Map<number, number>();
+  const queryText = combineAllPeopleDataToString(allPeopleData);
+  const candidateTexts = candidates.map(formatTMDBMovieEmbeddingText);
+
+  try {
+    const [queryEmbedRes, movieEmbedRes] = await Promise.all([
+      getOpenAIClient().embeddings.create(
+        { model: MODELS.EMBEDDING, input: queryText },
+        openAIRequestOptions(OPENAI_TIMEOUTS_MS.embedding),
+      ),
+      getOpenAIClient().embeddings.create(
+        { model: MODELS.EMBEDDING, input: candidateTexts },
+        openAIRequestOptions(OPENAI_TIMEOUTS_MS.embedding),
+      ),
+    ]);
+    const queryEmbedding = queryEmbedRes.data[0]?.embedding;
+    if (!queryEmbedding || queryEmbedding.length === 0) return similarityMap;
+
+    candidates.forEach((movie, index) => {
+      const movieEmbedding = movieEmbedRes.data[index]?.embedding;
+      if (movieEmbedding && movieEmbedding.length === queryEmbedding.length) {
+        similarityMap.set(movie.id, cosineSimilarity(queryEmbedding, movieEmbedding));
+      }
+    });
+  } catch (err) {
+    logger.warn({ err }, 'more-picks pipeline: embedding similarity failed — using fallback score');
+  }
+
+  return similarityMap;
+}
+
+function buildDescriptionSystemPrompt(language: string, preferenceContext: string): string {
+  return `CRITICAL: Your entire response MUST be written in ${language} only. Never use English or any other language unless ${language} is English.
+
+You are PopChoice, a movie expert creating personalized movie descriptions. Write a brief, engaging description (2-3 sentences) that:
+
+1. Explains why this movie would appeal to the user based on their preferences
+2. Highlights the most compelling aspects of the film
+3. Uses an enthusiastic, conversational tone
+4. Avoids spoilers but creates excitement
+
+User preferences context: ${preferenceContext}
+
+Respond in ${language} only.`;
+}
+
+async function fetchLocalizedMovieDetail(input: {
+  tmdbApiKey: string;
+  tmdb: MorePicksTMDBMovie;
+  tmdbLang: string;
+}): Promise<{ title: string; runtime?: number; overview: string }> {
+  const fallback = { title: input.tmdb.title, overview: input.tmdb.overview };
+
+  try {
+    const detailRes = await fetch(
+      `${TMDB_API_BASE}/movie/${input.tmdb.id}?language=${input.tmdbLang}`,
+      {
+        headers: { Authorization: `Bearer ${input.tmdbApiKey}`, Accept: 'application/json' },
+        signal: AbortSignal.timeout(TMDB_MOVIE_DETAILS_FETCH_TIMEOUT_MS),
+      },
+    );
+    if (!detailRes.ok) return fallback;
+
+    const parsedDetail = tmdbMovieDetailSchema.safeParse(await detailRes.json());
+    if (!parsedDetail.success) return fallback;
+
+    return {
+      title: parsedDetail.data.title || fallback.title,
+      runtime: parsedDetail.data.runtime ?? undefined,
+      overview: parsedDetail.data.overview || fallback.overview,
+    };
+  } catch (err) {
+    logger.warn(
+      { err, tmdbId: input.tmdb.id },
+      'more-picks pipeline: detail fetch failed — using discover response fields',
+    );
+    return fallback;
+  }
+}
+
+async function generateLocalizedDescription(input: {
+  tmdbId: number;
+  localizedTitle: string;
+  year: number;
+  score: number;
+  localizedOverview: string;
+  descriptionSystemPrompt: string;
+}): Promise<string> {
+  try {
+    const descriptionResponse = await getOpenAIClient().chat.completions.create(
+      {
+        model: MODELS.MINI,
+        messages: [
+          { role: 'system', content: input.descriptionSystemPrompt },
+          {
+            role: 'user',
+            content: `Movie: ${input.localizedTitle} (${input.year})\nRating: ${input.score}/10\nPlot: ${input.localizedOverview}`,
+          },
+        ],
+        max_completion_tokens: 150,
+      },
+      openAIRequestOptions(OPENAI_TIMEOUTS_MS.description),
+    );
+    return descriptionResponse.choices[0]?.message?.content?.trim() || input.localizedOverview;
+  } catch (err) {
+    logger.warn(
+      { err, tmdbId: input.tmdbId },
+      'more-picks pipeline: description generation failed — using localized overview',
+    );
+    return input.localizedOverview;
+  }
+}
+
+async function createMorePicksMovieRow(input: {
+  tmdb: MorePicksTMDBMovie;
+  tmdbApiKey: string;
+  tmdbLang: string;
+  descriptionSystemPrompt: string;
+  similarityMap: Map<number, number>;
+}): Promise<MovieRowToInsert> {
+  const year = parseTMDBReleaseYear(input.tmdb.release_date);
+  const score = Number(input.tmdb.vote_average?.toFixed(1)) || 0;
+  const posterURL = input.tmdb.poster_path
+    ? `${IMAGE_BASE_URL}/w500${input.tmdb.poster_path}`
+    : undefined;
+  const detail = await fetchLocalizedMovieDetail({
+    tmdbApiKey: input.tmdbApiKey,
+    tmdb: input.tmdb,
+    tmdbLang: input.tmdbLang,
+  });
+  const aiDescription = await generateLocalizedDescription({
+    tmdbId: input.tmdb.id,
+    localizedTitle: detail.title,
+    year,
+    score,
+    localizedOverview: detail.overview,
+    descriptionSystemPrompt: input.descriptionSystemPrompt,
+  });
+
+  return {
+    id: -input.tmdb.id,
+    name: input.tmdb.title,
+    year,
+    similarity: input.similarityMap.get(input.tmdb.id) ?? 0.35,
+    age_rating: 'NR',
+    duration: detail.runtime,
+    score_rating: score,
+    posterURL,
+    aiDescription,
+    localizedName: detail.title !== input.tmdb.title ? detail.title : undefined,
+    isMainRecommendation: false,
+    fromTMDB: true,
+    source: 'tmdb-search',
+  };
+}
+
+async function buildMorePicksMovieRows(input: {
+  candidates: MorePicksTMDBMovie[];
+  tmdbApiKey: string;
+  tmdbLang: string;
+  descriptionSystemPrompt: string;
+  similarityMap: Map<number, number>;
+}): Promise<MovieRowToInsert[]> {
+  const movies: MovieRowToInsert[] = [];
+
+  for (let i = 0; i < input.candidates.length; i += MORE_PICKS_BATCH_SIZE) {
+    const batch = input.candidates.slice(i, i + MORE_PICKS_BATCH_SIZE);
+    const batchResults = await Promise.all(
+      batch.map((tmdb) =>
+        createMorePicksMovieRow({
+          tmdb,
+          tmdbApiKey: input.tmdbApiKey,
+          tmdbLang: input.tmdbLang,
+          descriptionSystemPrompt: input.descriptionSystemPrompt,
+          similarityMap: input.similarityMap,
+        }),
+      ),
+    );
+    movies.push(...batchResults);
+
+    if (i + MORE_PICKS_BATCH_SIZE < input.candidates.length) {
+      await new Promise((resolve) => setTimeout(resolve, MORE_PICKS_BATCH_DELAY_MS));
+    }
+  }
+
+  return movies;
+}
+
 // ---------------------------------------------------------------------------
 // Main export
 // ---------------------------------------------------------------------------
@@ -174,229 +472,20 @@ export async function runMorePicksPipeline(
 
   const language = LOCALE_LANGUAGE[locale] ?? 'English';
   const tmdbLang = LOCALE_TO_TMDB_LANG[locale] ?? 'en-US';
-
-  // Parse quiz data with the permissive schema (extra fields like favoriteMovieWhy are fine)
-  const parsed = z
-    .union([morePicksPersonFormDataSchema, z.array(morePicksPersonFormDataSchema).min(1)])
-    .safeParse(quizData);
-  if (!parsed.success) throw new Error('Invalid quiz data in recommendation');
-  const allPeopleData: MorePicksPersonFormData[] = Array.isArray(parsed.data)
-    ? parsed.data
-    : [parsed.data];
-
+  const allPeopleData = parseMorePicksQuizData(quizData);
   const params = extractTMDBParams(allPeopleData);
-
-  // Build TMDB discover URL
-  const url = new URL(`${TMDB_API_BASE}/discover/movie`);
-  if (params.genre_ids.length > 0) {
-    url.searchParams.set('with_genres', params.genre_ids.join('|'));
-  }
-  url.searchParams.set('sort_by', params.sort_by);
-  url.searchParams.set('vote_count.gte', '100');
-  url.searchParams.set('include_adult', 'false');
-  url.searchParams.set('page', String(page));
-  if (params.primary_release_date_gte) {
-    url.searchParams.set('primary_release_date.gte', params.primary_release_date_gte);
-  }
-  if (params.primary_release_date_lte) {
-    url.searchParams.set('primary_release_date.lte', params.primary_release_date_lte);
-  }
-
-  const tmdbResponse = await fetch(url.toString(), {
-    headers: { Authorization: `Bearer ${tmdbApiKey}`, Accept: 'application/json' },
-    signal: AbortSignal.timeout(TMDB_DISCOVER_FETCH_TIMEOUT_MS),
-  });
-
-  if (!tmdbResponse.ok) {
-    throw new Error(`TMDB discover failed with status ${tmdbResponse.status}`);
-  }
-
-  const parsedDiscover = tmdbDiscoverResponseSchema.safeParse(await tmdbResponse.json());
-  if (!parsedDiscover.success) {
-    logger.error(
-      { err: parsedDiscover.error },
-      'more-picks pipeline: Invalid TMDB discover response',
-    );
-    throw new Error('TMDB discover response validation failed');
-  }
-
-  // Deduplicate against already-shown movies (excludeIds uses negative TMDB IDs in DB)
-  const excludedTmdbIds = new Set(excludeIds.map((id) => -id));
-  const candidates = (parsedDiscover.data.results ?? [])
-    .filter((m) => !excludedTmdbIds.has(m.id))
-    .slice(0, MORE_PICKS_PAGE_SIZE);
+  const candidates = await fetchMorePicksCandidates({ tmdbApiKey, params, page, excludeIds });
 
   if (candidates.length === 0) return [];
 
-  // Queue seeding job so TMDB movies are persisted for future local searches
-  if (seedQueue) {
-    const queue = seedQueue;
-    const tmdbMoviesForSeeding: TMDBDiscoverMovie[] = candidates.map((m) => ({
-      id: m.id,
-      title: m.title,
-      overview: m.overview,
-      release_date: m.release_date,
-      vote_average: m.vote_average,
-      vote_count: m.vote_count ?? 100,
-      genre_ids: m.genre_ids ?? [],
-      popularity: m.popularity ?? 0,
-      poster_path: m.poster_path,
-    }));
-    withTraceSpan(
-      'movie_seed.enqueue',
-      {
-        attributes: {
-          'messaging.system': 'bullmq',
-          'messaging.destination.name': 'movie-seed',
-          'messaging.operation.name': 'enqueue',
-          'movie.count': tmdbMoviesForSeeding.length,
-        },
-      },
-      async (span) => {
-        const job = await queue.add(
-          'seed-movies',
-          { tmdbMovies: tmdbMoviesForSeeding, localKeys: [], trace: getTraceCarrier() },
-          MOVIE_SEED_JOB_OPTIONS,
-        );
-        span.setAttribute('job.id', String(job.id ?? 'unknown'));
-      },
-    )
-      .then(() =>
-        logger.info({ queuedMovies: candidates.length }, 'more-picks pipeline: Queued seeding job'),
-      )
-      .catch((err) => logger.warn({ err }, 'more-picks pipeline: Failed to enqueue seeding job'));
-  }
-
-  // Compute cosine similarity scores
+  await enqueueMorePicksSeedJob(candidates);
   const queryText = combineAllPeopleDataToString(allPeopleData);
-  const candidateTexts = candidates.map(formatTMDBMovieEmbeddingText);
-
-  const similarityMap = new Map<number, number>();
-  try {
-    const [queryEmbedRes, movieEmbedRes] = await Promise.all([
-      getOpenAIClient().embeddings.create(
-        { model: MODELS.EMBEDDING, input: queryText },
-        openAIRequestOptions(OPENAI_TIMEOUTS_MS.embedding),
-      ),
-      getOpenAIClient().embeddings.create(
-        { model: MODELS.EMBEDDING, input: candidateTexts },
-        openAIRequestOptions(OPENAI_TIMEOUTS_MS.embedding),
-      ),
-    ]);
-    const queryEmbedding = queryEmbedRes.data[0]?.embedding;
-    if (queryEmbedding && queryEmbedding.length > 0) {
-      candidates.forEach((m, i) => {
-        const movieEmbedding = movieEmbedRes.data[i]?.embedding;
-        if (movieEmbedding && movieEmbedding.length === queryEmbedding.length) {
-          similarityMap.set(m.id, cosineSimilarity(queryEmbedding, movieEmbedding));
-        }
-      });
-    }
-  } catch (err) {
-    logger.warn({ err }, 'more-picks pipeline: embedding similarity failed — using fallback score');
-  }
-
-  const preferenceContext = queryText;
-  const descriptionSystemPrompt = `CRITICAL: Your entire response MUST be written in ${language} only. Never use English or any other language unless ${language} is English.
-
-You are PopChoice, a movie expert creating personalized movie descriptions. Write a brief, engaging description (2-3 sentences) that:
-
-1. Explains why this movie would appeal to the user based on their preferences
-2. Highlights the most compelling aspects of the film
-3. Uses an enthusiastic, conversational tone
-4. Avoids spoilers but creates excitement
-
-User preferences context: ${preferenceContext}
-
-Respond in ${language} only.`;
-
-  const movies: MovieRowToInsert[] = [];
-  const BATCH_SIZE = 2;
-
-  for (let i = 0; i < candidates.length; i += BATCH_SIZE) {
-    const batch = candidates.slice(i, i + BATCH_SIZE);
-    const batchResults = await Promise.all(
-      batch.map(async (tmdb) => {
-        const year = parseTMDBReleaseYear(tmdb.release_date);
-        const score = Number(tmdb.vote_average?.toFixed(1)) || 0;
-        const posterURL = tmdb.poster_path
-          ? `${IMAGE_BASE_URL}/w500${tmdb.poster_path}`
-          : undefined;
-
-        // Fetch localized title + runtime
-        let localizedTitle = tmdb.title;
-        let runtime: number | undefined;
-        let localizedOverview = tmdb.overview;
-        try {
-          const detailRes = await fetch(`${TMDB_API_BASE}/movie/${tmdb.id}?language=${tmdbLang}`, {
-            headers: { Authorization: `Bearer ${tmdbApiKey}`, Accept: 'application/json' },
-            signal: AbortSignal.timeout(TMDB_MOVIE_DETAILS_FETCH_TIMEOUT_MS),
-          });
-
-          if (detailRes.ok) {
-            const parsedDetail = tmdbMovieDetailSchema.safeParse(await detailRes.json());
-            if (parsedDetail.success) {
-              localizedTitle = parsedDetail.data.title || localizedTitle;
-              runtime = parsedDetail.data.runtime ?? undefined;
-              localizedOverview = parsedDetail.data.overview || localizedOverview;
-            }
-          }
-        } catch (err) {
-          logger.warn(
-            { err, tmdbId: tmdb.id },
-            'more-picks pipeline: detail fetch failed — using discover response fields',
-          );
-        }
-
-        // AI-generated description in the target language
-        let aiDescription = localizedOverview;
-        try {
-          const descriptionResponse = await getOpenAIClient().chat.completions.create(
-            {
-              model: MODELS.MINI,
-              messages: [
-                { role: 'system', content: descriptionSystemPrompt },
-                {
-                  role: 'user',
-                  content: `Movie: ${localizedTitle} (${year})\nRating: ${score}/10\nPlot: ${localizedOverview}`,
-                },
-              ],
-              max_completion_tokens: 150,
-            },
-            openAIRequestOptions(OPENAI_TIMEOUTS_MS.description),
-          );
-          aiDescription = descriptionResponse.choices[0]?.message?.content?.trim() || aiDescription;
-        } catch (err) {
-          logger.warn(
-            { err, tmdbId: tmdb.id },
-            'more-picks pipeline: description generation failed — using localized overview',
-          );
-        }
-
-        return {
-          id: -tmdb.id,
-          name: tmdb.title,
-          year,
-          similarity: similarityMap.get(tmdb.id) ?? 0.35,
-          age_rating: 'NR',
-          duration: runtime,
-          score_rating: score,
-          posterURL,
-          aiDescription,
-          localizedName: localizedTitle !== tmdb.title ? localizedTitle : undefined,
-          isMainRecommendation: false,
-          fromTMDB: true,
-          source: 'tmdb-search',
-        } satisfies MovieRowToInsert;
-      }),
-    );
-
-    movies.push(...batchResults);
-
-    if (i + BATCH_SIZE < candidates.length) {
-      await new Promise((resolve) => setTimeout(resolve, 200));
-    }
-  }
-
-  return movies;
+  const similarityMap = await computeMorePicksSimilarityMap(allPeopleData, candidates);
+  return buildMorePicksMovieRows({
+    candidates,
+    tmdbApiKey,
+    tmdbLang,
+    descriptionSystemPrompt: buildDescriptionSystemPrompt(language, queryText),
+    similarityMap,
+  });
 }

--- a/apps/web/src/features/recommendation/tmdb.ts
+++ b/apps/web/src/features/recommendation/tmdb.ts
@@ -330,69 +330,124 @@ export async function enrichTMDBMatchesWithDetails(
   if (tmdbMatches.length === 0) return matches;
 
   const language = LOCALE_TO_TMDB_LANG[locale] ?? 'en-US';
-  const detailsByTMDBId = new Map(
-    (
-      await Promise.all(
-        tmdbMatches.map(async (movie) => {
-          const tmdbId = movie.tmdbId;
-          if (!tmdbId) return null;
-          const details = await fetchMovieDetails(tmdbApiKey, tmdbId, language);
-          return details ? ([tmdbId, details] as const) : null;
-        }),
-      )
-    ).filter((entry): entry is readonly [number, TMDBMovieDetails] => entry !== null),
+  const detailsByTMDBId = await fetchTMDBDetailsById(tmdbMatches, tmdbApiKey, language);
+  return matches.map((movie) =>
+    enrichTMDBMatchWithDetails(movie, detailsByTMDBId.get(movie.tmdbId ?? 0)),
+  );
+}
+
+async function fetchTMDBDetailsById(
+  tmdbMatches: EnhancedMovieMatch[],
+  tmdbApiKey: string,
+  language: string,
+): Promise<Map<number, TMDBMovieDetails>> {
+  const entries = await Promise.all(
+    tmdbMatches.map(async (movie) => {
+      const tmdbId = movie.tmdbId;
+      if (!tmdbId) return null;
+      const details = await fetchMovieDetails(tmdbApiKey, tmdbId, language);
+      return details ? ([tmdbId, details] as const) : null;
+    }),
   );
 
-  return matches.map((movie) => {
-    if (!movie.tmdbId || movie.id >= 0) return movie;
-    const details = detailsByTMDBId.get(movie.tmdbId);
-    if (!details) {
-      return {
-        ...movie,
-        metadataQualityFlags: [...(movie.metadataQualityFlags ?? []), 'missing_details'],
-        metadataQualityScore: movie.metadataQualityScore ?? 0,
-      };
-    }
+  return new Map(
+    entries.filter((entry): entry is readonly [number, TMDBMovieDetails] => entry !== null),
+  );
+}
 
-    const metadata = extractCatalogMetadata(details);
-    const ageRating = extractUSCertification(details);
-    const runtime = details.runtime ?? movie.duration;
-    const scoreRating = Number((details.vote_average ?? movie.score_rating ?? 0).toFixed(1));
-    const qualityBoost = (metadata.qualityScore / 100) * MAX_METADATA_QUALITY_SIMILARITY_BOOST;
+function markMissingTMDBDetails(movie: EnhancedMovieMatch): EnhancedMovieMatch {
+  return {
+    ...movie,
+    metadataQualityFlags: [...(movie.metadataQualityFlags ?? []), 'missing_details'],
+    metadataQualityScore: movie.metadataQualityScore ?? 0,
+  };
+}
 
-    return {
-      ...movie,
-      age_rating: ageRating,
-      content: [
-        `${details.title} (${parseTMDBReleaseYear(details.release_date)}) | ${ageRating}`,
-        `Duration: ${runtime || 'unknown'} min | TMDB Score: ${scoreRating}/10`,
-        details.overview || movie.description || '',
-      ]
-        .filter(Boolean)
-        .join('\n'),
-      description: details.overview || movie.description,
-      duration: runtime,
-      metadataQualityFlags: metadata.qualityFlags,
-      metadataQualityScore: metadata.qualityScore,
-      name: details.title || movie.name,
-      originalLanguage: details.original_language ?? null,
-      popularity: details.popularity ?? null,
-      posterURL: getPosterUrl(details.poster_path) ?? movie.posterURL,
-      score_rating: scoreRating,
-      similarity: Number((movie.similarity + qualityBoost).toFixed(6)),
-      voteCount: details.vote_count ?? null,
-      watchProviders: metadata.providers.map(
-        ({ availabilityType, displayPriority, providerId, providerName, region }) => ({
-          availabilityType,
-          displayPriority,
-          providerId,
-          providerName,
-          region,
-        }),
-      ),
-      year: parseTMDBReleaseYear(details.release_date) || movie.year,
-    };
-  });
+function mapTMDBWatchProviders(metadata: ReturnType<typeof extractCatalogMetadata>) {
+  return metadata.providers.map(
+    ({ availabilityType, displayPriority, providerId, providerName, region }) => ({
+      availabilityType,
+      displayPriority,
+      providerId,
+      providerName,
+      region,
+    }),
+  );
+}
+
+function shouldEnrichTMDBMatch(movie: EnhancedMovieMatch): boolean {
+  return Boolean(movie.tmdbId) && movie.id < 0;
+}
+
+function getTMDBDetailsDescription(details: TMDBMovieDetails, movie: EnhancedMovieMatch): string {
+  return details.overview || movie.description;
+}
+
+function getTMDBDetailsRuntime(details: TMDBMovieDetails, movie: EnhancedMovieMatch): number {
+  return details.runtime ?? movie.duration;
+}
+
+function getTMDBDetailsScore(details: TMDBMovieDetails, movie: EnhancedMovieMatch): number {
+  return Number((details.vote_average ?? movie.score_rating ?? 0).toFixed(1));
+}
+
+function buildTMDBDetailsContent(input: {
+  title: string;
+  releaseYear: number;
+  ageRating: string;
+  runtime: number;
+  scoreRating: number;
+  description: string;
+}): string {
+  const runtimeLabel = input.runtime ? input.runtime : 'unknown';
+  const lines = [
+    `${input.title} (${input.releaseYear}) | ${input.ageRating}`,
+    `Duration: ${runtimeLabel} min | TMDB Score: ${input.scoreRating}/10`,
+  ];
+  if (input.description) lines.push(input.description);
+  return lines.join('\n');
+}
+
+function enrichTMDBMatchWithDetails(
+  movie: EnhancedMovieMatch,
+  details?: TMDBMovieDetails,
+): EnhancedMovieMatch {
+  if (!shouldEnrichTMDBMatch(movie)) return movie;
+  if (!details) return markMissingTMDBDetails(movie);
+
+  const metadata = extractCatalogMetadata(details);
+  const ageRating = extractUSCertification(details);
+  const runtime = getTMDBDetailsRuntime(details, movie);
+  const scoreRating = getTMDBDetailsScore(details, movie);
+  const releaseYear = parseTMDBReleaseYear(details.release_date);
+  const description = getTMDBDetailsDescription(details, movie);
+  const qualityBoost = (metadata.qualityScore / 100) * MAX_METADATA_QUALITY_SIMILARITY_BOOST;
+
+  return {
+    ...movie,
+    age_rating: ageRating,
+    content: buildTMDBDetailsContent({
+      title: details.title,
+      releaseYear,
+      ageRating,
+      runtime,
+      scoreRating,
+      description,
+    }),
+    description,
+    duration: runtime,
+    metadataQualityFlags: metadata.qualityFlags,
+    metadataQualityScore: metadata.qualityScore,
+    name: details.title || movie.name,
+    originalLanguage: details.original_language ?? null,
+    popularity: details.popularity ?? null,
+    posterURL: getPosterUrl(details.poster_path) ?? movie.posterURL,
+    score_rating: scoreRating,
+    similarity: Number((movie.similarity + qualityBoost).toFixed(6)),
+    voteCount: details.vote_count ?? null,
+    watchProviders: mapTMDBWatchProviders(metadata),
+    year: releaseYear || movie.year,
+  };
 }
 
 /**
@@ -498,6 +553,153 @@ function logJITSeedingError(input: { error: unknown; movieTitle: string; warnMes
   logger.warn({ err: input.error, movieTitle: input.movieTitle }, input.warnMessage);
 }
 
+function getTMDBSeedMovieKey(movie: TMDBDiscoverMovie): string {
+  return `${movie.title.toLowerCase()}|${parseTMDBReleaseYear(movie.release_date)}`;
+}
+
+function getJITSeedCandidates(
+  tmdbMovies: TMDBDiscoverMovie[],
+  existingLocalKeys: Set<string>,
+): TMDBDiscoverMovie[] {
+  return tmdbMovies
+    .filter((movie) => !existingLocalKeys.has(getTMDBSeedMovieKey(movie)))
+    .slice(0, MAX_JIT_SEED_MOVIES);
+}
+
+async function getExistingMovieKeys(
+  db: ReturnType<typeof getDbClient>,
+  candidateMovies: TMDBDiscoverMovie[],
+): Promise<Set<string>> {
+  const existingMovieKeys = new Set<string>();
+
+  try {
+    const movieNames = candidateMovies.map((movie) => movie.title);
+    const { data: existingMovies, error } = await db
+      .from<{ name: string; year: number }>('movies')
+      .select('name, year')
+      .in('name', movieNames);
+
+    if (error) {
+      logger.warn({ err: error }, 'JIT seeding existence pre-check failed');
+      return existingMovieKeys;
+    }
+
+    for (const row of existingMovies ?? []) {
+      existingMovieKeys.add(`${row.name.toLowerCase()}|${Number(row.year ?? 0)}`);
+    }
+  } catch (err) {
+    logger.warn({ err }, 'JIT seeding existence pre-check failed with unexpected error');
+  }
+
+  return existingMovieKeys;
+}
+
+async function getTMDBSeedEmbedding(
+  movie: TMDBDiscoverMovie,
+  precomputedEmbeddings?: Map<number, number[]>,
+): Promise<number[] | undefined> {
+  const precomputed = precomputedEmbeddings?.get(movie.id);
+  if (precomputed) return precomputed;
+
+  const embeddingResponse = await getOpenAIClient().embeddings.create(
+    {
+      model: MODELS.EMBEDDING,
+      input: formatTMDBMovieEmbeddingText(movie),
+    },
+    openAIRequestOptions(OPENAI_TIMEOUTS_MS.embedding),
+  );
+  return embeddingResponse.data[0]?.embedding;
+}
+
+function isZeroMagnitudeEmbedding(embedding: number[]): boolean {
+  return embedding.every((value) => value === 0);
+}
+
+async function insertTMDBSeedMovie(input: {
+  db: ReturnType<typeof getDbClient>;
+  movie: TMDBDiscoverMovie;
+  year: number;
+  score: number;
+  embedding: number[];
+}) {
+  return input.db.from('movies').insert({
+    tmdb_id: input.movie.id,
+    name: input.movie.title,
+    year: input.year,
+    age_rating: 'NR',
+    description: input.movie.overview || '',
+    duration: 0,
+    score_rating: input.score,
+    embedding: input.embedding,
+  });
+}
+
+async function seedOneTMDBMovie(input: {
+  db: ReturnType<typeof getDbClient>;
+  movie: TMDBDiscoverMovie;
+  existingMovieKeys: Set<string>;
+  precomputedEmbeddings?: Map<number, number[]>;
+}): Promise<void> {
+  const year = parseTMDBReleaseYear(input.movie.release_date);
+  const movieKey = getTMDBSeedMovieKey(input.movie);
+
+  if (input.existingMovieKeys.has(movieKey)) {
+    logger.debug(
+      { movieTitle: input.movie.title, year },
+      'JIT seeding skipped — movie already in database',
+    );
+    return;
+  }
+
+  const score = Number(input.movie.vote_average?.toFixed(1)) || 0;
+  const embedding = await getTMDBSeedEmbedding(input.movie, input.precomputedEmbeddings);
+  if (!embedding) return;
+
+  if (isZeroMagnitudeEmbedding(embedding)) {
+    logger.warn(
+      { movieTitle: input.movie.title, year },
+      'JIT seeding skipped — zero-magnitude embedding',
+    );
+    return;
+  }
+
+  const { error: insertError } = await insertTMDBSeedMovie({
+    db: input.db,
+    movie: input.movie,
+    year,
+    score,
+    embedding,
+  });
+
+  if (insertError) {
+    logJITSeedingError({
+      error: insertError,
+      movieTitle: input.movie.title,
+      warnMessage: 'JIT seeding insert failed',
+    });
+    return;
+  }
+
+  logger.info({ movieTitle: input.movie.title, year }, 'JIT seeded TMDB movie into database');
+}
+
+async function seedOneTMDBMovieWithLogging(input: {
+  db: ReturnType<typeof getDbClient>;
+  movie: TMDBDiscoverMovie;
+  existingMovieKeys: Set<string>;
+  precomputedEmbeddings?: Map<number, number[]>;
+}): Promise<void> {
+  try {
+    await seedOneTMDBMovie(input);
+  } catch (err) {
+    logJITSeedingError({
+      error: err,
+      movieTitle: input.movie.title,
+      warnMessage: 'JIT seeding failed with unexpected error',
+    });
+  }
+}
+
 /**
  * Seed TMDB movies into the local DB for future local vector search.
  */
@@ -509,116 +711,13 @@ export async function seedMovies(
   const db = getDbClient();
   if (!db.isConfigured()) return;
 
-  // Avoid re-seeding movies already present in the local results for this request
-  const toSeed = tmdbMovies.filter(
-    (m) =>
-      !existingLocalKeys.has(`${m.title.toLowerCase()}|${parseTMDBReleaseYear(m.release_date)}`),
-  );
-  if (toSeed.length === 0) return;
-
-  const candidateMovies = toSeed.slice(0, MAX_JIT_SEED_MOVIES);
+  const candidateMovies = getJITSeedCandidates(tmdbMovies, existingLocalKeys);
   if (candidateMovies.length === 0) return;
 
-  // Bulk DB existence check to avoid wasting OpenAI embedding tokens on rows that already exist.
-  // The DB uniqueness constraint is (name, year). We query by the movies.name column (matching
-  // the TMDB title) only, then filter by year in-memory to build exact composite keys —
-  // avoids a Cartesian product from two .in() clauses.
-  const existingMovieKeys = new Set<string>();
-  try {
-    // TMDB movies use `title`; the DB column is `name` — same value, different field names.
-    const movieNames = candidateMovies.map((m) => m.title);
-    const { data: existingMovies, error } = await db
-      .from<{ name: string; year: number }>('movies')
-      .select('name, year')
-      .in('name', movieNames);
-
-    if (error) {
-      logger.warn({ err: error }, 'JIT seeding existence pre-check failed');
-    } else {
-      for (const row of existingMovies ?? []) {
-        existingMovieKeys.add(`${row.name.toLowerCase()}|${Number(row.year ?? 0)}`);
-      }
-    }
-  } catch (err) {
-    logger.warn({ err }, 'JIT seeding existence pre-check failed with unexpected error');
-  }
+  const existingMovieKeys = await getExistingMovieKeys(db, candidateMovies);
 
   for (const movie of candidateMovies) {
-    try {
-      const year = parseTMDBReleaseYear(movie.release_date);
-      const movieKey = `${movie.title.toLowerCase()}|${year}`;
-
-      if (existingMovieKeys.has(movieKey)) {
-        logger.debug(
-          { movieTitle: movie.title, year },
-          'JIT seeding skipped — movie already in database',
-        );
-        continue;
-      }
-
-      const score = Number(movie.vote_average?.toFixed(1)) || 0;
-
-      // Reuse the embedding already computed during similarity scoring if available,
-      // falling back to a fresh API call only for movies not in the precomputed map.
-      let embedding: number[] | undefined = precomputedEmbeddings?.get(movie.id);
-      if (!embedding) {
-        const embeddingText = [
-          `${movie.title} (${year})`,
-          `Rating: NR`,
-          `Duration: 0 min`,
-          `Score: ${score}/10`,
-          `Description: ${movie.overview || ''}`,
-        ].join('\n');
-
-        const embeddingResponse = await getOpenAIClient().embeddings.create(
-          {
-            model: MODELS.EMBEDDING,
-            input: embeddingText,
-          },
-          openAIRequestOptions(OPENAI_TIMEOUTS_MS.embedding),
-        );
-        embedding = embeddingResponse.data[0]?.embedding;
-      }
-      if (!embedding) continue;
-
-      // Reject zero-magnitude embeddings — pgvector cosine distance returns NaN for them
-      if (embedding.every((v) => v === 0)) {
-        logger.warn(
-          { movieTitle: movie.title, year },
-          'JIT seeding skipped — zero-magnitude embedding',
-        );
-        continue;
-      }
-
-      const { error: insertError } = await db.from('movies').insert({
-        tmdb_id: movie.id,
-        name: movie.title,
-        year,
-        age_rating: 'NR',
-        description: movie.overview || '',
-        duration: 0,
-        score_rating: score,
-        embedding,
-      });
-
-      if (insertError) {
-        logJITSeedingError({
-          error: insertError,
-          movieTitle: movie.title,
-          warnMessage: 'JIT seeding insert failed',
-        });
-        continue;
-      }
-
-      logger.info({ movieTitle: movie.title, year }, 'JIT seeded TMDB movie into database');
-    } catch (err) {
-      // Catch truly thrown errors (e.g. network failures during embedding)
-      logJITSeedingError({
-        error: err,
-        movieTitle: movie.title,
-        warnMessage: 'JIT seeding failed with unexpected error',
-      });
-    }
+    await seedOneTMDBMovieWithLogging({ db, movie, existingMovieKeys, precomputedEmbeddings });
   }
 }
 

--- a/apps/web/src/features/recommendation/tmdb.ts
+++ b/apps/web/src/features/recommendation/tmdb.ts
@@ -14,14 +14,10 @@ import logger from '@/lib/logger';
 import { recordOpenAIProviderError, recordTMDBProviderError } from '@/lib/metrics';
 import { MODELS } from '@/lib/models';
 import { OPENAI_TIMEOUTS_MS, openAIRequestOptions } from '@/lib/openaiTimeout';
-import {
-  GENRE_LABEL_TO_TMDB_ID,
-  cosineSimilarity,
-  normalizeGenreLabel,
-  parseTMDBReleaseYear,
-} from '@/lib/tmdb';
+import { GENRE_LABEL_TO_TMDB_ID, cosineSimilarity, parseTMDBReleaseYear } from '@/lib/tmdb';
 
 import { MAX_JIT_SEED_MOVIES, MAX_TOTAL_MOVIES } from './config';
+import { formatTMDBMovieEmbeddingText, getTopTMDBGenreIds } from './tmdbDiscoverHelpers';
 
 import type { EnhancedMovieMatch, PersonFormData } from './types';
 import type { TMDBMovieDetails } from '@/features/catalogMaintenance/tmdb';
@@ -102,16 +98,6 @@ function hasAnyPreferenceTerm(text: string, terms: string[]): boolean {
 export function buildTMDBDiscoverQueryShape(
   allPeopleData: PersonFormData[],
 ): TMDBDiscoverQueryShape {
-  // Aggregate mood preferences across all people.
-  // Normalize labels: "Sci-Fi" → "scifi", "Action" → "action", etc.
-  const moodCounts: Record<string, number> = {};
-  allPeopleData.forEach((p) => {
-    p.moodPreference.forEach((mood) => {
-      const key = normalizeGenreLabel(mood);
-      moodCounts[key] = (moodCounts[key] ?? 0) + 1;
-    });
-  });
-
   // Top genres (up to 3) mapped to TMDB IDs
   const preferenceText = getPreferenceText(allPeopleData);
   const withoutGenreIds = new Set<number>();
@@ -122,11 +108,10 @@ export function buildTMDBDiscoverQueryShape(
     withoutGenreIds.add(GENRE_LABEL_TO_TMDB_ID.horror);
   }
 
-  const genreIds = Object.entries(moodCounts)
-    .sort(([, a], [, b]) => b - a)
-    .slice(0, 3)
-    .map(([key]) => GENRE_LABEL_TO_TMDB_ID[key])
-    .filter((id): id is number => id !== undefined && !withoutGenreIds.has(id));
+  const genreIds = getTopTMDBGenreIds(
+    allPeopleData.flatMap((person) => person.moodPreference),
+    { withoutGenreIds },
+  );
 
   // Era preference: normalize to 'new' | 'classic' | 'both' by keyword matching.
   // Quiz sends e.g. "New", "Classic", "Both new and classic".
@@ -301,13 +286,7 @@ export async function scoreAndConvertTMDBMovies(
 ): Promise<{ matches: EnhancedMovieMatch[]; embeddings: Map<number, number[]> }> {
   if (movies.length === 0) return { matches: [], embeddings: new Map() };
 
-  const texts = movies.map((m) => {
-    const year = parseTMDBReleaseYear(m.release_date);
-    const score = Number(m.vote_average?.toFixed(1)) || 0;
-    return [`${m.title} (${year}) | TMDB Score: ${score}/10`, m.overview || '']
-      .filter(Boolean)
-      .join('\n');
-  });
+  const texts = movies.map(formatTMDBMovieEmbeddingText);
 
   let rawEmbeddings: number[][] = [];
   try {
@@ -490,6 +469,35 @@ export function deserializeTMDBEmbeddings(
   return new Map(entries);
 }
 
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'object' && error !== null && 'message' in error) {
+    return String((error as { message: unknown }).message);
+  }
+  return String(error);
+}
+
+function isDuplicateEntryErrorMessage(message: string): boolean {
+  const normalizedMessage = message.toLowerCase();
+  return (
+    normalizedMessage.includes('unique') ||
+    normalizedMessage.includes('duplicate') ||
+    normalizedMessage.includes('already exists')
+  );
+}
+
+function logJITSeedingError(input: { error: unknown; movieTitle: string; warnMessage: string }) {
+  if (isDuplicateEntryErrorMessage(getErrorMessage(input.error))) {
+    logger.debug(
+      { movieTitle: input.movieTitle },
+      'JIT seeding skipped — movie already in database',
+    );
+    return;
+  }
+
+  logger.warn({ err: input.error, movieTitle: input.movieTitle }, input.warnMessage);
+}
+
 /**
  * Seed TMDB movies into the local DB for future local vector search.
  */
@@ -594,40 +602,22 @@ export async function seedMovies(
       });
 
       if (insertError) {
-        const errMsg = insertError.message;
-        const isDuplicateEntry =
-          errMsg.toLowerCase().includes('unique') ||
-          errMsg.toLowerCase().includes('duplicate') ||
-          errMsg.toLowerCase().includes('already exists');
-
-        if (isDuplicateEntry) {
-          logger.debug(
-            { movieTitle: movie.title },
-            'JIT seeding skipped — movie already in database',
-          );
-        } else {
-          logger.warn({ err: insertError, movieTitle: movie.title }, 'JIT seeding insert failed');
-        }
+        logJITSeedingError({
+          error: insertError,
+          movieTitle: movie.title,
+          warnMessage: 'JIT seeding insert failed',
+        });
         continue;
       }
 
       logger.info({ movieTitle: movie.title, year }, 'JIT seeded TMDB movie into database');
     } catch (err) {
       // Catch truly thrown errors (e.g. network failures during embedding)
-      const errMsg = err instanceof Error ? err.message : String(err);
-      const isDuplicateEntry =
-        errMsg.toLowerCase().includes('unique') ||
-        errMsg.toLowerCase().includes('duplicate') ||
-        errMsg.toLowerCase().includes('already exists');
-
-      if (isDuplicateEntry) {
-        logger.debug(
-          { movieTitle: movie.title },
-          'JIT seeding skipped — movie already in database',
-        );
-      } else {
-        logger.warn({ err, movieTitle: movie.title }, 'JIT seeding failed with unexpected error');
-      }
+      logJITSeedingError({
+        error: err,
+        movieTitle: movie.title,
+        warnMessage: 'JIT seeding failed with unexpected error',
+      });
     }
   }
 }

--- a/apps/web/src/features/recommendation/tmdbDiscoverHelpers.ts
+++ b/apps/web/src/features/recommendation/tmdbDiscoverHelpers.ts
@@ -1,0 +1,34 @@
+import { GENRE_LABEL_TO_TMDB_ID, normalizeGenreLabel, parseTMDBReleaseYear } from '@/lib/tmdb';
+
+export type TMDBMovieEmbeddingTextInput = {
+  title: string;
+  overview?: string | null;
+  release_date: string;
+  vote_average?: number | null;
+};
+
+function incrementCount<TKey>(counts: Map<TKey, number>, key: TKey) {
+  counts.set(key, (counts.get(key) ?? 0) + 1);
+}
+
+export function getTopTMDBGenreIds(
+  moodPreferences: string[],
+  options: { withoutGenreIds?: ReadonlySet<number> } = {},
+): number[] {
+  const moodCounts = new Map<string, number>();
+  for (const mood of moodPreferences) incrementCount(moodCounts, normalizeGenreLabel(mood));
+
+  return Array.from(moodCounts.entries())
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, 3)
+    .map(([key]) => GENRE_LABEL_TO_TMDB_ID[key])
+    .filter((id): id is number => id !== undefined && !(options.withoutGenreIds?.has(id) ?? false));
+}
+
+export function formatTMDBMovieEmbeddingText(movie: TMDBMovieEmbeddingTextInput): string {
+  const year = parseTMDBReleaseYear(movie.release_date);
+  const score = Number(movie.vote_average?.toFixed(1)) || 0;
+  return [`${movie.title} (${year}) | TMDB Score: ${score}/10`, movie.overview || '']
+    .filter(Boolean)
+    .join('\n');
+}


### PR DESCRIPTION
## Summary
- split more-picks TMDB parameter extraction into focused era, tone, genre, and date helpers
- share recommendation TMDB discover helper logic for top genre IDs and embedding text formatting
- centralize duplicate-entry logging in JIT TMDB seeding

## Verification
- npm run test --workspace=apps/web -- src/app/api/more-tmdb-picks/pipeline.test.ts src/features/recommendation/tmdb.test.ts
- npm run type-check --workspace=apps/web
- npm run lint:check
- npm run eval:recommendations
- npm run quality:fallow:dupes -- --changed-since origin/development --top 20 --format json --quiet
- npm run quality:fallow:dead-code -- --changed-since origin/development --format json --quiet
- pre-push: lint, server tests, production build