### PR TITLE
Refactor movies route query validation

### DIFF
--- a/apps/web/src/app/api/movies/route.ts
+++ b/apps/web/src/app/api/movies/route.ts
@@ -12,6 +12,18 @@ const MAX_MOVIE_YEAR = 2100;
 const DURATION_FILTERS = new Set<MovieDurationFilter>(['under-90', '90-120', 'over-120']);
 const VALID_AGE_RATINGS = new Set<string>(ageRatings.options);
 
+type MoviesQueryParams = {
+  page: number;
+  pageSize: number;
+  query: string;
+  yearFrom?: number;
+  yearTo?: number;
+  duration?: MovieDurationFilter;
+  requestedDuration?: string;
+  minScore?: number;
+  ageRatingFilters?: string[];
+};
+
 function parseRequiredPositiveInteger(value: string | null, fallback: number): number {
   if (value == null || value.trim() === '') return fallback;
   if (!/^\d+$/.test(value.trim())) return Number.NaN;
@@ -55,67 +67,74 @@ function parseAgeRatingFilters(searchParams: URLSearchParams): string[] | undefi
   return uniqueValues.every((value) => VALID_AGE_RATINGS.has(value)) ? uniqueValues : [];
 }
 
+function parseMoviesQueryParams(searchParams: URLSearchParams): MoviesQueryParams {
+  return {
+    page: parseRequiredPositiveInteger(searchParams.get('page'), 1),
+    pageSize: parseRequiredPositiveInteger(searchParams.get('pageSize'), 50),
+    query: (searchParams.get('query') ?? searchParams.get('title') ?? '').trim(),
+    yearFrom: parseOptionalYear(searchParams.get('yearFrom')),
+    yearTo: parseOptionalYear(searchParams.get('yearTo')),
+    duration: parseOptionalDurationFilter(searchParams.get('duration')),
+    requestedDuration: searchParams.get('duration')?.trim(),
+    minScore: parseOptionalMinScore(searchParams.get('minScore')),
+    ageRatingFilters: parseAgeRatingFilters(searchParams),
+  };
+}
+
+function isInvalidPagination(params: Pick<MoviesQueryParams, 'page' | 'pageSize'>): boolean {
+  if (!Number.isInteger(params.page) || params.page < 1) return true;
+  return !Number.isInteger(params.pageSize) || params.pageSize < 1 || params.pageSize > 100;
+}
+
+function isYearOutsideCatalogRange(year: number): boolean {
+  return !Number.isFinite(year) || year < MIN_MOVIE_YEAR || year > MAX_MOVIE_YEAR;
+}
+
+function isInvalidYearFilter(params: Pick<MoviesQueryParams, 'yearFrom' | 'yearTo'>): boolean {
+  if (params.yearFrom !== undefined && isYearOutsideCatalogRange(params.yearFrom)) return true;
+  if (params.yearTo !== undefined && isYearOutsideCatalogRange(params.yearTo)) return true;
+  return (
+    params.yearFrom !== undefined && params.yearTo !== undefined && params.yearFrom > params.yearTo
+  );
+}
+
+function isInvalidScoreFilter(minScore: number | undefined): boolean {
+  if (minScore === undefined) return false;
+  return !Number.isFinite(minScore) || minScore < 0 || minScore > 10;
+}
+
+function getMoviesQueryValidationError(params: MoviesQueryParams): string | undefined {
+  if (isInvalidPagination(params)) return 'Invalid page or pageSize parameters';
+  if (params.query.length > 80) return 'Invalid query parameter';
+  if (isInvalidYearFilter(params)) return 'Invalid year filter parameters';
+  if (params.requestedDuration && params.duration === undefined) {
+    return 'Invalid duration filter parameter';
+  }
+  if (isInvalidScoreFilter(params.minScore)) return 'Invalid score filter parameter';
+  if (params.ageRatingFilters && params.ageRatingFilters.length === 0) {
+    return 'Invalid age rating filter parameter';
+  }
+  return undefined;
+}
+
+function badRequest(error: string): NextResponse {
+  return NextResponse.json({ error }, { status: 400 });
+}
+
 async function getHandler(request: NextRequest): Promise<NextResponse> {
   try {
     const { searchParams } = new URL(request.url);
-    const page = parseRequiredPositiveInteger(searchParams.get('page'), 1);
-    const pageSize = parseRequiredPositiveInteger(searchParams.get('pageSize'), 50);
-    const query = (searchParams.get('query') ?? searchParams.get('title') ?? '').trim();
-    const yearFrom = parseOptionalYear(searchParams.get('yearFrom'));
-    const yearTo = parseOptionalYear(searchParams.get('yearTo'));
-    const duration = parseOptionalDurationFilter(searchParams.get('duration'));
-    const minScore = parseOptionalMinScore(searchParams.get('minScore'));
-    const ageRatingFilters = parseAgeRatingFilters(searchParams);
+    const params = parseMoviesQueryParams(searchParams);
+    const validationError = getMoviesQueryValidationError(params);
+    if (validationError) return badRequest(validationError);
 
-    // Validate page and pageSize
-    if (
-      !Number.isInteger(page) ||
-      !Number.isInteger(pageSize) ||
-      page < 1 ||
-      pageSize < 1 ||
-      pageSize > 100
-    ) {
-      return NextResponse.json({ error: 'Invalid page or pageSize parameters' }, { status: 400 });
-    }
-
-    if (query.length > 80) {
-      return NextResponse.json({ error: 'Invalid query parameter' }, { status: 400 });
-    }
-
-    const hasInvalidYear =
-      (yearFrom !== undefined &&
-        (!Number.isFinite(yearFrom) || yearFrom < MIN_MOVIE_YEAR || yearFrom > MAX_MOVIE_YEAR)) ||
-      (yearTo !== undefined &&
-        (!Number.isFinite(yearTo) || yearTo < MIN_MOVIE_YEAR || yearTo > MAX_MOVIE_YEAR)) ||
-      (yearFrom !== undefined && yearTo !== undefined && yearFrom > yearTo);
-
-    if (hasInvalidYear) {
-      return NextResponse.json({ error: 'Invalid year filter parameters' }, { status: 400 });
-    }
-
-    const requestedDuration = searchParams.get('duration')?.trim();
-    if (requestedDuration && duration === undefined) {
-      return NextResponse.json({ error: 'Invalid duration filter parameter' }, { status: 400 });
-    }
-
-    if (
-      !Number.isFinite(minScore ?? 0) ||
-      (minScore !== undefined && (minScore < 0 || minScore > 10))
-    ) {
-      return NextResponse.json({ error: 'Invalid score filter parameter' }, { status: 400 });
-    }
-
-    if (ageRatingFilters && ageRatingFilters.length === 0) {
-      return NextResponse.json({ error: 'Invalid age rating filter parameter' }, { status: 400 });
-    }
-
-    const response = await getMoviesPage(page, pageSize, {
-      query: query || undefined,
-      yearFrom,
-      yearTo,
-      duration,
-      minScore,
-      ageRatings: ageRatingFilters,
+    const response = await getMoviesPage(params.page, params.pageSize, {
+      query: params.query || undefined,
+      yearFrom: params.yearFrom,
+      yearTo: params.yearTo,
+      duration: params.duration,
+      minScore: params.minScore,
+      ageRatings: params.ageRatingFilters,
     });
     return NextResponse.json(response);
   } catch (error) {


### PR DESCRIPTION
## Summary
- extract /api/movies query parsing and validation helpers from the GET handler
- keep existing validation messages and getMoviesPage request shape unchanged
- remove the Fallow complexity hotspot from apps/web/src/app/api/movies/route.ts

## Verification
- npm run test --workspace=apps/web -- src/app/api/movies/route.test.ts
- npm run type-check --workspace=apps/web
- npm run lint:check
- npm run quality:fallow:dupes -- --changed-since origin/development --top 20 --format json --quiet
- npm run quality:fallow:dead-code -- --changed-since origin/development --format json --quiet
- Fallow health filtered for apps/web/src/app/api/movies/route.ts: []

Note: local Fallow audit still fails before analysis with `could not create a temporary worktree for base ref 'origin/development'`; CI Fallow Audit will run the gate.