### PR TITLE
Split movie memory server helpers

### DIFF
--- a/apps/web/src/app/api/account/movie-memory/route.ts
+++ b/apps/web/src/app/api/account/movie-memory/route.ts
@@ -39,127 +39,141 @@ function parseRequestedLocale(req: NextRequest): Locale {
   return parseMovieMemoryLocale(localeParam, parseLocaleFromRequest(req));
 }
 
-export async function GET(req: NextRequest): Promise<Response> {
-  const session = getSessionFromRequest(req);
-  if (!session) {
-    return movieMemoryJson({ error: 'Unauthorized' }, 401);
-  }
+type MovieMemoryGetRequest =
+  | { kind: 'candidates'; query: string }
+  | { kind: 'list'; query: string }
+  | { kind: 'search'; query: string };
 
-  const startedAt = Date.now();
-  const isCandidatesRequest = req.nextUrl.searchParams.get('mode') === 'candidates';
-  const isListRequest = req.nextUrl.searchParams.get('mode') === 'list';
+type MovieMemoryGetContext = {
+  request: MovieMemoryGetRequest;
+  startedAt: number;
+  userId: string;
+};
+
+function getMovieMemoryGetRequest(req: NextRequest): MovieMemoryGetRequest {
+  const mode = req.nextUrl.searchParams.get('mode');
   const query = req.nextUrl.searchParams.get('query') ?? req.nextUrl.searchParams.get('q') ?? '';
-  const requestKind = isCandidatesRequest ? 'candidates' : isListRequest ? 'list' : 'search';
+  if (mode === 'candidates') return { kind: 'candidates', query };
+  if (mode === 'list') return { kind: 'list', query };
+  return { kind: 'search', query };
+}
+
+function logMovieMemoryGetReceived(context: MovieMemoryGetContext): void {
   logger.info(
     {
-      userId: session.sub,
-      requestKind,
-      queryLength: isCandidatesRequest ? undefined : query.length,
+      userId: context.userId,
+      requestKind: context.request.kind,
+      queryLength: context.request.kind === 'candidates' ? undefined : context.request.query.length,
     },
     'Movie memory GET received',
   );
+}
 
-  const rateLimitResponse = await applyRateLimit(req);
-  if (rateLimitResponse) {
-    logger.warn(
-      {
-        userId: session.sub,
-        requestKind,
-        status: rateLimitResponse.status,
-        durationMs: elapsedMs(startedAt),
-      },
-      'Movie memory GET rate limited',
+async function handleCandidateGet(
+  req: NextRequest,
+  context: MovieMemoryGetContext,
+): Promise<Response> {
+  try {
+    const locale = parseRequestedLocale(req);
+    const { movies, source, emptyStats } = await loadMovieMemoryCandidatesForUser(
+      context.userId,
+      locale,
+      { logContext: { requestKind: context.request.kind } },
     );
-    return rateLimitResponse;
+    logger.info(
+      {
+        userId: context.userId,
+        requestKind: context.request.kind,
+        source,
+        requested: CANDIDATE_LIMIT,
+        returned: movies.length,
+        catalogCount: emptyStats?.catalogCount,
+        memoryCount: emptyStats?.memoryCount,
+        availableCatalogCount: emptyStats?.availableCatalogCount,
+        durationMs: elapsedMs(context.startedAt),
+      },
+      'Movie memory candidates loaded',
+    );
+    return movieMemoryJson({ movies }, 200);
+  } catch (err) {
+    logger.error(
+      {
+        err,
+        userId: context.userId,
+        requestKind: context.request.kind,
+        durationMs: elapsedMs(context.startedAt),
+      },
+      'Failed to load movie memory candidates',
+    );
+    return movieMemoryJson({ error: 'Failed to load movie memory candidates' }, 500);
   }
+}
 
-  if (isCandidatesRequest) {
-    try {
-      const locale = parseRequestedLocale(req);
-      const { movies, source, emptyStats } = await loadMovieMemoryCandidatesForUser(
-        session.sub,
-        locale,
-        { logContext: { requestKind } },
-      );
-      logger.info(
-        {
-          userId: session.sub,
-          requestKind,
-          source,
-          requested: CANDIDATE_LIMIT,
-          returned: movies.length,
-          catalogCount: emptyStats?.catalogCount,
-          memoryCount: emptyStats?.memoryCount,
-          availableCatalogCount: emptyStats?.availableCatalogCount,
-          durationMs: elapsedMs(startedAt),
-        },
-        'Movie memory candidates loaded',
-      );
-      return movieMemoryJson({ movies }, 200);
-    } catch (err) {
-      logger.error(
-        { err, userId: session.sub, requestKind, durationMs: elapsedMs(startedAt) },
-        'Failed to load movie memory candidates',
-      );
-      return movieMemoryJson({ error: 'Failed to load movie memory candidates' }, 500);
-    }
-  }
-
-  if (isListRequest) {
-    const parsed = listMovieMemorySchema.safeParse({
-      offset: req.nextUrl.searchParams.get('offset') ?? undefined,
-      limit: req.nextUrl.searchParams.get('limit') ?? undefined,
-    });
-    if (!parsed.success) {
-      logger.warn(
-        { userId: session.sub, requestKind, durationMs: elapsedMs(startedAt) },
-        'Movie memory list rejected: invalid pagination',
-      );
-      return movieMemoryJson({ error: 'Invalid movie memory pagination' }, 422);
-    }
-
-    try {
-      const page = await getMovieMemoryPageForUser(session.sub, parsed.data);
-      logger.info(
-        {
-          userId: session.sub,
-          requestKind,
-          requested: parsed.data.limit,
-          offset: parsed.data.offset,
-          returned: page.items.length,
-          total: page.total,
-          nextOffset: page.nextOffset,
-          durationMs: elapsedMs(startedAt),
-        },
-        'Movie memory list loaded',
-      );
-      return movieMemoryJson(
-        {
-          movieMemory: page.items,
-          total: page.total,
-          nextOffset: page.nextOffset,
-        },
-        200,
-      );
-    } catch (err) {
-      logger.error(
-        { err, userId: session.sub, requestKind, durationMs: elapsedMs(startedAt) },
-        'Failed to load movie memory list',
-      );
-      return movieMemoryJson({ error: 'Failed to load movie memory' }, 500);
-    }
-  }
-
-  const parsed = searchMovieMemorySchema.safeParse({
-    query,
+async function handleListGet(req: NextRequest, context: MovieMemoryGetContext): Promise<Response> {
+  const parsed = listMovieMemorySchema.safeParse({
+    offset: req.nextUrl.searchParams.get('offset') ?? undefined,
+    limit: req.nextUrl.searchParams.get('limit') ?? undefined,
   });
   if (!parsed.success) {
     logger.warn(
       {
-        userId: session.sub,
-        requestKind,
-        queryLength: query.length,
-        durationMs: elapsedMs(startedAt),
+        userId: context.userId,
+        requestKind: context.request.kind,
+        durationMs: elapsedMs(context.startedAt),
+      },
+      'Movie memory list rejected: invalid pagination',
+    );
+    return movieMemoryJson({ error: 'Invalid movie memory pagination' }, 422);
+  }
+
+  try {
+    const page = await getMovieMemoryPageForUser(context.userId, parsed.data);
+    logger.info(
+      {
+        userId: context.userId,
+        requestKind: context.request.kind,
+        requested: parsed.data.limit,
+        offset: parsed.data.offset,
+        returned: page.items.length,
+        total: page.total,
+        nextOffset: page.nextOffset,
+        durationMs: elapsedMs(context.startedAt),
+      },
+      'Movie memory list loaded',
+    );
+    return movieMemoryJson(
+      {
+        movieMemory: page.items,
+        total: page.total,
+        nextOffset: page.nextOffset,
+      },
+      200,
+    );
+  } catch (err) {
+    logger.error(
+      {
+        err,
+        userId: context.userId,
+        requestKind: context.request.kind,
+        durationMs: elapsedMs(context.startedAt),
+      },
+      'Failed to load movie memory list',
+    );
+    return movieMemoryJson({ error: 'Failed to load movie memory' }, 500);
+  }
+}
+
+async function handleSearchGet(context: MovieMemoryGetContext): Promise<Response> {
+  const parsed = searchMovieMemorySchema.safeParse({
+    query: context.request.query,
+  });
+  if (!parsed.success) {
+    logger.warn(
+      {
+        userId: context.userId,
+        requestKind: context.request.kind,
+        queryLength: context.request.query.length,
+        durationMs: elapsedMs(context.startedAt),
       },
       'Movie memory search rejected: invalid query',
     );
@@ -170,11 +184,11 @@ export async function GET(req: NextRequest): Promise<Response> {
     const movies = await searchMovieMemoryCatalog(parsed.data.query);
     logger.info(
       {
-        userId: session.sub,
-        requestKind,
+        userId: context.userId,
+        requestKind: context.request.kind,
         queryLength: parsed.data.query.length,
         returned: movies.length,
-        durationMs: elapsedMs(startedAt),
+        durationMs: elapsedMs(context.startedAt),
       },
       'Movie memory search completed',
     );
@@ -183,15 +197,51 @@ export async function GET(req: NextRequest): Promise<Response> {
     logger.error(
       {
         err,
-        userId: session.sub,
-        requestKind,
+        userId: context.userId,
+        requestKind: context.request.kind,
         queryLength: parsed.data.query.length,
-        durationMs: elapsedMs(startedAt),
+        durationMs: elapsedMs(context.startedAt),
       },
       'Failed to search movie catalog for memory',
     );
     return movieMemoryJson({ error: 'Failed to search movie catalog' }, 500);
   }
+}
+
+function handleGetByKind(req: NextRequest, context: MovieMemoryGetContext): Promise<Response> {
+  if (context.request.kind === 'candidates') return handleCandidateGet(req, context);
+  if (context.request.kind === 'list') return handleListGet(req, context);
+  return handleSearchGet(context);
+}
+
+export async function GET(req: NextRequest): Promise<Response> {
+  const session = getSessionFromRequest(req);
+  if (!session) {
+    return movieMemoryJson({ error: 'Unauthorized' }, 401);
+  }
+
+  const context: MovieMemoryGetContext = {
+    request: getMovieMemoryGetRequest(req),
+    startedAt: Date.now(),
+    userId: session.sub,
+  };
+  logMovieMemoryGetReceived(context);
+
+  const rateLimitResponse = await applyRateLimit(req);
+  if (rateLimitResponse) {
+    logger.warn(
+      {
+        userId: context.userId,
+        requestKind: context.request.kind,
+        status: rateLimitResponse.status,
+        durationMs: elapsedMs(context.startedAt),
+      },
+      'Movie memory GET rate limited',
+    );
+    return rateLimitResponse;
+  }
+
+  return handleGetByKind(req, context);
 }
 
 export async function POST(req: NextRequest): Promise<Response> {

--- a/apps/web/src/features/movie-memory/service.ts
+++ b/apps/web/src/features/movie-memory/service.ts
@@ -94,6 +94,8 @@ const tmdbDiscoverResponseSchema = z.object({
   results: z.array(tmdbCandidateSchema).optional(),
 });
 
+type TMDBCandidate = z.infer<typeof tmdbCandidateSchema>;
+type TMDBDiscoverResponse = z.infer<typeof tmdbDiscoverResponseSchema>;
 type MovieMemoryLogContext = Record<string, unknown>;
 
 export interface MovieMemoryCandidateResult {
@@ -128,6 +130,116 @@ function buildMemoryExclusionSet(items: UserMovieMemorySummary[]): Set<string> {
   return excluded;
 }
 
+function buildTMDBDiscoverUrl(page: number, tmdbLanguage: string): string {
+  const url = new URL('https://api.themoviedb.org/3/discover/movie');
+  url.searchParams.set('include_adult', 'false');
+  url.searchParams.set('language', tmdbLanguage);
+  url.searchParams.set('page', String(page));
+  url.searchParams.set('sort_by', 'vote_average.desc');
+  url.searchParams.set('vote_count.gte', '1000');
+  return url.toString();
+}
+
+async function fetchTMDBDiscoverPage(
+  page: number,
+  tmdbApiKey: string,
+  tmdbLanguage: string,
+): Promise<TMDBDiscoverResponse | null> {
+  try {
+    const response = await fetch(buildTMDBDiscoverUrl(page, tmdbLanguage), {
+      headers: { Authorization: `Bearer ${tmdbApiKey}`, Accept: 'application/json' },
+      signal: AbortSignal.timeout(TMDB_DISCOVER_FETCH_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      logger.warn({ status: response.status, page }, 'Movie memory TMDB fallback failed');
+      return null;
+    }
+
+    const responseBody = tmdbDiscoverResponseSchema.safeParse(await response.json());
+    if (!responseBody.success) {
+      logger.warn({ err: responseBody.error, page }, 'Movie memory TMDB fallback response invalid');
+      return null;
+    }
+
+    return responseBody.data;
+  } catch (err: unknown) {
+    logger.warn({ err, page }, 'Movie memory TMDB fallback failed');
+    return null;
+  }
+}
+
+function getTMDBCandidateTitles(movie: TMDBCandidate, locale: Locale) {
+  const canonicalTitle = movie.original_title?.trim() || movie.title;
+  const localizedName =
+    locale !== 'en' && movie.title.trim() && movie.title.trim() !== canonicalTitle
+      ? movie.title
+      : null;
+
+  return { canonicalTitle, localizedName };
+}
+
+function toMovieMemoryCandidate(
+  movie: TMDBCandidate,
+  locale: Locale,
+): MovieMemoryCandidate | undefined {
+  const movieYear = getYearFromReleaseDate(movie.release_date);
+  const { canonicalTitle, localizedName } = getTMDBCandidateTitles(movie, locale);
+  const movieKey = getMovieIdentityKey({
+    tmdbId: movie.id,
+    title: canonicalTitle,
+    year: movieYear,
+  });
+  if (!movieKey) return undefined;
+
+  return {
+    id: -movie.id,
+    tmdbId: movie.id,
+    movieName: canonicalTitle,
+    movieYear,
+    posterURL: getPosterURL(movie.poster_path),
+    localizedName,
+    duration: null,
+    description: locale === 'en' ? movie.overview || null : null,
+    localizedOverview: locale === 'en' ? null : movie.overview || null,
+  };
+}
+
+function appendTMDBMemoryCandidate(
+  candidates: MovieMemoryCandidate[],
+  seenCandidateKeys: Set<string>,
+  excluded: Set<string>,
+  movie: TMDBCandidate,
+  locale: Locale,
+): void {
+  const candidate = toMovieMemoryCandidate(movie, locale);
+  if (!candidate) return;
+
+  const movieKey = getMovieIdentityKey({
+    tmdbId: candidate.tmdbId,
+    title: candidate.movieName,
+    year: candidate.movieYear,
+  });
+  if (!movieKey || excluded.has(movieKey) || seenCandidateKeys.has(movieKey)) return;
+
+  seenCandidateKeys.add(movieKey);
+  candidates.push(candidate);
+}
+
+function appendTMDBMemoryCandidates(
+  candidates: MovieMemoryCandidate[],
+  seenCandidateKeys: Set<string>,
+  excluded: Set<string>,
+  movies: TMDBCandidate[],
+  locale: Locale,
+  limit: number,
+): void {
+  for (const movie of movies) {
+    appendTMDBMemoryCandidate(candidates, seenCandidateKeys, excluded, movie, locale);
+    if (candidates.length >= limit) break;
+  }
+}
+
 async function getTMDBMovieMemoryCandidatesForUser(
   userId: string,
   limit: number,
@@ -143,71 +255,16 @@ async function getTMDBMovieMemoryCandidatesForUser(
   const tmdbLanguage = LOCALE_TO_TMDB_LANG[locale] ?? 'en-US';
 
   for (let page = 1; page <= TMDB_DISCOVER_MAX_PAGES && candidates.length < limit; page++) {
-    const url = new URL('https://api.themoviedb.org/3/discover/movie');
-    url.searchParams.set('include_adult', 'false');
-    url.searchParams.set('language', tmdbLanguage);
-    url.searchParams.set('page', String(page));
-    url.searchParams.set('sort_by', 'vote_average.desc');
-    url.searchParams.set('vote_count.gte', '1000');
-
-    const parsed = await fetch(url.toString(), {
-      headers: { Authorization: `Bearer ${tmdbApiKey}`, Accept: 'application/json' },
-      signal: AbortSignal.timeout(TMDB_DISCOVER_FETCH_TIMEOUT_MS),
-    })
-      .then(async (response) => {
-        if (!response.ok) {
-          logger.warn({ status: response.status, page }, 'Movie memory TMDB fallback failed');
-          return null;
-        }
-
-        const responseBody = tmdbDiscoverResponseSchema.safeParse(await response.json());
-        if (!responseBody.success) {
-          logger.warn(
-            { err: responseBody.error, page },
-            'Movie memory TMDB fallback response invalid',
-          );
-          return null;
-        }
-
-        return responseBody.data;
-      })
-      .catch((err: unknown) => {
-        logger.warn({ err, page }, 'Movie memory TMDB fallback failed');
-        return null;
-      });
-    if (!parsed) {
-      break;
-    }
-
-    for (const movie of parsed.results ?? []) {
-      const movieYear = getYearFromReleaseDate(movie.release_date);
-      const canonicalTitle = movie.original_title?.trim() || movie.title;
-      const localizedTitle =
-        locale !== 'en' && movie.title.trim() && movie.title.trim() !== canonicalTitle
-          ? movie.title
-          : null;
-      const movieKey = getMovieIdentityKey({
-        tmdbId: movie.id,
-        title: canonicalTitle,
-        year: movieYear,
-      });
-      if (!movieKey || excluded.has(movieKey) || seenCandidateKeys.has(movieKey)) continue;
-
-      seenCandidateKeys.add(movieKey);
-      candidates.push({
-        id: -movie.id,
-        tmdbId: movie.id,
-        movieName: canonicalTitle,
-        movieYear,
-        posterURL: getPosterURL(movie.poster_path),
-        localizedName: localizedTitle,
-        duration: null,
-        description: locale === 'en' ? movie.overview || null : null,
-        localizedOverview: locale === 'en' ? null : movie.overview || null,
-      });
-
-      if (candidates.length >= limit) break;
-    }
+    const parsed = await fetchTMDBDiscoverPage(page, tmdbApiKey, tmdbLanguage);
+    if (!parsed) break;
+    appendTMDBMemoryCandidates(
+      candidates,
+      seenCandidateKeys,
+      excluded,
+      parsed.results ?? [],
+      locale,
+      limit,
+    );
   }
 
   return candidates;


### PR DESCRIPTION
## Summary
- split the account movie-memory GET route into candidates/list/search handlers
- extract TMDB movie-memory fallback URL, fetch, parse, normalize, and dedupe helpers
- keep existing movie-memory route and service behavior covered by focused tests

## Validation
- npm run test --workspace=apps/web -- src/app/api/account/movie-memory/route.test.ts src/features/movie-memory/service.test.ts
- npm run type-check --workspace=apps/web
- npm run lint:check --workspace=apps/web
- npx fallow health --changed-since origin/development --format json --quiet
- npx fallow dead-code --changed-since origin/development --format json --quiet
- npx fallow dupes --changed-since origin/development --format json --quiet
- pre-push: lint, server tests, production build

Part of #742