### PR TITLE
Split results id client view model

### DIFF
--- a/apps/web/src/app/results/[id]/ResultsIdClient.tsx
+++ b/apps/web/src/app/results/[id]/ResultsIdClient.tsx
@@ -1,89 +1,93 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { use, useEffect, useMemo } from 'react';
+import { use, useEffect, type ReactNode } from 'react';
 
-import { RecommendationFetchError, useRecommendation } from '@/hooks/useRecommendation';
+import { useRecommendation } from '@/hooks/useRecommendation';
 import { navigateToFreshQuiz } from '@/lib/quizNavigation';
-import { type MovieRecommendation } from '@/utils/client';
 
 import { RecommendationResultsView } from './RecommendationResultsView';
 import { ResultsErrorState } from './ResultsErrorState';
+import {
+  getResultsClientRenderState,
+  getReadyResultsViewModel,
+  getResultRouteId,
+  type LoadingResultsClientRenderState,
+  type ReadyResultsClientRenderState,
+  type ResultsClientRenderState,
+} from './resultsIdViewModel';
 import { ResultsLoadingState } from './ResultsLoadingState';
 
 export function ResultsIdClient({ params }: { params: Promise<{ id: string }> }) {
   const routeParams = use(params);
   const router = useRouter();
-  const id = typeof routeParams.id === 'string' ? routeParams.id : '';
+  const id = getResultRouteId(routeParams);
 
   const { data, error, isError, refetch, morePicksTimedOut } = useRecommendation(id);
+  const renderState = getResultsClientRenderState({ data, error, id, isError });
 
-  // Derive movies from the completed poll response — no secondary fetch needed because
-  // poster URLs are fetched during the BullMQ job and stored in recommendation_movies.
-  const movies = useMemo<MovieRecommendation[]>(() => {
-    if (data?.status !== 'completed' || !data.movies) return [];
-    return data.movies.map((m) => ({
-      id: m.id,
-      name: m.name,
-      year: m.year,
-      similarity: m.similarity ?? 0,
-      age_rating: m.age_rating,
-      duration: m.duration,
-      score_rating: m.score_rating,
-      posterURL: m.posterURL,
-      description: m.aiDescription,
-      localizedName: m.localizedName,
-      isMainRecommendation: m.isMainRecommendation,
-      fromTMDB: m.fromTMDB,
-    }));
-  }, [data]);
+  useRedirectMissingResultId(id, router);
 
-  const peopleCount = data?.peopleCount ?? 1;
-  const groupInsights = data?.groupInsights ?? null;
+  const renderers: Record<ResultsClientRenderState['kind'], () => ReactNode> = {
+    empty: () => <ResultsErrorState variant="empty" onRetry={navigateToFreshQuiz} />,
+    failed: () => <ResultsErrorState variant="failed" onRetry={navigateToFreshQuiz} />,
+    loading: () => (
+      <LoadingResultsState renderState={renderState as LoadingResultsClientRenderState} />
+    ),
+    missing: () => <ResultsErrorState variant="missing" onRetry={navigateToFreshQuiz} />,
+    ready: () => (
+      <ReadyResultsView
+        renderState={renderState as ReadyResultsClientRenderState}
+        recommendationSlug={id}
+        morePicksTimedOut={morePicksTimedOut}
+        onMorePicksRequested={refetch}
+      />
+    ),
+    redirect: () => null,
+  };
 
+  return renderers[renderState.kind]();
+}
+
+function useRedirectMissingResultId(id: string, router: ReturnType<typeof useRouter>) {
   useEffect(() => {
     if (!id) {
       router.replace('/quiz');
     }
   }, [id, router]);
+}
 
-  const status = data?.status;
-  const stage = data?.stage;
+function LoadingResultsState({ renderState }: { renderState: LoadingResultsClientRenderState }) {
+  return <ResultsLoadingState status={renderState.status} stage={renderState.stage} />;
+}
 
-  if (!id) return null;
-
-  if (isError) {
-    const variant =
-      error instanceof RecommendationFetchError && error.status === 404 ? 'missing' : 'failed';
-    return <ResultsErrorState variant={variant} onRetry={navigateToFreshQuiz} />;
-  }
-
-  if (status === 'failed') {
-    return <ResultsErrorState variant="failed" onRetry={navigateToFreshQuiz} />;
-  }
-
-  if (!data || status === 'pending' || status === 'processing') {
-    return <ResultsLoadingState status={status} stage={stage} />;
-  }
-
-  if (movies.length === 0) {
-    return <ResultsErrorState variant="empty" onRetry={navigateToFreshQuiz} />;
-  }
+function ReadyResultsView({
+  renderState,
+  recommendationSlug,
+  morePicksTimedOut,
+  onMorePicksRequested,
+}: {
+  renderState: ReadyResultsClientRenderState;
+  recommendationSlug: string;
+  morePicksTimedOut: boolean;
+  onMorePicksRequested: () => Promise<unknown>;
+}) {
+  const viewModel = getReadyResultsViewModel(renderState);
 
   return (
     <RecommendationResultsView
-      movies={movies}
-      usedBroaderSearch={data.usedBroaderSearch ?? false}
-      dbMovieCount={data.dbMovieCount}
-      peopleCount={peopleCount}
-      hasActorSignal={data.hasActorSignal ?? false}
-      groupInsights={groupInsights}
-      recommendationSlug={id}
-      morePicksStatus={data.morePicksStatus}
+      movies={viewModel.movies}
+      usedBroaderSearch={viewModel.usedBroaderSearch}
+      dbMovieCount={viewModel.dbMovieCount}
+      peopleCount={viewModel.peopleCount}
+      hasActorSignal={viewModel.hasActorSignal}
+      groupInsights={viewModel.groupInsights}
+      recommendationSlug={recommendationSlug}
+      morePicksStatus={viewModel.morePicksStatus}
       morePicksTimedOut={morePicksTimedOut}
-      viewerCanRate={data.viewerCanRate ?? false}
-      isSharedResult={data.isSharedResult ?? false}
-      onMorePicksRequested={refetch}
+      viewerCanRate={viewModel.viewerCanRate}
+      isSharedResult={viewModel.isSharedResult}
+      onMorePicksRequested={onMorePicksRequested}
     />
   );
 }

--- a/apps/web/src/app/results/[id]/resultsIdViewModel.test.ts
+++ b/apps/web/src/app/results/[id]/resultsIdViewModel.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+
+import { RecommendationFetchError } from '@/hooks/useRecommendation';
+
+import { getResultsClientRenderState, mapRecommendationMovies } from './resultsIdViewModel';
+
+import type { RecommendationWithMovies } from '@/lib/db/recommendations';
+
+const movie = {
+  age_rating: 'PG-13',
+  aiDescription: 'Because it fits.',
+  duration: 120,
+  fromTMDB: true,
+  id: 1,
+  isMainRecommendation: true,
+  localizedName: 'Localized',
+  name: 'Arrival',
+  posterURL: '/poster.jpg',
+  score_rating: 8.5,
+  similarity: undefined,
+  year: 2016,
+};
+
+function recommendation(
+  overrides: Partial<RecommendationWithMovies> = {},
+): RecommendationWithMovies {
+  return {
+    error: null,
+    movies: [],
+    stage: 'complete',
+    status: 'completed',
+    ...overrides,
+  };
+}
+
+describe('resultsIdViewModel', () => {
+  it('maps completed recommendation movies into client movie shape', () => {
+    expect(mapRecommendationMovies(recommendation({ movies: [movie] }))).toEqual([
+      {
+        age_rating: 'PG-13',
+        description: 'Because it fits.',
+        duration: 120,
+        fromTMDB: true,
+        id: 1,
+        isMainRecommendation: true,
+        localizedName: 'Localized',
+        name: 'Arrival',
+        posterURL: '/poster.jpg',
+        score_rating: 8.5,
+        similarity: 0,
+        year: 2016,
+      },
+    ]);
+  });
+
+  it('selects redirect, loading, empty, and ready render states', () => {
+    expect(
+      getResultsClientRenderState({ data: null, error: null, id: '', isError: false }),
+    ).toEqual({ kind: 'redirect' });
+    expect(
+      getResultsClientRenderState({
+        data: recommendation({ stage: 'ai-ranking', status: 'processing' }),
+        error: null,
+        id: 'abc',
+        isError: false,
+      }),
+    ).toEqual({ kind: 'loading', status: 'processing', stage: 'ai-ranking' });
+    expect(
+      getResultsClientRenderState({
+        data: recommendation(),
+        error: null,
+        id: 'abc',
+        isError: false,
+      }),
+    ).toEqual({ kind: 'empty' });
+    expect(
+      getResultsClientRenderState({
+        data: recommendation({ movies: [movie] }),
+        error: null,
+        id: 'abc',
+        isError: false,
+      }),
+    ).toMatchObject({ kind: 'ready', movies: [{ name: 'Arrival' }] });
+  });
+
+  it('maps fetch errors to missing or failed states', () => {
+    expect(
+      getResultsClientRenderState({
+        data: null,
+        error: new RecommendationFetchError('missing', 404),
+        id: 'abc',
+        isError: true,
+      }),
+    ).toEqual({ kind: 'missing' });
+    expect(
+      getResultsClientRenderState({
+        data: null,
+        error: new Error('boom'),
+        id: 'abc',
+        isError: true,
+      }),
+    ).toEqual({ kind: 'failed' });
+  });
+});

--- a/apps/web/src/app/results/[id]/resultsIdViewModel.ts
+++ b/apps/web/src/app/results/[id]/resultsIdViewModel.ts
@@ -1,0 +1,104 @@
+import { RecommendationFetchError } from '@/hooks/useRecommendation';
+
+import type {
+  RecommendationStage,
+  RecommendationStatus,
+  RecommendationWithMovies,
+} from '@/lib/db/recommendations';
+import type { MovieRecommendation } from '@/utils/client';
+
+export type ResultsClientRenderState =
+  | { kind: 'redirect' }
+  | { kind: 'missing' }
+  | { kind: 'failed' }
+  | { kind: 'empty' }
+  | {
+      kind: 'loading';
+      status: RecommendationStatus | undefined;
+      stage: RecommendationStage | undefined;
+    }
+  | { kind: 'ready'; data: RecommendationWithMovies; movies: MovieRecommendation[] };
+
+export type ReadyResultsClientRenderState = Extract<ResultsClientRenderState, { kind: 'ready' }>;
+export type LoadingResultsClientRenderState = Extract<
+  ResultsClientRenderState,
+  { kind: 'loading' }
+>;
+
+export function getResultRouteId(routeParams: { id?: unknown }): string {
+  return typeof routeParams.id === 'string' ? routeParams.id : '';
+}
+
+export function getReadyResultsViewModel(renderState: ReadyResultsClientRenderState) {
+  return {
+    dbMovieCount: renderState.data.dbMovieCount,
+    hasActorSignal: renderState.data.hasActorSignal === true,
+    isSharedResult: renderState.data.isSharedResult === true,
+    groupInsights: renderState.data.groupInsights ?? null,
+    morePicksStatus: renderState.data.morePicksStatus,
+    movies: renderState.movies,
+    peopleCount: renderState.data.peopleCount ?? 1,
+    usedBroaderSearch: renderState.data.usedBroaderSearch === true,
+    viewerCanRate: renderState.data.viewerCanRate === true,
+  };
+}
+
+export function getResultsClientRenderState({
+  data,
+  error,
+  id,
+  isError,
+}: {
+  data: RecommendationWithMovies | null | undefined;
+  error: unknown;
+  id: string;
+  isError: boolean;
+}): ResultsClientRenderState {
+  if (!id) return { kind: 'redirect' };
+  if (isError) return getFetchErrorState(error);
+  if (data?.status === 'failed') return { kind: 'failed' };
+
+  const movies = mapRecommendationMovies(data);
+  if (isLoadingRecommendation(data)) {
+    return { kind: 'loading', status: data?.status, stage: getRecommendationStage(data) };
+  }
+
+  return movies.length > 0 && data ? { kind: 'ready', data, movies } : { kind: 'empty' };
+}
+
+export function mapRecommendationMovies(
+  data: RecommendationWithMovies | null | undefined,
+): MovieRecommendation[] {
+  if (data?.status !== 'completed' || !data.movies) return [];
+
+  return data.movies.map((movie) => ({
+    id: movie.id,
+    name: movie.name,
+    year: movie.year,
+    similarity: movie.similarity ?? 0,
+    age_rating: movie.age_rating,
+    duration: movie.duration,
+    score_rating: movie.score_rating,
+    posterURL: movie.posterURL,
+    description: movie.aiDescription,
+    localizedName: movie.localizedName,
+    isMainRecommendation: movie.isMainRecommendation,
+    fromTMDB: movie.fromTMDB,
+  }));
+}
+
+function getFetchErrorState(error: unknown): ResultsClientRenderState {
+  return error instanceof RecommendationFetchError && error.status === 404
+    ? { kind: 'missing' }
+    : { kind: 'failed' };
+}
+
+function getRecommendationStage(
+  data: RecommendationWithMovies | null | undefined,
+): RecommendationStage | undefined {
+  return data?.stage;
+}
+
+function isLoadingRecommendation(data: RecommendationWithMovies | null | undefined): boolean {
+  return !data || data.status === 'pending' || data.status === 'processing';
+}


### PR DESCRIPTION
## Summary
- move results detail polling/render-state decisions into a focused view-model
- keep ResultsIdClient as a small renderer/redirect coordinator
- add unit coverage for recommendation movie mapping and render-state selection

## Validation
- npm run test --workspace=apps/web -- 'src/app/results/[id]/resultsIdViewModel.test.ts'
- npm run type-check --workspace=apps/web
- npm run lint:check --workspace=apps/web
- pre-push: lint, server tests, production build; Storybook skipped by scope
- npx fallow health --format json --quiet --changed-since origin/development
- npx fallow dead-code --format json --quiet --changed-since origin/development
- npx fallow dupes --format json --quiet --changed-since origin/development

Part of #743