### PR TITLE
Split auth page form complexity

### DIFF
--- a/apps/web/src/app/authFormLogic.test.ts
+++ b/apps/web/src/app/authFormLogic.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { en } from '@/i18n/locales/en';
+
+import {
+  hasAuthFieldErrors,
+  registerErrorsForResponse,
+  resetPasswordErrorsForResponse,
+  submitRegisterForm,
+  submitResetPasswordForm,
+  validateRegisterForm,
+  validateResetPasswordForm,
+} from './authFormLogic';
+import { getAuthSubmitButtonPresentation } from './authFormUi';
+
+const registerErrors = en.register.errors;
+const resetPasswordErrors = en.resetPassword.errors;
+
+describe('auth form validation', () => {
+  it('validates registration fields in display order', () => {
+    expect(
+      validateRegisterForm({ confirmPassword: '', email: '', password: '' }, registerErrors),
+    ).toEqual({
+      confirmPassword: registerErrors.confirmPasswordRequired,
+      email: registerErrors.emailRequired,
+      password: registerErrors.passwordRequired,
+    });
+
+    expect(
+      validateRegisterForm(
+        { confirmPassword: 'password123', email: 'bad-email', password: 'short' },
+        registerErrors,
+      ),
+    ).toEqual({
+      confirmPassword: registerErrors.passwordMismatch,
+      email: registerErrors.emailInvalid,
+      password: registerErrors.passwordTooShort,
+    });
+
+    expect(
+      hasAuthFieldErrors(
+        validateRegisterForm(
+          { confirmPassword: 'password123', email: 'ada@example.com', password: 'password123' },
+          registerErrors,
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it('validates reset password token and password confirmation', () => {
+    expect(
+      validateResetPasswordForm(
+        { confirmPassword: 'password124', password: 'password123' },
+        '',
+        resetPasswordErrors,
+      ),
+    ).toEqual({
+      confirmPassword: resetPasswordErrors.passwordMismatch,
+      general: resetPasswordErrors.invalidToken,
+    });
+
+    expect(
+      validateResetPasswordForm(
+        { confirmPassword: 'password123', password: 'password123' },
+        'reset-token',
+        resetPasswordErrors,
+      ),
+    ).toEqual({});
+  });
+});
+
+describe('auth form response mapping', () => {
+  it('maps register API responses to field errors', () => {
+    expect(registerErrorsForResponse(409, {}, registerErrors)).toEqual({
+      email: registerErrors.emailTaken,
+    });
+    expect(registerErrorsForResponse(500, {}, registerErrors)).toEqual({
+      general: registerErrors.generic,
+    });
+  });
+
+  it('maps reset password API responses to form errors', () => {
+    expect(resetPasswordErrorsForResponse(400, {}, resetPasswordErrors)).toEqual({
+      general: resetPasswordErrors.invalidToken,
+    });
+    expect(resetPasswordErrorsForResponse(500, {}, resetPasswordErrors)).toEqual({
+      general: resetPasswordErrors.generic,
+    });
+  });
+});
+
+describe('auth form submissions', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('refreshes the session after successful registration', async () => {
+    const refreshSession = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('{}', { status: 201 })));
+
+    await expect(
+      submitRegisterForm(
+        { confirmPassword: 'password123', email: ' ada@example.com ', password: 'password123' },
+        registerErrors,
+        refreshSession,
+      ),
+    ).resolves.toEqual({ success: true });
+    expect(refreshSession).toHaveBeenCalledOnce();
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/auth/register',
+      expect.objectContaining({
+        body: JSON.stringify({ email: 'ada@example.com', password: 'password123' }),
+      }),
+    );
+  });
+
+  it('sends CSRF-protected reset password requests', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('{}', { status: 200 })));
+
+    await expect(
+      submitResetPasswordForm(
+        { confirmPassword: 'password123', password: 'password123' },
+        'reset-token',
+        resetPasswordErrors,
+      ),
+    ).resolves.toEqual({ success: true });
+    const [, init] = vi.mocked(fetch).mock.calls[0] ?? [];
+    expect(init).toEqual(
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'X-CSRF-Token': '' }),
+      }),
+    );
+    expect(JSON.parse(String(init?.body))).toEqual({
+      password: 'password123',
+      token: 'reset-token',
+    });
+  });
+});
+
+describe('auth form presentation helpers', () => {
+  it('keeps submit button states deterministic', () => {
+    expect(
+      getAuthSubmitButtonPresentation({
+        label: 'Create account',
+        submitting: false,
+        submittingLabel: 'Creating account...',
+      }),
+    ).toMatchObject({
+      disabled: false,
+      text: 'Create account',
+    });
+    expect(
+      getAuthSubmitButtonPresentation({
+        label: 'Create account',
+        submitting: true,
+        submittingLabel: 'Creating account...',
+      }),
+    ).toMatchObject({
+      disabled: true,
+      text: 'Creating account...',
+    });
+    expect(
+      getAuthSubmitButtonPresentation({
+        disabled: true,
+        label: 'Update password',
+        submitting: false,
+        submittingLabel: 'Updating...',
+      }),
+    ).toMatchObject({
+      disabled: true,
+      text: 'Update password',
+    });
+  });
+});

--- a/apps/web/src/app/authFormLogic.ts
+++ b/apps/web/src/app/authFormLogic.ts
@@ -1,0 +1,241 @@
+import { getCsrfToken } from '@/lib/csrfClient';
+
+export type AuthFieldErrors = {
+  email?: string;
+  password?: string;
+  confirmPassword?: string;
+  general?: string;
+};
+
+export type RegisterFormState = {
+  email: string;
+  password: string;
+  confirmPassword: string;
+};
+
+export type ResetPasswordFormState = {
+  password: string;
+  confirmPassword: string;
+};
+
+export type RegisterErrorCopy = {
+  emailRequired: string;
+  emailInvalid: string;
+  passwordRequired: string;
+  passwordTooShort: string;
+  confirmPasswordRequired: string;
+  passwordMismatch: string;
+  emailTaken: string;
+  generic: string;
+};
+
+export type ResetPasswordErrorCopy = {
+  passwordRequired: string;
+  passwordTooShort: string;
+  confirmPasswordRequired: string;
+  passwordMismatch: string;
+  invalidToken: string;
+  generic: string;
+};
+
+export type SubmitResult = {
+  errors?: AuthFieldErrors;
+  success: boolean;
+};
+
+type ErrorResponse = {
+  error?: string;
+};
+
+type ErrorRule<TForm, TField extends keyof AuthFieldErrors> = {
+  field: TField;
+  message: string;
+  when: (form: TForm) => boolean;
+};
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function hasAuthFieldErrors(errors: AuthFieldErrors): boolean {
+  return Object.keys(errors).length > 0;
+}
+
+function collectErrors<TForm>(
+  form: TForm,
+  rules: Array<ErrorRule<TForm, keyof AuthFieldErrors>>,
+): AuthFieldErrors {
+  return rules.reduce<AuthFieldErrors>((errors, rule) => {
+    if (errors[rule.field] || !rule.when(form)) {
+      return errors;
+    }
+
+    return { ...errors, [rule.field]: rule.message };
+  }, {});
+}
+
+export function validateRegisterForm(
+  form: RegisterFormState,
+  messages: RegisterErrorCopy,
+): AuthFieldErrors {
+  const email = form.email.trim();
+
+  return collectErrors({ ...form, email }, [
+    { field: 'email', message: messages.emailRequired, when: (value) => !value.email },
+    {
+      field: 'email',
+      message: messages.emailInvalid,
+      when: (value) => Boolean(value.email) && !EMAIL_PATTERN.test(value.email),
+    },
+    {
+      field: 'password',
+      message: messages.passwordRequired,
+      when: (value) => !value.password,
+    },
+    {
+      field: 'password',
+      message: messages.passwordTooShort,
+      when: (value) => Boolean(value.password) && value.password.length < 8,
+    },
+    {
+      field: 'confirmPassword',
+      message: messages.confirmPasswordRequired,
+      when: (value) => !value.confirmPassword,
+    },
+    {
+      field: 'confirmPassword',
+      message: messages.passwordMismatch,
+      when: (value) => Boolean(value.confirmPassword) && value.password !== value.confirmPassword,
+    },
+  ]);
+}
+
+export function validateResetPasswordForm(
+  form: ResetPasswordFormState,
+  token: string,
+  messages: ResetPasswordErrorCopy,
+): AuthFieldErrors {
+  return collectErrors(form, [
+    { field: 'general', message: messages.invalidToken, when: () => !token },
+    {
+      field: 'password',
+      message: messages.passwordRequired,
+      when: (value) => !value.password,
+    },
+    {
+      field: 'password',
+      message: messages.passwordTooShort,
+      when: (value) => Boolean(value.password) && value.password.length < 8,
+    },
+    {
+      field: 'confirmPassword',
+      message: messages.confirmPasswordRequired,
+      when: (value) => !value.confirmPassword,
+    },
+    {
+      field: 'confirmPassword',
+      message: messages.passwordMismatch,
+      when: (value) => Boolean(value.confirmPassword) && value.password !== value.confirmPassword,
+    },
+  ]);
+}
+
+export function registerErrorsForResponse(
+  status: number,
+  data: ErrorResponse,
+  messages: RegisterErrorCopy,
+): AuthFieldErrors {
+  return status === 409 || data.error === 'email_taken'
+    ? { email: messages.emailTaken }
+    : { general: messages.generic };
+}
+
+export function resetPasswordErrorsForResponse(
+  status: number,
+  data: ErrorResponse,
+  messages: ResetPasswordErrorCopy,
+): AuthFieldErrors {
+  return status === 400 || data.error === 'invalid_or_expired_token'
+    ? { general: messages.invalidToken }
+    : { general: messages.generic };
+}
+
+export function applyAuthSubmitResult(
+  result: SubmitResult,
+  fallbackMessage: string,
+  onSuccess: () => void,
+  onErrors: (errors: AuthFieldErrors) => void,
+): void {
+  if (result.success) {
+    onSuccess();
+    return;
+  }
+
+  onErrors(result.errors ?? { general: fallbackMessage });
+}
+
+async function readErrorResponse(response: Response): Promise<ErrorResponse> {
+  return (await response.json().catch(() => ({}))) as ErrorResponse;
+}
+
+export async function submitRegisterForm(
+  form: RegisterFormState,
+  messages: RegisterErrorCopy,
+  refreshSession: () => Promise<unknown>,
+): Promise<SubmitResult> {
+  try {
+    const response = await fetch('/api/auth/register', {
+      body: JSON.stringify({ email: form.email.trim(), password: form.password }),
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+    });
+
+    if (response.status === 201) {
+      await refreshSession();
+      return { success: true };
+    }
+
+    return {
+      errors: registerErrorsForResponse(
+        response.status,
+        await readErrorResponse(response),
+        messages,
+      ),
+      success: false,
+    };
+  } catch {
+    return { errors: { general: messages.generic }, success: false };
+  }
+}
+
+export async function submitResetPasswordForm(
+  form: ResetPasswordFormState,
+  token: string,
+  messages: ResetPasswordErrorCopy,
+): Promise<SubmitResult> {
+  try {
+    const response = await fetch('/api/auth/reset-password', {
+      body: JSON.stringify({ token, password: form.password }),
+      credentials: 'same-origin',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': getCsrfToken(),
+      },
+      method: 'POST',
+    });
+
+    if (response.status === 200) {
+      return { success: true };
+    }
+
+    return {
+      errors: resetPasswordErrorsForResponse(
+        response.status,
+        await readErrorResponse(response),
+        messages,
+      ),
+      success: false,
+    };
+  } catch {
+    return { errors: { general: messages.generic }, success: false };
+  }
+}

--- a/apps/web/src/app/authFormUi.tsx
+++ b/apps/web/src/app/authFormUi.tsx
@@ -1,0 +1,322 @@
+'use client';
+
+import { CheckCircle } from 'lucide-react';
+import { motion } from 'motion/react';
+import Link from 'next/link';
+
+import { palette } from '@/styles/designTokens';
+
+import type { AuthFieldErrors, ResetPasswordFormState } from './authFormLogic';
+import type { ReactNode } from 'react';
+
+type AuthPanelProps = {
+  children: ReactNode;
+  mode?: 'center' | 'form';
+};
+
+type AuthHeaderProps = {
+  icon: ReactNode;
+  subtitle: string;
+  title: string;
+};
+
+type AuthSuccessPanelProps = {
+  body: string;
+  ctaHref: string;
+  ctaLabel: string;
+  title: string;
+};
+
+type AuthTextFieldProps = {
+  autoComplete: string;
+  error?: string;
+  id: string;
+  label: string;
+  onChange: (value: string) => void;
+  placeholder: string;
+  type: 'email' | 'password';
+  value: string;
+};
+
+type AuthSubmitButtonProps = {
+  disabled?: boolean;
+  label: string;
+  submitting: boolean;
+  submittingLabel: string;
+};
+
+type PasswordConfirmationCopy = {
+  confirmPasswordLabel: string;
+  confirmPasswordPlaceholder: string;
+  passwordLabel: string;
+  passwordPlaceholder: string;
+};
+
+type AuthPasswordConfirmationFieldsProps<TForm extends ResetPasswordFormState> = {
+  copy: PasswordConfirmationCopy;
+  errors: AuthFieldErrors;
+  form: TForm;
+  setForm: (next: TForm) => void;
+};
+
+type AuthSubmitButtonPresentation = {
+  background: string;
+  color: string;
+  cursor: 'not-allowed' | 'pointer';
+  disabled: boolean;
+  text: string;
+};
+
+type AuthLoginLinkProps = {
+  href: string;
+  label: string;
+  linkLabel: string;
+};
+
+export function AuthPanel({ children, mode = 'form' }: AuthPanelProps) {
+  return (
+    <div className="flex flex-col items-center justify-center flex-1 px-5 py-16">
+      <motion.div
+        initial={{
+          opacity: 0,
+          scale: mode === 'center' ? 0.9 : undefined,
+          y: mode === 'form' ? 20 : undefined,
+        }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+        className={mode === 'center' ? 'w-full max-w-sm text-center' : 'w-full max-w-sm'}
+      >
+        {children}
+      </motion.div>
+    </div>
+  );
+}
+
+export function AuthHeader({ icon, subtitle, title }: AuthHeaderProps) {
+  return (
+    <div className="text-center mb-8">
+      <div
+        className="w-12 h-12 rounded-xl flex items-center justify-center mx-auto mb-4"
+        style={{ background: `${palette.gold}20`, color: 'var(--pc-gold-text)' }}
+      >
+        {icon}
+      </div>
+      <h1
+        className="mb-2"
+        style={{
+          color: 'var(--pc-t1)',
+          fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
+          fontSize: '2rem',
+          fontWeight: '600',
+          letterSpacing: '0.05em',
+          textTransform: 'uppercase',
+        }}
+      >
+        {title}
+      </h1>
+      <p style={{ color: 'var(--pc-t3)', fontSize: '0.9rem' }}>{subtitle}</p>
+    </div>
+  );
+}
+
+export function AuthSuccessPanel({ body, ctaHref, ctaLabel, title }: AuthSuccessPanelProps) {
+  return (
+    <AuthPanel mode="center">
+      <div
+        className="w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-6"
+        style={{ background: `${palette.green}20`, color: palette.green }}
+      >
+        <CheckCircle size={32} />
+      </div>
+      <h1
+        className="mb-3"
+        style={{
+          color: 'var(--pc-t1)',
+          fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
+          fontSize: '2rem',
+          fontWeight: '600',
+          letterSpacing: '0.05em',
+          textTransform: 'uppercase',
+        }}
+      >
+        {title}
+      </h1>
+      <p style={{ color: 'var(--pc-t2)', marginBottom: '2rem' }}>{body}</p>
+      <Link
+        href={ctaHref}
+        className="inline-block px-6 py-3 rounded-xl text-sm font-semibold transition-colors duration-200"
+        style={{ background: 'var(--pc-cta)', color: 'var(--pc-cta-text)' }}
+      >
+        {ctaLabel}
+      </Link>
+    </AuthPanel>
+  );
+}
+
+export function AuthGeneralError({ errors }: { errors: AuthFieldErrors }) {
+  if (!errors.general) {
+    return null;
+  }
+
+  return (
+    <p
+      className="text-sm px-4 py-3 rounded-xl"
+      style={{
+        background: `${palette.red}18`,
+        border: `1px solid ${palette.red}40`,
+        color: palette.red,
+      }}
+    >
+      {errors.general}
+    </p>
+  );
+}
+
+export function AuthTextField({
+  autoComplete,
+  error,
+  id,
+  label,
+  onChange,
+  placeholder,
+  type,
+  value,
+}: AuthTextFieldProps) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label htmlFor={id} className="text-sm font-medium" style={{ color: 'var(--pc-t2)' }}>
+        {label}
+      </label>
+      <input
+        id={id}
+        type={type}
+        autoComplete={autoComplete}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        className="w-full px-4 py-3 rounded-xl text-sm transition-colors duration-200 outline-none"
+        style={{
+          background: 'var(--pc-input-bg, rgba(255,255,255,0.05))',
+          border: `1px solid ${error ? palette.red : 'var(--pc-bd2)'}`,
+          color: 'var(--pc-t1)',
+        }}
+      />
+      {error && (
+        <p className="text-xs" style={{ color: palette.red }}>
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export function AuthPasswordConfirmationFields<TForm extends ResetPasswordFormState>({
+  copy,
+  errors,
+  form,
+  setForm,
+}: AuthPasswordConfirmationFieldsProps<TForm>) {
+  return (
+    <>
+      <AuthTextField
+        autoComplete="new-password"
+        error={errors.password}
+        id="password"
+        label={copy.passwordLabel}
+        onChange={(password) => setForm({ ...form, password })}
+        placeholder={copy.passwordPlaceholder}
+        type="password"
+        value={form.password}
+      />
+      <AuthTextField
+        autoComplete="new-password"
+        error={errors.confirmPassword}
+        id="confirmPassword"
+        label={copy.confirmPasswordLabel}
+        onChange={(confirmPassword) => setForm({ ...form, confirmPassword })}
+        placeholder={copy.confirmPasswordPlaceholder}
+        type="password"
+        value={form.confirmPassword}
+      />
+    </>
+  );
+}
+
+export function getAuthSubmitButtonPresentation({
+  disabled,
+  label,
+  submitting,
+  submittingLabel,
+}: AuthSubmitButtonProps): AuthSubmitButtonPresentation {
+  if (submitting) {
+    return {
+      background: 'var(--pc-ghost)',
+      color: 'var(--pc-t3)',
+      cursor: 'not-allowed',
+      disabled: true,
+      text: submittingLabel,
+    };
+  }
+
+  if (disabled) {
+    return {
+      background: 'var(--pc-ghost)',
+      color: 'var(--pc-t3)',
+      cursor: 'not-allowed',
+      disabled: true,
+      text: label,
+    };
+  }
+
+  return {
+    background: 'var(--pc-cta)',
+    color: 'var(--pc-cta-text)',
+    cursor: 'pointer',
+    disabled: false,
+    text: label,
+  };
+}
+
+export function AuthSubmitButton({
+  disabled,
+  label,
+  submitting,
+  submittingLabel,
+}: AuthSubmitButtonProps) {
+  const presentation = getAuthSubmitButtonPresentation({
+    disabled,
+    label,
+    submitting,
+    submittingLabel,
+  });
+
+  return (
+    <button
+      type="submit"
+      disabled={presentation.disabled}
+      className="w-full px-4 py-3 rounded-xl text-sm font-semibold transition-all duration-200 mt-1"
+      style={{
+        background: presentation.background,
+        color: presentation.color,
+        cursor: presentation.cursor,
+      }}
+    >
+      {presentation.text}
+    </button>
+  );
+}
+
+export function AuthLoginLink({ href, label, linkLabel }: AuthLoginLinkProps) {
+  return (
+    <p className="text-center text-sm mt-6" style={{ color: 'var(--pc-t3)' }}>
+      {label}{' '}
+      <Link
+        href={href}
+        className="font-medium transition-colors duration-200"
+        style={{ color: 'var(--pc-gold-text)' }}
+      >
+        {linkLabel}
+      </Link>
+    </p>
+  );
+}

--- a/apps/web/src/app/register/page.tsx
+++ b/apps/web/src/app/register/page.tsx
@@ -1,302 +1,111 @@
 'use client';
 
-import { CheckCircle, UserPlus } from 'lucide-react';
-import { motion } from 'motion/react';
-import Link from 'next/link';
+import { UserPlus } from 'lucide-react';
 import { useState, type FormEvent } from 'react';
 
 import { useAuth } from '@/components/AuthProvider';
 import { useLanguage } from '@/i18n';
-import { palette } from '@/styles/designTokens';
 
-interface FormState {
-  email: string;
-  password: string;
-  confirmPassword: string;
-}
+import {
+  type AuthFieldErrors,
+  type RegisterFormState,
+  applyAuthSubmitResult,
+  hasAuthFieldErrors,
+  submitRegisterForm,
+  validateRegisterForm,
+} from '../authFormLogic';
+import {
+  AuthGeneralError,
+  AuthHeader,
+  AuthLoginLink,
+  AuthPanel,
+  AuthPasswordConfirmationFields,
+  AuthSubmitButton,
+  AuthSuccessPanel,
+  AuthTextField,
+} from '../authFormUi';
 
-interface FieldErrors {
-  email?: string;
-  password?: string;
-  confirmPassword?: string;
-  general?: string;
-}
+const INITIAL_FORM: RegisterFormState = {
+  confirmPassword: '',
+  email: '',
+  password: '',
+};
 
 export default function RegisterPage() {
   const { refreshSession } = useAuth();
   const { t } = useLanguage();
-  const r = t.register;
+  const copy = t.register;
 
-  const [form, setForm] = useState<FormState>({ email: '', password: '', confirmPassword: '' });
-  const [errors, setErrors] = useState<FieldErrors>({});
+  const [form, setForm] = useState<RegisterFormState>(INITIAL_FORM);
+  const [errors, setErrors] = useState<AuthFieldErrors>({});
   const [submitting, setSubmitting] = useState(false);
   const [success, setSuccess] = useState(false);
 
-  function validate(): FieldErrors {
-    const errs: FieldErrors = {};
-    if (!form.email.trim()) {
-      errs.email = r.errors.emailRequired;
-    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email.trim())) {
-      errs.email = r.errors.emailInvalid;
-    }
-    if (!form.password) {
-      errs.password = r.errors.passwordRequired;
-    } else if (form.password.length < 8) {
-      errs.password = r.errors.passwordTooShort;
-    }
-    if (!form.confirmPassword) {
-      errs.confirmPassword = r.errors.confirmPasswordRequired;
-    } else if (form.password !== form.confirmPassword) {
-      errs.confirmPassword = r.errors.passwordMismatch;
-    }
-    return errs;
-  }
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
 
-  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
-    e.preventDefault();
-    const errs = validate();
-    if (Object.keys(errs).length > 0) {
-      setErrors(errs);
+    const validationErrors = validateRegisterForm(form, copy.errors);
+    if (hasAuthFieldErrors(validationErrors)) {
+      setErrors(validationErrors);
       return;
     }
+
     setErrors({});
     setSubmitting(true);
-
-    try {
-      const res = await fetch('/api/auth/register', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'same-origin',
-        body: JSON.stringify({ email: form.email.trim(), password: form.password }),
-      });
-
-      if (res.status === 201) {
-        await refreshSession();
-        setSuccess(true);
-        return;
-      }
-
-      const data = (await res.json()) as { error?: string };
-      if (res.status === 409 || data.error === 'email_taken') {
-        setErrors({ email: r.errors.emailTaken });
-      } else if (res.status === 422) {
-        setErrors({ general: r.errors.generic });
-      } else {
-        setErrors({ general: r.errors.generic });
-      }
-    } catch {
-      setErrors({ general: r.errors.generic });
-    } finally {
-      setSubmitting(false);
-    }
+    const result = await submitRegisterForm(form, copy.errors, refreshSession);
+    setSubmitting(false);
+    applyAuthSubmitResult(result, copy.errors.generic, () => setSuccess(true), setErrors);
   }
 
   if (success) {
     return (
-      <div className="flex flex-col items-center justify-center flex-1 px-5 py-16">
-        <motion.div
-          initial={{ opacity: 0, scale: 0.9 }}
-          animate={{ opacity: 1, scale: 1 }}
-          transition={{ duration: 0.4 }}
-          className="w-full max-w-sm text-center"
-        >
-          <div
-            className="w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-6"
-            style={{ background: `${palette.green}20`, color: palette.green }}
-          >
-            <CheckCircle size={32} />
-          </div>
-          <h1
-            className="mb-3"
-            style={{
-              fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
-              fontWeight: '600',
-              textTransform: 'uppercase',
-              fontSize: '2rem',
-              letterSpacing: '0.05em',
-              color: 'var(--pc-t1)',
-            }}
-          >
-            {r.successTitle}
-          </h1>
-          <p style={{ color: 'var(--pc-t2)', marginBottom: '2rem' }}>{r.successMessage}</p>
-          <Link
-            href="/"
-            className="inline-block px-6 py-3 rounded-xl text-sm font-semibold transition-colors duration-200"
-            style={{ background: 'var(--pc-cta)', color: 'var(--pc-cta-text)' }}
-          >
-            {r.backToHome}
-          </Link>
-        </motion.div>
-      </div>
+      <AuthSuccessPanel
+        body={copy.successMessage}
+        ctaHref="/"
+        ctaLabel={copy.backToHome}
+        title={copy.successTitle}
+      />
     );
   }
 
   return (
-    <div className="flex flex-col items-center justify-center flex-1 px-5 py-16">
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.4 }}
-        className="w-full max-w-sm"
-      >
-        {/* Header */}
-        <div className="text-center mb-8">
-          <div
-            className="w-12 h-12 rounded-xl flex items-center justify-center mx-auto mb-4"
-            style={{ background: `${palette.gold}20`, color: 'var(--pc-gold-text)' }}
-          >
-            <UserPlus size={22} />
-          </div>
-          <h1
-            className="mb-2"
-            style={{
-              fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
-              fontWeight: '600',
-              textTransform: 'uppercase',
-              fontSize: '2rem',
-              letterSpacing: '0.05em',
-              color: 'var(--pc-t1)',
-            }}
-          >
-            {r.title}
-          </h1>
-          <p style={{ color: 'var(--pc-t3)', fontSize: '0.9rem' }}>{r.subtitle}</p>
-        </div>
+    <AuthPanel>
+      <AuthHeader icon={<UserPlus size={22} />} subtitle={copy.subtitle} title={copy.title} />
+      <form onSubmit={handleSubmit} noValidate className="flex flex-col gap-5">
+        <AuthGeneralError errors={errors} />
+        <RegisterFields copy={copy} errors={errors} form={form} setForm={setForm} />
+        <AuthSubmitButton
+          label={copy.submitButton}
+          submitting={submitting}
+          submittingLabel={copy.submitting}
+        />
+      </form>
+      <AuthLoginLink href="/login" label={copy.alreadyHaveAccount} linkLabel={copy.logIn} />
+    </AuthPanel>
+  );
+}
 
-        {/* Form */}
-        <form onSubmit={handleSubmit} noValidate className="flex flex-col gap-5">
-          {/* General error */}
-          {errors.general && (
-            <p
-              className="text-sm px-4 py-3 rounded-xl"
-              style={{
-                background: `${palette.red}18`,
-                border: `1px solid ${palette.red}40`,
-                color: palette.red,
-              }}
-            >
-              {errors.general}
-            </p>
-          )}
+type RegisterFieldsProps = {
+  copy: ReturnType<typeof useLanguage>['t']['register'];
+  errors: AuthFieldErrors;
+  form: RegisterFormState;
+  setForm: (next: RegisterFormState) => void;
+};
 
-          {/* Email */}
-          <div className="flex flex-col gap-1.5">
-            <label
-              htmlFor="email"
-              className="text-sm font-medium"
-              style={{ color: 'var(--pc-t2)' }}
-            >
-              {r.emailLabel}
-            </label>
-            <input
-              id="email"
-              type="email"
-              autoComplete="email"
-              value={form.email}
-              onChange={(e) => setForm((f) => ({ ...f, email: e.target.value }))}
-              placeholder={r.emailPlaceholder}
-              className="w-full px-4 py-3 rounded-xl text-sm transition-colors duration-200 outline-none"
-              style={{
-                background: 'var(--pc-input-bg, rgba(255,255,255,0.05))',
-                border: `1px solid ${errors.email ? palette.red : 'var(--pc-bd2)'}`,
-                color: 'var(--pc-t1)',
-              }}
-            />
-            {errors.email && (
-              <p className="text-xs" style={{ color: palette.red }}>
-                {errors.email}
-              </p>
-            )}
-          </div>
-
-          {/* Password */}
-          <div className="flex flex-col gap-1.5">
-            <label
-              htmlFor="password"
-              className="text-sm font-medium"
-              style={{ color: 'var(--pc-t2)' }}
-            >
-              {r.passwordLabel}
-            </label>
-            <input
-              id="password"
-              type="password"
-              autoComplete="new-password"
-              value={form.password}
-              onChange={(e) => setForm((f) => ({ ...f, password: e.target.value }))}
-              placeholder={r.passwordPlaceholder}
-              className="w-full px-4 py-3 rounded-xl text-sm transition-colors duration-200 outline-none"
-              style={{
-                background: 'var(--pc-input-bg, rgba(255,255,255,0.05))',
-                border: `1px solid ${errors.password ? palette.red : 'var(--pc-bd2)'}`,
-                color: 'var(--pc-t1)',
-              }}
-            />
-            {errors.password && (
-              <p className="text-xs" style={{ color: palette.red }}>
-                {errors.password}
-              </p>
-            )}
-          </div>
-
-          {/* Confirm password */}
-          <div className="flex flex-col gap-1.5">
-            <label
-              htmlFor="confirmPassword"
-              className="text-sm font-medium"
-              style={{ color: 'var(--pc-t2)' }}
-            >
-              {r.confirmPasswordLabel}
-            </label>
-            <input
-              id="confirmPassword"
-              type="password"
-              autoComplete="new-password"
-              value={form.confirmPassword}
-              onChange={(e) => setForm((f) => ({ ...f, confirmPassword: e.target.value }))}
-              placeholder={r.confirmPasswordPlaceholder}
-              className="w-full px-4 py-3 rounded-xl text-sm transition-colors duration-200 outline-none"
-              style={{
-                background: 'var(--pc-input-bg, rgba(255,255,255,0.05))',
-                border: `1px solid ${errors.confirmPassword ? palette.red : 'var(--pc-bd2)'}`,
-                color: 'var(--pc-t1)',
-              }}
-            />
-            {errors.confirmPassword && (
-              <p className="text-xs" style={{ color: palette.red }}>
-                {errors.confirmPassword}
-              </p>
-            )}
-          </div>
-
-          {/* Submit */}
-          <button
-            type="submit"
-            disabled={submitting}
-            className="w-full px-4 py-3 rounded-xl text-sm font-semibold transition-all duration-200 mt-1"
-            style={{
-              background: submitting ? 'var(--pc-ghost)' : 'var(--pc-cta)',
-              color: submitting ? 'var(--pc-t3)' : 'var(--pc-cta-text)',
-              cursor: submitting ? 'not-allowed' : 'pointer',
-            }}
-          >
-            {submitting ? r.submitting : r.submitButton}
-          </button>
-        </form>
-
-        {/* Link to login */}
-        <p className="text-center text-sm mt-6" style={{ color: 'var(--pc-t3)' }}>
-          {r.alreadyHaveAccount}{' '}
-          <Link
-            href="/login"
-            className="font-medium transition-colors duration-200"
-            style={{ color: 'var(--pc-gold-text)' }}
-          >
-            {r.logIn}
-          </Link>
-        </p>
-      </motion.div>
-    </div>
+function RegisterFields({ copy, errors, form, setForm }: RegisterFieldsProps) {
+  return (
+    <>
+      <AuthTextField
+        autoComplete="email"
+        error={errors.email}
+        id="email"
+        label={copy.emailLabel}
+        onChange={(email) => setForm({ ...form, email })}
+        placeholder={copy.emailPlaceholder}
+        type="email"
+        value={form.email}
+      />
+      <AuthPasswordConfirmationFields copy={copy} errors={errors} form={form} setForm={setForm} />
+    </>
   );
 }

--- a/apps/web/src/app/reset-password/page.tsx
+++ b/apps/web/src/app/reset-password/page.tsx
@@ -1,25 +1,32 @@
 'use client';
 
-import { CheckCircle, KeyRound } from 'lucide-react';
-import { motion } from 'motion/react';
-import Link from 'next/link';
+import { KeyRound } from 'lucide-react';
 import { useSearchParams } from 'next/navigation';
 import { Suspense, useState, type FormEvent } from 'react';
 
 import { useLanguage } from '@/i18n';
-import { getCsrfToken } from '@/lib/csrfClient';
-import { palette } from '@/styles/designTokens';
 
-interface FormState {
-  password: string;
-  confirmPassword: string;
-}
+import {
+  type AuthFieldErrors,
+  type ResetPasswordFormState,
+  applyAuthSubmitResult,
+  hasAuthFieldErrors,
+  submitResetPasswordForm,
+  validateResetPasswordForm,
+} from '../authFormLogic';
+import {
+  AuthGeneralError,
+  AuthHeader,
+  AuthPanel,
+  AuthPasswordConfirmationFields,
+  AuthSubmitButton,
+  AuthSuccessPanel,
+} from '../authFormUi';
 
-interface FieldErrors {
-  password?: string;
-  confirmPassword?: string;
-  general?: string;
-}
+const INITIAL_FORM: ResetPasswordFormState = {
+  confirmPassword: '',
+  password: '',
+};
 
 export default function ResetPasswordPage() {
   return (
@@ -31,235 +38,69 @@ export default function ResetPasswordPage() {
 
 function ResetPasswordContent() {
   const { t } = useLanguage();
-  const l = t.resetPassword;
-  const searchParams = useSearchParams();
-  const token = searchParams.get('token') ?? '';
+  const copy = t.resetPassword;
+  const token = useSearchParams().get('token') ?? '';
 
-  const [form, setForm] = useState<FormState>({ password: '', confirmPassword: '' });
-  const [errors, setErrors] = useState<FieldErrors>(
-    token ? {} : { general: l.errors.invalidToken },
+  const [form, setForm] = useState<ResetPasswordFormState>(INITIAL_FORM);
+  const [errors, setErrors] = useState<AuthFieldErrors>(
+    token ? {} : { general: copy.errors.invalidToken },
   );
   const [submitting, setSubmitting] = useState(false);
   const [success, setSuccess] = useState(false);
 
-  function validate(): FieldErrors {
-    const errs: FieldErrors = {};
-    if (!token) {
-      errs.general = l.errors.invalidToken;
-    }
-    if (!form.password) {
-      errs.password = l.errors.passwordRequired;
-    } else if (form.password.length < 8) {
-      errs.password = l.errors.passwordTooShort;
-    }
-    if (!form.confirmPassword) {
-      errs.confirmPassword = l.errors.confirmPasswordRequired;
-    } else if (form.password !== form.confirmPassword) {
-      errs.confirmPassword = l.errors.passwordMismatch;
-    }
-    return errs;
-  }
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
 
-  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
-    e.preventDefault();
-    const errs = validate();
-    if (Object.keys(errs).length > 0) {
-      setErrors(errs);
+    const validationErrors = validateResetPasswordForm(form, token, copy.errors);
+    if (hasAuthFieldErrors(validationErrors)) {
+      setErrors(validationErrors);
       return;
     }
 
     setErrors({});
     setSubmitting(true);
-
-    try {
-      const res = await fetch('/api/auth/reset-password', {
-        method: 'POST',
-        credentials: 'same-origin',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRF-Token': getCsrfToken(),
-        },
-        body: JSON.stringify({ token, password: form.password }),
-      });
-
-      if (res.status === 200) {
-        setSuccess(true);
-        return;
-      }
-
-      const data = (await res.json()) as { error?: string };
-      if (res.status === 400 || data.error === 'invalid_or_expired_token') {
-        setErrors({ general: l.errors.invalidToken });
-      } else if (res.status === 422) {
-        setErrors({ general: l.errors.generic });
-      } else {
-        setErrors({ general: l.errors.generic });
-      }
-    } catch {
-      setErrors({ general: l.errors.generic });
-    } finally {
-      setSubmitting(false);
-    }
+    const result = await submitResetPasswordForm(form, token, copy.errors);
+    setSubmitting(false);
+    applyAuthSubmitResult(result, copy.errors.generic, () => setSuccess(true), setErrors);
   }
 
   if (success) {
     return (
-      <div className="flex flex-col items-center justify-center flex-1 px-5 py-16">
-        <motion.div
-          initial={{ opacity: 0, scale: 0.9 }}
-          animate={{ opacity: 1, scale: 1 }}
-          transition={{ duration: 0.4 }}
-          className="w-full max-w-sm text-center"
-        >
-          <div
-            className="w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-6"
-            style={{ background: `${palette.green}20`, color: palette.green }}
-          >
-            <CheckCircle size={32} />
-          </div>
-          <h1
-            className="mb-3"
-            style={{
-              fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
-              fontWeight: '600',
-              textTransform: 'uppercase',
-              fontSize: '2rem',
-              letterSpacing: '0.05em',
-              color: 'var(--pc-t1)',
-            }}
-          >
-            {l.successTitle}
-          </h1>
-          <p style={{ color: 'var(--pc-t2)', marginBottom: '2rem' }}>{l.successMessage}</p>
-          <Link
-            href="/login"
-            className="inline-block px-6 py-3 rounded-xl text-sm font-semibold transition-colors duration-200"
-            style={{ background: 'var(--pc-cta)', color: 'var(--pc-cta-text)' }}
-          >
-            {l.backToLogin}
-          </Link>
-        </motion.div>
-      </div>
+      <AuthSuccessPanel
+        body={copy.successMessage}
+        ctaHref="/login"
+        ctaLabel={copy.backToLogin}
+        title={copy.successTitle}
+      />
     );
   }
 
   return (
-    <div className="flex flex-col items-center justify-center flex-1 px-5 py-16">
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.4 }}
-        className="w-full max-w-sm"
-      >
-        <div className="text-center mb-8">
-          <div
-            className="w-12 h-12 rounded-xl flex items-center justify-center mx-auto mb-4"
-            style={{ background: `${palette.gold}20`, color: 'var(--pc-gold-text)' }}
-          >
-            <KeyRound size={22} />
-          </div>
-          <h1
-            className="mb-2"
-            style={{
-              fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
-              fontWeight: '600',
-              textTransform: 'uppercase',
-              fontSize: '2rem',
-              letterSpacing: '0.05em',
-              color: 'var(--pc-t1)',
-            }}
-          >
-            {l.title}
-          </h1>
-          <p style={{ color: 'var(--pc-t3)', fontSize: '0.9rem' }}>{l.subtitle}</p>
-        </div>
+    <AuthPanel>
+      <AuthHeader icon={<KeyRound size={22} />} subtitle={copy.subtitle} title={copy.title} />
+      <form onSubmit={handleSubmit} noValidate className="flex flex-col gap-5">
+        <AuthGeneralError errors={errors} />
+        <ResetPasswordFields copy={copy} errors={errors} form={form} setForm={setForm} />
+        <AuthSubmitButton
+          disabled={!token}
+          label={copy.submitButton}
+          submitting={submitting}
+          submittingLabel={copy.submitting}
+        />
+      </form>
+    </AuthPanel>
+  );
+}
 
-        <form onSubmit={handleSubmit} noValidate className="flex flex-col gap-5">
-          {errors.general && (
-            <p
-              className="text-sm px-4 py-3 rounded-xl"
-              style={{
-                background: `${palette.red}18`,
-                border: `1px solid ${palette.red}40`,
-                color: palette.red,
-              }}
-            >
-              {errors.general}
-            </p>
-          )}
+type ResetPasswordFieldsProps = {
+  copy: ReturnType<typeof useLanguage>['t']['resetPassword'];
+  errors: AuthFieldErrors;
+  form: ResetPasswordFormState;
+  setForm: (next: ResetPasswordFormState) => void;
+};
 
-          <div className="flex flex-col gap-1.5">
-            <label
-              htmlFor="password"
-              className="text-sm font-medium"
-              style={{ color: 'var(--pc-t2)' }}
-            >
-              {l.passwordLabel}
-            </label>
-            <input
-              id="password"
-              type="password"
-              autoComplete="new-password"
-              value={form.password}
-              onChange={(e) => setForm((f) => ({ ...f, password: e.target.value }))}
-              placeholder={l.passwordPlaceholder}
-              className="w-full px-4 py-3 rounded-xl text-sm transition-colors duration-200 outline-none"
-              style={{
-                background: 'var(--pc-input-bg, rgba(255,255,255,0.05))',
-                border: `1px solid ${errors.password ? palette.red : 'var(--pc-bd2)'}`,
-                color: 'var(--pc-t1)',
-              }}
-            />
-            {errors.password && (
-              <p className="text-xs" style={{ color: palette.red }}>
-                {errors.password}
-              </p>
-            )}
-          </div>
-
-          <div className="flex flex-col gap-1.5">
-            <label
-              htmlFor="confirmPassword"
-              className="text-sm font-medium"
-              style={{ color: 'var(--pc-t2)' }}
-            >
-              {l.confirmPasswordLabel}
-            </label>
-            <input
-              id="confirmPassword"
-              type="password"
-              autoComplete="new-password"
-              value={form.confirmPassword}
-              onChange={(e) => setForm((f) => ({ ...f, confirmPassword: e.target.value }))}
-              placeholder={l.confirmPasswordPlaceholder}
-              className="w-full px-4 py-3 rounded-xl text-sm transition-colors duration-200 outline-none"
-              style={{
-                background: 'var(--pc-input-bg, rgba(255,255,255,0.05))',
-                border: `1px solid ${errors.confirmPassword ? palette.red : 'var(--pc-bd2)'}`,
-                color: 'var(--pc-t1)',
-              }}
-            />
-            {errors.confirmPassword && (
-              <p className="text-xs" style={{ color: palette.red }}>
-                {errors.confirmPassword}
-              </p>
-            )}
-          </div>
-
-          <button
-            type="submit"
-            disabled={submitting || !token}
-            className="w-full px-4 py-3 rounded-xl text-sm font-semibold transition-all duration-200 mt-1"
-            style={{
-              background: submitting || !token ? 'var(--pc-ghost)' : 'var(--pc-cta)',
-              color: submitting || !token ? 'var(--pc-t3)' : 'var(--pc-cta-text)',
-              cursor: submitting || !token ? 'not-allowed' : 'pointer',
-            }}
-          >
-            {submitting ? l.submitting : l.submitButton}
-          </button>
-        </form>
-      </motion.div>
-    </div>
+function ResetPasswordFields({ copy, errors, form, setForm }: ResetPasswordFieldsProps) {
+  return (
+    <AuthPasswordConfirmationFields copy={copy} errors={errors} form={form} setForm={setForm} />
   );
 }


### PR DESCRIPTION
## Summary
- Extract shared auth validation, response mapping, and submit orchestration into authFormLogic.
- Add shared auth form UI primitives for password/confirmation fields and submit-result rendering.
- Keep register/reset pages as thin controllers while preserving existing API behavior and copy.

## Fallow
- Target auth files: 0 health findings, 0 large functions, 0 health targets.
- Changed dead-code: 0 issues.
- Changed dupes: 0 clone groups.
- Local fallow audit still has the known temporary worktree issue; CI Fallow Audit is authoritative.

## Verification
- npm run test --workspace=apps/web -- src/app/authFormLogic.test.ts: 7 tests passed.
- npm run type-check --workspace=apps/web: passed.
- npm run lint:check: passed.
- npm run build: passed.
- Pre-push: lint, server tests 74 files / 1120 tests, production build passed; Storybook skipped as not relevant.

Closes #728