### PR TITLE
Reduce catalog and TMDB complexity

### DIFF
--- a/apps/web/src/app/available-movies/availableMoviesComponents.tsx
+++ b/apps/web/src/app/available-movies/availableMoviesComponents.tsx
@@ -1,0 +1,523 @@
+import { ChevronLeft, ChevronRight, Search, X } from 'lucide-react';
+
+import { MoviesTable, MoviesTableSkeleton } from '@/components';
+
+import {
+  AGE_RATING_FILTERS,
+  generatePageNumbers,
+  hasActiveMovieFilters,
+} from './availableMoviesViewModel';
+
+import type { MovieFilters } from './availableMoviesViewModel';
+import type { Movie } from '@/features/movies/catalog';
+import type { useLanguage } from '@/i18n';
+import type { FormEvent, ReactNode } from 'react';
+
+type MoviesPageLabels = ReturnType<typeof useLanguage>['t']['moviesPage'];
+
+type FilterUpdater = (updater: (current: MovieFilters) => MovieFilters) => void;
+
+const inputStyle = {
+  background: 'var(--pc-surface)',
+  border: '1px solid var(--pc-bd2)',
+  color: 'var(--pc-t1)',
+};
+
+interface AvailableMoviesHeaderProps {
+  labels: MoviesPageLabels;
+  summary: string;
+}
+
+export function AvailableMoviesHeader({ labels, summary }: AvailableMoviesHeaderProps) {
+  return (
+    <div className="mb-8">
+      <h1
+        className="text-3xl font-bold mb-2"
+        style={{
+          fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
+          color: 'var(--pc-t1)',
+        }}
+      >
+        {labels.title}
+      </h1>
+      <p className="text-sm" style={{ color: 'var(--pc-t3)' }}>
+        {summary}
+      </p>
+    </div>
+  );
+}
+
+interface AvailableMoviesErrorProps {
+  error: string;
+  labels: MoviesPageLabels;
+  onRetry: () => void;
+}
+
+export function AvailableMoviesError({ error, labels, onRetry }: AvailableMoviesErrorProps) {
+  return (
+    <section className="flex-1 flex flex-col items-center justify-center px-5 py-16 text-center">
+      <p className="text-sm mb-4" style={{ color: 'var(--rating-mature-text)' }}>
+        {error}
+      </p>
+      <button
+        onClick={onRetry}
+        className="px-5 py-2.5 rounded-xl text-sm font-semibold"
+        style={{ background: 'var(--pc-cta)', color: 'var(--pc-cta-text)' }}
+      >
+        {labels.tryAgain}
+      </button>
+    </section>
+  );
+}
+
+interface MoviesFilterFormProps {
+  draftFilters: MovieFilters;
+  labels: MoviesPageLabels;
+  onAgeRatingToggle: (rating: string) => void;
+  onClearFilters: () => void;
+  onDraftFiltersChange: FilterUpdater;
+  onFilterSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  onImmediateFilterChange: (filters: MovieFilters) => void;
+}
+
+export function MoviesFilterForm({
+  draftFilters,
+  labels,
+  onAgeRatingToggle,
+  onClearFilters,
+  onDraftFiltersChange,
+  onFilterSubmit,
+  onImmediateFilterChange,
+}: MoviesFilterFormProps) {
+  return (
+    <form onSubmit={onFilterSubmit} className="mb-6 flex flex-col gap-4">
+      <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_6.5rem_6.5rem_9rem_8rem_auto_auto] lg:items-end">
+        <SearchFilterInput
+          filters={draftFilters}
+          labels={labels}
+          onDraftFiltersChange={onDraftFiltersChange}
+        />
+        <YearFilterInput
+          field="yearFrom"
+          label={labels.yearFrom}
+          value={draftFilters.yearFrom}
+          onDraftFiltersChange={onDraftFiltersChange}
+        />
+        <YearFilterInput
+          field="yearTo"
+          label={labels.yearTo}
+          value={draftFilters.yearTo}
+          onDraftFiltersChange={onDraftFiltersChange}
+        />
+        <DurationFilterSelect
+          filters={draftFilters}
+          labels={labels}
+          onDraftFiltersChange={onDraftFiltersChange}
+          onImmediateFilterChange={onImmediateFilterChange}
+        />
+        <ScoreFilterSelect
+          filters={draftFilters}
+          labels={labels}
+          onDraftFiltersChange={onDraftFiltersChange}
+          onImmediateFilterChange={onImmediateFilterChange}
+        />
+        <FilterButton icon={<Search size={16} aria-hidden="true" />} label={labels.applyFilters} />
+        <FilterButton
+          icon={<X size={16} aria-hidden="true" />}
+          label={labels.clearFilters}
+          onClick={onClearFilters}
+          variant="secondary"
+        />
+      </div>
+      <AgeRatingFilterGroup
+        filters={draftFilters}
+        labels={labels}
+        onAgeRatingToggle={onAgeRatingToggle}
+      />
+    </form>
+  );
+}
+
+function SearchFilterInput({
+  filters,
+  labels,
+  onDraftFiltersChange,
+}: {
+  filters: MovieFilters;
+  labels: MoviesPageLabels;
+  onDraftFiltersChange: FilterUpdater;
+}) {
+  return (
+    <label
+      className="flex flex-col gap-1.5 text-xs font-semibold"
+      style={{ color: 'var(--pc-t3)' }}
+    >
+      {labels.searchLabel}
+      <span
+        className="flex items-center gap-2 rounded-lg px-3 py-2"
+        style={{
+          background: 'var(--pc-surface)',
+          border: '1px solid var(--pc-bd2)',
+          color: 'var(--pc-t2)',
+        }}
+      >
+        <Search size={16} aria-hidden="true" />
+        <input
+          value={filters.query}
+          onChange={(event) =>
+            onDraftFiltersChange((current) => ({ ...current, query: event.target.value }))
+          }
+          maxLength={80}
+          placeholder={labels.searchPlaceholder}
+          className="min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:opacity-70"
+          style={{ color: 'var(--pc-t1)' }}
+        />
+      </span>
+    </label>
+  );
+}
+
+function YearFilterInput({
+  field,
+  label,
+  onDraftFiltersChange,
+  value,
+}: {
+  field: 'yearFrom' | 'yearTo';
+  label: string;
+  onDraftFiltersChange: FilterUpdater;
+  value: string;
+}) {
+  return (
+    <label
+      className="flex flex-col gap-1.5 text-xs font-semibold"
+      style={{ color: 'var(--pc-t3)' }}
+    >
+      {label}
+      <input
+        value={value}
+        onChange={(event) =>
+          onDraftFiltersChange((current) => ({ ...current, [field]: event.target.value }))
+        }
+        inputMode="numeric"
+        pattern="[0-9]*"
+        maxLength={4}
+        className="h-10 rounded-lg px-3 text-sm outline-none"
+        style={inputStyle}
+      />
+    </label>
+  );
+}
+
+function DurationFilterSelect({
+  filters,
+  labels,
+  onDraftFiltersChange,
+  onImmediateFilterChange,
+}: {
+  filters: MovieFilters;
+  labels: MoviesPageLabels;
+  onDraftFiltersChange: FilterUpdater;
+  onImmediateFilterChange: (filters: MovieFilters) => void;
+}) {
+  return (
+    <label
+      className="flex flex-col gap-1.5 text-xs font-semibold"
+      style={{ color: 'var(--pc-t3)' }}
+    >
+      {labels.durationFilter}
+      <select
+        value={filters.duration}
+        onChange={(event) => {
+          const nextFilters = {
+            ...filters,
+            duration: event.target.value as MovieFilters['duration'],
+          };
+          onDraftFiltersChange(() => nextFilters);
+          onImmediateFilterChange(nextFilters);
+        }}
+        className="h-10 rounded-lg px-3 text-sm outline-none"
+        style={inputStyle}
+      >
+        <option value="">{labels.anyFilter}</option>
+        <option value="under-90">{labels.durationOptions.under90}</option>
+        <option value="90-120">{labels.durationOptions.between90And120}</option>
+        <option value="over-120">{labels.durationOptions.over120}</option>
+      </select>
+    </label>
+  );
+}
+
+function ScoreFilterSelect({
+  filters,
+  labels,
+  onDraftFiltersChange,
+  onImmediateFilterChange,
+}: {
+  filters: MovieFilters;
+  labels: MoviesPageLabels;
+  onDraftFiltersChange: FilterUpdater;
+  onImmediateFilterChange: (filters: MovieFilters) => void;
+}) {
+  return (
+    <label
+      className="flex flex-col gap-1.5 text-xs font-semibold"
+      style={{ color: 'var(--pc-t3)' }}
+    >
+      {labels.scoreFilter}
+      <select
+        value={filters.minScore}
+        onChange={(event) => {
+          const nextFilters = { ...filters, minScore: event.target.value };
+          onDraftFiltersChange(() => nextFilters);
+          onImmediateFilterChange(nextFilters);
+        }}
+        className="h-10 rounded-lg px-3 text-sm outline-none"
+        style={inputStyle}
+      >
+        <option value="">{labels.anyFilter}</option>
+        <option value="7">7.0+</option>
+        <option value="8">8.0+</option>
+        <option value="9">9.0+</option>
+      </select>
+    </label>
+  );
+}
+
+function FilterButton({
+  icon,
+  label,
+  onClick,
+  variant = 'primary',
+}: {
+  icon: ReactNode;
+  label: string;
+  onClick?: () => void;
+  variant?: 'primary' | 'secondary';
+}) {
+  const style =
+    variant === 'primary'
+      ? { background: 'var(--pc-cta)', color: 'var(--pc-cta-text)' }
+      : {
+          background: 'var(--pc-surface)',
+          border: '1px solid var(--pc-bd2)',
+          color: 'var(--pc-t2)',
+        };
+
+  return (
+    <button
+      type={onClick ? 'button' : 'submit'}
+      onClick={onClick}
+      className="inline-flex h-10 items-center justify-center gap-2 rounded-lg px-4 text-sm font-semibold"
+      style={style}
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}
+
+function AgeRatingFilterGroup({
+  filters,
+  labels,
+  onAgeRatingToggle,
+}: {
+  filters: MovieFilters;
+  labels: MoviesPageLabels;
+  onAgeRatingToggle: (rating: string) => void;
+}) {
+  return (
+    <fieldset className="flex flex-col gap-2">
+      <legend className="text-xs font-semibold" style={{ color: 'var(--pc-t3)' }}>
+        {labels.ageRatingFilter}
+      </legend>
+      <div className="flex flex-wrap gap-2">
+        {AGE_RATING_FILTERS.map((rating) => (
+          <AgeRatingOption
+            key={rating}
+            rating={rating}
+            selected={filters.ageRatings.includes(rating)}
+            onAgeRatingToggle={onAgeRatingToggle}
+          />
+        ))}
+      </div>
+    </fieldset>
+  );
+}
+
+function AgeRatingOption({
+  onAgeRatingToggle,
+  rating,
+  selected,
+}: {
+  onAgeRatingToggle: (rating: string) => void;
+  rating: string;
+  selected: boolean;
+}) {
+  const style = selected
+    ? {
+        background: 'var(--pc-gold-subtle)',
+        border: '1px solid var(--pc-gold)',
+        color: 'var(--pc-gold-text)',
+      }
+    : {
+        background: 'var(--pc-surface)',
+        border: '1px solid var(--pc-bd2)',
+        color: 'var(--pc-t2)',
+      };
+
+  return (
+    <label
+      className="inline-flex h-9 cursor-pointer items-center gap-2 rounded-lg px-3 text-sm font-semibold transition-colors duration-150"
+      style={style}
+    >
+      <input
+        type="checkbox"
+        checked={selected}
+        onChange={() => onAgeRatingToggle(rating)}
+        className="h-3.5 w-3.5 accent-[var(--pc-gold)]"
+      />
+      {rating}
+    </label>
+  );
+}
+
+interface MoviesResultPanelProps {
+  appliedFilters: MovieFilters;
+  loading: boolean;
+  movies: Movie[];
+  onClearFilters: () => void;
+}
+
+export function MoviesResultPanel({
+  appliedFilters,
+  loading,
+  movies,
+  onClearFilters,
+}: MoviesResultPanelProps) {
+  return loading ? (
+    <MoviesTableSkeleton />
+  ) : (
+    <MoviesTable
+      movies={movies}
+      hasActiveFilters={hasActiveMovieFilters(appliedFilters)}
+      onClearFilters={onClearFilters}
+    />
+  );
+}
+
+interface MoviesPaginationProps {
+  currentPage: number;
+  labels: MoviesPageLabels;
+  onPageChange: (page: number) => void;
+  totalPages: number;
+}
+
+export function MoviesPagination({
+  currentPage,
+  labels,
+  onPageChange,
+  totalPages,
+}: MoviesPaginationProps) {
+  if (totalPages <= 1) return null;
+
+  return (
+    <div className="flex items-center justify-between mt-8 gap-3 flex-wrap">
+      <div className="flex items-center gap-1.5 flex-wrap">
+        <PaginationButton
+          disabled={currentPage === 1}
+          label={labels.prev}
+          onClick={() => onPageChange(currentPage - 1)}
+          prefix={<ChevronLeft size={14} />}
+        />
+        {generatePageNumbers(currentPage, totalPages).map((page, index) => (
+          <PaginationPageButton
+            key={page === '...' ? `dots-${index}` : page}
+            currentPage={currentPage}
+            onPageChange={onPageChange}
+            page={page}
+          />
+        ))}
+        <PaginationButton
+          disabled={currentPage === totalPages}
+          label={labels.next}
+          onClick={() => onPageChange(currentPage + 1)}
+          suffix={<ChevronRight size={14} />}
+        />
+      </div>
+
+      <span className="text-xs" style={{ color: 'var(--pc-t4)' }}>
+        {labels.pageOf
+          .replace('{current}', String(currentPage))
+          .replace('{total}', String(totalPages))}
+      </span>
+    </div>
+  );
+}
+
+function PaginationButton({
+  disabled,
+  label,
+  onClick,
+  prefix,
+  suffix,
+}: {
+  disabled: boolean;
+  label: string;
+  onClick: () => void;
+  prefix?: ReactNode;
+  suffix?: ReactNode;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className="flex items-center gap-1 px-3 py-2 rounded-xl text-sm transition-colors duration-150 disabled:opacity-40 disabled:cursor-not-allowed"
+      style={{
+        background: 'var(--pc-surface)',
+        border: '1px solid var(--pc-bd2)',
+        color: 'var(--pc-t2)',
+      }}
+    >
+      {prefix}
+      {label}
+      {suffix}
+    </button>
+  );
+}
+
+function PaginationPageButton({
+  currentPage,
+  onPageChange,
+  page,
+}: {
+  currentPage: number;
+  onPageChange: (page: number) => void;
+  page: number | '...';
+}) {
+  if (page === '...') {
+    return (
+      <span className="px-2 py-2 text-sm" style={{ color: 'var(--pc-t4)' }}>
+        …
+      </span>
+    );
+  }
+
+  return (
+    <button
+      onClick={() => onPageChange(page)}
+      className="w-9 h-9 rounded-xl text-sm font-medium transition-colors duration-150"
+      style={
+        page === currentPage
+          ? { background: 'var(--pc-cta)', color: 'var(--pc-cta-text)' }
+          : {
+              background: 'var(--pc-surface)',
+              border: '1px solid var(--pc-bd2)',
+              color: 'var(--pc-t2)',
+            }
+      }
+    >
+      {page}
+    </button>
+  );
+}

--- a/apps/web/src/app/available-movies/availableMoviesViewModel.test.ts
+++ b/apps/web/src/app/available-movies/availableMoviesViewModel.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  buildMoviesCacheKey,
+  buildMoviesUrl,
+  cloneEmptyMovieFilters,
+  generatePageNumbers,
+  getMoviesPageSummary,
+  hasActiveMovieFilters,
+  normalizeMovieFilters,
+  toggleAgeRatingFilter,
+} from './availableMoviesViewModel';
+
+import type { MovieFilters } from './availableMoviesViewModel';
+
+vi.mock('@/lib/csrfClient', () => ({
+  getCsrfToken: () => 'csrf-token',
+}));
+
+const emptyFilters = cloneEmptyMovieFilters();
+
+function makeFilters(overrides: Partial<MovieFilters> = {}): MovieFilters {
+  return { ...emptyFilters, ...overrides };
+}
+
+describe('available movies view model', () => {
+  it('builds stable API URLs and cache keys from trimmed filters', () => {
+    const filters = makeFilters({
+      ageRatings: ['PG-13', 'R'],
+      duration: '90-120',
+      minScore: ' 8 ',
+      query: ' Nolan ',
+      yearFrom: ' 2000 ',
+      yearTo: '2020',
+    });
+
+    expect(buildMoviesUrl(2, 50, filters)).toBe(
+      '/api/movies?page=2&pageSize=50&query=Nolan&yearFrom=2000&yearTo=2020&duration=90-120&minScore=8&ageRatings=PG-13%2CR',
+    );
+    expect(buildMoviesCacheKey(2, filters)).toBe(
+      JSON.stringify([2, 'Nolan', '2000', '2020', '90-120', '8', ['PG-13', 'R']]),
+    );
+  });
+
+  it('normalizes and detects active filters', () => {
+    expect(hasActiveMovieFilters(emptyFilters)).toBe(false);
+    expect(normalizeMovieFilters(makeFilters({ query: ' Kurosawa ', yearFrom: ' 1950 ' }))).toEqual(
+      makeFilters({ query: 'Kurosawa', yearFrom: '1950' }),
+    );
+    expect(hasActiveMovieFilters(makeFilters({ minScore: '7' }))).toBe(true);
+  });
+
+  it('toggles age ratings without mutating the original filters', () => {
+    const selected = toggleAgeRatingFilter(emptyFilters, 'PG-13');
+    const cleared = toggleAgeRatingFilter(selected, 'PG-13');
+
+    expect(selected.ageRatings).toEqual(['PG-13']);
+    expect(cleared.ageRatings).toEqual([]);
+    expect(emptyFilters.ageRatings).toEqual([]);
+  });
+
+  it('generates compact pagination numbers', () => {
+    expect(generatePageNumbers(1, 1)).toEqual([]);
+    expect(generatePageNumbers(5, 10)).toEqual([1, '...', 3, 4, 5, 6, 7, '...', 10]);
+    expect(generatePageNumbers(2, 4)).toEqual([1, 2, 3, 4]);
+  });
+
+  it('formats loading, empty, and result summaries', () => {
+    const base = {
+      currentPage: 2,
+      noMoviesFoundText: 'No movies',
+      pageSize: 50,
+      showingText: 'Showing {start}-{end} of {total}',
+    };
+
+    expect(getMoviesPageSummary({ ...base, loading: true, totalCount: 80 })).toBe('');
+    expect(getMoviesPageSummary({ ...base, loading: false, totalCount: 0 })).toBe('No movies');
+    expect(getMoviesPageSummary({ ...base, loading: false, totalCount: 80 })).toBe(
+      'Showing 51-80 of 80',
+    );
+  });
+});

--- a/apps/web/src/app/available-movies/availableMoviesViewModel.ts
+++ b/apps/web/src/app/available-movies/availableMoviesViewModel.ts
@@ -1,0 +1,153 @@
+import { getCsrfToken } from '@/lib/csrfClient';
+
+import type { MovieDurationFilter, MoviesResponse } from '@/features/movies/catalog';
+
+export type MoviesFetchOutcome =
+  | { ok: true; data: MoviesResponse }
+  | { ok: false; errorMessage: string };
+
+export interface MovieFilters {
+  query: string;
+  yearFrom: string;
+  yearTo: string;
+  duration: '' | MovieDurationFilter;
+  minScore: string;
+  ageRatings: string[];
+}
+
+export const AGE_RATING_FILTERS = ['G', 'PG', 'PG-13', 'R', 'NR', '12+', '15', '16+', '18+'];
+
+const emptyMovieFilters: MovieFilters = {
+  query: '',
+  yearFrom: '',
+  yearTo: '',
+  duration: '',
+  minScore: '',
+  ageRatings: [],
+};
+
+export function cloneEmptyMovieFilters(): MovieFilters {
+  return { ...emptyMovieFilters, ageRatings: [] };
+}
+
+export function buildMoviesCacheKey(page: number, filters: MovieFilters): string {
+  return JSON.stringify([
+    page,
+    filters.query.trim(),
+    filters.yearFrom.trim(),
+    filters.yearTo.trim(),
+    filters.duration,
+    filters.minScore.trim(),
+    filters.ageRatings,
+  ]);
+}
+
+function appendTrimmedParam(params: URLSearchParams, key: string, value: string): void {
+  const trimmed = value.trim();
+  if (trimmed) params.set(key, trimmed);
+}
+
+export function buildMoviesUrl(page: number, pageSize: number, filters: MovieFilters): string {
+  const params = new URLSearchParams({ page: String(page), pageSize: String(pageSize) });
+  appendTrimmedParam(params, 'query', filters.query);
+  appendTrimmedParam(params, 'yearFrom', filters.yearFrom);
+  appendTrimmedParam(params, 'yearTo', filters.yearTo);
+  if (filters.duration) params.set('duration', filters.duration);
+  appendTrimmedParam(params, 'minScore', filters.minScore);
+  if (filters.ageRatings.length > 0) params.set('ageRatings', filters.ageRatings.join(','));
+
+  return `/api/movies?${params.toString()}`;
+}
+
+export function hasActiveMovieFilters(filters: MovieFilters): boolean {
+  return Object.values(normalizeMovieFilters(filters)).some((value) =>
+    Array.isArray(value) ? value.length > 0 : Boolean(value),
+  );
+}
+
+export function normalizeMovieFilters(filters: MovieFilters): MovieFilters {
+  return {
+    query: filters.query.trim(),
+    yearFrom: filters.yearFrom.trim(),
+    yearTo: filters.yearTo.trim(),
+    duration: filters.duration,
+    minScore: filters.minScore.trim(),
+    ageRatings: filters.ageRatings,
+  };
+}
+
+export function toggleAgeRatingFilter(filters: MovieFilters, rating: string): MovieFilters {
+  const ageRatings = filters.ageRatings.includes(rating)
+    ? filters.ageRatings.filter((value) => value !== rating)
+    : [...filters.ageRatings, rating];
+  return { ...filters, ageRatings };
+}
+
+export function generatePageNumbers(currentPage: number, totalPages: number): (number | '...')[] {
+  if (totalPages <= 1) return [];
+
+  const delta = 2;
+  const start = Math.max(2, currentPage - delta);
+  const end = Math.min(totalPages - 1, currentPage + delta);
+  const middlePages = Array.from({ length: end - start + 1 }, (_, index) => start + index);
+
+  return [
+    1,
+    ...(start > 2 ? (['...'] as const) : []),
+    ...middlePages,
+    ...(end < totalPages - 1 ? (['...'] as const) : []),
+    totalPages,
+  ];
+}
+
+export function getMoviesPageSummary(params: {
+  currentPage: number;
+  loading: boolean;
+  pageSize: number;
+  totalCount: number;
+  noMoviesFoundText: string;
+  showingText: string;
+}): string {
+  if (params.loading) return '';
+  if (params.totalCount <= 0) return params.noMoviesFoundText;
+
+  return params.showingText
+    .replace('{start}', String((params.currentPage - 1) * params.pageSize + 1))
+    .replace('{end}', String(Math.min(params.currentPage * params.pageSize, params.totalCount)))
+    .replace('{total}', String(params.totalCount));
+}
+
+async function fetchMoviesResponse(
+  page: number,
+  pageSize: number,
+  filters: MovieFilters,
+  signal: AbortSignal,
+): Promise<MoviesResponse> {
+  const response = await fetch(buildMoviesUrl(page, pageSize, filters), {
+    signal,
+    headers: { 'X-CSRF-Token': getCsrfToken() },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch movies: ${response.statusText}`);
+  }
+
+  return response.json() as Promise<MoviesResponse>;
+}
+
+function getFetchErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'An error occurred';
+}
+
+export async function fetchMoviesOutcome(
+  page: number,
+  pageSize: number,
+  filters: MovieFilters,
+  signal: AbortSignal,
+): Promise<MoviesFetchOutcome> {
+  try {
+    return { ok: true, data: await fetchMoviesResponse(page, pageSize, filters, signal) };
+  } catch (error) {
+    return { ok: false, errorMessage: getFetchErrorMessage(error) };
+  }
+}

--- a/apps/web/src/app/available-movies/page.tsx
+++ b/apps/web/src/app/available-movies/page.tsx
@@ -1,84 +1,27 @@
 'use client';
 
-import { ChevronLeft, ChevronRight, Search, X } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState, type FormEvent } from 'react';
 
-import { MoviesTable, MoviesTableSkeleton } from '@/components';
 import { useLanguage } from '@/i18n';
-import { getCsrfToken } from '@/lib/csrfClient';
 
-import type { Movie, MovieDurationFilter, MoviesResponse } from '@/features/movies/catalog';
+import {
+  AvailableMoviesError,
+  AvailableMoviesHeader,
+  MoviesFilterForm,
+  MoviesPagination,
+  MoviesResultPanel,
+} from './availableMoviesComponents';
+import {
+  buildMoviesCacheKey,
+  cloneEmptyMovieFilters,
+  fetchMoviesOutcome,
+  getMoviesPageSummary,
+  normalizeMovieFilters,
+  toggleAgeRatingFilter,
+} from './availableMoviesViewModel';
 
-interface MovieFilters {
-  query: string;
-  yearFrom: string;
-  yearTo: string;
-  duration: '' | MovieDurationFilter;
-  minScore: string;
-  ageRatings: string[];
-}
-
-const AGE_RATING_FILTERS = ['G', 'PG', 'PG-13', 'R', 'NR', '12+', '15', '16+', '18+'];
-
-const emptyFilters: MovieFilters = {
-  query: '',
-  yearFrom: '',
-  yearTo: '',
-  duration: '',
-  minScore: '',
-  ageRatings: [],
-};
-
-function buildCacheKey(page: number, filters: MovieFilters): string {
-  return JSON.stringify([
-    page,
-    filters.query.trim(),
-    filters.yearFrom.trim(),
-    filters.yearTo.trim(),
-    filters.duration,
-    filters.minScore.trim(),
-    filters.ageRatings,
-  ]);
-}
-
-function buildMoviesUrl(page: number, pageSize: number, filters: MovieFilters): string {
-  const params = new URLSearchParams({ page: String(page), pageSize: String(pageSize) });
-  const query = filters.query.trim();
-  const yearFrom = filters.yearFrom.trim();
-  const yearTo = filters.yearTo.trim();
-  const minScore = filters.minScore.trim();
-
-  if (query) params.set('query', query);
-  if (yearFrom) params.set('yearFrom', yearFrom);
-  if (yearTo) params.set('yearTo', yearTo);
-  if (filters.duration) params.set('duration', filters.duration);
-  if (minScore) params.set('minScore', minScore);
-  if (filters.ageRatings.length > 0) params.set('ageRatings', filters.ageRatings.join(','));
-
-  return `/api/movies?${params.toString()}`;
-}
-
-function hasActiveMovieFilters(filters: MovieFilters): boolean {
-  return Boolean(
-    filters.query.trim() ||
-    filters.yearFrom.trim() ||
-    filters.yearTo.trim() ||
-    filters.duration ||
-    filters.minScore.trim() ||
-    filters.ageRatings.length > 0,
-  );
-}
-
-function normalizeMovieFilters(filters: MovieFilters): MovieFilters {
-  return {
-    query: filters.query.trim(),
-    yearFrom: filters.yearFrom.trim(),
-    yearTo: filters.yearTo.trim(),
-    duration: filters.duration,
-    minScore: filters.minScore.trim(),
-    ageRatings: filters.ageRatings,
-  };
-}
+import type { MovieFilters } from './availableMoviesViewModel';
+import type { Movie, MoviesResponse } from '@/features/movies/catalog';
 
 export default function AvailableMoviesPage() {
   const { t } = useLanguage();
@@ -88,8 +31,8 @@ export default function AvailableMoviesPage() {
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(0);
   const [totalCount, setTotalCount] = useState(0);
-  const [draftFilters, setDraftFilters] = useState<MovieFilters>(emptyFilters);
-  const [appliedFilters, setAppliedFilters] = useState<MovieFilters>(emptyFilters);
+  const [draftFilters, setDraftFilters] = useState<MovieFilters>(cloneEmptyMovieFilters);
+  const [appliedFilters, setAppliedFilters] = useState<MovieFilters>(cloneEmptyMovieFilters);
   const pageSize = 50;
 
   // Client-side cache: page/filter key → response data. Avoids redundant fetches
@@ -100,7 +43,7 @@ export default function AvailableMoviesPage() {
 
   const fetchMovies = useCallback(
     async (page: number, filters: MovieFilters) => {
-      const cacheKey = buildCacheKey(page, filters);
+      const cacheKey = buildMoviesCacheKey(page, filters);
       // Serve from cache when available.
       const cached = cache.current.get(cacheKey);
       if (cached) {
@@ -124,33 +67,20 @@ export default function AvailableMoviesPage() {
       setLoading(true);
       setError(null);
 
-      try {
-        const response = await fetch(buildMoviesUrl(page, pageSize, filters), {
-          signal: controller.signal,
-          headers: { 'X-CSRF-Token': getCsrfToken() },
-        });
+      const outcome = await fetchMoviesOutcome(page, pageSize, filters, controller.signal);
+      if (controller.signal.aborted) return;
 
-        if (!response.ok) {
-          throw new Error(`Failed to fetch movies: ${response.statusText}`);
-        }
-
-        const data: MoviesResponse = await response.json();
-        if (controller.signal.aborted) return;
+      if (outcome.ok) {
+        const { data } = outcome;
         cache.current.set(cacheKey, data);
         setMovies(data.movies);
         setTotalPages(data.totalPages);
         setTotalCount(data.totalCount);
         setCurrentPage(data.page);
-      } catch (err) {
-        // fetch() rejects with a DOMException (not always an Error subclass) on abort.
-        // Guard on the signal instead of relying on instanceof Error.
-        if (controller.signal.aborted) return;
-        setError(err instanceof Error ? err.message : 'An error occurred');
-      } finally {
-        if (!controller.signal.aborted) {
-          setLoading(false);
-        }
+      } else {
+        setError(outcome.errorMessage);
       }
+      setLoading(false);
     },
     [pageSize],
   );
@@ -176,16 +106,13 @@ export default function AvailableMoviesPage() {
   };
 
   const handleClearFilters = () => {
-    setDraftFilters({ ...emptyFilters });
-    setAppliedFilters({ ...emptyFilters });
+    setDraftFilters(cloneEmptyMovieFilters());
+    setAppliedFilters(cloneEmptyMovieFilters());
     setCurrentPage(1);
   };
 
   const handleAgeRatingToggle = (rating: string) => {
-    const ageRatings = draftFilters.ageRatings.includes(rating)
-      ? draftFilters.ageRatings.filter((value) => value !== rating)
-      : [...draftFilters.ageRatings, rating];
-    const nextFilters = { ...draftFilters, ageRatings };
+    const nextFilters = toggleAgeRatingFilter(draftFilters, rating);
     setDraftFilters(nextFilters);
     applyFilters(nextFilters);
   };
@@ -197,340 +124,53 @@ export default function AvailableMoviesPage() {
     }
   };
 
-  const generatePageNumbers = () => {
-    const delta = 2;
-    const rangeWithDots: (number | '...')[] = [];
-
-    if (totalPages <= 1) return rangeWithDots;
-
-    const start = Math.max(2, currentPage - delta);
-    const end = Math.min(totalPages - 1, currentPage + delta);
-
-    rangeWithDots.push(1);
-
-    if (start > 2) rangeWithDots.push('...');
-
-    for (let i = start; i <= end; i++) {
-      rangeWithDots.push(i);
-    }
-
-    if (end < totalPages - 1) rangeWithDots.push('...');
-
-    if (totalPages > 1) rangeWithDots.push(totalPages);
-
-    return rangeWithDots;
-  };
-
   if (error) {
     return (
-      <section className="flex-1 flex flex-col items-center justify-center px-5 py-16 text-center">
-        <p className="text-sm mb-4" style={{ color: 'var(--rating-mature-text)' }}>
-          {error}
-        </p>
-        <button
-          onClick={() => fetchMovies(currentPage, appliedFilters)}
-          className="px-5 py-2.5 rounded-xl text-sm font-semibold"
-          style={{ background: 'var(--pc-cta)', color: 'var(--pc-cta-text)' }}
-        >
-          {t.moviesPage.tryAgain}
-        </button>
-      </section>
+      <AvailableMoviesError
+        error={error}
+        labels={t.moviesPage}
+        onRetry={() => fetchMovies(currentPage, appliedFilters)}
+      />
     );
   }
 
   return (
     <section className="flex-1 flex flex-col px-4 md:px-8 py-10 max-w-5xl mx-auto w-full">
-      {/* Page header */}
-      <div className="mb-8">
-        <h1
-          className="text-3xl font-bold mb-2"
-          style={{
-            fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
-            color: 'var(--pc-t1)',
-          }}
-        >
-          {t.moviesPage.title}
-        </h1>
-        <p className="text-sm" style={{ color: 'var(--pc-t3)' }}>
-          {!loading &&
-            (totalCount > 0
-              ? t.moviesPage.showing
-                  .replace('{start}', String((currentPage - 1) * pageSize + 1))
-                  .replace('{end}', String(Math.min(currentPage * pageSize, totalCount)))
-                  .replace('{total}', String(totalCount))
-              : t.moviesPage.noMoviesFound)}
-        </p>
-      </div>
+      <AvailableMoviesHeader
+        labels={t.moviesPage}
+        summary={getMoviesPageSummary({
+          currentPage,
+          loading,
+          noMoviesFoundText: t.moviesPage.noMoviesFound,
+          pageSize,
+          showingText: t.moviesPage.showing,
+          totalCount,
+        })}
+      />
 
-      <form onSubmit={handleFilterSubmit} className="mb-6 flex flex-col gap-4">
-        <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_6.5rem_6.5rem_9rem_8rem_auto_auto] lg:items-end">
-          <label
-            className="flex flex-col gap-1.5 text-xs font-semibold"
-            style={{ color: 'var(--pc-t3)' }}
-          >
-            {t.moviesPage.searchLabel}
-            <span
-              className="flex items-center gap-2 rounded-lg px-3 py-2"
-              style={{
-                background: 'var(--pc-surface)',
-                border: '1px solid var(--pc-bd2)',
-                color: 'var(--pc-t2)',
-              }}
-            >
-              <Search size={16} aria-hidden="true" />
-              <input
-                value={draftFilters.query}
-                onChange={(event) =>
-                  setDraftFilters((current) => ({ ...current, query: event.target.value }))
-                }
-                maxLength={80}
-                placeholder={t.moviesPage.searchPlaceholder}
-                className="min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:opacity-70"
-                style={{ color: 'var(--pc-t1)' }}
-              />
-            </span>
-          </label>
+      <MoviesFilterForm
+        draftFilters={draftFilters}
+        labels={t.moviesPage}
+        onAgeRatingToggle={handleAgeRatingToggle}
+        onClearFilters={handleClearFilters}
+        onDraftFiltersChange={setDraftFilters}
+        onFilterSubmit={handleFilterSubmit}
+        onImmediateFilterChange={applyFilters}
+      />
 
-          <label
-            className="flex flex-col gap-1.5 text-xs font-semibold"
-            style={{ color: 'var(--pc-t3)' }}
-          >
-            {t.moviesPage.yearFrom}
-            <input
-              value={draftFilters.yearFrom}
-              onChange={(event) =>
-                setDraftFilters((current) => ({ ...current, yearFrom: event.target.value }))
-              }
-              inputMode="numeric"
-              pattern="[0-9]*"
-              maxLength={4}
-              className="h-10 rounded-lg px-3 text-sm outline-none"
-              style={{
-                background: 'var(--pc-surface)',
-                border: '1px solid var(--pc-bd2)',
-                color: 'var(--pc-t1)',
-              }}
-            />
-          </label>
+      <MoviesResultPanel
+        appliedFilters={appliedFilters}
+        loading={loading}
+        movies={movies}
+        onClearFilters={handleClearFilters}
+      />
 
-          <label
-            className="flex flex-col gap-1.5 text-xs font-semibold"
-            style={{ color: 'var(--pc-t3)' }}
-          >
-            {t.moviesPage.yearTo}
-            <input
-              value={draftFilters.yearTo}
-              onChange={(event) =>
-                setDraftFilters((current) => ({ ...current, yearTo: event.target.value }))
-              }
-              inputMode="numeric"
-              pattern="[0-9]*"
-              maxLength={4}
-              className="h-10 rounded-lg px-3 text-sm outline-none"
-              style={{
-                background: 'var(--pc-surface)',
-                border: '1px solid var(--pc-bd2)',
-                color: 'var(--pc-t1)',
-              }}
-            />
-          </label>
-
-          <label
-            className="flex flex-col gap-1.5 text-xs font-semibold"
-            style={{ color: 'var(--pc-t3)' }}
-          >
-            {t.moviesPage.durationFilter}
-            <select
-              value={draftFilters.duration}
-              onChange={(event) => {
-                const nextFilters = {
-                  ...draftFilters,
-                  duration: event.target.value as MovieFilters['duration'],
-                };
-                setDraftFilters(nextFilters);
-                applyFilters(nextFilters);
-              }}
-              className="h-10 rounded-lg px-3 text-sm outline-none"
-              style={{
-                background: 'var(--pc-surface)',
-                border: '1px solid var(--pc-bd2)',
-                color: 'var(--pc-t1)',
-              }}
-            >
-              <option value="">{t.moviesPage.anyFilter}</option>
-              <option value="under-90">{t.moviesPage.durationOptions.under90}</option>
-              <option value="90-120">{t.moviesPage.durationOptions.between90And120}</option>
-              <option value="over-120">{t.moviesPage.durationOptions.over120}</option>
-            </select>
-          </label>
-
-          <label
-            className="flex flex-col gap-1.5 text-xs font-semibold"
-            style={{ color: 'var(--pc-t3)' }}
-          >
-            {t.moviesPage.scoreFilter}
-            <select
-              value={draftFilters.minScore}
-              onChange={(event) => {
-                const nextFilters = { ...draftFilters, minScore: event.target.value };
-                setDraftFilters(nextFilters);
-                applyFilters(nextFilters);
-              }}
-              className="h-10 rounded-lg px-3 text-sm outline-none"
-              style={{
-                background: 'var(--pc-surface)',
-                border: '1px solid var(--pc-bd2)',
-                color: 'var(--pc-t1)',
-              }}
-            >
-              <option value="">{t.moviesPage.anyFilter}</option>
-              <option value="7">7.0+</option>
-              <option value="8">8.0+</option>
-              <option value="9">9.0+</option>
-            </select>
-          </label>
-
-          <button
-            type="submit"
-            className="inline-flex h-10 items-center justify-center gap-2 rounded-lg px-4 text-sm font-semibold"
-            style={{ background: 'var(--pc-cta)', color: 'var(--pc-cta-text)' }}
-          >
-            <Search size={16} aria-hidden="true" />
-            {t.moviesPage.applyFilters}
-          </button>
-
-          <button
-            type="button"
-            onClick={handleClearFilters}
-            className="inline-flex h-10 items-center justify-center gap-2 rounded-lg px-4 text-sm font-semibold"
-            style={{
-              background: 'var(--pc-surface)',
-              border: '1px solid var(--pc-bd2)',
-              color: 'var(--pc-t2)',
-            }}
-          >
-            <X size={16} aria-hidden="true" />
-            {t.moviesPage.clearFilters}
-          </button>
-        </div>
-
-        <fieldset className="flex flex-col gap-2">
-          <legend className="text-xs font-semibold" style={{ color: 'var(--pc-t3)' }}>
-            {t.moviesPage.ageRatingFilter}
-          </legend>
-          <div className="flex flex-wrap gap-2">
-            {AGE_RATING_FILTERS.map((rating) => {
-              const selected = draftFilters.ageRatings.includes(rating);
-              return (
-                <label
-                  key={rating}
-                  className="inline-flex h-9 cursor-pointer items-center gap-2 rounded-lg px-3 text-sm font-semibold transition-colors duration-150"
-                  style={
-                    selected
-                      ? {
-                          background: 'var(--pc-gold-subtle)',
-                          border: '1px solid var(--pc-gold)',
-                          color: 'var(--pc-gold-text)',
-                        }
-                      : {
-                          background: 'var(--pc-surface)',
-                          border: '1px solid var(--pc-bd2)',
-                          color: 'var(--pc-t2)',
-                        }
-                  }
-                >
-                  <input
-                    type="checkbox"
-                    checked={selected}
-                    onChange={() => handleAgeRatingToggle(rating)}
-                    className="h-3.5 w-3.5 accent-[var(--pc-gold)]"
-                  />
-                  {rating}
-                </label>
-              );
-            })}
-          </div>
-        </fieldset>
-      </form>
-
-      {/* Table / Cards */}
-      {loading ? (
-        <MoviesTableSkeleton />
-      ) : (
-        <MoviesTable
-          movies={movies}
-          hasActiveFilters={hasActiveMovieFilters(appliedFilters)}
-          onClearFilters={handleClearFilters}
-        />
-      )}
-
-      {/* Pagination */}
-      {totalPages > 1 && (
-        <div className="flex items-center justify-between mt-8 gap-3 flex-wrap">
-          <div className="flex items-center gap-1.5 flex-wrap">
-            <button
-              onClick={() => handlePageChange(currentPage - 1)}
-              disabled={currentPage === 1}
-              className="flex items-center gap-1 px-3 py-2 rounded-xl text-sm transition-colors duration-150 disabled:opacity-40 disabled:cursor-not-allowed"
-              style={{
-                background: 'var(--pc-surface)',
-                border: '1px solid var(--pc-bd2)',
-                color: 'var(--pc-t2)',
-              }}
-            >
-              <ChevronLeft size={14} /> {t.moviesPage.prev}
-            </button>
-
-            {generatePageNumbers().map((page, index) =>
-              page === '...' ? (
-                <span
-                  key={`dots-${index}`}
-                  className="px-2 py-2 text-sm"
-                  style={{ color: 'var(--pc-t4)' }}
-                >
-                  …
-                </span>
-              ) : (
-                <button
-                  key={page}
-                  onClick={() => handlePageChange(page)}
-                  className="w-9 h-9 rounded-xl text-sm font-medium transition-colors duration-150"
-                  style={
-                    page === currentPage
-                      ? { background: 'var(--pc-cta)', color: 'var(--pc-cta-text)' }
-                      : {
-                          background: 'var(--pc-surface)',
-                          border: '1px solid var(--pc-bd2)',
-                          color: 'var(--pc-t2)',
-                        }
-                  }
-                >
-                  {page}
-                </button>
-              ),
-            )}
-
-            <button
-              onClick={() => handlePageChange(currentPage + 1)}
-              disabled={currentPage === totalPages}
-              className="flex items-center gap-1 px-3 py-2 rounded-xl text-sm transition-colors duration-150 disabled:opacity-40 disabled:cursor-not-allowed"
-              style={{
-                background: 'var(--pc-surface)',
-                border: '1px solid var(--pc-bd2)',
-                color: 'var(--pc-t2)',
-              }}
-            >
-              {t.moviesPage.next} <ChevronRight size={14} />
-            </button>
-          </div>
-
-          <span className="text-xs" style={{ color: 'var(--pc-t4)' }}>
-            {t.moviesPage.pageOf
-              .replace('{current}', String(currentPage))
-              .replace('{total}', String(totalPages))}
-          </span>
-        </div>
-      )}
+      <MoviesPagination
+        currentPage={currentPage}
+        labels={t.moviesPage}
+        onPageChange={handlePageChange}
+        totalPages={totalPages}
+      />
     </section>
   );
 }

--- a/apps/web/src/features/catalogMaintenance/tmdb.ts
+++ b/apps/web/src/features/catalogMaintenance/tmdb.ts
@@ -347,6 +347,75 @@ function extractWatchProviders(details: TMDBMovieDetails): TMDBCatalogMetadata['
   });
 }
 
+type MetadataQualityInput = {
+  ageRating: string;
+  details: TMDBMovieDetails;
+  genres: TMDBCatalogMetadata['genres'];
+  keywords: TMDBCatalogMetadata['keywords'];
+  people: TMDBCatalogMetadata['people'];
+  providers: TMDBCatalogMetadata['providers'];
+};
+
+type MetadataQualityRule = {
+  flag: string;
+  isMissing: (input: MetadataQualityInput) => boolean;
+};
+
+const CORE_METADATA_QUALITY_RULES = [
+  {
+    flag: 'missing_runtime',
+    isMissing: ({ details }) => !details.runtime || details.runtime <= 0,
+  },
+  {
+    flag: 'missing_certification',
+    isMissing: ({ ageRating }) => !ageRating || ageRating === 'NR',
+  },
+  {
+    flag: 'missing_poster',
+    isMissing: ({ details }) => !details.poster_path,
+  },
+  {
+    flag: 'missing_overview',
+    isMissing: ({ details }) => !details.overview?.trim(),
+  },
+  {
+    flag: 'missing_original_language',
+    isMissing: ({ details }) => !details.original_language?.trim(),
+  },
+  {
+    flag: 'missing_vote_count',
+    isMissing: ({ details }) =>
+      !Number.isFinite(details.vote_count) || Number(details.vote_count ?? 0) <= 0,
+  },
+  {
+    flag: 'missing_popularity',
+    isMissing: ({ details }) =>
+      !Number.isFinite(details.popularity) || Number(details.popularity ?? 0) <= 0,
+  },
+  {
+    flag: 'missing_genres',
+    isMissing: ({ genres }) => genres.length === 0,
+  },
+  {
+    flag: 'missing_keywords',
+    isMissing: ({ keywords }) => keywords.length === 0,
+  },
+  {
+    flag: 'missing_cast',
+    isMissing: ({ people }) => !people.some((person) => person.role === 'cast'),
+  },
+  {
+    flag: 'missing_director',
+    isMissing: ({ people }) => !people.some((person) => person.role === 'director'),
+  },
+] satisfies MetadataQualityRule[];
+
+function getMissingProviderFlags(input: MetadataQualityInput): string[] {
+  return SUPPORTED_PROVIDER_REGIONS.filter(
+    (region) => !input.providers.some((provider) => provider.region === region),
+  ).map((region) => `missing_provider_${region.toLowerCase()}`);
+}
+
 function getMetadataQualityFlags(input: {
   ageRating: string;
   details: TMDBMovieDetails;
@@ -355,28 +424,10 @@ function getMetadataQualityFlags(input: {
   people: TMDBCatalogMetadata['people'];
   providers: TMDBCatalogMetadata['providers'];
 }): string[] {
-  const flags: string[] = [];
-  if (!input.details.runtime || input.details.runtime <= 0) flags.push('missing_runtime');
-  if (!input.ageRating || input.ageRating === 'NR') flags.push('missing_certification');
-  if (!input.details.poster_path) flags.push('missing_poster');
-  if (!input.details.overview?.trim()) flags.push('missing_overview');
-  if (!input.details.original_language?.trim()) flags.push('missing_original_language');
-  if (!Number.isFinite(input.details.vote_count) || Number(input.details.vote_count ?? 0) <= 0) {
-    flags.push('missing_vote_count');
-  }
-  if (!Number.isFinite(input.details.popularity) || Number(input.details.popularity ?? 0) <= 0) {
-    flags.push('missing_popularity');
-  }
-  if (input.genres.length === 0) flags.push('missing_genres');
-  if (input.keywords.length === 0) flags.push('missing_keywords');
-  if (!input.people.some((person) => person.role === 'cast')) flags.push('missing_cast');
-  if (!input.people.some((person) => person.role === 'director')) flags.push('missing_director');
-  for (const region of SUPPORTED_PROVIDER_REGIONS) {
-    if (!input.providers.some((provider) => provider.region === region)) {
-      flags.push(`missing_provider_${region.toLowerCase()}`);
-    }
-  }
-  return flags;
+  return [
+    ...CORE_METADATA_QUALITY_RULES.filter((rule) => rule.isMissing(input)).map((rule) => rule.flag),
+    ...getMissingProviderFlags(input),
+  ];
 }
 
 export function getMetadataQualityScore(flags: string[]): number {

--- a/apps/web/src/features/movies/catalog.ts
+++ b/apps/web/src/features/movies/catalog.ts
@@ -34,6 +34,18 @@ interface CountRow {
   count: number | string;
 }
 
+type QueryFilterApplier<T extends Movie> = (
+  query: QuerySelect<T> | QueryFilter<T>,
+  filters: MoviesPageFilters,
+) => QuerySelect<T> | QueryFilter<T>;
+
+type SqlClauseBuilder = (clauses: string[], values: unknown[], filters: MoviesPageFilters) => void;
+
+interface DurationBounds {
+  min?: number;
+  max?: number;
+}
+
 function escapeLikePattern(value: string): string {
   return value.replace(/[\\%_]/g, (match) => `\\${match}`);
 }
@@ -43,37 +55,76 @@ function normalizeQuery(query: string | undefined): string | undefined {
   return trimmed ? trimmed : undefined;
 }
 
+function getDurationBounds(duration: MovieDurationFilter | undefined): DurationBounds | undefined {
+  if (duration === 'under-90') return { max: 89 };
+  if (duration === '90-120') return { min: 90, max: 120 };
+  if (duration === 'over-120') return { min: 121 };
+  return undefined;
+}
+
+function applyTitleQueryFilter<T extends Movie>(
+  query: QuerySelect<T> | QueryFilter<T>,
+  filters: MoviesPageFilters,
+): QuerySelect<T> | QueryFilter<T> {
+  const titleQuery = normalizeQuery(filters.query);
+  return titleQuery ? query.ilike('name', `%${escapeLikePattern(titleQuery)}%`) : query;
+}
+
+function applyRangeQueryFilter<T extends Movie>(
+  query: QuerySelect<T> | QueryFilter<T>,
+  column: keyof Movie & string,
+  range: DurationBounds | undefined,
+): QuerySelect<T> | QueryFilter<T> {
+  let nextQuery = query;
+  if (typeof range?.min === 'number') nextQuery = nextQuery.gte(column, range.min);
+  if (typeof range?.max === 'number') nextQuery = nextQuery.lte(column, range.max);
+  return nextQuery;
+}
+
+function applyYearQueryFilter<T extends Movie>(
+  query: QuerySelect<T> | QueryFilter<T>,
+  filters: MoviesPageFilters,
+): QuerySelect<T> | QueryFilter<T> {
+  return applyRangeQueryFilter(query, 'year', { min: filters.yearFrom, max: filters.yearTo });
+}
+
+function applyDurationQueryFilter<T extends Movie>(
+  query: QuerySelect<T> | QueryFilter<T>,
+  filters: MoviesPageFilters,
+): QuerySelect<T> | QueryFilter<T> {
+  return applyRangeQueryFilter(query, 'duration', getDurationBounds(filters.duration));
+}
+
+function applyScoreQueryFilter<T extends Movie>(
+  query: QuerySelect<T> | QueryFilter<T>,
+  filters: MoviesPageFilters,
+): QuerySelect<T> | QueryFilter<T> {
+  return typeof filters.minScore === 'number' ? query.gte('score_rating', filters.minScore) : query;
+}
+
+function applyAgeRatingQueryFilter<T extends Movie>(
+  query: QuerySelect<T> | QueryFilter<T>,
+  filters: MoviesPageFilters,
+): QuerySelect<T> | QueryFilter<T> {
+  return filters.ageRatings?.length ? query.in('age_rating', filters.ageRatings) : query;
+}
+
+const QUERY_FILTER_APPLIERS = [
+  applyTitleQueryFilter,
+  applyYearQueryFilter,
+  applyDurationQueryFilter,
+  applyScoreQueryFilter,
+  applyAgeRatingQueryFilter,
+] satisfies QueryFilterApplier<Movie>[];
+
 function applyMovieFilters<T extends Movie>(
   select: QuerySelect<T>,
   filters: MoviesPageFilters,
 ): QuerySelect<T> | QueryFilter<T> {
-  let query: QuerySelect<T> | QueryFilter<T> = select;
-  const titleQuery = normalizeQuery(filters.query);
-
-  if (titleQuery) {
-    query = query.ilike('name', `%${escapeLikePattern(titleQuery)}%`);
-  }
-  if (typeof filters.yearFrom === 'number') {
-    query = query.gte('year', filters.yearFrom);
-  }
-  if (typeof filters.yearTo === 'number') {
-    query = query.lte('year', filters.yearTo);
-  }
-  if (filters.duration === 'under-90') {
-    query = query.lte('duration', 89);
-  } else if (filters.duration === '90-120') {
-    query = query.gte('duration', 90).lte('duration', 120);
-  } else if (filters.duration === 'over-120') {
-    query = query.gte('duration', 121);
-  }
-  if (typeof filters.minScore === 'number') {
-    query = query.gte('score_rating', filters.minScore);
-  }
-  if (filters.ageRatings && filters.ageRatings.length > 0) {
-    query = query.in('age_rating', filters.ageRatings);
-  }
-
-  return query;
+  return QUERY_FILTER_APPLIERS.reduce<QuerySelect<T> | QueryFilter<T>>(
+    (query, applyFilter) => applyFilter(query, filters),
+    select,
+  );
 }
 
 function addSqlParam(values: unknown[], value: unknown): string {
@@ -81,14 +132,12 @@ function addSqlParam(values: unknown[], value: unknown): string {
   return `$${values.length}`;
 }
 
-function buildMoviesWhereSql(filters: MoviesPageFilters): { whereSql: string; values: unknown[] } {
-  const clauses: string[] = [];
-  const values: unknown[] = [];
+function addTitleSqlClause(clauses: string[], values: unknown[], filters: MoviesPageFilters): void {
   const searchQuery = normalizeQuery(filters.query);
+  if (!searchQuery) return;
 
-  if (searchQuery) {
-    const patternParam = addSqlParam(values, `%${escapeLikePattern(searchQuery)}%`);
-    clauses.push(`(
+  const patternParam = addSqlParam(values, `%${escapeLikePattern(searchQuery)}%`);
+  clauses.push(`(
       movies.name ILIKE ${patternParam} ESCAPE '\\'
       OR EXISTS (
         SELECT 1
@@ -105,28 +154,70 @@ function buildMoviesWhereSql(filters: MoviesPageFilters): { whereSql: string; va
           AND catalog_genres.name ILIKE ${patternParam} ESCAPE '\\'
       )
     )`);
-  }
-  if (typeof filters.yearFrom === 'number') {
-    clauses.push(`movies.year >= ${addSqlParam(values, filters.yearFrom)}`);
-  }
-  if (typeof filters.yearTo === 'number') {
-    clauses.push(`movies.year <= ${addSqlParam(values, filters.yearTo)}`);
-  }
-  if (filters.duration === 'under-90') {
-    clauses.push(`movies.duration <= ${addSqlParam(values, 89)}`);
-  } else if (filters.duration === '90-120') {
+}
+
+function addRangeSqlClause(
+  clauses: string[],
+  values: unknown[],
+  column: keyof Movie & string,
+  range: DurationBounds | undefined,
+): void {
+  if (typeof range?.min === 'number' && typeof range.max === 'number') {
     clauses.push(
-      `movies.duration BETWEEN ${addSqlParam(values, 90)} AND ${addSqlParam(values, 120)}`,
+      `movies.${column} BETWEEN ${addSqlParam(values, range.min)} AND ${addSqlParam(
+        values,
+        range.max,
+      )}`,
     );
-  } else if (filters.duration === 'over-120') {
-    clauses.push(`movies.duration >= ${addSqlParam(values, 121)}`);
+    return;
   }
+
+  if (typeof range?.min === 'number')
+    clauses.push(`movies.${column} >= ${addSqlParam(values, range.min)}`);
+  if (typeof range?.max === 'number')
+    clauses.push(`movies.${column} <= ${addSqlParam(values, range.max)}`);
+}
+
+function addYearSqlClause(clauses: string[], values: unknown[], filters: MoviesPageFilters): void {
+  addRangeSqlClause(clauses, values, 'year', { min: filters.yearFrom, max: filters.yearTo });
+}
+
+function addDurationSqlClause(
+  clauses: string[],
+  values: unknown[],
+  filters: MoviesPageFilters,
+): void {
+  addRangeSqlClause(clauses, values, 'duration', getDurationBounds(filters.duration));
+}
+
+function addScoreSqlClause(clauses: string[], values: unknown[], filters: MoviesPageFilters): void {
   if (typeof filters.minScore === 'number') {
     clauses.push(`movies.score_rating >= ${addSqlParam(values, filters.minScore)}`);
   }
-  if (filters.ageRatings && filters.ageRatings.length > 0) {
+}
+
+function addAgeRatingSqlClause(
+  clauses: string[],
+  values: unknown[],
+  filters: MoviesPageFilters,
+): void {
+  if (filters.ageRatings?.length) {
     clauses.push(`movies.age_rating = ANY(${addSqlParam(values, filters.ageRatings)}::text[])`);
   }
+}
+
+const SQL_CLAUSE_BUILDERS = [
+  addTitleSqlClause,
+  addYearSqlClause,
+  addDurationSqlClause,
+  addScoreSqlClause,
+  addAgeRatingSqlClause,
+] satisfies SqlClauseBuilder[];
+
+function buildMoviesWhereSql(filters: MoviesPageFilters): { whereSql: string; values: unknown[] } {
+  const clauses: string[] = [];
+  const values: unknown[] = [];
+  SQL_CLAUSE_BUILDERS.forEach((buildClause) => buildClause(clauses, values, filters));
 
   return {
     whereSql: clauses.length > 0 ? `WHERE ${clauses.join('\n  AND ')}` : '',
@@ -187,34 +278,27 @@ async function getMoviesPageFromSql(
 
 function filterMockMovies(movies: Movie[], filters: MoviesPageFilters): Movie[] {
   const titleQuery = normalizeQuery(filters.query)?.toLocaleLowerCase();
-  return movies.filter((movie) => {
-    const matchesTitle = titleQuery ? movie.name.toLocaleLowerCase().includes(titleQuery) : true;
-    const matchesYearFrom =
-      typeof filters.yearFrom === 'number' ? movie.year >= filters.yearFrom : true;
-    const matchesYearTo = typeof filters.yearTo === 'number' ? movie.year <= filters.yearTo : true;
-    const matchesDuration =
-      filters.duration === 'under-90'
-        ? movie.duration < 90
-        : filters.duration === '90-120'
-          ? movie.duration >= 90 && movie.duration <= 120
-          : filters.duration === 'over-120'
-            ? movie.duration > 120
-            : true;
-    const matchesScore =
-      typeof filters.minScore === 'number' ? movie.score_rating >= filters.minScore : true;
-    const matchesAgeRating =
-      filters.ageRatings && filters.ageRatings.length > 0
-        ? filters.ageRatings.includes(movie.age_rating)
-        : true;
-    return (
-      matchesTitle &&
-      matchesYearFrom &&
-      matchesYearTo &&
-      matchesDuration &&
-      matchesScore &&
-      matchesAgeRating
-    );
-  });
+  return movies.filter((movie) => movieMatchesFilters(movie, filters, titleQuery));
+}
+
+function isInRange(value: number, range: DurationBounds | undefined): boolean {
+  if (typeof range?.min === 'number' && value < range.min) return false;
+  if (typeof range?.max === 'number' && value > range.max) return false;
+  return true;
+}
+
+function movieMatchesFilters(
+  movie: Movie,
+  filters: MoviesPageFilters,
+  titleQuery: string | undefined,
+): boolean {
+  return (
+    (!titleQuery || movie.name.toLocaleLowerCase().includes(titleQuery)) &&
+    isInRange(movie.year, { min: filters.yearFrom, max: filters.yearTo }) &&
+    isInRange(movie.duration, getDurationBounds(filters.duration)) &&
+    (typeof filters.minScore !== 'number' || movie.score_rating >= filters.minScore) &&
+    (!filters.ageRatings?.length || filters.ageRatings.includes(movie.age_rating))
+  );
 }
 
 export async function getMoviesPage(

--- a/apps/web/src/integrations/tmdb/posters.ts
+++ b/apps/web/src/integrations/tmdb/posters.ts
@@ -48,38 +48,56 @@ type PosterProxySuccess = {
 
 export type PosterProxyResult = PosterProxyFailure | PosterProxySuccess;
 
-export async function proxyPosterImage(url: string | null): Promise<PosterProxyResult> {
+function posterProxyFailure(status: number, message: string): PosterProxyFailure {
+  return { ok: false, status, message };
+}
+
+function parsePosterUrl(url: string | null): URL | PosterProxyFailure {
   if (!url) {
-    return { ok: false, status: 400, message: 'Missing url' };
+    return posterProxyFailure(400, 'Missing url');
   }
 
-  let parsed: URL;
   try {
-    parsed = new URL(url);
+    return new URL(url);
   } catch {
-    return { ok: false, status: 400, message: 'Invalid url' };
+    return posterProxyFailure(400, 'Invalid url');
   }
+}
 
+function validatePosterOrigin(parsed: URL): PosterProxyFailure | undefined {
   if (parsed.hostname !== TMDB_IMAGE_HOST || parsed.protocol !== 'https:') {
-    return { ok: false, status: 403, message: 'Forbidden' };
+    return posterProxyFailure(403, 'Forbidden');
   }
+  return undefined;
+}
 
-  let normalizedPathname: string;
+function decodePosterPathname(pathname: string): string | PosterProxyFailure {
   try {
-    normalizedPathname = decodeURIComponent(parsed.pathname);
+    return decodeURIComponent(pathname);
   } catch {
-    return { ok: false, status: 400, message: 'Invalid url' };
+    return posterProxyFailure(400, 'Invalid url');
   }
+}
 
+function validatePosterPath(parsed: URL): PosterProxyFailure | undefined {
+  const normalizedPathname = decodePosterPathname(parsed.pathname);
+  if (isPosterProxyFailure(normalizedPathname)) return normalizedPathname;
   if (
     !ALLOWED_PATHNAME.test(parsed.pathname) ||
     normalizedPathname.includes('..') ||
     normalizedPathname.includes('\\') ||
     normalizedPathname.includes('//')
   ) {
-    return { ok: false, status: 403, message: 'Forbidden' };
+    return posterProxyFailure(403, 'Forbidden');
   }
+  return undefined;
+}
 
+function isPosterProxyFailure(value: unknown): value is PosterProxyFailure {
+  return Boolean(value && typeof value === 'object' && 'ok' in value && value.ok === false);
+}
+
+function buildSafePosterUrl(parsed: URL): URL {
   const safeSearchParams = new URLSearchParams();
   for (const [key, value] of parsed.searchParams.entries()) {
     if (!ALLOWED_QUERY_KEYS.has(key)) continue;
@@ -90,6 +108,19 @@ export async function proxyPosterImage(url: string | null): Promise<PosterProxyR
 
   const safeUrl = new URL(`https://${TMDB_IMAGE_HOST}${parsed.pathname}`);
   safeUrl.search = safeSearchParams.toString();
+  return safeUrl;
+}
+
+function validatePosterUrl(url: string | null): URL | PosterProxyFailure {
+  const parsed = parsePosterUrl(url);
+  if (isPosterProxyFailure(parsed)) return parsed;
+
+  return validatePosterOrigin(parsed) ?? validatePosterPath(parsed) ?? buildSafePosterUrl(parsed);
+}
+
+export async function proxyPosterImage(url: string | null): Promise<PosterProxyResult> {
+  const safeUrl = validatePosterUrl(url);
+  if (isPosterProxyFailure(safeUrl)) return safeUrl;
 
   const res = await fetch(safeUrl, {
     next: { revalidate: 86400 },
@@ -97,7 +128,7 @@ export async function proxyPosterImage(url: string | null): Promise<PosterProxyR
   });
 
   if (!res.ok) {
-    return { ok: false, status: res.status, message: 'Upstream error' };
+    return posterProxyFailure(res.status, 'Upstream error');
   }
 
   const upstreamType = res.headers.get('Content-Type')?.split(';')[0].trim() ?? '';


### PR DESCRIPTION
## Summary
- split the available movies page into focused view-model and UI components
- refactor catalog filters and SQL clause assembly into small reusable helpers
- make TMDB metadata quality flags and poster proxy validation more linear and testable

## Validation
- npm run test --workspace=apps/web -- src/features/movies/catalog.test.ts src/features/catalogMaintenance/tmdb.test.ts src/app/api/poster-proxy/route.test.ts src/app/available-movies/availableMoviesViewModel.test.ts
- npm run type-check --workspace=apps/web
- npm run lint:check --workspace=apps/web
- npx fallow health --changed-since origin/development --format json --quiet
- npx fallow dead-code --changed-since origin/development --format json --quiet
- npx fallow dupes --changed-since origin/development --format json --quiet
- pre-push: lint, server tests, production build

Closes #726