### PR TITLE
Track repo-wide Fallow complexity epic

### DIFF
--- a/docs/QUALITY.md
+++ b/docs/QUALITY.md
@@ -29,7 +29,7 @@ legacy findings, so PR review should focus on findings introduced by a changeset
 and on obvious cleanup candidates. Use `fallow audit` for PR-shaped feedback and
 the focused commands when planning cleanup work.
 
-## Initial Baseline Notes
+## Baseline Notes
 
 The first scoped pass on `@pop-choice/web` found useful signal:
 
@@ -51,6 +51,23 @@ recommended adoption path is:
 3. Add baselines or suppressions only when a finding is intentionally kept.
 4. Make the PR audit blocking once new-only failures are consistently low-noise.
 
+The repo-wide changed-code hygiene rollout is complete: PR-local Fallow Audit is
+green on the cleanup PRs, and changed-code dead-code and duplication checks are
+clean for the focused cleanup slices. The remaining backlog is inherited
+complexity rather than new-code regressions.
+
+Fresh `development` complexity baseline on 2026-06-05:
+
+- `health`: 165 findings.
+- Severity split: 37 critical, 47 high, 81 moderate.
+- Workspace split: 136 in `apps/web`, 28 in `apps/backoffice`, and 1 script
+  finding.
+
+Track the repo-wide complexity cleanup in
+[#717](https://github.com/shchilkin/PopChoice/issues/717). The child issues split
+the work by file/workflow so each PR can keep behavior stable and avoid broad
+complexity suppressions.
+
 ## Monorepo Follow-ups
 
 Fallow is configured at the repository root and sees all npm workspaces:
@@ -69,6 +86,13 @@ Completed focused follow-ups:
   entrypoint ownership ([#703](https://github.com/shchilkin/PopChoice/issues/703)),
   and shared package health hotspots
   ([#704](https://github.com/shchilkin/PopChoice/issues/704)).
+
+Active repo-wide complexity follow-up:
+
+- [#717](https://github.com/shchilkin/PopChoice/issues/717): drive inherited
+  Fallow complexity findings to zero actionable items. Start with the highest
+  risk worker, recommendation, persistence, eval, backoffice, account/results,
+  auth, catalog, and UI helper slices tracked by its child issues.
 
 The root config intentionally ignores `**/e2e/**` for dead-code reachability and
 `collections/server` as a generated Fumadocs import. Keep those ignores narrow:

--- a/docs/ROADMAP-ARCHITECTURE.md
+++ b/docs/ROADMAP-ARCHITECTURE.md
@@ -143,6 +143,10 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 - Align CI checks to the new boundaries and ownership model.
 - [x] Adopt Fallow code-quality analysis in [#684](https://github.com/shchilkin/PopChoice/issues/684), starting advisory with PR-local findings before making it a required gate.
 - [x] Extend Fallow cleanup beyond `apps/web` through [#697](https://github.com/shchilkin/PopChoice/issues/697) for backoffice/docs and [#698](https://github.com/shchilkin/PopChoice/issues/698) for shared/services.
+- [ ] Drive inherited repo-wide Fallow complexity to zero actionable findings
+      through [#717](https://github.com/shchilkin/PopChoice/issues/717), split into
+      focused worker, recommendation, persistence, eval, backoffice, account/results,
+      auth, catalog, and UI helper cleanup issues.
 
 ### CI/CD and Deployment Track
 


### PR DESCRIPTION
## Summary
- documents the fresh repo-wide Fallow complexity baseline: 165 findings, split into 37 critical / 47 high / 81 moderate
- links the new umbrella epic #717 and focused child issues #718-#728
- adds the active Fallow complexity cleanup track to the architecture roadmap

## Verification
- Fallow baseline captured with `fallow health --top 200 --format json --quiet`
- `git diff --check`
- pre-commit: shared build, web type-check, backoffice type-check
- pre-push: lint, server tests, production build; Storybook tests skipped as no relevant changes