### PR TITLE
Split group result insight parsing

### DIFF
--- a/apps/web/src/features/recommendation/groupResultInsightInput.ts
+++ b/apps/web/src/features/recommendation/groupResultInsightInput.ts
@@ -1,0 +1,61 @@
+export type QuizPersonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is QuizPersonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function cleanString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function cleanStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.map(cleanString).filter((item): item is string => item !== null);
+}
+
+export function cleanStringValues(values: unknown[]): string[] {
+  return values.map(cleanString).filter((item): item is string => item !== null);
+}
+
+export function uniqueStrings(values: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const value of values) {
+    const key = value.toLocaleLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(value);
+  }
+
+  return result;
+}
+
+export function quizPeople(quizData: unknown): unknown[] {
+  return Array.isArray(quizData) ? quizData : [quizData];
+}
+
+export function groupPeople(quizData: unknown): QuizPersonRecord[] | null {
+  if (!Array.isArray(quizData) || quizData.length < 2) return null;
+
+  const people = quizData.filter(isRecord);
+  return people.length >= 2 ? people : null;
+}
+
+export function hasFavoriteActor(person: unknown): boolean {
+  return isRecord(person) && cleanString(person.favoriteActor) !== null;
+}
+
+export function intersectMoodPreferences(people: QuizPersonRecord[]): string[] {
+  const moodGroups = people.map((person) => cleanStringArray(person.moodPreference));
+  if (moodGroups.some((moods) => moods.length === 0)) return [];
+
+  const [firstGroup = []] = moodGroups;
+  return firstGroup.filter((mood) =>
+    moodGroups.every((moods) =>
+      moods.some((candidate) => candidate.toLocaleLowerCase() === mood.toLocaleLowerCase()),
+    ),
+  );
+}

--- a/apps/web/src/features/recommendation/groupResultInsights.ts
+++ b/apps/web/src/features/recommendation/groupResultInsights.ts
@@ -1,4 +1,13 @@
-type UnknownRecord = Record<string, unknown>;
+import {
+  cleanString,
+  cleanStringArray,
+  cleanStringValues,
+  groupPeople,
+  hasFavoriteActor,
+  intersectMoodPreferences,
+  quizPeople,
+  uniqueStrings,
+} from './groupResultInsightInput';
 
 export interface GroupResultInsights {
   participantNames: string[];
@@ -22,60 +31,12 @@ export function getQuizPeopleCount(quizData: unknown): number {
 }
 
 export function hasFavoriteActorSignal(quizData: unknown): boolean {
-  const people = Array.isArray(quizData) ? quizData : [quizData];
-  return people.some((person) => isRecord(person) && cleanString(person.favoriteActor) !== null);
-}
-
-function isRecord(value: unknown): value is UnknownRecord {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function cleanString(value: unknown): string | null {
-  if (typeof value !== 'string') return null;
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : null;
-}
-
-function cleanStringArray(value: unknown): string[] {
-  if (!Array.isArray(value)) return [];
-  return value.map(cleanString).filter((item): item is string => item !== null);
-}
-
-function cleanStringValues(values: unknown[]): string[] {
-  return values.map(cleanString).filter((item): item is string => item !== null);
-}
-
-function uniqueStrings(values: string[]): string[] {
-  const seen = new Set<string>();
-  const result: string[] = [];
-
-  for (const value of values) {
-    const key = value.toLocaleLowerCase();
-    if (seen.has(key)) continue;
-    seen.add(key);
-    result.push(value);
-  }
-
-  return result;
-}
-
-function intersectMoodPreferences(people: UnknownRecord[]): string[] {
-  const moodGroups = people.map((person) => cleanStringArray(person.moodPreference));
-  if (moodGroups.some((moods) => moods.length === 0)) return [];
-
-  const [firstGroup = []] = moodGroups;
-  return firstGroup.filter((mood) =>
-    moodGroups.every((moods) =>
-      moods.some((candidate) => candidate.toLocaleLowerCase() === mood.toLocaleLowerCase()),
-    ),
-  );
+  return quizPeople(quizData).some(hasFavoriteActor);
 }
 
 export function buildGroupResultInsights(quizData: unknown): GroupResultInsights | null {
-  if (!Array.isArray(quizData) || quizData.length < 2) return null;
-
-  const people = quizData.filter(isRecord);
-  if (people.length < 2) return null;
+  const people = groupPeople(quizData);
+  if (!people) return null;
 
   return {
     participantNames: people.map(


### PR DESCRIPTION
## Summary
- Extract quiz-data normalization, string cleanup, uniqueness, actor detection, and mood intersection into a focused helper module.
- Keep groupResultInsights as the public API for result views and recommendation persistence.
- Preserve existing group insight behavior and type exports.

## Fallow
- group result insight files: 0 health findings, 0 large functions, 0 health targets.
- Changed dead-code: 0 issues.
- Changed dupes: 0 clone groups.

## Verification
- npm run test --workspace=apps/web -- src/features/recommendation/groupResultInsights.test.ts: 5 tests passed.
- npm run type-check --workspace=apps/web: passed.
- Commit hook: shared/web/backoffice type-check passed.
- Pre-push: lint, server tests 74 files / 1120 tests, production build passed; Storybook skipped as not relevant.

Closes #723