### PR TITLE
Make Fallow audit a blocking PR gate

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -93,7 +93,6 @@ jobs:
     needs: changes
     if: needs.changes.outputs.docs_only != 'true'
     runs-on: ubuntu-latest
-    continue-on-error: true
     permissions:
       contents: read
     steps:
@@ -111,7 +110,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run advisory Fallow audit
+      - name: Run Fallow audit
         run: npm run quality:fallow:audit -- --changed-since origin/development --format compact
 
   server-tests:
@@ -393,6 +392,7 @@ jobs:
     needs:
       - changes
       - lint
+      - fallow-audit
       - type-check
       - server-tests
       - backoffice-tests
@@ -409,6 +409,7 @@ jobs:
     env:
       DOCS_ONLY: ${{ needs.changes.outputs.docs_only }}
       LINT_RESULT: ${{ needs.lint.result }}
+      FALLOW_AUDIT_RESULT: ${{ needs.fallow-audit.result }}
       TYPE_CHECK_RESULT: ${{ needs.type-check.result }}
       SERVER_TESTS_RESULT: ${{ needs.server-tests.result }}
       BACKOFFICE_TESTS_RESULT: ${{ needs.backoffice-tests.result }}
@@ -434,6 +435,7 @@ jobs:
           failures=()
 
           [[ "$LINT_RESULT" == "success" ]] || failures+=("Lint & Format: $LINT_RESULT")
+          [[ "$FALLOW_AUDIT_RESULT" == "success" ]] || failures+=("Fallow Audit: $FALLOW_AUDIT_RESULT")
           [[ "$TYPE_CHECK_RESULT" == "success" ]] || failures+=("Type Check: $TYPE_CHECK_RESULT")
           [[ "$SERVER_TESTS_RESULT" == "success" ]] || failures+=("Server Tests: $SERVER_TESTS_RESULT")
           [[ "$BACKOFFICE_TESTS_RESULT" == "success" ]] || failures+=("Backoffice Tests: $BACKOFFICE_TESTS_RESULT")

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Live runs require configured provider/database environment variables and are int
 
 ### Static code quality
 
-Fallow provides advisory unused-code, duplication, complexity, and PR audit checks:
+Fallow provides unused-code, duplication, complexity, and PR audit checks. The PR audit runs as a required new-only CI gate:
 
 ```bash
 npm run quality:fallow:audit -- --changed-since origin/development

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -8,7 +8,7 @@ title: 'CI/CD Documentation'
 
 This project uses these GitHub Actions workflow files for pull request validation and security scanning:
 
-- `.github/workflows/pr.yml` – main application and workspace checks (lint, type-check, web tests, recommendation evals, Storybook tests, e2e smoke tests, build, service CI, dependency review)
+- `.github/workflows/pr.yml` – main application and workspace checks (lint, Fallow audit, type-check, web tests, recommendation evals, Storybook tests, e2e smoke tests, build, service CI, dependency review)
 - `.github/workflows/recommendation-real-data-evals.yml` – scheduled/manual recommendation evals against a seeded database and real catalog retrieval
 - `.github/workflows/container-images.yml` – production container image builds for app and service runtimes, published to GitHub Container Registry with commit and PR provenance metadata
 - `.github/workflows/movie-discovery-ci.yml` – TypeScript compilation and tests for the `services/movie-discovery` service, triggered when files under `services/movie-discovery/` change or when `.github/workflows/movie-discovery-ci.yml` itself changes
@@ -24,7 +24,7 @@ The PR validation workflows run automatically on pull requests targeting the `de
 | ------------------------------------ | -------------------------------- | ------------------------------------------------------------------------------- |
 | `pr.yml`                             | `changes`                        | Classifies PR as docs-only vs code-changing                                     |
 | `pr.yml`                             | `lint`                           | ESLint code quality + Prettier formatting                                       |
-| `pr.yml`                             | `fallow-audit`                   | Advisory new-only Fallow audit for changed TypeScript/JavaScript quality risks  |
+| `pr.yml`                             | `fallow-audit`                   | Required new-only Fallow audit for changed TypeScript/JavaScript quality risks  |
 | `pr.yml`                             | `type-check`                     | TypeScript type safety (`tsc --noEmit`)                                         |
 | `pr.yml`                             | `server-tests`                   | Vitest server tests with coverage collection and artifact upload                |
 | `pr.yml`                             | `recommendation-evals`           | Deterministic recommendation quality fixtures and scoring                       |
@@ -81,9 +81,9 @@ Server tests run with `--coverage` via `@vitest/coverage-v8`. Coverage reports (
 ### Fallow Code Quality Audit
 
 The `fallow-audit` PR job runs `npm run quality:fallow:audit -- --changed-since origin/development --format compact`.
-It is intentionally advisory during the first rollout (`continue-on-error: true`) and is not included in the required
-`PR Validation` aggregate yet. This lets reviewers see newly introduced unused-code, duplication, and complexity
-findings while the project tunes false positives and turns high-confidence baseline findings into focused cleanup work.
+It is a required new-only gate for code-changing PRs and is included in the required
+`PR Validation` aggregate. The job fails when a changeset introduces unused-code, duplication,
+or complexity findings that Fallow reports against the changed files.
 The audit runs from the repository root, so findings can come from any npm workspace, not only `apps/web`.
 
 ### Google Fonts Build Reliability

--- a/docs/QUALITY.md
+++ b/docs/QUALITY.md
@@ -4,7 +4,7 @@ title: 'Code Quality Checks'
 
 # Code Quality Checks
 
-PopChoice uses Fallow for advisory static analysis across the TypeScript/JavaScript
+PopChoice uses Fallow for static analysis across the TypeScript/JavaScript
 monorepo. Fallow complements ESLint, TypeScript, tests, CodeQL, and dependency
 review by finding unused code, duplicate code, complexity hotspots, and
 PR-local regressions.
@@ -24,9 +24,9 @@ npm run quality:fallow:health -- --workspace @pop-choice/web --summary
 npm run quality:fallow:audit -- --changed-since origin/development
 ```
 
-The first rollout is intentionally advisory. Current `development` still has
-legacy findings, so PR review should focus on findings introduced by a changeset
-and on obvious cleanup candidates. Use `fallow audit` for PR-shaped feedback and
+The PR audit is a blocking new-only gate in CI. Current `development` still has
+legacy findings, so the gate focuses on findings introduced by a changeset rather
+than failing every inherited issue. Use `fallow audit` for PR-shaped feedback and
 the focused commands when planning cleanup work.
 
 ## Baseline Notes
@@ -44,12 +44,12 @@ The first scoped pass on `@pop-choice/web` found useful signal:
 
 Treat these numbers as orientation, not a target to clear in one PR. Track the
 rollout in [#684](https://github.com/shchilkin/PopChoice/issues/684). The
-recommended adoption path is:
+adoption path is:
 
-1. Keep the PR audit advisory while tuning false positives.
-2. Convert high-confidence findings into focused cleanup tickets.
+1. PR-local Fallow Audit runs as a required new-only CI gate.
+2. Convert high-confidence inherited findings into focused cleanup tickets.
 3. Add baselines or suppressions only when a finding is intentionally kept.
-4. Make the PR audit blocking once new-only failures are consistently low-noise.
+4. Keep broad repo-wide cleanup under focused issues instead of relaxing the gate.
 
 The repo-wide changed-code hygiene rollout is complete: PR-local Fallow Audit is
 green on the cleanup PRs, and changed-code dead-code and duplication checks are

--- a/docs/ROADMAP-ARCHITECTURE.md
+++ b/docs/ROADMAP-ARCHITECTURE.md
@@ -141,7 +141,7 @@ This is an extraction direction, not a mandate for large-scale file moves right 
 - Consolidate shared TypeScript, lint, formatting, and test conventions.
 - Reuse config packages where duplication exists across app/services.
 - Align CI checks to the new boundaries and ownership model.
-- [x] Adopt Fallow code-quality analysis in [#684](https://github.com/shchilkin/PopChoice/issues/684), starting advisory with PR-local findings before making it a required gate.
+- [x] Adopt Fallow code-quality analysis in [#684](https://github.com/shchilkin/PopChoice/issues/684), with PR-local Fallow Audit promoted to a required new-only gate.
 - [x] Extend Fallow cleanup beyond `apps/web` through [#697](https://github.com/shchilkin/PopChoice/issues/697) for backoffice/docs and [#698](https://github.com/shchilkin/PopChoice/issues/698) for shared/services.
 - [ ] Drive inherited repo-wide Fallow complexity to zero actionable findings
       through [#717](https://github.com/shchilkin/PopChoice/issues/717), split into


### PR DESCRIPTION
## Summary
- Remove advisory `continue-on-error` from the PR `fallow-audit` job.
- Include `fallow-audit` in the required `PR Validation` aggregate for code-changing PRs.
- Update README, CI/CD, quality, and roadmap docs to describe Fallow Audit as a required new-only gate.

Closes #688.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pr.yml"); puts "yaml ok"'`
- `git diff --check`
- `npm run lint:check`
- `npm run type-check`
- Pre-push: lint, server tests (73 files / 1113 tests), production build

## Fallow note
- Local direct Fallow audit was attempted with `./node_modules/.bin/fallow audit --changed-since origin/development --format json --quiet 2>/dev/null || true`, but hit the known local temp-worktree error: `could not create a temporary worktree for base ref 'origin/development'`. This PR intentionally relies on CI Fallow Audit to prove the promoted gate.
