### PR TITLE
Split backoffice repair submit flow

### DIFF
--- a/apps/backoffice/src/components/catalogRepairEnhancement.test.ts
+++ b/apps/backoffice/src/components/catalogRepairEnhancement.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { formActionUrl } from './catalogRepairEnhancement';
+import {
+  acceptedRepairMessage,
+  formActionUrl,
+  orchestrationAcceptedMessage,
+  partialRepairMessage,
+} from './catalogRepairEnhancement';
 
 describe('formActionUrl', () => {
   it('uses the action attribute instead of the clobberable form.action property', () => {
@@ -21,6 +26,32 @@ describe('formActionUrl', () => {
 
     expect(formActionUrl(form, 'https://backoffice.pop-choice.shchilkin.dev/catalog')).toBe(
       'https://backoffice.pop-choice.shchilkin.dev/catalog',
+    );
+  });
+});
+
+describe('repair status messages', () => {
+  it('keeps accepted messages aligned with single and bulk repair statuses', () => {
+    expect(acceptedRepairMessage({ status: 'queued' })).toBe('Accepted for worker');
+    expect(acceptedRepairMessage({ status: 'deduped' })).toBe('Already queued for worker');
+    expect(
+      acceptedRepairMessage({
+        mode: 'bulk',
+        status: 'queued',
+        summary: { deduped: 2, queued: 5 },
+      }),
+    ).toBe('Accepted 5, already queued 2');
+  });
+
+  it('keeps orchestration and partial repair summaries stable', () => {
+    expect(orchestrationAcceptedMessage({ batchId: 'batch-123' })).toBe(
+      'Batch batch-123 accepted. Worker will queue jobs in chunks.',
+    );
+    expect(orchestrationAcceptedMessage(undefined)).toBe(
+      'Batch accepted. Worker will queue jobs in chunks.',
+    );
+    expect(partialRepairMessage({ deduped: 2, failed: 3, queued: 1, unavailable: 4 })).toBe(
+      'Partial: queued 1, deduped 2, failed 3, unavailable 4',
     );
   });
 });

--- a/apps/backoffice/src/components/catalogRepairEnhancement.test.ts
+++ b/apps/backoffice/src/components/catalogRepairEnhancement.test.ts
@@ -1,11 +1,105 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { requestCatalogHealthRefresh } from './catalogHealthRefreshEvent';
 
 import {
   acceptedRepairMessage,
+  beginRepairSubmission,
   formActionUrl,
+  handleRepairResponse,
   orchestrationAcceptedMessage,
   partialRepairMessage,
 } from './catalogRepairEnhancement';
+
+vi.mock('./catalogHealthRefreshEvent', () => ({
+  requestCatalogHealthRefresh: vi.fn(),
+}));
+
+class FakeClassList {
+  private readonly values = new Set<string>();
+
+  add(value: string): void {
+    this.values.add(value);
+  }
+
+  contains(value: string): boolean {
+    return this.values.has(value);
+  }
+
+  remove(value: string): void {
+    this.values.delete(value);
+  }
+
+  toggle(value: string, force?: boolean): void {
+    if (force) {
+      this.add(value);
+      return;
+    }
+
+    this.remove(value);
+  }
+}
+
+type FakeRepairDom = {
+  body: { appendChild: ReturnType<typeof vi.fn>; querySelector: ReturnType<typeof vi.fn> };
+  button: { disabled: boolean; textContent: string };
+  form: HTMLFormElement;
+  message: { classList: FakeClassList; textContent: string };
+  row: {
+    classList: FakeClassList;
+    parentElement: FakeRepairDom['body'];
+    remove: ReturnType<typeof vi.fn>;
+    cells: unknown[];
+  };
+};
+
+function createFakeElement() {
+  return {
+    appendChild: vi.fn(),
+    className: '',
+    colSpan: 0,
+    textContent: '',
+  };
+}
+
+function createRepairDom(buttonText = 'Queue backfill'): FakeRepairDom {
+  const button = { disabled: false, textContent: buttonText };
+  const message = { classList: new FakeClassList(), textContent: '' };
+  const body = { appendChild: vi.fn(), querySelector: vi.fn(() => null) };
+  const row = {
+    cells: [{}],
+    classList: new FakeClassList(),
+    parentElement: body,
+    remove: vi.fn(),
+  };
+  const form = {
+    closest: vi.fn(() => row),
+    querySelector: vi.fn((selector: string) => {
+      if (selector === '[data-repair-submit]') return button;
+      if (selector === '[data-repair-message]') return message;
+      return null;
+    }),
+  } as unknown as HTMLFormElement;
+
+  return { body, button, form, message, row };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.mocked(requestCatalogHealthRefresh).mockClear();
+  vi.stubGlobal('window', {
+    clearTimeout: globalThis.clearTimeout,
+    setTimeout: globalThis.setTimeout,
+  });
+  vi.stubGlobal('document', {
+    createElement: vi.fn(() => createFakeElement()),
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
 
 describe('formActionUrl', () => {
   it('uses the action attribute instead of the clobberable form.action property', () => {
@@ -27,6 +121,79 @@ describe('formActionUrl', () => {
     expect(formActionUrl(form, 'https://backoffice.pop-choice.shchilkin.dev/catalog')).toBe(
       'https://backoffice.pop-choice.shchilkin.dev/catalog',
     );
+  });
+});
+
+describe('repair response side effects', () => {
+  it('accepts queued repairs and removes the row after the settle delay', async () => {
+    const dom = createRepairDom();
+    const timeouts: number[] = [];
+    const state = beginRepairSubmission(dom.form);
+
+    expect(dom.button).toMatchObject({ disabled: true, textContent: 'Queueing...' });
+    expect(dom.row.classList.contains('repair-pending')).toBe(true);
+
+    handleRepairResponse(state, { ok: true, payload: { status: 'queued' } }, timeouts);
+
+    expect(requestCatalogHealthRefresh).toHaveBeenCalledOnce();
+    expect(dom.button).toMatchObject({ disabled: true, textContent: 'Accepted' });
+    expect(dom.message).toMatchObject({ textContent: 'Accepted for worker' });
+    expect(dom.message.classList.contains('accepted')).toBe(true);
+    expect(dom.row.classList.contains('repair-accepted')).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(450);
+
+    expect(dom.row.remove).toHaveBeenCalledOnce();
+    expect(dom.body.appendChild).toHaveBeenCalledOnce();
+    expect(timeouts).toHaveLength(1);
+  });
+
+  it('restores partial repairs to the original submit state', () => {
+    const dom = createRepairDom('Retry repair');
+    const state = beginRepairSubmission(dom.form);
+
+    handleRepairResponse(
+      state,
+      {
+        ok: true,
+        payload: {
+          status: 'partial',
+          summary: { deduped: 2, failed: 3, queued: 1, unavailable: 4 },
+        },
+      },
+      [],
+    );
+
+    expect(requestCatalogHealthRefresh).toHaveBeenCalledOnce();
+    expect(dom.button).toMatchObject({ disabled: false, textContent: 'Retry repair' });
+    expect(dom.message).toMatchObject({
+      textContent: 'Partial: queued 1, deduped 2, failed 3, unavailable 4',
+    });
+    expect(dom.message.classList.contains('warn')).toBe(true);
+  });
+
+  it('accepts orchestration repair batches without removing the row', () => {
+    const dom = createRepairDom();
+    const state = beginRepairSubmission(dom.form);
+
+    handleRepairResponse(
+      state,
+      {
+        ok: true,
+        payload: { status: 'orchestration_queued', summary: { batchId: 'batch-123' } },
+      },
+      [],
+    );
+
+    expect(requestCatalogHealthRefresh).toHaveBeenCalledOnce();
+    expect(dom.button).toMatchObject({
+      disabled: true,
+      textContent: 'Orchestration accepted',
+    });
+    expect(dom.message).toMatchObject({
+      textContent: 'Batch batch-123 accepted. Worker will queue jobs in chunks.',
+    });
+    expect(dom.row.remove).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/backoffice/src/components/catalogRepairEnhancement.tsx
+++ b/apps/backoffice/src/components/catalogRepairEnhancement.tsx
@@ -6,6 +6,38 @@ import { requestCatalogHealthRefresh } from './catalogHealthRefreshEvent';
 
 type RepairTone = '' | 'accepted' | 'good' | 'warn';
 
+type RepairSummary = {
+  batchId?: string;
+  queued?: number;
+  deduped?: number;
+  failed?: number;
+  unavailable?: number;
+};
+
+type RepairPayload = {
+  message?: string;
+  mode?: string;
+  status?: string;
+  summary?: RepairSummary;
+};
+
+type RepairResponse = {
+  ok: boolean;
+  payload: RepairPayload | null;
+};
+
+type RepairSubmissionState = {
+  form: HTMLFormElement;
+  originalText: string;
+  row: HTMLTableRowElement | null;
+};
+
+type RepairStatusHandler = (
+  state: RepairSubmissionState,
+  payload: RepairPayload,
+  timeouts: number[],
+) => void;
+
 function setMessage(form: HTMLFormElement, text: string, tone: RepairTone): void {
   const message = form.querySelector<HTMLElement>('[data-repair-message]');
   if (!message) return;
@@ -93,6 +125,145 @@ function formBody(form: HTMLFormElement): URLSearchParams {
   return body;
 }
 
+function confirmInlineSubmission(form: HTMLFormElement): boolean {
+  const confirmMessage = form.dataset.confirmMessage;
+  if (confirmMessage && form.dataset.confirmed !== 'true') {
+    showInlineConfirmation(form, confirmMessage);
+    setMessage(form, 'Confirm this batch in-place to continue.', 'warn');
+    return false;
+  }
+
+  delete form.dataset.confirmed;
+  removeInlineConfirmation(form);
+  return true;
+}
+
+function submitButtonText(form: HTMLFormElement): string {
+  return form.querySelector('[data-repair-submit]')?.textContent || 'Queue backfill';
+}
+
+function beginRepairSubmission(form: HTMLFormElement): RepairSubmissionState {
+  const state = {
+    form,
+    originalText: submitButtonText(form),
+    row: form.closest<HTMLTableRowElement>('[data-repair-row]'),
+  };
+
+  state.row?.classList.add('repair-pending');
+  setButton(form, 'Queueing...', true);
+  setMessage(form, 'Queueing...', '');
+  return state;
+}
+
+async function readRepairPayload(response: Response): Promise<RepairPayload | null> {
+  return (await response.json().catch(() => null)) as RepairPayload | null;
+}
+
+async function postRepairSubmission(form: HTMLFormElement): Promise<RepairResponse> {
+  const response = await fetch(formActionUrl(form), {
+    body: formBody(form),
+    headers: { Accept: 'application/json', 'X-Requested-With': 'fetch' },
+    method: 'POST',
+  });
+
+  return {
+    ok: response.ok,
+    payload: await readRepairPayload(response),
+  };
+}
+
+function clearPending(state: RepairSubmissionState): void {
+  state.row?.classList.remove('repair-pending');
+}
+
+function restoreRepairForm(state: RepairSubmissionState, message: string): void {
+  clearPending(state);
+  setButton(state.form, state.originalText, false);
+  setMessage(state.form, message, 'warn');
+}
+
+export function acceptedRepairMessage(payload: RepairPayload): string {
+  const bulkSummary = payload.mode === 'bulk' ? payload.summary : null;
+  if (bulkSummary) {
+    return `Accepted ${bulkSummary.queued ?? 0}, already queued ${bulkSummary.deduped ?? 0}`;
+  }
+
+  return payload.status === 'deduped' ? 'Already queued for worker' : 'Accepted for worker';
+}
+
+function scheduleAcceptedRowRemoval(row: HTMLTableRowElement | null, timeouts: number[]): void {
+  if (!row) return;
+
+  const timeoutId = window.setTimeout(() => {
+    const body = row.parentElement;
+    const columnCount = row.cells.length;
+    row.remove();
+    appendEmptyPlaceholder(body, columnCount);
+  }, 450);
+  timeouts.push(timeoutId);
+}
+
+function handleQueuedOrDedupedRepair(
+  state: RepairSubmissionState,
+  payload: RepairPayload,
+  timeouts: number[],
+): void {
+  requestCatalogHealthRefresh();
+  clearPending(state);
+  state.row?.classList.add('repair-accepted');
+  setButton(state.form, payload.status === 'deduped' ? 'Already queued' : 'Accepted', true);
+  setMessage(state.form, acceptedRepairMessage(payload), 'accepted');
+  scheduleAcceptedRowRemoval(state.row, timeouts);
+}
+
+export function orchestrationAcceptedMessage(summary: RepairSummary | undefined): string {
+  return summary?.batchId
+    ? `Batch ${summary.batchId} accepted. Worker will queue jobs in chunks.`
+    : 'Batch accepted. Worker will queue jobs in chunks.';
+}
+
+function handleOrchestrationQueuedRepair(
+  state: RepairSubmissionState,
+  payload: RepairPayload,
+): void {
+  requestCatalogHealthRefresh();
+  clearPending(state);
+  setButton(state.form, 'Orchestration accepted', true);
+  setMessage(state.form, orchestrationAcceptedMessage(payload.summary), 'accepted');
+}
+
+export function partialRepairMessage(summary: RepairSummary | undefined): string {
+  return `Partial: queued ${summary?.queued ?? 0}, deduped ${summary?.deduped ?? 0}, failed ${summary?.failed ?? 0}, unavailable ${summary?.unavailable ?? 0}`;
+}
+
+function handlePartialRepair(state: RepairSubmissionState, payload: RepairPayload): void {
+  requestCatalogHealthRefresh();
+  restoreRepairForm(state, partialRepairMessage(payload.summary));
+}
+
+const REPAIR_STATUS_HANDLERS: Record<string, RepairStatusHandler> = {
+  deduped: handleQueuedOrDedupedRepair,
+  orchestration_queued: handleOrchestrationQueuedRepair,
+  partial: handlePartialRepair,
+  queued: handleQueuedOrDedupedRepair,
+};
+
+function handleRepairResponse(
+  state: RepairSubmissionState,
+  response: RepairResponse,
+  timeouts: number[],
+): void {
+  const status = response.payload?.status;
+  const handler = status ? REPAIR_STATUS_HANDLERS[status] : undefined;
+
+  if (response.ok && handler && response.payload) {
+    handler(state, response.payload, timeouts);
+    return;
+  }
+
+  restoreRepairForm(state, response.payload?.message || 'Queue unavailable. Check Redis and logs.');
+}
+
 export function formActionUrl(
   form: Pick<HTMLFormElement, 'getAttribute'>,
   baseUrl = window.location.href,
@@ -115,103 +286,16 @@ export function CatalogRepairEnhancement() {
       const submit = async (event: SubmitEvent) => {
         event.preventDefault();
 
-        const confirmMessage = form.dataset.confirmMessage;
-        if (confirmMessage && form.dataset.confirmed !== 'true') {
-          showInlineConfirmation(form, confirmMessage);
-          setMessage(form, 'Confirm this batch in-place to continue.', 'warn');
+        if (!confirmInlineSubmission(form)) {
           return;
         }
-        delete form.dataset.confirmed;
-        removeInlineConfirmation(form);
 
-        const row = form.closest<HTMLTableRowElement>('[data-repair-row]');
-        const originalText =
-          form.querySelector('[data-repair-submit]')?.textContent || 'Queue backfill';
-
-        row?.classList.add('repair-pending');
-        setButton(form, 'Queueing...', true);
-        setMessage(form, 'Queueing...', '');
+        const state = beginRepairSubmission(form);
 
         try {
-          const response = await fetch(formActionUrl(form), {
-            body: formBody(form),
-            headers: { Accept: 'application/json', 'X-Requested-With': 'fetch' },
-            method: 'POST',
-          });
-          const payload = (await response.json().catch(() => null)) as {
-            message?: string;
-            mode?: string;
-            status?: string;
-            summary?: {
-              batchId?: string;
-              queued?: number;
-              deduped?: number;
-              failed?: number;
-              unavailable?: number;
-            };
-          } | null;
-
-          if (response.ok && (payload?.status === 'queued' || payload?.status === 'deduped')) {
-            requestCatalogHealthRefresh();
-            row?.classList.remove('repair-pending');
-            row?.classList.add('repair-accepted');
-            const deduped = payload.status === 'deduped';
-            setButton(form, deduped ? 'Already queued' : 'Accepted', true);
-            const bulkSummary = payload.mode === 'bulk' ? payload.summary : null;
-            const bulkMessage = bulkSummary
-              ? `Accepted ${bulkSummary.queued ?? 0}, already queued ${bulkSummary.deduped ?? 0}`
-              : deduped
-                ? 'Already queued for worker'
-                : 'Accepted for worker';
-            setMessage(form, bulkMessage, 'accepted');
-
-            if (row) {
-              const timeoutId = window.setTimeout(() => {
-                const body = row.parentElement;
-                const columnCount = row.cells.length;
-                row.remove();
-                appendEmptyPlaceholder(body, columnCount);
-              }, 450);
-              timeouts.push(timeoutId);
-            }
-            return;
-          }
-
-          if (response.ok && payload?.status === 'orchestration_queued') {
-            requestCatalogHealthRefresh();
-            row?.classList.remove('repair-pending');
-            setButton(form, 'Orchestration accepted', true);
-            const batchId = payload.summary?.batchId;
-            setMessage(
-              form,
-              batchId
-                ? `Batch ${batchId} accepted. Worker will queue jobs in chunks.`
-                : 'Batch accepted. Worker will queue jobs in chunks.',
-              'accepted',
-            );
-            return;
-          }
-
-          if (response.ok && payload?.status === 'partial') {
-            requestCatalogHealthRefresh();
-            const bulkSummary = payload.summary;
-            row?.classList.remove('repair-pending');
-            setButton(form, originalText, false);
-            setMessage(
-              form,
-              `Partial: queued ${bulkSummary?.queued ?? 0}, deduped ${bulkSummary?.deduped ?? 0}, failed ${bulkSummary?.failed ?? 0}, unavailable ${bulkSummary?.unavailable ?? 0}`,
-              'warn',
-            );
-            return;
-          }
-
-          row?.classList.remove('repair-pending');
-          setButton(form, originalText, false);
-          setMessage(form, payload?.message || 'Queue unavailable. Check Redis and logs.', 'warn');
+          handleRepairResponse(state, await postRepairSubmission(form), timeouts);
         } catch {
-          row?.classList.remove('repair-pending');
-          setButton(form, originalText, false);
-          setMessage(form, 'Request failed. Try again.', 'warn');
+          restoreRepairForm(state, 'Request failed. Try again.');
         }
       };
 

--- a/apps/backoffice/src/components/catalogRepairEnhancement.tsx
+++ b/apps/backoffice/src/components/catalogRepairEnhancement.tsx
@@ -38,6 +38,8 @@ type RepairStatusHandler = (
   timeouts: number[],
 ) => void;
 
+const REPAIR_SUBMISSION_TIMEOUT_MS = 15_000;
+
 function setMessage(form: HTMLFormElement, text: string, tone: RepairTone): void {
   const message = form.querySelector<HTMLElement>('[data-repair-message]');
   if (!message) return;
@@ -142,7 +144,7 @@ function submitButtonText(form: HTMLFormElement): string {
   return form.querySelector('[data-repair-submit]')?.textContent || 'Queue backfill';
 }
 
-function beginRepairSubmission(form: HTMLFormElement): RepairSubmissionState {
+export function beginRepairSubmission(form: HTMLFormElement): RepairSubmissionState {
   const state = {
     form,
     originalText: submitButtonText(form),
@@ -159,17 +161,34 @@ async function readRepairPayload(response: Response): Promise<RepairPayload | nu
   return (await response.json().catch(() => null)) as RepairPayload | null;
 }
 
-async function postRepairSubmission(form: HTMLFormElement): Promise<RepairResponse> {
-  const response = await fetch(formActionUrl(form), {
-    body: formBody(form),
-    headers: { Accept: 'application/json', 'X-Requested-With': 'fetch' },
-    method: 'POST',
-  });
+function repairSubmissionAbortSignal(): { clear: () => void; signal: AbortSignal } {
+  const controller = new AbortController();
+  const timeoutId = window.setTimeout(() => controller.abort(), REPAIR_SUBMISSION_TIMEOUT_MS);
 
   return {
-    ok: response.ok,
-    payload: await readRepairPayload(response),
+    clear: () => window.clearTimeout(timeoutId),
+    signal: controller.signal,
   };
+}
+
+async function postRepairSubmission(form: HTMLFormElement): Promise<RepairResponse> {
+  const abort = repairSubmissionAbortSignal();
+
+  try {
+    const response = await fetch(formActionUrl(form), {
+      body: formBody(form),
+      headers: { Accept: 'application/json', 'X-Requested-With': 'fetch' },
+      method: 'POST',
+      signal: abort.signal,
+    });
+
+    return {
+      ok: response.ok,
+      payload: await readRepairPayload(response),
+    };
+  } finally {
+    abort.clear();
+  }
 }
 
 function clearPending(state: RepairSubmissionState): void {
@@ -248,7 +267,7 @@ const REPAIR_STATUS_HANDLERS: Record<string, RepairStatusHandler> = {
   queued: handleQueuedOrDedupedRepair,
 };
 
-function handleRepairResponse(
+export function handleRepairResponse(
   state: RepairSubmissionState,
   response: RepairResponse,
   timeouts: number[],


### PR DESCRIPTION
## Summary
- split the catalog repair submit callback into confirmation, request, response dispatch, and status-specific handlers
- preserved queued/deduped/orchestration/partial/failure UX copy and button state behavior
- added focused tests for repair status message builders

## Fallow
- apps/backoffice/src/components/catalogRepairEnhancement.tsx health findings: 0 after refactor
- changed dead-code: 0 issues
- changed dupes: 0 clone groups
- local changed audit still hits the known temp-worktree error: could not create a temporary worktree for base ref origin/development

## Verification
- npm run test --workspace=apps/backoffice -- src/components/catalogRepairEnhancement.test.ts
- npm run type-check --workspace=apps/backoffice
- npm run test:backoffice
- npm run build:backoffice
- pre-push hook: lint, server tests, production build; Storybook skipped as not relevant

Closes #722