### PR TITLE
Split movie memory training UI

### DIFF
--- a/apps/web/src/app/account/movie-memory/movieMemoryTrainingComponents.tsx
+++ b/apps/web/src/app/account/movie-memory/movieMemoryTrainingComponents.tsx
@@ -1,0 +1,1162 @@
+import { ArrowRight, Check, ChevronDown, Eye, Film, Loader2, Search, X } from 'lucide-react';
+import { motion, useReducedMotion } from 'motion/react';
+import Image from 'next/image';
+import Link from 'next/link';
+import { useId, useState, type FormEvent } from 'react';
+
+import { palette } from '@/styles/designTokens';
+
+import {
+  formatDuration,
+  formatMovieName,
+  getDeckCardAnimate,
+  getMovieSummary,
+  getMovieTitle,
+  getOriginalTitle,
+} from './movieMemoryViewModel';
+
+import type { useLanguage } from '@/i18n';
+
+type UserMovieInteractionKind = 'watched' | 'not_seen';
+type DeckExitAction = UserMovieInteractionKind | 'unsure';
+type MovieMemoryLabels = ReturnType<typeof useLanguage>['t']['account'];
+
+type MovieMemoryCandidate = {
+  id: number;
+  tmdbId: number | null;
+  movieName: string;
+  movieYear: number | null;
+  posterURL: string | null;
+  localizedName: string | null;
+  duration: number | null;
+  description: string | null;
+  localizedOverview: string | null;
+};
+
+type ActionState =
+  | { status: 'idle' }
+  | { status: 'saving'; movieId: number; kind: UserMovieInteractionKind }
+  | { status: 'error' };
+
+type CatalogSearchState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'loaded'; movies: MovieMemoryCandidate[] }
+  | { status: 'error' };
+
+type DeckSessionStats = {
+  watched: number;
+  notSeen: number;
+  unsure: number;
+};
+
+type TrainingChoiceKind = Exclude<UserMovieInteractionKind, 'not_seen'> | 'not_seen';
+
+const TRAINING_CHOICE_CONFIG = {
+  not_seen: {
+    backgroundAlpha: '22',
+    borderAlpha: '70',
+    icon: X,
+    paletteColor: palette.red,
+    prefix: '\u2190 ',
+    suffix: '',
+  },
+  watched: {
+    backgroundAlpha: '26',
+    borderAlpha: '75',
+    icon: Eye,
+    paletteColor: palette.green,
+    prefix: '',
+    suffix: ' \u2192',
+  },
+} satisfies Record<
+  TrainingChoiceKind,
+  {
+    backgroundAlpha: string;
+    borderAlpha: string;
+    icon: typeof Eye;
+    paletteColor: string;
+    prefix: string;
+    suffix: string;
+  }
+>;
+
+const COMPLETION_ICON_CONFIG = {
+  complete: {
+    background: 'var(--pc-gold-subtle)',
+    border: '1px solid var(--pc-gold-bd)',
+    color: 'var(--pc-gold-text)',
+    icon: Check,
+  },
+  empty: {
+    background: 'var(--pc-surface-hover)',
+    border: '1px solid var(--pc-bd2)',
+    color: 'var(--pc-t2)',
+    icon: Film,
+  },
+} satisfies Record<
+  'complete' | 'empty',
+  { background: string; border: string; color: string; icon: typeof Film }
+>;
+
+export function CompletionPanel({
+  labels,
+  onLoadMore,
+  onOpenManualSearch,
+  stats,
+  variant,
+}: {
+  labels: MovieMemoryLabels;
+  onLoadMore: () => void;
+  onOpenManualSearch: () => void;
+  stats: DeckSessionStats;
+  variant: 'complete' | 'empty';
+}) {
+  const isEmpty = variant === 'empty';
+
+  return (
+    <div
+      className="flex flex-col items-center gap-5 rounded-3xl p-8 text-center md:p-10"
+      style={{
+        background:
+          'linear-gradient(145deg, color-mix(in srgb, var(--pc-surface) 92%, var(--pc-gold) 8%), var(--pc-surface))',
+        border: '1px solid var(--pc-bd2)',
+        boxShadow: 'var(--pc-card-shadow)',
+        color: 'var(--pc-t2)',
+      }}
+    >
+      <CompletionIcon variant={variant} />
+      <CompletionCopy isEmpty={isEmpty} labels={labels} />
+      <CompletionStats isEmpty={isEmpty} labels={labels} stats={stats} />
+      <CompletionPrimaryActions isEmpty={isEmpty} labels={labels} onLoadMore={onLoadMore} />
+      <CompletionSecondaryActions
+        isEmpty={isEmpty}
+        labels={labels}
+        onLoadMore={onLoadMore}
+        onOpenManualSearch={onOpenManualSearch}
+      />
+    </div>
+  );
+}
+
+function CompletionIcon({ variant }: { variant: 'complete' | 'empty' }) {
+  const config = COMPLETION_ICON_CONFIG[variant];
+  const Icon = config.icon;
+
+  return (
+    <div
+      className="flex h-16 w-16 items-center justify-center rounded-2xl"
+      style={{
+        background: config.background,
+        border: config.border,
+        color: config.color,
+      }}
+    >
+      <Icon size={30} />
+    </div>
+  );
+}
+
+function CompletionCopy({ isEmpty, labels }: { isEmpty: boolean; labels: MovieMemoryLabels }) {
+  return (
+    <div className="max-w-xl">
+      <h2 className="mb-2 text-2xl font-semibold" style={{ color: 'var(--pc-t1)' }}>
+        {isEmpty ? labels.memoryDeckEmptyTitle : labels.memoryDeckCompleteTitle}
+      </h2>
+      <p>{isEmpty ? labels.memoryDeckEmptyBody : labels.memoryDeckCompleteBody}</p>
+    </div>
+  );
+}
+
+function CompletionStats({
+  isEmpty,
+  labels,
+  stats,
+}: {
+  isEmpty: boolean;
+  labels: MovieMemoryLabels;
+  stats: DeckSessionStats;
+}) {
+  if (isEmpty) return null;
+
+  return (
+    <div className="grid w-full max-w-lg grid-cols-3 gap-2" aria-label={labels.memorySummary}>
+      <CompletionStat label={labels.seenMovie} value={stats.watched} tone="seen" />
+      <CompletionStat label={labels.notSeenMovie} value={stats.notSeen} tone="notSeen" />
+      <CompletionStat label={labels.skipMovie} value={stats.unsure} tone="unsure" />
+    </div>
+  );
+}
+
+function CompletionPrimaryActions({
+  isEmpty,
+  labels,
+  onLoadMore,
+}: {
+  isEmpty: boolean;
+  labels: MovieMemoryLabels;
+  onLoadMore: () => void;
+}) {
+  return (
+    <div className="flex w-full max-w-xl flex-col gap-3 sm:flex-row sm:justify-center">
+      {isEmpty ? (
+        <button
+          type="button"
+          onClick={onLoadMore}
+          className="rounded-xl px-5 py-3 text-sm font-semibold transition hover:-translate-y-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pc-gold)]"
+          style={{ background: 'var(--pc-cta)', color: 'var(--pc-cta-text)' }}
+        >
+          {labels.memoryDeckEmptyAction}
+        </button>
+      ) : (
+        <>
+          <Link
+            href="/account"
+            className="inline-flex items-center justify-center gap-2 rounded-xl px-5 py-3 text-sm font-semibold transition hover:-translate-y-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pc-gold)]"
+            style={{ background: 'var(--pc-cta)', color: 'var(--pc-cta-text)' }}
+          >
+            {labels.memoryDeckBackToMemory}
+            <ArrowRight size={16} />
+          </Link>
+          <Link
+            href="/quiz"
+            className="inline-flex items-center justify-center rounded-xl px-5 py-3 text-sm font-semibold transition hover:-translate-y-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pc-gold)]"
+            style={{
+              background: 'var(--pc-ghost)',
+              border: '1px solid var(--pc-bd2)',
+              color: 'var(--pc-t2)',
+            }}
+          >
+            {labels.memoryDeckFindRecommendation}
+          </Link>
+        </>
+      )}
+    </div>
+  );
+}
+
+function CompletionSecondaryActions({
+  isEmpty,
+  labels,
+  onLoadMore,
+  onOpenManualSearch,
+}: {
+  isEmpty: boolean;
+  labels: MovieMemoryLabels;
+  onLoadMore: () => void;
+  onOpenManualSearch: () => void;
+}) {
+  if (isEmpty) return null;
+
+  return (
+    <div className="flex flex-wrap justify-center gap-2">
+      <button
+        type="button"
+        onClick={onLoadMore}
+        className="rounded-full px-3 py-1.5 text-xs font-semibold transition hover:bg-[var(--pc-ghost)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pc-gold)]"
+        style={{ color: 'var(--pc-t3)' }}
+      >
+        {labels.loadMoreMovies}
+      </button>
+      <button
+        type="button"
+        onClick={onOpenManualSearch}
+        className="rounded-full px-3 py-1.5 text-xs font-semibold transition hover:bg-[var(--pc-ghost)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pc-gold)]"
+        style={{ color: 'var(--pc-t3)' }}
+      >
+        {labels.memoryDeckAddManual}
+      </button>
+    </div>
+  );
+}
+
+function CompletionStat({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: number;
+  tone: 'seen' | 'notSeen' | 'unsure';
+}) {
+  const color = tone === 'seen' ? palette.green : tone === 'notSeen' ? palette.red : 'var(--pc-t2)';
+
+  return (
+    <div
+      className="rounded-2xl px-3 py-4"
+      style={{
+        background: 'var(--pc-bg)',
+        border: '1px solid var(--pc-bd2)',
+      }}
+    >
+      <div className="text-2xl font-bold" style={{ color }}>
+        {value}
+      </div>
+      <div className="mt-1 text-xs font-semibold" style={{ color: 'var(--pc-t3)' }}>
+        {label}
+      </div>
+    </div>
+  );
+}
+
+export function MovieTrainingCard({
+  movie,
+  labels,
+  locale,
+  exitAction,
+  counter,
+  progressPercent,
+  action,
+  isSubmitting,
+  onSave,
+  onSkip,
+}: {
+  movie: MovieMemoryCandidate;
+  labels: MovieMemoryLabels;
+  locale: string;
+  exitAction: DeckExitAction | null;
+  counter: string;
+  progressPercent: number;
+  action: ActionState;
+  isSubmitting: boolean;
+  onSave: (movieId: number, kind: UserMovieInteractionKind) => void;
+  onSkip: (movieId: number) => void;
+}) {
+  const shouldReduceMotion = useReducedMotion();
+  const title = getMovieTitle(movie, locale);
+
+  return (
+    <motion.article
+      key={movie.id}
+      initial={{ opacity: 0, y: 18, scale: 0.98 }}
+      animate={getDeckCardAnimate(exitAction, Boolean(shouldReduceMotion))}
+      transition={{ duration: exitAction ? 0.28 : 0.18, ease: [0.22, 1, 0.36, 1] }}
+      className="relative overflow-hidden rounded-[1.75rem]"
+      style={{
+        background:
+          'linear-gradient(145deg, color-mix(in srgb, var(--pc-surface) 92%, var(--pc-gold) 8%), var(--pc-surface))',
+        border: '1px solid var(--pc-bd2)',
+        boxShadow: 'var(--pc-card-shadow)',
+      }}
+    >
+      <div className="grid gap-6 p-4 sm:p-5 md:grid-cols-[minmax(220px,320px)_1fr] md:items-stretch md:p-6">
+        <PosterFrame
+          key={`${movie.id}:${movie.posterURL ?? 'missing'}`}
+          movie={movie}
+          title={title}
+          labels={labels}
+        />
+        <MovieTrainingDetails
+          counter={counter}
+          locale={locale}
+          movie={movie}
+          progressPercent={progressPercent}
+          title={title}
+        />
+      </div>
+      <div
+        className="px-4 pb-4 sm:px-5 sm:pb-5 md:px-6 md:pb-6"
+        style={{ borderTop: '1px solid var(--pc-bd1)' }}
+      >
+        <MovieTrainingControls
+          movie={movie}
+          labels={labels}
+          action={action}
+          isSubmitting={isSubmitting}
+          onSave={onSave}
+          onSkip={onSkip}
+        />
+      </div>
+      <DeckActionOverlay action={exitAction} labels={labels} />
+    </motion.article>
+  );
+}
+
+function MovieTrainingDetails({
+  counter,
+  locale,
+  movie,
+  progressPercent,
+  title,
+}: {
+  counter: string;
+  locale: string;
+  movie: MovieMemoryCandidate;
+  progressPercent: number;
+  title: string;
+}) {
+  const summary = getMovieSummary(movie, locale);
+  const duration = formatDuration(movie.duration, locale);
+  const originalTitle = getOriginalTitle(movie, locale);
+
+  return (
+    <div className="flex min-w-0 flex-col justify-between gap-6 py-1 md:py-2">
+      <MovieTrainingProgress counter={counter} progressPercent={progressPercent} />
+      <div>
+        <h2
+          className="text-3xl font-semibold leading-tight md:text-5xl"
+          style={{ color: 'var(--pc-t1)' }}
+        >
+          {formatMovieName(title, movie.movieYear)}
+        </h2>
+        <MovieTrainingMeta duration={duration} originalTitle={originalTitle} />
+        <MovieSummaryText summary={summary} />
+      </div>
+    </div>
+  );
+}
+
+function MovieSummaryText({ summary }: { summary: string | null }) {
+  if (!summary) return null;
+
+  return (
+    <p className="mt-5 max-w-[62ch] text-sm leading-6" style={{ color: 'var(--pc-t2)' }}>
+      {summary}
+    </p>
+  );
+}
+
+function MovieTrainingProgress({
+  counter,
+  progressPercent,
+}: {
+  counter: string;
+  progressPercent: number;
+}) {
+  return (
+    <div className="p-1" style={{ color: 'var(--pc-t2)' }}>
+      <div className="mb-2 flex items-center gap-3">
+        <span
+          className="rounded-full px-3 py-1 text-xs font-semibold"
+          style={{
+            background: 'var(--pc-gold-subtle)',
+            border: '1px solid var(--pc-gold-bd)',
+            color: 'var(--pc-gold-text)',
+          }}
+        >
+          {counter}
+        </span>
+      </div>
+      <div
+        className="h-2 overflow-hidden rounded-full"
+        style={{ background: 'var(--pc-ghost)' }}
+        aria-hidden="true"
+      >
+        <div
+          className="h-full rounded-full"
+          style={{ width: `${progressPercent}%`, background: 'var(--pc-progress)' }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function MovieTrainingMeta({
+  duration,
+  originalTitle,
+}: {
+  duration: string | null;
+  originalTitle: string | null;
+}) {
+  return (
+    <div className="mt-4 flex flex-wrap items-center gap-2 text-sm font-medium">
+      {duration ? (
+        <span
+          className="rounded-full px-3 py-1"
+          style={{ background: 'var(--pc-ghost)', color: 'var(--pc-t2)' }}
+        >
+          {duration}
+        </span>
+      ) : null}
+      {originalTitle ? (
+        <span className="min-w-0 truncate" style={{ color: 'var(--pc-t3)' }}>
+          {originalTitle}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+function DeckActionOverlay({
+  action,
+  labels,
+}: {
+  action: DeckExitAction | null;
+  labels: MovieMemoryLabels;
+}) {
+  if (!action) return null;
+
+  const config = getDeckOverlayConfig(action, labels);
+  const { Icon } = config;
+
+  return (
+    <motion.div
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.1 }}
+      style={{ background: config.background }}
+    >
+      <motion.div
+        className="inline-flex items-center gap-3 rounded-2xl px-6 py-4 text-xl font-black uppercase tracking-[0.14em] md:text-3xl"
+        initial={{ scale: 0.92, rotate: config.rotate }}
+        animate={{ scale: 1, rotate: config.rotate }}
+        transition={{ duration: 0.14, ease: [0.22, 1, 0.36, 1] }}
+        style={{
+          border: `2px solid ${config.border}`,
+          color: config.color,
+          background: 'var(--pc-bg)',
+          boxShadow: 'var(--pc-card-shadow)',
+        }}
+      >
+        <Icon size={24} />
+        {config.label}
+      </motion.div>
+    </motion.div>
+  );
+}
+
+function getDeckOverlayConfig(action: DeckExitAction, labels: MovieMemoryLabels) {
+  return {
+    not_seen: {
+      label: labels.memoryOverlayNotSeen,
+      Icon: X,
+      background: `${palette.red}38`,
+      border: `${palette.red}80`,
+      color: palette.red,
+      rotate: -5,
+    },
+    unsure: {
+      label: labels.memoryOverlayUnsure,
+      Icon: ChevronDown,
+      background: 'color-mix(in srgb, var(--pc-surface-hover) 84%, transparent)',
+      border: 'var(--pc-bd3)',
+      color: 'var(--pc-t1)',
+      rotate: 0,
+    },
+    watched: {
+      label: labels.memoryOverlaySeen,
+      Icon: Eye,
+      background: `${palette.green}38`,
+      border: `${palette.green}80`,
+      color: palette.green,
+      rotate: 5,
+    },
+  }[action];
+}
+
+function MovieTrainingControls({
+  movie,
+  labels,
+  action,
+  isSubmitting,
+  onSave,
+  onSkip,
+}: {
+  movie: MovieMemoryCandidate;
+  labels: MovieMemoryLabels;
+  action: ActionState;
+  isSubmitting: boolean;
+  onSave: (movieId: number, kind: UserMovieInteractionKind) => void;
+  onSkip: (movieId: number) => void;
+}) {
+  const isSaving = action.status === 'saving' || isSubmitting;
+
+  return (
+    <motion.div
+      key={`${movie.id}-controls`}
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="pt-4"
+    >
+      <div className="mb-3 flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+        <p className="text-sm font-semibold" style={{ color: 'var(--pc-t2)' }}>
+          {labels.memoryCardQuestion}
+        </p>
+        <p className="text-xs" style={{ color: 'var(--pc-t3)' }}>
+          {labels.memoryKeyboardHint}
+        </p>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <TrainingChoiceButton
+          action={action}
+          disabled={isSaving}
+          kind="not_seen"
+          label={labels.notSeenMovie}
+          movieId={movie.id}
+          onSave={onSave}
+        />
+        <TrainingChoiceButton
+          action={action}
+          disabled={isSaving}
+          kind="watched"
+          label={labels.seenMovie}
+          movieId={movie.id}
+          onSave={onSave}
+        />
+      </div>
+      <button
+        type="button"
+        disabled={isSaving}
+        onClick={() => onSkip(movie.id)}
+        className="mt-3 inline-flex min-h-12 w-full items-center justify-center gap-2 rounded-2xl bg-transparent px-5 text-sm font-semibold transition hover:-translate-y-0.5 hover:border-[var(--pc-bd3)] hover:bg-[var(--pc-surface-hover)] hover:text-[var(--pc-t1)] active:translate-y-0 active:scale-[0.99] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pc-gold)] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:translate-y-0"
+        style={{
+          border: '1px solid var(--pc-bd2)',
+          color: 'var(--pc-t2)',
+        }}
+      >
+        <ChevronDown size={18} />
+        &darr; {labels.skipMovie}
+      </button>
+    </motion.div>
+  );
+}
+
+function TrainingChoiceButton({
+  action,
+  disabled,
+  kind,
+  label,
+  movieId,
+  onSave,
+}: {
+  action: ActionState;
+  disabled: boolean;
+  kind: UserMovieInteractionKind;
+  label: string;
+  movieId: number;
+  onSave: (movieId: number, kind: UserMovieInteractionKind) => void;
+}) {
+  const config = TRAINING_CHOICE_CONFIG[kind];
+  const Icon = config.icon;
+  const saving = action.status === 'saving' && action.movieId === movieId && action.kind === kind;
+
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={() => onSave(movieId, kind)}
+      className="inline-flex min-h-14 items-center justify-center gap-2 rounded-2xl px-5 py-4 text-sm font-semibold transition hover:-translate-y-0.5 hover:brightness-110 active:translate-y-0 active:scale-[0.99] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pc-gold)] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:translate-y-0"
+      style={{
+        background: `${config.paletteColor}${config.backgroundAlpha}`,
+        border: `1px solid ${config.paletteColor}${config.borderAlpha}`,
+        color: config.paletteColor,
+      }}
+    >
+      {saving ? <Loader2 className="animate-spin" size={18} /> : <Icon size={18} />}
+      {config.prefix}
+      {label}
+      {config.suffix}
+    </button>
+  );
+}
+
+function PosterFrame({
+  movie,
+  title,
+  labels,
+}: {
+  movie: MovieMemoryCandidate;
+  title: string;
+  labels: MovieMemoryLabels;
+}) {
+  const [imageState, setImageState] = useState<'loading' | 'loaded' | 'failed'>(() =>
+    movie.posterURL ? 'loading' : 'failed',
+  );
+  const posterURL = imageState !== 'failed' ? movie.posterURL : null;
+
+  return (
+    <div
+      className="relative mx-auto aspect-[2/3] w-full max-w-[320px] overflow-hidden rounded-[1.25rem] md:max-w-none"
+      style={{
+        background: 'var(--pc-surface-deep)',
+        border: '1px solid var(--pc-bd2)',
+        boxShadow: '0 18px 42px rgba(9,9,15,0.16)',
+      }}
+    >
+      {posterURL ? (
+        <PosterImage
+          imageState={imageState}
+          posterURL={posterURL}
+          title={title}
+          onError={() => setImageState('failed')}
+          onLoad={() => setImageState('loaded')}
+        />
+      ) : (
+        <PosterFallback labels={labels} movie={movie} title={title} />
+      )}
+    </div>
+  );
+}
+
+function PosterImage({
+  imageState,
+  posterURL,
+  title,
+  onError,
+  onLoad,
+}: {
+  imageState: 'loading' | 'loaded' | 'failed';
+  posterURL: string;
+  title: string;
+  onError: () => void;
+  onLoad: () => void;
+}) {
+  return (
+    <>
+      {imageState === 'loading' ? (
+        <div
+          aria-hidden="true"
+          className="absolute inset-0 animate-pulse"
+          style={{
+            background:
+              'linear-gradient(110deg, var(--pc-surface-deep), var(--pc-surface-hover), var(--pc-surface-deep))',
+          }}
+        />
+      ) : null}
+      <Image
+        src={posterURL}
+        alt={title}
+        fill
+        priority
+        sizes="(min-width: 768px) 320px, min(320px, 100vw)"
+        className={`object-contain transition-opacity duration-200 ${
+          imageState === 'loaded' ? 'opacity-100' : 'opacity-0'
+        }`}
+        onLoad={onLoad}
+        onError={onError}
+      />
+    </>
+  );
+}
+
+function PosterFallback({
+  labels,
+  movie,
+  title,
+}: {
+  labels: MovieMemoryLabels;
+  movie: MovieMemoryCandidate;
+  title: string;
+}) {
+  return (
+    <div
+      className="absolute inset-0 flex flex-col justify-between overflow-hidden p-5 text-center"
+      style={{
+        background:
+          'linear-gradient(160deg, color-mix(in srgb, var(--pc-surface-hover) 86%, var(--pc-gold) 14%), var(--pc-surface-deep) 58%, color-mix(in srgb, var(--pc-bg) 88%, var(--pc-gold) 12%))',
+      }}
+    >
+      <PosterFallbackTop movieYear={movie.movieYear} />
+      <PosterFallbackTitle title={title} />
+      <div className="relative z-[1]">
+        <p
+          className="rounded-full px-3 py-2 text-xs font-bold uppercase tracking-[0.14em]"
+          style={{
+            background: 'var(--pc-bg)',
+            border: '1px solid var(--pc-bd2)',
+            color: 'var(--pc-t3)',
+          }}
+        >
+          {labels.posterUnavailable}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function PosterFallbackTop({ movieYear }: { movieYear: number | null }) {
+  return (
+    <>
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-x-0 top-0 h-16"
+        style={{
+          background:
+            'repeating-linear-gradient(90deg, transparent 0 12px, color-mix(in srgb, var(--pc-gold) 24%, transparent) 12px 14px)',
+          opacity: 0.55,
+        }}
+      />
+      <div className="relative z-[1] flex items-center justify-between">
+        <span
+          className="rounded-full px-3 py-1 text-[0.65rem] font-black uppercase tracking-[0.16em]"
+          style={{
+            background: 'var(--pc-gold-subtle)',
+            border: '1px solid var(--pc-gold-bd)',
+            color: 'var(--pc-gold-text)',
+          }}
+        >
+          PopChoice
+        </span>
+        {movieYear ? (
+          <span
+            className="rounded-full px-3 py-1 text-xs font-bold"
+            style={{
+              background: 'var(--pc-bg)',
+              border: '1px solid var(--pc-bd2)',
+              color: 'var(--pc-t2)',
+            }}
+          >
+            {movieYear}
+          </span>
+        ) : null}
+      </div>
+    </>
+  );
+}
+
+function PosterFallbackTitle({ title }: { title: string }) {
+  return (
+    <div className="relative z-[1] flex flex-1 flex-col items-center justify-center gap-5">
+      <div
+        className="flex h-20 w-20 items-center justify-center rounded-3xl"
+        style={{
+          background: 'var(--pc-bg)',
+          border: '1px solid var(--pc-bd2)',
+          boxShadow: '0 16px 34px rgba(9,9,15,0.22)',
+        }}
+      >
+        <Film size={42} style={{ color: 'var(--pc-gold-text)' }} />
+      </div>
+      <p
+        className="max-w-[15rem] text-xl font-black leading-tight"
+        style={{ color: 'var(--pc-t1)' }}
+      >
+        {title}
+      </p>
+    </div>
+  );
+}
+
+export function ManualSearchPanel({
+  query,
+  search,
+  labels,
+  locale,
+  action,
+  isOpen,
+  onToggle,
+  onQueryChange,
+  onSearch,
+  onSave,
+}: {
+  query: string;
+  search: CatalogSearchState;
+  labels: MovieMemoryLabels;
+  locale: string;
+  action: ActionState;
+  isOpen: boolean;
+  onToggle: () => void;
+  onQueryChange: (value: string) => void;
+  onSearch: (event: FormEvent<HTMLFormElement>) => void;
+  onSave: (movieId: number, kind: UserMovieInteractionKind) => void;
+}) {
+  return (
+    <section className="mx-auto mt-8 max-w-3xl">
+      <ManualSearchToggle isOpen={isOpen} labels={labels} onToggle={onToggle} />
+      {isOpen ? (
+        <ManualSearchBody
+          action={action}
+          labels={labels}
+          locale={locale}
+          query={query}
+          search={search}
+          onQueryChange={onQueryChange}
+          onSave={onSave}
+          onSearch={onSearch}
+        />
+      ) : null}
+    </section>
+  );
+}
+
+function ManualSearchToggle({
+  isOpen,
+  labels,
+  onToggle,
+}: {
+  isOpen: boolean;
+  labels: MovieMemoryLabels;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className="relative mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-transparent transition hover:-translate-y-0.5 hover:bg-[var(--pc-ghost)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pc-gold)]"
+      style={{
+        border: '1px solid var(--pc-bd1)',
+        color: 'var(--pc-t3)',
+      }}
+      aria-expanded={isOpen}
+      aria-label={labels.manualSearchTitle}
+      title={labels.manualSearchTitle}
+    >
+      <Search size={18} />
+      <ChevronDown
+        size={14}
+        className={`absolute translate-x-3 translate-y-3 transition-transform ${isOpen ? 'rotate-180' : ''}`}
+        aria-hidden="true"
+      />
+    </button>
+  );
+}
+
+function ManualSearchBody({
+  action,
+  labels,
+  locale,
+  query,
+  search,
+  onQueryChange,
+  onSave,
+  onSearch,
+}: {
+  action: ActionState;
+  labels: MovieMemoryLabels;
+  locale: string;
+  query: string;
+  search: CatalogSearchState;
+  onQueryChange: (value: string) => void;
+  onSave: (movieId: number, kind: UserMovieInteractionKind) => void;
+  onSearch: (event: FormEvent<HTMLFormElement>) => void;
+}) {
+  const searchInputId = useId();
+
+  return (
+    <motion.div initial={{ opacity: 0, y: -8 }} animate={{ opacity: 1, y: 0 }} className="mt-5">
+      <div className="mb-4 text-center">
+        <h2 className="text-sm font-semibold" style={{ color: 'var(--pc-t1)' }}>
+          {labels.manualSearchTitle}
+        </h2>
+        <p className="mt-1 text-sm" style={{ color: 'var(--pc-t2)' }}>
+          {labels.manualSearchBody}
+        </p>
+      </div>
+
+      <ManualSearchForm
+        labels={labels}
+        query={query}
+        search={search}
+        searchInputId={searchInputId}
+        onQueryChange={onQueryChange}
+        onSearch={onSearch}
+      />
+      <ManualSearchResults
+        action={action}
+        labels={labels}
+        locale={locale}
+        search={search}
+        onSave={onSave}
+      />
+    </motion.div>
+  );
+}
+
+function ManualSearchForm({
+  labels,
+  query,
+  search,
+  searchInputId,
+  onQueryChange,
+  onSearch,
+}: {
+  labels: MovieMemoryLabels;
+  query: string;
+  search: CatalogSearchState;
+  searchInputId: string;
+  onQueryChange: (value: string) => void;
+  onSearch: (event: FormEvent<HTMLFormElement>) => void;
+}) {
+  return (
+    <form onSubmit={onSearch} className="flex flex-col gap-3 sm:flex-row">
+      <label htmlFor={searchInputId} className="sr-only">
+        {labels.searchMovieMemory}
+      </label>
+      <div
+        className="flex min-h-14 flex-1 items-center gap-3 rounded-2xl px-4"
+        style={{ background: 'var(--pc-bg)', border: '1px solid var(--pc-bd2)' }}
+      >
+        <Search size={20} style={{ color: 'var(--pc-t2)' }} />
+        <input
+          id={searchInputId}
+          value={query}
+          onChange={(event) => onQueryChange(event.target.value)}
+          placeholder={labels.catalogSearchPlaceholder}
+          className="min-w-0 flex-1 bg-transparent text-base outline-none"
+          style={{ color: 'var(--pc-t1)' }}
+        />
+      </div>
+      <button
+        type="submit"
+        disabled={query.trim().length < 2 || search.status === 'loading'}
+        className="inline-flex min-h-14 items-center justify-center rounded-2xl px-6 text-sm font-semibold focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pc-gold)] disabled:opacity-60"
+        style={{ background: 'var(--pc-cta)', color: 'var(--pc-cta-text)' }}
+      >
+        {search.status === 'loading' ? (
+          <Loader2 className="animate-spin" size={18} />
+        ) : (
+          labels.searchCatalog
+        )}
+      </button>
+    </form>
+  );
+}
+
+function ManualSearchResults({
+  action,
+  labels,
+  locale,
+  search,
+  onSave,
+}: {
+  action: ActionState;
+  labels: MovieMemoryLabels;
+  locale: string;
+  search: CatalogSearchState;
+  onSave: (movieId: number, kind: UserMovieInteractionKind) => void;
+}) {
+  if (search.status === 'error') {
+    return <ManualSearchNotice tone="error">{labels.catalogSearchError}</ManualSearchNotice>;
+  }
+  if (search.status !== 'loaded') return null;
+
+  return (
+    <LoadedManualSearchResults
+      action={action}
+      labels={labels}
+      locale={locale}
+      movies={search.movies}
+      onSave={onSave}
+    />
+  );
+}
+
+function LoadedManualSearchResults({
+  action,
+  labels,
+  locale,
+  movies,
+  onSave,
+}: {
+  action: ActionState;
+  labels: MovieMemoryLabels;
+  locale: string;
+  movies: MovieMemoryCandidate[];
+  onSave: (movieId: number, kind: UserMovieInteractionKind) => void;
+}) {
+  if (movies.length === 0)
+    return <ManualSearchNotice>{labels.catalogSearchEmpty}</ManualSearchNotice>;
+
+  return (
+    <div className="mt-4 grid gap-3">
+      {movies.map((movie) => (
+        <MovieSearchResultRow
+          key={movie.id}
+          movie={movie}
+          labels={labels}
+          locale={locale}
+          action={action}
+          onSave={onSave}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ManualSearchNotice({
+  children,
+  tone = 'neutral',
+}: {
+  children: string;
+  tone?: 'error' | 'neutral';
+}) {
+  return (
+    <div
+      className="mt-4 rounded-2xl p-4 text-sm"
+      style={{
+        background: tone === 'error' ? `${palette.red}14` : 'var(--pc-surface)',
+        color: 'var(--pc-t2)',
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function MovieSearchResultRow({
+  movie,
+  labels,
+  locale,
+  action,
+  onSave,
+}: {
+  movie: MovieMemoryCandidate;
+  labels: MovieMemoryLabels;
+  locale: string;
+  action: ActionState;
+  onSave: (movieId: number, kind: UserMovieInteractionKind) => void;
+}) {
+  const title = getMovieTitle(movie, locale);
+  const saving = action.status === 'saving' && action.movieId === movie.id;
+
+  return (
+    <div
+      className="flex items-center gap-4 rounded-2xl p-3"
+      style={{ background: 'var(--pc-surface)', border: '1px solid var(--pc-bd2)' }}
+    >
+      <MovieSearchPoster movie={movie} title={title} />
+      <MovieSearchTitle movie={movie} title={title} />
+      <button
+        type="button"
+        disabled={saving}
+        onClick={() => onSave(movie.id, 'watched')}
+        className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl px-4 text-sm font-semibold disabled:opacity-60"
+        style={{ background: 'var(--pc-gold-subtle)', color: 'var(--pc-gold-text)' }}
+      >
+        {saving ? <Loader2 className="animate-spin" size={16} /> : <Eye size={16} />}
+        {labels.seenMovie}
+      </button>
+    </div>
+  );
+}
+
+function MovieSearchPoster({ movie, title }: { movie: MovieMemoryCandidate; title: string }) {
+  if (!movie.posterURL) {
+    return (
+      <div
+        className="flex h-20 w-14 items-center justify-center rounded-xl"
+        style={{ background: 'var(--pc-ghost)', color: 'var(--pc-t3)' }}
+      >
+        <Film size={22} />
+      </div>
+    );
+  }
+
+  return (
+    <Image
+      src={movie.posterURL}
+      alt={title}
+      width={56}
+      height={80}
+      sizes="56px"
+      className="h-20 w-14 rounded-xl object-cover"
+    />
+  );
+}
+
+function MovieSearchTitle({ movie, title }: { movie: MovieMemoryCandidate; title: string }) {
+  return (
+    <div className="min-w-0 flex-1">
+      <p className="truncate font-semibold" style={{ color: 'var(--pc-t1)' }}>
+        {formatMovieName(title, movie.movieYear)}
+      </p>
+      {movie.localizedName && movie.localizedName !== movie.movieName ? (
+        <p className="truncate text-sm" style={{ color: 'var(--pc-t2)' }}>
+          {movie.movieName}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/app/account/movie-memory/movieMemoryViewModel.test.ts
+++ b/apps/web/src/app/account/movie-memory/movieMemoryViewModel.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatDuration,
+  formatMovieName,
+  getDeckCardAnimate,
+  getDeckKeyboardAction,
+  getMovieSummary,
+  getMovieTitle,
+  getOriginalTitle,
+} from './movieMemoryViewModel';
+
+describe('movieMemoryViewModel', () => {
+  it('maps deck keyboard shortcuts when the event can be handled', () => {
+    const baseEvent = {
+      altKey: false,
+      ctrlKey: false,
+      defaultPrevented: false,
+      metaKey: false,
+      shiftKey: false,
+      target: null,
+    };
+
+    expect(getDeckKeyboardAction({ ...baseEvent, key: 'ArrowLeft' })).toBe('not_seen');
+    expect(getDeckKeyboardAction({ ...baseEvent, key: 'ArrowRight' })).toBe('watched');
+    expect(getDeckKeyboardAction({ ...baseEvent, key: 'ArrowDown' })).toBe('unsure');
+    expect(getDeckKeyboardAction({ ...baseEvent, key: 'Enter' })).toBeNull();
+  });
+
+  it('ignores deck keyboard shortcuts when modifier or handled state is present', () => {
+    const baseEvent = {
+      altKey: false,
+      ctrlKey: false,
+      defaultPrevented: false,
+      key: 'ArrowRight',
+      metaKey: false,
+      shiftKey: false,
+      target: null,
+    };
+
+    expect(getDeckKeyboardAction({ ...baseEvent, defaultPrevented: true })).toBeNull();
+    expect(getDeckKeyboardAction({ ...baseEvent, metaKey: true })).toBeNull();
+    expect(getDeckKeyboardAction({ ...baseEvent, ctrlKey: true })).toBeNull();
+    expect(getDeckKeyboardAction({ ...baseEvent, altKey: true })).toBeNull();
+    expect(getDeckKeyboardAction({ ...baseEvent, shiftKey: true })).toBeNull();
+  });
+
+  it('returns deck card animation variants', () => {
+    expect(getDeckCardAnimate(null, false)).toEqual({
+      opacity: 1,
+      rotate: 0,
+      scale: 1,
+      x: 0,
+      y: 0,
+    });
+    expect(getDeckCardAnimate('watched', false)).toMatchObject({ opacity: 0, x: 520 });
+    expect(getDeckCardAnimate('not_seen', false)).toMatchObject({ opacity: 0, x: -520 });
+    expect(getDeckCardAnimate('unsure', false)).toMatchObject({ opacity: 0, y: 150 });
+    expect(getDeckCardAnimate('watched', true)).toEqual({
+      opacity: 0,
+      rotate: 0,
+      scale: 0.98,
+      x: 0,
+      y: 0,
+    });
+  });
+
+  it('formats localized movie titles and summaries', () => {
+    expect(getMovieTitle({ movieName: 'Original', localizedName: 'Localized' }, 'ru')).toBe(
+      'Localized',
+    );
+    expect(getMovieTitle({ movieName: 'Original', localizedName: 'Localized' }, 'en')).toBe(
+      'Original',
+    );
+    expect(formatMovieName('Movie', 1999)).toBe('Movie (1999)');
+    expect(formatMovieName('Movie', null)).toBe('Movie');
+    expect(getOriginalTitle({ movieName: 'Original', localizedName: 'Localized' }, 'ru')).toBe(
+      'Original',
+    );
+    expect(getOriginalTitle({ movieName: 'Original', localizedName: 'Original' }, 'ru')).toBeNull();
+    expect(
+      getOriginalTitle({ movieName: 'Original', localizedName: 'Localized' }, 'en'),
+    ).toBeNull();
+
+    expect(
+      getMovieSummary({ description: '  English overview  ', localizedOverview: null }, 'en'),
+    ).toBe('English overview');
+    expect(getMovieSummary({ description: 'English', localizedOverview: 'Localized' }, 'fi')).toBe(
+      'Localized',
+    );
+    expect(getMovieSummary({ description: '   ', localizedOverview: null }, 'en')).toBeNull();
+    expect(
+      getMovieSummary({ description: 'x'.repeat(300), localizedOverview: null }, 'en'),
+    ).toHaveLength(260);
+  });
+
+  it('formats durations per supported locale', () => {
+    expect(formatDuration(null, 'en')).toBeNull();
+    expect(formatDuration(0, 'en')).toBeNull();
+    expect(formatDuration(45, 'en')).toBe('45 m');
+    expect(formatDuration(125, 'en')).toBe('2 h 5 m');
+    expect(formatDuration(120, 'en')).toBe('2 h');
+    expect(formatDuration(125, 'ru')).toBe('2 ч 5 мин');
+    expect(formatDuration(120, 'ru')).toBe('2 ч');
+    expect(formatDuration(125, 'fi')).toBe('2 t 5 min');
+    expect(formatDuration(125, 'es')).toBe('2 h 5 m');
+  });
+});

--- a/apps/web/src/app/account/movie-memory/movieMemoryViewModel.ts
+++ b/apps/web/src/app/account/movie-memory/movieMemoryViewModel.ts
@@ -1,0 +1,109 @@
+export type MovieMemoryDeckAction = 'watched' | 'not_seen' | 'unsure';
+
+type MovieTitleFields = {
+  localizedName: string | null;
+  movieName: string;
+};
+
+type MovieSummaryFields = {
+  description: string | null;
+  localizedOverview: string | null;
+};
+
+type MovieOriginalTitleFields = {
+  localizedName: string | null;
+  movieName: string;
+};
+
+type KeyboardEventLike = {
+  altKey: boolean;
+  ctrlKey: boolean;
+  defaultPrevented: boolean;
+  key: string;
+  metaKey: boolean;
+  shiftKey: boolean;
+  target: EventTarget | null;
+};
+
+const DECK_CARD_IDLE_ANIMATE = { opacity: 1, x: 0, y: 0, rotate: 0, scale: 1 };
+const DECK_CARD_REDUCED_EXIT_ANIMATE = { opacity: 0, x: 0, y: 0, rotate: 0, scale: 0.98 };
+const DECK_CARD_EXIT_ANIMATE_BY_ACTION = {
+  watched: { opacity: 0, x: 520, y: 8, rotate: 8, scale: 0.98 },
+  not_seen: { opacity: 0, x: -520, y: 8, rotate: -8, scale: 0.98 },
+  unsure: { opacity: 0, x: 0, y: 150, rotate: 0, scale: 0.95 },
+} satisfies Record<MovieMemoryDeckAction, typeof DECK_CARD_IDLE_ANIMATE>;
+
+const KEYBOARD_ACTION_BY_KEY: Partial<Record<string, MovieMemoryDeckAction>> = {
+  ArrowLeft: 'not_seen',
+  ArrowRight: 'watched',
+  ArrowDown: 'unsure',
+};
+
+const DURATION_LABELS_BY_LOCALE = {
+  en: { hour: 'h', minute: 'm', separator: ' ' },
+  fi: { hour: 't', minute: 'min', separator: ' ' },
+  ru: { hour: 'ч', minute: 'мин', separator: ' ' },
+} as const;
+
+function isEditableKeyboardTarget(target: EventTarget | null): boolean {
+  if (typeof HTMLElement === 'undefined' || !(target instanceof HTMLElement)) return false;
+  return ['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName) || target.isContentEditable;
+}
+
+export function getDeckKeyboardAction(event: KeyboardEventLike): MovieMemoryDeckAction | null {
+  if (
+    event.defaultPrevented ||
+    event.metaKey ||
+    event.ctrlKey ||
+    event.altKey ||
+    event.shiftKey ||
+    isEditableKeyboardTarget(event.target)
+  ) {
+    return null;
+  }
+
+  return KEYBOARD_ACTION_BY_KEY[event.key] ?? null;
+}
+
+export function getDeckCardAnimate(action: MovieMemoryDeckAction | null, reducedMotion: boolean) {
+  if (!action) return DECK_CARD_IDLE_ANIMATE;
+  return reducedMotion ? DECK_CARD_REDUCED_EXIT_ANIMATE : DECK_CARD_EXIT_ANIMATE_BY_ACTION[action];
+}
+
+export function getMovieTitle(movie: MovieTitleFields, locale: string): string {
+  if (locale !== 'en' && movie.localizedName) return movie.localizedName;
+  return movie.movieName;
+}
+
+export function getMovieSummary(movie: MovieSummaryFields, locale: string): string | null {
+  const summary =
+    locale !== 'en' ? movie.localizedOverview || movie.description : movie.description;
+  const trimmed = summary?.trim();
+  if (!trimmed) return null;
+  return trimmed.length > 260 ? `${trimmed.slice(0, 257).trimEnd()}...` : trimmed;
+}
+
+export function getOriginalTitle(movie: MovieOriginalTitleFields, locale: string): string | null {
+  if (locale === 'en') return null;
+  if (!movie.localizedName || movie.localizedName === movie.movieName) return null;
+  return movie.movieName;
+}
+
+export function formatMovieName(name: string, year: number | null): string {
+  return year ? `${name} (${year})` : name;
+}
+
+export function formatDuration(duration: number | null, locale: string): string | null {
+  if (!duration || duration <= 0) return null;
+
+  const hours = Math.floor(duration / 60);
+  const minutes = duration % 60;
+  const labels =
+    DURATION_LABELS_BY_LOCALE[locale as keyof typeof DURATION_LABELS_BY_LOCALE] ??
+    DURATION_LABELS_BY_LOCALE.en;
+
+  if (hours === 0) return `${minutes} ${labels.minute}`;
+  return minutes
+    ? `${hours} ${labels.hour}${labels.separator}${minutes} ${labels.minute}`
+    : `${hours} ${labels.hour}`;
+}

--- a/apps/web/src/app/account/movie-memory/page.tsx
+++ b/apps/web/src/app/account/movie-memory/page.tsx
@@ -1,35 +1,21 @@
 'use client';
 
-import {
-  AlertCircle,
-  ArrowLeft,
-  ArrowRight,
-  Check,
-  ChevronDown,
-  Eye,
-  Film,
-  Loader2,
-  Search,
-  Sparkles,
-  X,
-} from 'lucide-react';
-import { motion, useReducedMotion } from 'motion/react';
-import Image from 'next/image';
+import { AlertCircle, ArrowLeft, Eye, Loader2, Sparkles } from 'lucide-react';
+import { motion } from 'motion/react';
 import Link from 'next/link';
-import {
-  useCallback,
-  useEffect,
-  useId,
-  useRef,
-  useState,
-  type FormEvent,
-  type ReactNode,
-} from 'react';
+import { useCallback, useEffect, useRef, useState, type FormEvent, type ReactNode } from 'react';
 
 import { useAuth } from '@/components/AuthProvider';
 import { useLanguage } from '@/i18n';
 import { getCsrfToken } from '@/lib/csrfClient';
 import { palette } from '@/styles/designTokens';
+
+import {
+  CompletionPanel,
+  ManualSearchPanel,
+  MovieTrainingCard,
+} from './movieMemoryTrainingComponents';
+import { getDeckKeyboardAction } from './movieMemoryViewModel';
 
 type UserMovieInteractionKind = 'watched' | 'not_seen';
 
@@ -117,11 +103,6 @@ const MOVIE_MEMORY_DECK_VIEW_BY_STATUS = {
   loading: 'loading',
   error: 'error',
 } satisfies Record<Exclude<CandidateState['status'], 'loaded'>, MovieMemoryDeckView>;
-
-function isEditableKeyboardTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof HTMLElement)) return false;
-  return ['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName) || target.isContentEditable;
-}
 
 function preferExistingMetadata(
   current: string | null | undefined,
@@ -307,6 +288,35 @@ async function fetchPosterLookupResults(
   return new Map(results.map((result) => [result.id, result]));
 }
 
+function noopDeckFlushAction(_: ActionState) {}
+
+function getDeckFlushActionUpdater(
+  updateState: boolean,
+  setAction: (state: ActionState) => void,
+): (state: ActionState) => void {
+  return updateState ? setAction : noopDeckFlushAction;
+}
+
+function getCatalogSearchQuery(query: string): string | null {
+  const trimmedQuery = query.trim();
+  return trimmedQuery.length < 2 ? null : trimmedQuery;
+}
+
+async function fetchCatalogSearchMovies(query: string): Promise<MovieMemoryCandidate[]> {
+  const response = await fetch(`/api/account/movie-memory?query=${encodeURIComponent(query)}`, {
+    method: 'GET',
+    cache: 'no-store',
+    credentials: 'same-origin',
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to search movie catalog');
+  }
+
+  const data = (await response.json()) as { movies?: MovieMemoryCandidate[] };
+  return Array.isArray(data.movies) ? data.movies : [];
+}
+
 export default function MovieMemoryPage() {
   const { auth } = useAuth();
   const { locale, t } = useLanguage();
@@ -377,6 +387,7 @@ export default function MovieMemoryPage() {
       if (items.length === 0) return;
 
       pendingDeckItems.current = [];
+      const applyFlushAction = getDeckFlushActionUpdater(updateState, setAction);
 
       try {
         const response = await fetch('/api/account/movie-memory', {
@@ -395,14 +406,10 @@ export default function MovieMemoryPage() {
           throw new Error('Failed to save movie memory batch');
         }
 
-        if (updateState) {
-          setAction({ status: 'idle' });
-        }
+        applyFlushAction({ status: 'idle' });
       } catch {
         pendingDeckItems.current = [...items, ...pendingDeckItems.current];
-        if (updateState) {
-          setAction({ status: 'error' });
-        }
+        applyFlushAction({ status: 'error' });
       }
     },
     [locale],
@@ -570,26 +577,14 @@ export default function MovieMemoryPage() {
     if (!activeDeckMovie) return;
 
     function handleKeyDown(event: KeyboardEvent) {
-      if (
-        event.defaultPrevented ||
-        event.metaKey ||
-        event.ctrlKey ||
-        event.altKey ||
-        event.shiftKey ||
-        isEditableKeyboardTarget(event.target)
-      ) {
-        return;
-      }
+      const action = getDeckKeyboardAction(event);
+      if (!action) return;
 
-      if (event.key === 'ArrowLeft') {
-        event.preventDefault();
-        answerDeckMovie(activeDeckMovie.id, 'not_seen');
-      } else if (event.key === 'ArrowRight') {
-        event.preventDefault();
-        answerDeckMovie(activeDeckMovie.id, 'watched');
-      } else if (event.key === 'ArrowDown') {
-        event.preventDefault();
+      event.preventDefault();
+      if (action === 'unsure') {
         skipActiveDeckMovie(activeDeckMovie.id);
+      } else {
+        answerDeckMovie(activeDeckMovie.id, action);
       }
     }
 
@@ -638,27 +633,13 @@ export default function MovieMemoryPage() {
 
   async function handleCatalogSearch(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    const query = catalogQuery.trim();
-    if (query.length < 2) return;
+    const query = getCatalogSearchQuery(catalogQuery);
+    if (!query) return;
 
     setCatalogSearch({ status: 'loading' });
 
     try {
-      const response = await fetch(`/api/account/movie-memory?query=${encodeURIComponent(query)}`, {
-        method: 'GET',
-        cache: 'no-store',
-        credentials: 'same-origin',
-      });
-
-      if (!response.ok) {
-        throw new Error('Failed to search movie catalog');
-      }
-
-      const data = (await response.json()) as { movies?: MovieMemoryCandidate[] };
-      setCatalogSearch({
-        status: 'loaded',
-        movies: Array.isArray(data.movies) ? data.movies : [],
-      });
+      setCatalogSearch({ status: 'loaded', movies: await fetchCatalogSearchMovies(query) });
     } catch {
       setCatalogSearch({ status: 'error' });
     }
@@ -1055,781 +1036,4 @@ function ErrorPanel({
       </button>
     </div>
   );
-}
-
-function CompletionPanel({
-  labels,
-  onLoadMore,
-  onOpenManualSearch,
-  stats,
-  variant,
-}: {
-  labels: ReturnType<typeof useLanguage>['t']['account'];
-  onLoadMore: () => void;
-  onOpenManualSearch: () => void;
-  stats: DeckSessionStats;
-  variant: 'complete' | 'empty';
-}) {
-  const isEmpty = variant === 'empty';
-  const Icon = isEmpty ? Film : Check;
-
-  return (
-    <div
-      className="flex flex-col items-center gap-5 rounded-3xl p-8 text-center md:p-10"
-      style={{
-        background:
-          'linear-gradient(145deg, color-mix(in srgb, var(--pc-surface) 92%, var(--pc-gold) 8%), var(--pc-surface))',
-        border: '1px solid var(--pc-bd2)',
-        boxShadow: 'var(--pc-card-shadow)',
-        color: 'var(--pc-t2)',
-      }}
-    >
-      <div
-        className="flex h-16 w-16 items-center justify-center rounded-2xl"
-        style={{
-          background: isEmpty ? 'var(--pc-surface-hover)' : 'var(--pc-gold-subtle)',
-          border: isEmpty ? '1px solid var(--pc-bd2)' : '1px solid var(--pc-gold-bd)',
-          color: isEmpty ? 'var(--pc-t2)' : 'var(--pc-gold-text)',
-        }}
-      >
-        <Icon size={30} />
-      </div>
-      <div className="max-w-xl">
-        <h2 className="mb-2 text-2xl font-semibold" style={{ color: 'var(--pc-t1)' }}>
-          {isEmpty ? labels.memoryDeckEmptyTitle : labels.memoryDeckCompleteTitle}
-        </h2>
-        <p>{isEmpty ? labels.memoryDeckEmptyBody : labels.memoryDeckCompleteBody}</p>
-      </div>
-
-      {!isEmpty ? (
-        <div className="grid w-full max-w-lg grid-cols-3 gap-2" aria-label={labels.memorySummary}>
-          <CompletionStat label={labels.seenMovie} value={stats.watched} tone="seen" />
-          <CompletionStat label={labels.notSeenMovie} value={stats.notSeen} tone="notSeen" />
-          <CompletionStat label={labels.skipMovie} value={stats.unsure} tone="unsure" />
-        </div>
-      ) : null}
-
-      <div className="flex w-full max-w-xl flex-col gap-3 sm:flex-row sm:justify-center">
-        {isEmpty ? (
-          <button
-            type="button"
-            onClick={onLoadMore}
-            className="rounded-xl px-5 py-3 text-sm font-semibold transition hover:-translate-y-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pc-gold)]"
-            style={{ background: 'var(--pc-cta)', color: 'var(--pc-cta-text)' }}
-          >
-            {labels.memoryDeckEmptyAction}
-          </button>
-        ) : (
-          <>
-            <Link
-              href="/account"
-              className="inline-flex items-center justify-center gap-2 rounded-xl px-5 py-3 text-sm font-semibold transition hover:-translate-y-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pc-gold)]"
-              style={{ background: 'var(--pc-cta)', color: 'var(--pc-cta-text)' }}
-            >
-              {labels.memoryDeckBackToMemory}
-              <ArrowRight size={16} />
-            </Link>
-            <Link
-              href="/quiz"
-              className="inline-flex items-center justify-center rounded-xl px-5 py-3 text-sm font-semibold transition hover:-translate-y-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pc-gold)]"
-              style={{
-                background: 'var(--pc-ghost)',
-                border: '1px solid var(--pc-bd2)',
-                color: 'var(--pc-t2)',
-              }}
-            >
-              {labels.memoryDeckFindRecommendation}
-            </Link>
-          </>
-        )}
-      </div>
-
-      {!isEmpty ? (
-        <div className="flex flex-wrap justify-center gap-2">
-          <button
-            type="button"
-            onClick={onLoadMore}
-            className="rounded-full px-3 py-1.5 text-xs font-semibold transition hover:bg-[var(--pc-ghost)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pc-gold)]"
-            style={{ color: 'var(--pc-t3)' }}
-          >
-            {labels.loadMoreMovies}
-          </button>
-          <button
-            type="button"
-            onClick={onOpenManualSearch}
-            className="rounded-full px-3 py-1.5 text-xs font-semibold transition hover:bg-[var(--pc-ghost)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pc-gold)]"
-            style={{ color: 'var(--pc-t3)' }}
-          >
-            {labels.memoryDeckAddManual}
-          </button>
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-function CompletionStat({
-  label,
-  value,
-  tone,
-}: {
-  label: string;
-  value: number;
-  tone: 'seen' | 'notSeen' | 'unsure';
-}) {
-  const color = tone === 'seen' ? palette.green : tone === 'notSeen' ? palette.red : 'var(--pc-t2)';
-
-  return (
-    <div
-      className="rounded-2xl px-3 py-4"
-      style={{
-        background: 'var(--pc-bg)',
-        border: '1px solid var(--pc-bd2)',
-      }}
-    >
-      <div className="text-2xl font-bold" style={{ color }}>
-        {value}
-      </div>
-      <div className="mt-1 text-xs font-semibold" style={{ color: 'var(--pc-t3)' }}>
-        {label}
-      </div>
-    </div>
-  );
-}
-
-function MovieTrainingCard({
-  movie,
-  labels,
-  locale,
-  exitAction,
-  counter,
-  progressPercent,
-  action,
-  isSubmitting,
-  onSave,
-  onSkip,
-}: {
-  movie: MovieMemoryCandidate;
-  labels: ReturnType<typeof useLanguage>['t']['account'];
-  locale: string;
-  exitAction: DeckExitAction | null;
-  counter: string;
-  progressPercent: number;
-  action: ActionState;
-  isSubmitting: boolean;
-  onSave: (movieId: number, kind: UserMovieInteractionKind) => void;
-  onSkip: (movieId: number) => void;
-}) {
-  const shouldReduceMotion = useReducedMotion();
-  const title = getMovieTitle(movie, locale);
-  const summary = getMovieSummary(movie, locale);
-  const duration = formatDuration(movie.duration, locale);
-  const originalTitle =
-    locale !== 'en' && movie.localizedName && movie.localizedName !== movie.movieName
-      ? movie.movieName
-      : null;
-
-  return (
-    <motion.article
-      key={movie.id}
-      initial={{ opacity: 0, y: 18, scale: 0.98 }}
-      animate={getDeckCardAnimate(exitAction, Boolean(shouldReduceMotion))}
-      transition={{ duration: exitAction ? 0.28 : 0.18, ease: [0.22, 1, 0.36, 1] }}
-      className="relative overflow-hidden rounded-[1.75rem]"
-      style={{
-        background:
-          'linear-gradient(145deg, color-mix(in srgb, var(--pc-surface) 92%, var(--pc-gold) 8%), var(--pc-surface))',
-        border: '1px solid var(--pc-bd2)',
-        boxShadow: 'var(--pc-card-shadow)',
-      }}
-    >
-      <div className="grid gap-6 p-4 sm:p-5 md:grid-cols-[minmax(220px,320px)_1fr] md:items-stretch md:p-6">
-        <PosterFrame
-          key={`${movie.id}:${movie.posterURL ?? 'missing'}`}
-          movie={movie}
-          title={title}
-          labels={labels}
-        />
-
-        <div className="flex min-w-0 flex-col justify-between gap-6 py-1 md:py-2">
-          <div
-            className="p-1"
-            style={{
-              color: 'var(--pc-t2)',
-            }}
-          >
-            <div className="mb-2 flex items-center gap-3">
-              <span
-                className="rounded-full px-3 py-1 text-xs font-semibold"
-                style={{
-                  background: 'var(--pc-gold-subtle)',
-                  border: '1px solid var(--pc-gold-bd)',
-                  color: 'var(--pc-gold-text)',
-                }}
-              >
-                {counter}
-              </span>
-            </div>
-            <div
-              className="h-2 overflow-hidden rounded-full"
-              style={{ background: 'var(--pc-ghost)' }}
-              aria-hidden="true"
-            >
-              <div
-                className="h-full rounded-full"
-                style={{ width: `${progressPercent}%`, background: 'var(--pc-progress)' }}
-              />
-            </div>
-          </div>
-
-          <div>
-            <h2
-              className="text-3xl font-semibold leading-tight md:text-5xl"
-              style={{ color: 'var(--pc-t1)' }}
-            >
-              {formatMovieName(title, movie.movieYear)}
-            </h2>
-            <div className="mt-4 flex flex-wrap items-center gap-2 text-sm font-medium">
-              {duration ? (
-                <span
-                  className="rounded-full px-3 py-1"
-                  style={{ background: 'var(--pc-ghost)', color: 'var(--pc-t2)' }}
-                >
-                  {duration}
-                </span>
-              ) : null}
-              {originalTitle ? (
-                <span className="min-w-0 truncate" style={{ color: 'var(--pc-t3)' }}>
-                  {originalTitle}
-                </span>
-              ) : null}
-            </div>
-            {summary ? (
-              <p className="mt-5 max-w-[62ch] text-sm leading-6" style={{ color: 'var(--pc-t2)' }}>
-                {summary}
-              </p>
-            ) : null}
-          </div>
-        </div>
-      </div>
-      <div
-        className="px-4 pb-4 sm:px-5 sm:pb-5 md:px-6 md:pb-6"
-        style={{ borderTop: '1px solid var(--pc-bd1)' }}
-      >
-        <MovieTrainingControls
-          movie={movie}
-          labels={labels}
-          action={action}
-          isSubmitting={isSubmitting}
-          onSave={onSave}
-          onSkip={onSkip}
-        />
-      </div>
-      <DeckActionOverlay action={exitAction} labels={labels} />
-    </motion.article>
-  );
-}
-
-function getDeckCardAnimate(action: DeckExitAction | null, reducedMotion: boolean) {
-  if (!action) return { opacity: 1, x: 0, y: 0, rotate: 0, scale: 1 };
-  if (reducedMotion) return { opacity: 0, x: 0, y: 0, rotate: 0, scale: 0.98 };
-  if (action === 'watched') return { opacity: 0, x: 520, y: 8, rotate: 8, scale: 0.98 };
-  if (action === 'not_seen') return { opacity: 0, x: -520, y: 8, rotate: -8, scale: 0.98 };
-  return { opacity: 0, x: 0, y: 150, rotate: 0, scale: 0.95 };
-}
-
-function DeckActionOverlay({
-  action,
-  labels,
-}: {
-  action: DeckExitAction | null;
-  labels: ReturnType<typeof useLanguage>['t']['account'];
-}) {
-  if (!action) return null;
-
-  const config =
-    action === 'watched'
-      ? {
-          label: labels.memoryOverlaySeen,
-          Icon: Eye,
-          background: `${palette.green}38`,
-          border: `${palette.green}80`,
-          color: palette.green,
-          rotate: 5,
-        }
-      : action === 'not_seen'
-        ? {
-            label: labels.memoryOverlayNotSeen,
-            Icon: X,
-            background: `${palette.red}38`,
-            border: `${palette.red}80`,
-            color: palette.red,
-            rotate: -5,
-          }
-        : {
-            label: labels.memoryOverlayUnsure,
-            Icon: ChevronDown,
-            background: 'color-mix(in srgb, var(--pc-surface-hover) 84%, transparent)',
-            border: 'var(--pc-bd3)',
-            color: 'var(--pc-t1)',
-            rotate: 0,
-          };
-  const { Icon } = config;
-
-  return (
-    <motion.div
-      aria-hidden="true"
-      className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center"
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      transition={{ duration: 0.1 }}
-      style={{ background: config.background }}
-    >
-      <motion.div
-        className="inline-flex items-center gap-3 rounded-2xl px-6 py-4 text-xl font-black uppercase tracking-[0.14em] md:text-3xl"
-        initial={{ scale: 0.92, rotate: config.rotate }}
-        animate={{ scale: 1, rotate: config.rotate }}
-        transition={{ duration: 0.14, ease: [0.22, 1, 0.36, 1] }}
-        style={{
-          border: `2px solid ${config.border}`,
-          color: config.color,
-          background: 'var(--pc-bg)',
-          boxShadow: 'var(--pc-card-shadow)',
-        }}
-      >
-        <Icon size={24} />
-        {config.label}
-      </motion.div>
-    </motion.div>
-  );
-}
-
-function MovieTrainingControls({
-  movie,
-  labels,
-  action,
-  isSubmitting,
-  onSave,
-  onSkip,
-}: {
-  movie: MovieMemoryCandidate;
-  labels: ReturnType<typeof useLanguage>['t']['account'];
-  action: ActionState;
-  isSubmitting: boolean;
-  onSave: (movieId: number, kind: UserMovieInteractionKind) => void;
-  onSkip: (movieId: number) => void;
-}) {
-  const savingSeen =
-    action.status === 'saving' && action.movieId === movie.id && action.kind === 'watched';
-  const savingUnseen =
-    action.status === 'saving' && action.movieId === movie.id && action.kind === 'not_seen';
-  const isSaving = action.status === 'saving' || isSubmitting;
-
-  return (
-    <motion.div
-      key={`${movie.id}-controls`}
-      initial={{ opacity: 0, y: 10 }}
-      animate={{ opacity: 1, y: 0 }}
-      className="pt-4"
-    >
-      <div className="mb-3 flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
-        <p className="text-sm font-semibold" style={{ color: 'var(--pc-t2)' }}>
-          {labels.memoryCardQuestion}
-        </p>
-        <p className="text-xs" style={{ color: 'var(--pc-t3)' }}>
-          {labels.memoryKeyboardHint}
-        </p>
-      </div>
-      <div className="grid gap-3 sm:grid-cols-2">
-        <button
-          type="button"
-          disabled={isSaving}
-          onClick={() => onSave(movie.id, 'not_seen')}
-          className="inline-flex min-h-14 items-center justify-center gap-2 rounded-2xl px-5 py-4 text-sm font-semibold transition hover:-translate-y-0.5 hover:brightness-110 active:translate-y-0 active:scale-[0.99] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pc-gold)] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:translate-y-0"
-          style={{
-            background: `${palette.red}22`,
-            border: `1px solid ${palette.red}70`,
-            color: palette.red,
-          }}
-        >
-          {savingUnseen ? <Loader2 className="animate-spin" size={18} /> : <X size={18} />}
-          &larr; {labels.notSeenMovie}
-        </button>
-        <button
-          type="button"
-          disabled={isSaving}
-          onClick={() => onSave(movie.id, 'watched')}
-          className="inline-flex min-h-14 items-center justify-center gap-2 rounded-2xl px-5 py-4 text-sm font-semibold transition hover:-translate-y-0.5 hover:brightness-110 active:translate-y-0 active:scale-[0.99] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pc-gold)] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:translate-y-0"
-          style={{
-            background: `${palette.green}26`,
-            border: `1px solid ${palette.green}75`,
-            color: palette.green,
-          }}
-        >
-          {savingSeen ? <Loader2 className="animate-spin" size={18} /> : <Eye size={18} />}
-          {labels.seenMovie} &rarr;
-        </button>
-      </div>
-      <button
-        type="button"
-        disabled={isSaving}
-        onClick={() => onSkip(movie.id)}
-        className="mt-3 inline-flex min-h-12 w-full items-center justify-center gap-2 rounded-2xl bg-transparent px-5 text-sm font-semibold transition hover:-translate-y-0.5 hover:border-[var(--pc-bd3)] hover:bg-[var(--pc-surface-hover)] hover:text-[var(--pc-t1)] active:translate-y-0 active:scale-[0.99] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pc-gold)] disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:translate-y-0"
-        style={{
-          border: '1px solid var(--pc-bd2)',
-          color: 'var(--pc-t2)',
-        }}
-      >
-        <ChevronDown size={18} />
-        &darr; {labels.skipMovie}
-      </button>
-    </motion.div>
-  );
-}
-
-function PosterFrame({
-  movie,
-  title,
-  labels,
-}: {
-  movie: MovieMemoryCandidate;
-  title: string;
-  labels: ReturnType<typeof useLanguage>['t']['account'];
-}) {
-  const [imageState, setImageState] = useState<'loading' | 'loaded' | 'failed'>(() =>
-    movie.posterURL ? 'loading' : 'failed',
-  );
-  const shouldShowPoster = movie.posterURL && imageState !== 'failed';
-
-  return (
-    <div
-      className="relative mx-auto aspect-[2/3] w-full max-w-[320px] overflow-hidden rounded-[1.25rem] md:max-w-none"
-      style={{
-        background: 'var(--pc-surface-deep)',
-        border: '1px solid var(--pc-bd2)',
-        boxShadow: '0 18px 42px rgba(9,9,15,0.16)',
-      }}
-    >
-      {shouldShowPoster ? (
-        <>
-          {imageState === 'loading' ? (
-            <div
-              aria-hidden="true"
-              className="absolute inset-0 animate-pulse"
-              style={{
-                background:
-                  'linear-gradient(110deg, var(--pc-surface-deep), var(--pc-surface-hover), var(--pc-surface-deep))',
-              }}
-            />
-          ) : null}
-          <Image
-            src={movie.posterURL as string}
-            alt={title}
-            fill
-            priority
-            sizes="(min-width: 768px) 320px, min(320px, 100vw)"
-            className={`object-contain transition-opacity duration-200 ${
-              imageState === 'loaded' ? 'opacity-100' : 'opacity-0'
-            }`}
-            onLoad={() => setImageState('loaded')}
-            onError={() => setImageState('failed')}
-          />
-        </>
-      ) : (
-        <div
-          className="absolute inset-0 flex flex-col justify-between overflow-hidden p-5 text-center"
-          style={{
-            background:
-              'linear-gradient(160deg, color-mix(in srgb, var(--pc-surface-hover) 86%, var(--pc-gold) 14%), var(--pc-surface-deep) 58%, color-mix(in srgb, var(--pc-bg) 88%, var(--pc-gold) 12%))',
-          }}
-        >
-          <div
-            aria-hidden="true"
-            className="pointer-events-none absolute inset-x-0 top-0 h-16"
-            style={{
-              background:
-                'repeating-linear-gradient(90deg, transparent 0 12px, color-mix(in srgb, var(--pc-gold) 24%, transparent) 12px 14px)',
-              opacity: 0.55,
-            }}
-          />
-          <div className="relative z-[1] flex items-center justify-between">
-            <span
-              className="rounded-full px-3 py-1 text-[0.65rem] font-black uppercase tracking-[0.16em]"
-              style={{
-                background: 'var(--pc-gold-subtle)',
-                border: '1px solid var(--pc-gold-bd)',
-                color: 'var(--pc-gold-text)',
-              }}
-            >
-              PopChoice
-            </span>
-            {movie.movieYear ? (
-              <span
-                className="rounded-full px-3 py-1 text-xs font-bold"
-                style={{
-                  background: 'var(--pc-bg)',
-                  border: '1px solid var(--pc-bd2)',
-                  color: 'var(--pc-t2)',
-                }}
-              >
-                {movie.movieYear}
-              </span>
-            ) : null}
-          </div>
-          <div className="relative z-[1] flex flex-1 flex-col items-center justify-center gap-5">
-            <div
-              className="flex h-20 w-20 items-center justify-center rounded-3xl"
-              style={{
-                background: 'var(--pc-bg)',
-                border: '1px solid var(--pc-bd2)',
-                boxShadow: '0 16px 34px rgba(9,9,15,0.22)',
-              }}
-            >
-              <Film size={42} style={{ color: 'var(--pc-gold-text)' }} />
-            </div>
-            <p
-              className="max-w-[15rem] text-xl font-black leading-tight"
-              style={{ color: 'var(--pc-t1)' }}
-            >
-              {title}
-            </p>
-          </div>
-          <div className="relative z-[1]">
-            <p
-              className="rounded-full px-3 py-2 text-xs font-bold uppercase tracking-[0.14em]"
-              style={{
-                background: 'var(--pc-bg)',
-                border: '1px solid var(--pc-bd2)',
-                color: 'var(--pc-t3)',
-              }}
-            >
-              {labels.posterUnavailable}
-            </p>
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}
-
-function ManualSearchPanel({
-  query,
-  search,
-  labels,
-  locale,
-  action,
-  isOpen,
-  onToggle,
-  onQueryChange,
-  onSearch,
-  onSave,
-}: {
-  query: string;
-  search: CatalogSearchState;
-  labels: ReturnType<typeof useLanguage>['t']['account'];
-  locale: string;
-  action: ActionState;
-  isOpen: boolean;
-  onToggle: () => void;
-  onQueryChange: (value: string) => void;
-  onSearch: (event: FormEvent<HTMLFormElement>) => void;
-  onSave: (movieId: number, kind: UserMovieInteractionKind) => void;
-}) {
-  const searchInputId = useId();
-
-  return (
-    <section className="mx-auto mt-8 max-w-3xl">
-      <button
-        type="button"
-        onClick={onToggle}
-        className="relative mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-transparent transition hover:-translate-y-0.5 hover:bg-[var(--pc-ghost)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pc-gold)]"
-        style={{
-          border: '1px solid var(--pc-bd1)',
-          color: 'var(--pc-t3)',
-        }}
-        aria-expanded={isOpen}
-        aria-label={labels.manualSearchTitle}
-        title={labels.manualSearchTitle}
-      >
-        <Search size={18} />
-        <ChevronDown
-          size={14}
-          className={`absolute translate-x-3 translate-y-3 transition-transform ${isOpen ? 'rotate-180' : ''}`}
-          aria-hidden="true"
-        />
-      </button>
-
-      {isOpen ? (
-        <motion.div initial={{ opacity: 0, y: -8 }} animate={{ opacity: 1, y: 0 }} className="mt-5">
-          <div className="mb-4 text-center">
-            <h2 className="text-sm font-semibold" style={{ color: 'var(--pc-t1)' }}>
-              {labels.manualSearchTitle}
-            </h2>
-            <p className="mt-1 text-sm" style={{ color: 'var(--pc-t2)' }}>
-              {labels.manualSearchBody}
-            </p>
-          </div>
-
-          <form onSubmit={onSearch} className="flex flex-col gap-3 sm:flex-row">
-            <label htmlFor={searchInputId} className="sr-only">
-              {labels.searchMovieMemory}
-            </label>
-            <div
-              className="flex min-h-14 flex-1 items-center gap-3 rounded-2xl px-4"
-              style={{ background: 'var(--pc-bg)', border: '1px solid var(--pc-bd2)' }}
-            >
-              <Search size={20} style={{ color: 'var(--pc-t2)' }} />
-              <input
-                id={searchInputId}
-                value={query}
-                onChange={(event) => onQueryChange(event.target.value)}
-                placeholder={labels.catalogSearchPlaceholder}
-                className="min-w-0 flex-1 bg-transparent text-base outline-none"
-                style={{ color: 'var(--pc-t1)' }}
-              />
-            </div>
-            <button
-              type="submit"
-              disabled={query.trim().length < 2 || search.status === 'loading'}
-              className="inline-flex min-h-14 items-center justify-center rounded-2xl px-6 text-sm font-semibold focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pc-gold)] disabled:opacity-60"
-              style={{ background: 'var(--pc-cta)', color: 'var(--pc-cta-text)' }}
-            >
-              {search.status === 'loading' ? (
-                <Loader2 className="animate-spin" size={18} />
-              ) : (
-                labels.searchCatalog
-              )}
-            </button>
-          </form>
-
-          <div className="mt-4 grid gap-3">
-            {search.status === 'error' ? (
-              <div
-                className="rounded-2xl p-4 text-sm"
-                style={{ background: `${palette.red}14`, color: 'var(--pc-t2)' }}
-              >
-                {labels.catalogSearchError}
-              </div>
-            ) : null}
-            {search.status === 'loaded' && search.movies.length === 0 ? (
-              <div
-                className="rounded-2xl p-4 text-sm"
-                style={{ background: 'var(--pc-surface)', color: 'var(--pc-t2)' }}
-              >
-                {labels.catalogSearchEmpty}
-              </div>
-            ) : null}
-            {search.status === 'loaded'
-              ? search.movies.map((movie) => (
-                  <MovieSearchResultRow
-                    key={movie.id}
-                    movie={movie}
-                    labels={labels}
-                    locale={locale}
-                    action={action}
-                    onSave={onSave}
-                  />
-                ))
-              : null}
-          </div>
-        </motion.div>
-      ) : null}
-    </section>
-  );
-}
-
-function MovieSearchResultRow({
-  movie,
-  labels,
-  locale,
-  action,
-  onSave,
-}: {
-  movie: MovieMemoryCandidate;
-  labels: ReturnType<typeof useLanguage>['t']['account'];
-  locale: string;
-  action: ActionState;
-  onSave: (movieId: number, kind: UserMovieInteractionKind) => void;
-}) {
-  const title = getMovieTitle(movie, locale);
-  const saving = action.status === 'saving' && action.movieId === movie.id;
-
-  return (
-    <div
-      className="flex items-center gap-4 rounded-2xl p-3"
-      style={{ background: 'var(--pc-surface)', border: '1px solid var(--pc-bd2)' }}
-    >
-      {movie.posterURL ? (
-        <Image
-          src={movie.posterURL}
-          alt={title}
-          width={56}
-          height={80}
-          sizes="56px"
-          className="h-20 w-14 rounded-xl object-cover"
-        />
-      ) : (
-        <div
-          className="flex h-20 w-14 items-center justify-center rounded-xl"
-          style={{ background: 'var(--pc-ghost)', color: 'var(--pc-t3)' }}
-        >
-          <Film size={22} />
-        </div>
-      )}
-      <div className="min-w-0 flex-1">
-        <p className="truncate font-semibold" style={{ color: 'var(--pc-t1)' }}>
-          {formatMovieName(title, movie.movieYear)}
-        </p>
-        {movie.localizedName && movie.localizedName !== movie.movieName ? (
-          <p className="truncate text-sm" style={{ color: 'var(--pc-t2)' }}>
-            {movie.movieName}
-          </p>
-        ) : null}
-      </div>
-      <button
-        type="button"
-        disabled={saving}
-        onClick={() => onSave(movie.id, 'watched')}
-        className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl px-4 text-sm font-semibold disabled:opacity-60"
-        style={{ background: 'var(--pc-gold-subtle)', color: 'var(--pc-gold-text)' }}
-      >
-        {saving ? <Loader2 className="animate-spin" size={16} /> : <Eye size={16} />}
-        {labels.seenMovie}
-      </button>
-    </div>
-  );
-}
-
-function getMovieTitle(movie: MovieMemoryCandidate, locale: string): string {
-  if (locale !== 'en' && movie.localizedName) return movie.localizedName;
-  return movie.movieName;
-}
-
-function getMovieSummary(movie: MovieMemoryCandidate, locale: string): string | null {
-  const summary =
-    locale !== 'en' ? movie.localizedOverview || movie.description : movie.description;
-  const trimmed = summary?.trim();
-  if (!trimmed) return null;
-  return trimmed.length > 260 ? `${trimmed.slice(0, 257).trimEnd()}...` : trimmed;
-}
-
-function formatMovieName(name: string, year: number | null): string {
-  return year ? `${name} (${year})` : name;
-}
-
-function formatDuration(duration: number | null, locale: string): string | null {
-  if (!duration || duration <= 0) return null;
-  const hours = Math.floor(duration / 60);
-  const minutes = duration % 60;
-  if (hours === 0) return locale === 'ru' ? `${minutes} мин` : `${minutes} min`;
-
-  if (locale === 'ru') {
-    return minutes ? `${hours} ч ${minutes} мин` : `${hours} ч`;
-  }
-
-  if (locale === 'fi') {
-    return minutes ? `${hours} t ${minutes} min` : `${hours} t`;
-  }
-
-  return minutes ? `${hours}h ${minutes}m` : `${hours}h`;
 }


### PR DESCRIPTION
## Summary
- Split the movie-memory training/completion/manual-search UI out of the page orchestration file.
- Moved keyboard, animation, title, summary, and duration decisions into tested view-model helpers.
- Simplified deck flush and catalog search handlers so the touched page slice has no changed-code Fallow health findings.

## Fallow
- Changed health: 0 findings.
- Changed dead-code: 0 issues.
- Changed dupes: 0 clone groups.

## Verification
- npm run test --workspace=apps/web -- src/app/account/movie-memory/movieMemoryViewModel.test.ts
- npm run type-check --workspace=apps/web
- npm run lint:check --workspace=apps/web
- pre-push: lint, server tests, production build

Closes #724