### PR TITLE
Split same-origin request guard helpers

### DIFF
--- a/apps/backoffice/src/lib/sameOriginRequest.test.ts
+++ b/apps/backoffice/src/lib/sameOriginRequest.test.ts
@@ -31,10 +31,53 @@ describe('isSameOriginRequest', () => {
     ).toBe(true);
   });
 
+  it('uses the last forwarded host and first forwarded protocol', () => {
+    expect(
+      isSameOriginRequest(
+        request('http://127.0.0.1:3004/catalog-health/actions', {
+          origin: 'https://backoffice.pop-choice.shchilkin.dev',
+          'x-forwarded-host': 'internal.invalid, backoffice.pop-choice.shchilkin.dev',
+          'x-forwarded-proto': 'https, http',
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('accepts matching referer headers when origin is absent', () => {
+    expect(
+      isSameOriginRequest(
+        request('https://backoffice.pop-choice.shchilkin.dev/catalog-health/actions', {
+          referer: 'https://backoffice.pop-choice.shchilkin.dev/catalog-health',
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects a mismatched origin even when referer matches', () => {
+    expect(
+      isSameOriginRequest(
+        request('https://backoffice.pop-choice.shchilkin.dev/catalog-health/actions', {
+          origin: 'https://evil.example',
+          referer: 'https://backoffice.pop-choice.shchilkin.dev/catalog-health',
+        }),
+      ),
+    ).toBe(false);
+  });
+
   it('rejects requests without origin or referer evidence', () => {
     expect(
       isSameOriginRequest(
         request('https://backoffice.pop-choice.shchilkin.dev/catalog-health/actions', {}),
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects malformed origin evidence', () => {
+    expect(
+      isSameOriginRequest(
+        request('https://backoffice.pop-choice.shchilkin.dev/catalog-health/actions', {
+          origin: 'not a url',
+        }),
       ),
     ).toBe(false);
   });

--- a/apps/backoffice/src/lib/sameOriginRequest.ts
+++ b/apps/backoffice/src/lib/sameOriginRequest.ts
@@ -1,64 +1,7 @@
 import type { NextRequest } from 'next/server';
 
-function normalizedOrigin(value: string): string | null {
-  try {
-    return new URL(value).origin;
-  } catch {
-    return null;
-  }
-}
-
-function lastHeaderValue(value: string | null): string | null {
-  const last = value
-    ?.split(',')
-    .map((part) => part.trim())
-    .filter(Boolean)
-    .at(-1);
-
-  return last || null;
-}
-
-function firstHeaderValue(value: string | null): string | null {
-  const first = value
-    ?.split(',')
-    .map((part) => part.trim())
-    .filter(Boolean)
-    .at(0);
-
-  return first || null;
-}
-
-function expectedOrigins(request: NextRequest): Set<string> {
-  const origins = new Set<string>();
-  const requestOrigin = normalizedOrigin(request.url);
-  if (requestOrigin) origins.add(requestOrigin);
-
-  const forwardedHost = lastHeaderValue(request.headers.get('x-forwarded-host'));
-  const host = forwardedHost ?? request.headers.get('host');
-  if (!host) return origins;
-
-  const forwardedProto = firstHeaderValue(request.headers.get('x-forwarded-proto'));
-  const requestProtocol = normalizedOrigin(request.url)
-    ? new URL(request.url).protocol.replace(/:$/, '')
-    : 'http';
-  const protocol = forwardedProto || requestProtocol;
-  const forwardedOrigin = normalizedOrigin(`${protocol}://${host}`);
-  if (forwardedOrigin) origins.add(forwardedOrigin);
-
-  return origins;
-}
+import { expectedSameOrigins, hasMatchingOriginEvidence } from './sameOriginRequestOrigins';
 
 export function isSameOriginRequest(request: NextRequest): boolean {
-  const origins = expectedOrigins(request);
-  const origin = request.headers.get('origin');
-  if (origin) {
-    const normalized = normalizedOrigin(origin);
-    return normalized !== null && origins.has(normalized);
-  }
-
-  const referer = request.headers.get('referer');
-  if (!referer) return false;
-
-  const normalizedReferer = normalizedOrigin(referer);
-  return normalizedReferer !== null && origins.has(normalizedReferer);
+  return hasMatchingOriginEvidence(request.headers, expectedSameOrigins(request));
 }

--- a/apps/backoffice/src/lib/sameOriginRequestOrigins.ts
+++ b/apps/backoffice/src/lib/sameOriginRequestOrigins.ts
@@ -1,0 +1,81 @@
+type SameOriginHeaders = Pick<Headers, 'get'>;
+
+export type SameOriginRequestParts = {
+  headers: SameOriginHeaders;
+  url: string;
+};
+
+function normalizedOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}
+
+function headerValues(value: string | null): string[] {
+  return (
+    value
+      ?.split(',')
+      .map((part) => part.trim())
+      .filter(Boolean) ?? []
+  );
+}
+
+function firstHeaderValue(value: string | null): string | null {
+  return headerValues(value).at(0) ?? null;
+}
+
+function lastHeaderValue(value: string | null): string | null {
+  return headerValues(value).at(-1) ?? null;
+}
+
+function protocolFromRequestUrl(url: string): string {
+  const origin = normalizedOrigin(url);
+  if (!origin) return 'http';
+
+  return new URL(url).protocol.replace(/:$/, '');
+}
+
+function requestOrigin(url: string): string | null {
+  return normalizedOrigin(url);
+}
+
+function forwardedOrigin({ headers, url }: SameOriginRequestParts): string | null {
+  const forwardedHost = lastHeaderValue(headers.get('x-forwarded-host'));
+  const host = forwardedHost ?? headers.get('host');
+  if (!host) return null;
+
+  const forwardedProto = firstHeaderValue(headers.get('x-forwarded-proto'));
+  const protocol = forwardedProto || protocolFromRequestUrl(url);
+
+  return normalizedOrigin(`${protocol}://${host}`);
+}
+
+export function expectedSameOrigins(request: SameOriginRequestParts): Set<string> {
+  const origins = new Set<string>();
+  const directOrigin = requestOrigin(request.url);
+  if (directOrigin) origins.add(directOrigin);
+
+  const proxyOrigin = forwardedOrigin(request);
+  if (proxyOrigin) origins.add(proxyOrigin);
+
+  return origins;
+}
+
+function headerOriginMatches(value: string | null, expectedOrigins: Set<string>): boolean {
+  if (!value) return false;
+
+  const normalized = normalizedOrigin(value);
+  return normalized !== null && expectedOrigins.has(normalized);
+}
+
+export function hasMatchingOriginEvidence(
+  headers: SameOriginHeaders,
+  expectedOrigins: Set<string>,
+): boolean {
+  const origin = headers.get('origin');
+  if (origin) return headerOriginMatches(origin, expectedOrigins);
+
+  return headerOriginMatches(headers.get('referer'), expectedOrigins);
+}


### PR DESCRIPTION
## Summary
- Split same-origin URL/header parsing into a pure helper module.
- Keep isSameOriginRequest as a thin NextRequest wrapper used by backoffice action routes.
- Add coverage for forwarded multi-value headers, referer fallback, malformed origin evidence, and origin-over-referer precedence.

## Fallow
- sameOriginRequest files: 0 health findings, 0 large functions, 0 health targets.
- Changed dead-code: 0 issues.
- Changed dupes: 0 clone groups.

## Verification
- npm run test --workspace=apps/backoffice -- src/lib/sameOriginRequest.test.ts: 7 tests passed.
- npm run type-check --workspace=apps/backoffice: passed.
- npm run test:backoffice: 35 files / 148 tests passed.
- Commit hook: shared/web/backoffice type-check passed.
- Pre-push: lint, server tests 74 files / 1120 tests, production build passed; Storybook skipped as not relevant.

Closes #725