### PR TITLE
Split recommendation eval scoring complexity

### DIFF
--- a/apps/web/src/features/recommendation/evals/scoring.ts
+++ b/apps/web/src/features/recommendation/evals/scoring.ts
@@ -11,7 +11,7 @@ import type {
   RecommendationEvalRunMode,
   RecommendationEvalSourceStrategy,
 } from './types';
-import type { ApiResponse } from '../types';
+import type { ApiResponse, CandidateSourceDistribution } from '../types';
 
 const DEFAULT_MIN_PASSING_SCORE = 85;
 const TOTAL_SCORE = 100;
@@ -20,6 +20,35 @@ const AUDIENCE_REPRESENTATION_TERMS: Record<RecommendationEvalAudience, string[]
   group: ['both', 'group'],
   solo: ['solo'],
 };
+
+type ScenarioResult = { details: string; passed: boolean };
+
+type ScoringContext = {
+  fixture: RecommendationEvalFixture;
+  mainTitle: string;
+  response: ApiResponse;
+  responseMovieTitles: string[];
+  responseText: string;
+  sourceDistribution: CandidateSourceDistribution;
+};
+
+type SourceCounts = {
+  curatedCount: number;
+  localCacheCount: number;
+  tmdbCount: number;
+  totalCount: number;
+};
+
+type CandidateValidityState = {
+  mainTitle: string;
+  mainTitleAllowed: boolean;
+  mainTitleIsCandidate: boolean;
+  minSimilarMovies: number;
+  responseMovieTitles: string[];
+  unknownCandidateTitles: string[];
+};
+
+type CandidateSourceKey = keyof NonNullable<CandidateSourceDistribution>;
 
 function normalizeText(value: string): string {
   return value.toLocaleLowerCase('en-US').replace(/\s+/g, ' ').trim();
@@ -71,179 +100,8 @@ export function scoreRecommendationEvalFixture(
   response: ApiResponse,
   mode: RecommendationEvalRunMode = 'mock',
 ): RecommendationEvalResult {
-  const checks: RecommendationEvalCheck[] = [];
-  const parsed = apiResponseSchema.safeParse(response);
-  checks.push(
-    buildCheck(
-      'output-shape',
-      'Output shape',
-      20,
-      parsed.success,
-      parsed.success
-        ? 'Response matches the ApiResponse schema.'
-        : parsed.error.issues
-            .map((issue) => `${issue.path.join('.')}: ${issue.message}`)
-            .join('; '),
-    ),
-  );
-
-  const candidateTitles = new Set(fixture.candidates.map((movie) => normalizeTitle(movie.name)));
-  const allowedMainTitles = new Set(
-    fixture.expectations.allowedMainTitles.map((title) => normalizeTitle(title)),
-  );
-  const responseMovieTitles =
-    response.similarMovies?.map((movie) => normalizeTitle(movie.name)) ?? [];
-  const mainTitle = normalizeTitle(getMainRecommendationTitle(response));
-  const unknownCandidateTitles = responseMovieTitles.filter((title) => !candidateTitles.has(title));
-  const minSimilarMovies = fixture.expectations.minSimilarMovies ?? 1;
-  const candidateValidityPassed =
-    allowedMainTitles.has(mainTitle) &&
-    candidateTitles.has(mainTitle) &&
-    unknownCandidateTitles.length === 0 &&
-    responseMovieTitles.length >= minSimilarMovies;
-  checks.push(
-    buildCheck(
-      'candidate-validity',
-      'Candidate validity',
-      25,
-      candidateValidityPassed,
-      candidateValidityPassed
-        ? 'Main pick and alternates come from the fixture candidate set.'
-        : [
-            allowedMainTitles.has(mainTitle) ? null : `main title "${mainTitle}" is not allowed`,
-            candidateTitles.has(mainTitle) ? null : `main title "${mainTitle}" is not a candidate`,
-            unknownCandidateTitles.length === 0
-              ? null
-              : `unknown candidates: ${unknownCandidateTitles.join(', ')}`,
-            responseMovieTitles.length >= minSimilarMovies
-              ? null
-              : `expected at least ${minSimilarMovies} similar movies`,
-          ]
-            .filter((detail): detail is string => typeof detail === 'string')
-            .join('; '),
-    ),
-  );
-
-  const responseText = collectResponseText(response);
-  const forbiddenTerms = fixture.expectations.forbiddenTerms ?? [];
-  const foundForbiddenTerms = forbiddenTerms.filter((term) =>
-    responseText.includes(normalizeText(term)),
-  );
-  checks.push(
-    buildCheck(
-      'safety-constraints',
-      'Safety constraints',
-      20,
-      foundForbiddenTerms.length === 0,
-      foundForbiddenTerms.length === 0
-        ? 'No forbidden safety terms were found in the response.'
-        : `Found forbidden terms: ${foundForbiddenTerms.join(', ')}`,
-    ),
-  );
-
-  const forbiddenTitleKeys = new Set(
-    [
-      ...(fixture.expectations.forbiddenTitles ?? []).map((title) => normalizeTitle(title)),
-      ...fixture.userMemories
-        .filter((memory) => memory.kind !== 'liked')
-        .map((memory) => normalizeTitle(memory.movieName, memory.movieYear)),
-      ...fixture.userMemories
-        .filter((memory) => memory.kind !== 'liked')
-        .map((memory) => normalizeTitle(memory.movieName)),
-    ].filter((title) => title.length > 0),
-  );
-  const repeatedTitles = [
-    normalizeTitle(response.title),
-    ...responseMovieTitles,
-    ...(response.similarMovies?.map((movie) => normalizeTitle(movie.name, movie.year)) ?? []),
-  ].filter((title) => forbiddenTitleKeys.has(title));
-  checks.push(
-    buildCheck(
-      'repeat-avoidance',
-      'Repeat avoidance',
-      20,
-      repeatedTitles.length === 0,
-      repeatedTitles.length === 0
-        ? 'Response avoids watched, rejected, and explicitly forbidden titles.'
-        : `Repeated forbidden titles: ${Array.from(new Set(repeatedTitles)).join(', ')}`,
-    ),
-  );
-
-  const minDescriptionCharacters = fixture.expectations.minDescriptionCharacters ?? 60;
-  const requiredTerms = fixture.expectations.requiredExplanationTerms ?? [];
-  const missingExplanationTerms = requiredTerms.filter(
-    (term) => !responseText.includes(normalizeText(term)),
-  );
-  const explanationQualityPassed =
-    response.description.trim().length >= minDescriptionCharacters &&
-    missingExplanationTerms.length === 0;
-  checks.push(
-    buildCheck(
-      'explanation-quality',
-      'Explanation quality',
-      15,
-      explanationQualityPassed,
-      explanationQualityPassed
-        ? 'Explanation is specific enough for the fixture expectations.'
-        : [
-            response.description.trim().length >= minDescriptionCharacters
-              ? null
-              : `description is shorter than ${minDescriptionCharacters} characters`,
-            missingExplanationTerms.length === 0
-              ? null
-              : `missing terms: ${missingExplanationTerms.join(', ')}`,
-          ]
-            .filter((detail): detail is string => typeof detail === 'string')
-            .join('; '),
-    ),
-  );
-
-  const audienceTerms = AUDIENCE_REPRESENTATION_TERMS[fixture.audience];
-  checks.push(
-    buildCheck(
-      'scenario-audience-representation',
-      'Scenario audience representation',
-      0,
-      textIncludesAnyTerm(responseText, audienceTerms),
-      textIncludesAnyTerm(responseText, audienceTerms)
-        ? `Response represents the ${fixture.audience} audience.`
-        : `Expected response text to include one of: ${audienceTerms.join(', ')}`,
-    ),
-  );
-
-  const depthResult = getScenarioDepthResult(fixture.depth, fixture, response, responseText);
-  checks.push(
-    buildCheck(
-      'scenario-depth-representation',
-      'Scenario depth representation',
-      0,
-      depthResult.passed,
-      depthResult.details,
-    ),
-  );
-
-  const sourceResult = getScenarioSourceStrategyResult(fixture.sourceStrategy, response);
-  checks.push(
-    buildCheck(
-      'scenario-source-strategy-representation',
-      'Scenario source strategy representation',
-      0,
-      sourceResult.passed,
-      sourceResult.details,
-    ),
-  );
-
-  const qualityThresholdResult = getQualityThresholdResult(fixture, response);
-  checks.push(
-    buildCheck(
-      'scenario-quality-thresholds',
-      'Scenario quality thresholds',
-      0,
-      qualityThresholdResult.passed,
-      qualityThresholdResult.details,
-    ),
-  );
-
+  const context = buildScoringContext(fixture, response);
+  const checks = buildRecommendationEvalChecks(context);
   const score = checks.reduce((sum, check) => sum + check.score, 0);
   const minPassingScore = fixture.expectations.minPassingScore ?? DEFAULT_MIN_PASSING_SCORE;
 
@@ -256,43 +114,311 @@ export function scoreRecommendationEvalFixture(
     mode,
     passed: score >= minPassingScore && checks.every((check) => check.passed),
     score,
-    sourceDistribution:
-      response.candidateSourceDistribution ?? summarizeCandidateSources(response.similarMovies),
+    sourceDistribution: context.sourceDistribution,
   };
 }
 
-function getScenarioDepthResult(
-  depth: RecommendationEvalDepth,
+function buildScoringContext(
   fixture: RecommendationEvalFixture,
   response: ApiResponse,
-  responseText: string,
-): { details: string; passed: boolean } {
+): ScoringContext {
+  return {
+    fixture,
+    mainTitle: normalizeTitle(getMainRecommendationTitle(response)),
+    response,
+    responseMovieTitles: response.similarMovies?.map((movie) => normalizeTitle(movie.name)) ?? [],
+    responseText: collectResponseText(response),
+    sourceDistribution: getResponseSourceDistribution(response),
+  };
+}
+
+function getResponseSourceDistribution(response: ApiResponse): CandidateSourceDistribution {
+  return response.candidateSourceDistribution ?? summarizeCandidateSources(response.similarMovies);
+}
+
+function buildRecommendationEvalChecks(context: ScoringContext): RecommendationEvalCheck[] {
+  return [
+    buildOutputShapeCheck(context.response),
+    buildCandidateValidityCheck(context),
+    buildSafetyConstraintsCheck(context),
+    buildRepeatAvoidanceCheck(context),
+    buildExplanationQualityCheck(context),
+    buildScenarioAudienceCheck(context),
+    buildScenarioDepthCheck(context),
+    buildScenarioSourceStrategyCheck(context),
+    buildQualityThresholdCheck(context),
+  ];
+}
+
+function buildOutputShapeCheck(response: ApiResponse): RecommendationEvalCheck {
+  const parsed = apiResponseSchema.safeParse(response);
+
+  return buildCheck(
+    'output-shape',
+    'Output shape',
+    20,
+    parsed.success,
+    parsed.success
+      ? 'Response matches the ApiResponse schema.'
+      : parsed.error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`).join('; '),
+  );
+}
+
+function buildCandidateValidityCheck({
+  fixture,
+  mainTitle,
+  responseMovieTitles,
+}: ScoringContext): RecommendationEvalCheck {
+  const state = getCandidateValidityState({ fixture, mainTitle, responseMovieTitles });
+  const passed = isCandidateValidityPassed(state);
+
+  return buildCheck(
+    'candidate-validity',
+    'Candidate validity',
+    25,
+    passed,
+    passed
+      ? 'Main pick and alternates come from the fixture candidate set.'
+      : getCandidateValidityFailureDetails(state),
+  );
+}
+
+function getCandidateValidityState({
+  fixture,
+  mainTitle,
+  responseMovieTitles,
+}: {
+  fixture: RecommendationEvalFixture;
+  mainTitle: string;
+  responseMovieTitles: string[];
+}): CandidateValidityState {
+  const candidateTitles = new Set(fixture.candidates.map((movie) => normalizeTitle(movie.name)));
+  const allowedMainTitles = new Set(
+    fixture.expectations.allowedMainTitles.map((title) => normalizeTitle(title)),
+  );
+
+  return {
+    mainTitle,
+    mainTitleAllowed: allowedMainTitles.has(mainTitle),
+    mainTitleIsCandidate: candidateTitles.has(mainTitle),
+    minSimilarMovies: fixture.expectations.minSimilarMovies ?? 1,
+    responseMovieTitles,
+    unknownCandidateTitles: responseMovieTitles.filter((title) => !candidateTitles.has(title)),
+  };
+}
+
+function isCandidateValidityPassed(state: CandidateValidityState): boolean {
+  return (
+    state.mainTitleAllowed &&
+    state.mainTitleIsCandidate &&
+    state.unknownCandidateTitles.length === 0 &&
+    state.responseMovieTitles.length >= state.minSimilarMovies
+  );
+}
+
+function getCandidateValidityFailureDetails(state: CandidateValidityState): string {
+  const details: string[] = [];
+
+  if (!state.mainTitleAllowed) details.push(`main title "${state.mainTitle}" is not allowed`);
+  if (!state.mainTitleIsCandidate) {
+    details.push(`main title "${state.mainTitle}" is not a candidate`);
+  }
+  if (state.unknownCandidateTitles.length > 0) {
+    details.push(`unknown candidates: ${state.unknownCandidateTitles.join(', ')}`);
+  }
+  if (state.responseMovieTitles.length < state.minSimilarMovies) {
+    details.push(`expected at least ${state.minSimilarMovies} similar movies`);
+  }
+
+  return details.join('; ');
+}
+
+function buildSafetyConstraintsCheck({
+  fixture,
+  responseText,
+}: ScoringContext): RecommendationEvalCheck {
+  const forbiddenTerms = fixture.expectations.forbiddenTerms ?? [];
+  const foundForbiddenTerms = forbiddenTerms.filter((term) =>
+    responseText.includes(normalizeText(term)),
+  );
+
+  return buildCheck(
+    'safety-constraints',
+    'Safety constraints',
+    20,
+    foundForbiddenTerms.length === 0,
+    foundForbiddenTerms.length === 0
+      ? 'No forbidden safety terms were found in the response.'
+      : `Found forbidden terms: ${foundForbiddenTerms.join(', ')}`,
+  );
+}
+
+function buildRepeatAvoidanceCheck({
+  fixture,
+  response,
+  responseMovieTitles,
+}: ScoringContext): RecommendationEvalCheck {
+  const forbiddenTitleKeys = getForbiddenTitleKeys(fixture);
+  const repeatedTitles = [
+    normalizeTitle(response.title),
+    ...responseMovieTitles,
+    ...(response.similarMovies?.map((movie) => normalizeTitle(movie.name, movie.year)) ?? []),
+  ].filter((title) => forbiddenTitleKeys.has(title));
+
+  return buildCheck(
+    'repeat-avoidance',
+    'Repeat avoidance',
+    20,
+    repeatedTitles.length === 0,
+    repeatedTitles.length === 0
+      ? 'Response avoids watched, rejected, and explicitly forbidden titles.'
+      : `Repeated forbidden titles: ${Array.from(new Set(repeatedTitles)).join(', ')}`,
+  );
+}
+
+function getForbiddenTitleKeys(fixture: RecommendationEvalFixture): Set<string> {
+  const nonLikedMemories = fixture.userMemories.filter((memory) => memory.kind !== 'liked');
+  const forbiddenTitles = [
+    ...(fixture.expectations.forbiddenTitles ?? []).map((title) => normalizeTitle(title)),
+    ...nonLikedMemories.map((memory) => normalizeTitle(memory.movieName, memory.movieYear)),
+    ...nonLikedMemories.map((memory) => normalizeTitle(memory.movieName)),
+  ].filter((title) => title.length > 0);
+
+  return new Set(forbiddenTitles);
+}
+
+function buildExplanationQualityCheck({
+  fixture,
+  response,
+  responseText,
+}: ScoringContext): RecommendationEvalCheck {
   const minDescriptionCharacters = fixture.expectations.minDescriptionCharacters ?? 60;
+  const requiredTerms = fixture.expectations.requiredExplanationTerms ?? [];
+  const missingExplanationTerms = requiredTerms.filter(
+    (term) => !responseText.includes(normalizeText(term)),
+  );
+  const explanationQualityPassed =
+    response.description.trim().length >= minDescriptionCharacters &&
+    missingExplanationTerms.length === 0;
 
-  if (depth === 'focused') {
-    const minSimilarMovies = fixture.expectations.minSimilarMovies ?? 1;
-    const passed =
-      response.description.trim().length >= minDescriptionCharacters &&
-      (response.similarMovies?.length ?? 0) >= minSimilarMovies;
-    return {
-      details: passed
-        ? 'Focused scenario includes a concise rationale and enough ranked candidates.'
-        : `Expected description of at least ${minDescriptionCharacters} characters and ${minSimilarMovies} similar movies.`,
-      passed,
-    };
-  }
+  return buildCheck(
+    'explanation-quality',
+    'Explanation quality',
+    15,
+    explanationQualityPassed,
+    explanationQualityPassed
+      ? 'Explanation is specific enough for the fixture expectations.'
+      : joinFailureDetails([
+          response.description.trim().length >= minDescriptionCharacters
+            ? null
+            : `description is shorter than ${minDescriptionCharacters} characters`,
+          missingExplanationTerms.length === 0
+            ? null
+            : `missing terms: ${missingExplanationTerms.join(', ')}`,
+        ]),
+  );
+}
 
-  if (depth === 'memory-aware') {
-    const passed = responseText.includes('avoid');
-    return {
-      details: passed
-        ? 'Memory-aware scenario explicitly acknowledges repeat avoidance.'
-        : 'Expected memory-aware response text to mention avoiding repeat or rejected movies.',
-      passed,
-    };
-  }
+function buildScenarioAudienceCheck({
+  fixture,
+  responseText,
+}: ScoringContext): RecommendationEvalCheck {
+  const audienceTerms = AUDIENCE_REPRESENTATION_TERMS[fixture.audience];
+  const passed = textIncludesAnyTerm(responseText, audienceTerms);
 
+  return buildCheck(
+    'scenario-audience-representation',
+    'Scenario audience representation',
+    0,
+    passed,
+    passed
+      ? `Response represents the ${fixture.audience} audience.`
+      : `Expected response text to include one of: ${audienceTerms.join(', ')}`,
+  );
+}
+
+function buildScenarioDepthCheck(context: ScoringContext): RecommendationEvalCheck {
+  const depthResult = getScenarioDepthResult(context);
+
+  return buildCheck(
+    'scenario-depth-representation',
+    'Scenario depth representation',
+    0,
+    depthResult.passed,
+    depthResult.details,
+  );
+}
+
+function buildScenarioSourceStrategyCheck(context: ScoringContext): RecommendationEvalCheck {
+  const sourceResult = getScenarioSourceStrategyResult(context);
+
+  return buildCheck(
+    'scenario-source-strategy-representation',
+    'Scenario source strategy representation',
+    0,
+    sourceResult.passed,
+    sourceResult.details,
+  );
+}
+
+function buildQualityThresholdCheck(context: ScoringContext): RecommendationEvalCheck {
+  const qualityThresholdResult = getQualityThresholdResult(context);
+
+  return buildCheck(
+    'scenario-quality-thresholds',
+    'Scenario quality thresholds',
+    0,
+    qualityThresholdResult.passed,
+    qualityThresholdResult.details,
+  );
+}
+
+function joinFailureDetails(details: Array<string | null>): string {
+  return details.filter((detail): detail is string => typeof detail === 'string').join('; ');
+}
+
+const DEPTH_RESULT_BUILDERS: Record<
+  RecommendationEvalDepth,
+  (context: ScoringContext) => ScenarioResult
+> = {
+  compromise: getCompromiseDepthResult,
+  focused: getFocusedDepthResult,
+  'memory-aware': getMemoryAwareDepthResult,
+};
+
+function getScenarioDepthResult(context: ScoringContext): ScenarioResult {
+  return DEPTH_RESULT_BUILDERS[context.fixture.depth](context);
+}
+
+function getFocusedDepthResult({ fixture, response }: ScoringContext): ScenarioResult {
+  const minDescriptionCharacters = fixture.expectations.minDescriptionCharacters ?? 60;
+  const minSimilarMovies = fixture.expectations.minSimilarMovies ?? 1;
+  const passed =
+    response.description.trim().length >= minDescriptionCharacters &&
+    (response.similarMovies?.length ?? 0) >= minSimilarMovies;
+
+  return {
+    details: passed
+      ? 'Focused scenario includes a concise rationale and enough ranked candidates.'
+      : `Expected description of at least ${minDescriptionCharacters} characters and ${minSimilarMovies} similar movies.`,
+    passed,
+  };
+}
+
+function getMemoryAwareDepthResult({ responseText }: ScoringContext): ScenarioResult {
+  const passed = responseText.includes('avoid');
+
+  return {
+    details: passed
+      ? 'Memory-aware scenario explicitly acknowledges repeat avoidance.'
+      : 'Expected memory-aware response text to mention avoiding repeat or rejected movies.',
+    passed,
+  };
+}
+
+function getCompromiseDepthResult({ responseText }: ScoringContext): ScenarioResult {
   const passed = responseText.includes('both');
+
   return {
     details: passed
       ? 'Compromise scenario explains the pick in terms of both viewers.'
@@ -301,40 +427,79 @@ function getScenarioDepthResult(
   };
 }
 
-function getScenarioSourceStrategyResult(
-  sourceStrategy: RecommendationEvalSourceStrategy,
-  response: ApiResponse,
-): { details: string; passed: boolean } {
-  const distribution =
-    response.candidateSourceDistribution ?? summarizeCandidateSources(response.similarMovies);
-  const curatedCount = distribution?.curated ?? 0;
-  const localCacheCount = distribution?.['local-cache'] ?? 0;
-  const tmdbCount = (distribution?.['tmdb-discover'] ?? 0) + (distribution?.['tmdb-search'] ?? 0);
-  const totalCount = Object.values(distribution ?? {}).reduce((sum, count) => sum + count, 0);
+const SOURCE_STRATEGY_RESULT_BUILDERS: Record<
+  RecommendationEvalSourceStrategy,
+  (context: ScoringContext, counts: SourceCounts) => ScenarioResult
+> = {
+  'curated-showcase': getCuratedShowcaseSourceResult,
+  'hybrid-fast': getHybridFastSourceResult,
+  'tmdb-first': getTMDBFirstSourceResult,
+};
 
-  if (sourceStrategy === 'curated-showcase') {
-    const passed =
-      totalCount > 0 && curatedCount === totalCount && response.usedBroaderSearch !== true;
-    return {
-      details: passed
-        ? 'Result stays within curated showcase candidates.'
-        : 'Expected curated-only candidates without TMDB broadening.',
-      passed,
-    };
-  }
+function getScenarioSourceStrategyResult(context: ScoringContext): ScenarioResult {
+  return SOURCE_STRATEGY_RESULT_BUILDERS[context.fixture.sourceStrategy](
+    context,
+    getSourceCounts(context.sourceDistribution),
+  );
+}
 
-  if (sourceStrategy === 'hybrid-fast') {
-    const passed =
-      localCacheCount + curatedCount > 0 && tmdbCount > 0 && response.usedBroaderSearch === true;
-    return {
-      details: passed
-        ? 'Result mixes local/cache candidates with bounded TMDB fallback candidates.'
-        : 'Expected a hybrid source mix with local/cache candidates and TMDB fallback candidates.',
-      passed,
-    };
-  }
+function getSourceCounts(distribution: CandidateSourceDistribution): SourceCounts {
+  const curatedCount = getSourceCount(distribution, 'curated');
+  const localCacheCount = getSourceCount(distribution, 'local-cache');
+  const tmdbCount =
+    getSourceCount(distribution, 'tmdb-discover') + getSourceCount(distribution, 'tmdb-search');
 
+  return {
+    curatedCount,
+    localCacheCount,
+    tmdbCount,
+    totalCount: Object.values(distribution ?? {}).reduce((sum, count) => sum + count, 0),
+  };
+}
+
+function getSourceCount(
+  distribution: CandidateSourceDistribution,
+  source: CandidateSourceKey,
+): number {
+  return distribution?.[source] ?? 0;
+}
+
+function getCuratedShowcaseSourceResult(
+  { response }: ScoringContext,
+  { curatedCount, totalCount }: SourceCounts,
+): ScenarioResult {
+  const passed =
+    totalCount > 0 && curatedCount === totalCount && response.usedBroaderSearch !== true;
+
+  return {
+    details: passed
+      ? 'Result stays within curated showcase candidates.'
+      : 'Expected curated-only candidates without TMDB broadening.',
+    passed,
+  };
+}
+
+function getHybridFastSourceResult(
+  { response }: ScoringContext,
+  { curatedCount, localCacheCount, tmdbCount }: SourceCounts,
+): ScenarioResult {
+  const passed =
+    localCacheCount + curatedCount > 0 && tmdbCount > 0 && response.usedBroaderSearch === true;
+
+  return {
+    details: passed
+      ? 'Result mixes local/cache candidates with bounded TMDB fallback candidates.'
+      : 'Expected a hybrid source mix with local/cache candidates and TMDB fallback candidates.',
+    passed,
+  };
+}
+
+function getTMDBFirstSourceResult(
+  _context: ScoringContext,
+  { curatedCount, localCacheCount, tmdbCount }: SourceCounts,
+): ScenarioResult {
   const passed = tmdbCount > 0 && tmdbCount >= localCacheCount + curatedCount;
+
   return {
     details: passed
       ? 'Result prioritizes TMDB discovery/search candidates.'
@@ -343,15 +508,14 @@ function getScenarioSourceStrategyResult(
   };
 }
 
-function getQualityThresholdResult(
-  fixture: RecommendationEvalFixture,
-  response: ApiResponse,
-): { details: string; passed: boolean } {
-  const distribution =
-    response.candidateSourceDistribution ?? summarizeCandidateSources(response.similarMovies);
+function getQualityThresholdResult({
+  fixture,
+  response,
+  sourceDistribution,
+}: ScoringContext): ScenarioResult {
   const minSources = fixture.expectations.minCandidateSources ?? {};
   const missingSourceThresholds = Object.entries(minSources).flatMap(([source, minCount]) => {
-    const actualCount = distribution?.[source as keyof typeof distribution] ?? 0;
+    const actualCount = sourceDistribution?.[source as keyof typeof sourceDistribution] ?? 0;
     return actualCount >= minCount
       ? []
       : [`${source}: expected at least ${minCount}, got ${actualCount}`];


### PR DESCRIPTION
## Summary
- Split `scoreRecommendationEvalFixture` into small check builders for output shape, candidate validity, safety, repeat avoidance, explanation quality, scenario metadata, and thresholds.
- Replace depth/source strategy branching with typed strategy maps and focused helper functions.
- Preserve the public scoring API, 100-point score distribution, scenario hard gates, source distribution fallback, and report aggregation behavior.

Closes #721.

## Fallow
- Before: `apps/web/src/features/recommendation/evals/scoring.ts` had findings for `scoreRecommendationEvalFixture`, `getScenarioSourceStrategyResult`, and `getScenarioDepthResult`.
- After: `apps/web/src/features/recommendation/evals/scoring.ts` has 0 Fallow health findings.
- Repo health count moved from 152 to 149.
- Changed-code dead-code and dupes are clean.
- Local changed-code audit still hits the known temp-worktree issue: `could not create a temporary worktree for base ref 'origin/development'`; CI Fallow Audit is the authoritative gate.

## Verification
- `npm run test --workspace=apps/web -- src/features/recommendation/evals/scoring.test.ts src/features/recommendation/evals/runner.test.ts` (2 files / 12 tests)
- `npm run type-check --workspace=apps/web`
- `npm run lint:check`
- `npm run eval:recommendations` (27/27 passed after rerun outside sandbox; first run hit local tsx IPC EPERM)
- `git diff --check`
- Pre-push: lint, server tests (73 files / 1113 tests), production build
