### PR TITLE
Split results card view models

### DIFF
--- a/apps/web/src/app/results/components/ExpandedSuggestion.tsx
+++ b/apps/web/src/app/results/components/ExpandedSuggestion.tsx
@@ -8,6 +8,11 @@ import { useLanguage } from '@/i18n';
 import { palette } from '@/styles/designTokens';
 
 import { MarkdownText } from './MarkdownText';
+import {
+  buildResultMovieCardViewModel,
+  type ResultMovieCardViewModel,
+  type ResultMovieMetaItem,
+} from './resultMovieCardViewModel';
 import { SimilarityBadge } from './SimilarityBadge';
 import { StarRating } from './StarRating';
 
@@ -21,8 +26,10 @@ export function ExpandedSuggestion({
   isGroup?: boolean;
 }) {
   const { t } = useLanguage();
-  const score = movie.score_rating ?? 0;
-  const hasRating = !!movie.age_rating && movie.age_rating !== 'NR';
+  const view = buildResultMovieCardViewModel(movie, t.results, {
+    isGroup,
+    rationaleVariant: 'expanded',
+  });
 
   return (
     <motion.div
@@ -41,99 +48,133 @@ export function ExpandedSuggestion({
         }}
       >
         <div className="flex items-start gap-4">
-          {movie.posterURL && (
-            <div className="relative shrink-0 w-20 h-28 rounded-xl overflow-hidden">
-              <Image
-                src={movie.posterURL}
-                alt={movie.name}
-                fill
-                sizes="80px"
-                className="object-cover"
-              />
-            </div>
-          )}
-          <div className="flex-1 min-w-0">
-            <div className="flex items-start justify-between gap-2 mb-2">
-              <div>
-                <h3
-                  style={{
-                    fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
-                    fontWeight: '600',
-                    textTransform: 'uppercase',
-                    fontSize: '1.3rem',
-                    letterSpacing: '0.03em',
-                    color: 'var(--pc-t1)',
-                  }}
-                >
-                  {movie.localizedName ?? movie.name}
-                </h3>
-                <div
-                  className="flex items-center gap-2"
-                  style={{ color: 'var(--pc-t3)', fontSize: '0.78rem' }}
-                >
-                  <span>{movie.year}</span>
-                  {hasRating && (
-                    <>
-                      <span>·</span>
-                      <span>{movie.age_rating}</span>
-                    </>
-                  )}
-                  {score > 0 && (
-                    <>
-                      <span>·</span>
-                      <span className="flex items-center gap-0.5">
-                        <Star size={10} fill={palette.gold} stroke="none" />
-                        {score}
-                      </span>
-                    </>
-                  )}
-                  {(movie.duration ?? 0) > 0 && (
-                    <>
-                      <span>·</span>
-                      <span className="flex items-center gap-0.5">
-                        <Clock size={10} />
-                        {movie.duration}m
-                      </span>
-                    </>
-                  )}
-                </div>
-              </div>
-              <SimilarityBadge similarity={movie.similarity} />
-            </div>
-            {score > 0 && <StarRating score={score} />}
-          </div>
+          {view.hasPoster && <ExpandedPoster movie={movie} view={view} />}
+          <ExpandedHeader movie={movie} view={view} />
         </div>
 
-        {movie.description && (
-          <div
-            className="mt-4 p-3.5 rounded-xl"
-            style={{
-              background: 'var(--pc-ai-bg)',
-              border: '1px solid',
-              borderColor: 'var(--pc-ai-bd)',
-            }}
-          >
-            <div className="flex items-center gap-2 mb-1.5">
-              <Sparkles size={11} style={{ color: 'var(--pc-gold-text)' }} />
-              <span
-                className="uppercase tracking-widest"
-                style={{ color: 'var(--pc-gold-text)', fontSize: '0.62rem' }}
-              >
-                {isGroup ? t.results.whyThisFilmForGroup : t.results.whyThisFilm}
-              </span>
-            </div>
-            <p
-              style={{
-                color: 'var(--pc-t2)',
-                fontSize: '0.82rem',
-                lineHeight: 1.7,
-              }}
-            >
-              <MarkdownText text={movie.description ?? ''} />
-            </p>
-          </div>
-        )}
+        {view.hasDescription && <ExpandedRationale view={view} />}
       </div>
     </motion.div>
+  );
+}
+
+function ExpandedPoster({
+  movie,
+  view,
+}: {
+  movie: MovieRecommendation;
+  view: ResultMovieCardViewModel;
+}) {
+  return (
+    <div className="relative shrink-0 w-20 h-28 rounded-xl overflow-hidden">
+      <Image src={view.posterUrl!} alt={movie.name} fill sizes="80px" className="object-cover" />
+    </div>
+  );
+}
+
+function ExpandedHeader({
+  movie,
+  view,
+}: {
+  movie: MovieRecommendation;
+  view: ResultMovieCardViewModel;
+}) {
+  return (
+    <div className="flex-1 min-w-0">
+      <div className="flex items-start justify-between gap-2 mb-2">
+        <div>
+          <h3
+            style={{
+              fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
+              fontWeight: '600',
+              textTransform: 'uppercase',
+              fontSize: '1.3rem',
+              letterSpacing: '0.03em',
+              color: 'var(--pc-t1)',
+            }}
+          >
+            {view.title}
+          </h3>
+          <ExpandedMetaItems items={view.expandedMetaItems} />
+        </div>
+        <SimilarityBadge similarity={movie.similarity} />
+      </div>
+      {view.hasScore && <StarRating score={view.score} />}
+    </div>
+  );
+}
+
+function ExpandedMetaItems({ items }: { items: ResultMovieMetaItem[] }) {
+  return (
+    <div className="flex items-center gap-2" style={{ color: 'var(--pc-t3)', fontSize: '0.78rem' }}>
+      {items.map((item, index) => (
+        <ExpandedMetaItem
+          key={`${item.kind}-${item.label}`}
+          item={item}
+          showSeparator={index > 0}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ExpandedMetaItem({
+  item,
+  showSeparator,
+}: {
+  item: ResultMovieMetaItem;
+  showSeparator: boolean;
+}) {
+  return (
+    <>
+      {showSeparator && <span>·</span>}
+      <ExpandedMetaValue item={item} />
+    </>
+  );
+}
+
+function ExpandedMetaValue({ item }: { item: ResultMovieMetaItem }) {
+  if (item.kind === 'score') {
+    return (
+      <span className="flex items-center gap-0.5">
+        <Star size={10} fill={palette.gold} stroke="none" />
+        {item.label}
+      </span>
+    );
+  }
+  if (item.kind === 'duration') {
+    return (
+      <span className="flex items-center gap-0.5">
+        <Clock size={10} />
+        {item.label}
+      </span>
+    );
+  }
+  return <span>{item.label}</span>;
+}
+
+function ExpandedRationale({ view }: { view: ResultMovieCardViewModel }) {
+  return (
+    <div
+      className="mt-4 p-3.5 rounded-xl"
+      style={{
+        background: 'var(--pc-ai-bg)',
+        border: '1px solid',
+        borderColor: 'var(--pc-ai-bd)',
+      }}
+    >
+      <div className="flex items-center gap-2 mb-1.5">
+        <Sparkles size={11} style={{ color: 'var(--pc-gold-text)' }} />
+        <span
+          className="uppercase tracking-widest"
+          style={{ color: 'var(--pc-gold-text)', fontSize: '0.62rem' }}
+        >
+          {view.rationaleLabel}
+        </span>
+      </div>
+      <p style={{ color: 'var(--pc-t2)', fontSize: '0.82rem', lineHeight: 1.7 }}>
+        <MarkdownText text={view.description} />
+      </p>
+    </div>
   );
 }

--- a/apps/web/src/app/results/components/MainMovieCard.tsx
+++ b/apps/web/src/app/results/components/MainMovieCard.tsx
@@ -7,14 +7,19 @@ import { useState } from 'react';
 
 import { useLanguage } from '@/i18n';
 import { palette } from '@/styles/designTokens';
-import { getSimilarityTier } from '@/utils/ui';
 
 import { AgeRatingPill } from './AgeRatingPill';
 import { MarkdownText } from './MarkdownText';
+import {
+  buildResultMovieCardViewModel,
+  type ResultMovieCardViewModel,
+  type ResultMovieMetaItem,
+} from './resultMovieCardViewModel';
 import { SimilarityBadge } from './SimilarityBadge';
 import { StarRating } from './StarRating';
 
 import type { MovieRecommendation } from '@/utils/client';
+import type { ReactNode } from 'react';
 
 export function MainMovieCard({
   movie,
@@ -25,11 +30,7 @@ export function MainMovieCard({
 }) {
   const { t } = useLanguage();
   const [imgLoaded, setImgLoaded] = useState(false);
-  const score = movie.score_rating ?? 0;
-  const { pct, tier } = getSimilarityTier(movie.similarity);
-  const matchLabel = t.results.matchTiers[tier];
-  const matchExactLabel = t.results.matchTierExact.replace('{pct}', String(pct));
-  const hasRating = !!movie.age_rating && movie.age_rating !== 'NR';
+  const view = buildResultMovieCardViewModel(movie, t.results, { isGroup });
 
   return (
     <motion.div
@@ -43,199 +44,293 @@ export function MainMovieCard({
         boxShadow: 'var(--pc-card-shadow)',
       }}
     >
-      {movie.posterURL && (
-        <div className="relative h-72 md:h-96 overflow-hidden">
-          <div
-            className="absolute inset-0 transition-opacity duration-700"
-            style={{
-              opacity: imgLoaded ? 0 : 1,
-              background: 'var(--pc-surface-deep)',
-            }}
-          />
-          <Image
-            src={movie.posterURL}
-            alt={movie.name}
-            fill
-            priority
-            sizes="(max-width: 768px) 100vw, 600px"
-            className="object-cover transition-opacity duration-700"
-            style={{ opacity: imgLoaded ? 1 : 0 }}
-            onLoad={() => setImgLoaded(true)}
-          />
-          <div
-            className="absolute inset-0"
-            style={{
-              background: 'var(--pc-poster-grad)',
-            }}
-          />
+      <MainPosterSection
+        imgLoaded={imgLoaded}
+        movie={movie}
+        onImageLoad={() => setImgLoaded(true)}
+        view={view}
+      />
 
-          {/* Match badge */}
-          <div className="absolute top-4 right-4">
-            <SimilarityBadge similarity={movie.similarity} />
-          </div>
-
-          {/* AI pick label */}
-          <div className="absolute top-4 left-4">
-            <div
-              className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs"
-              style={{
-                background: 'var(--pc-overlay-bg)',
-                border: `1px solid ${palette.gold}40`,
-                color: 'var(--pc-gold-text)',
-                backdropFilter: 'blur(8px)',
-              }}
-            >
-              <Sparkles size={10} />
-              {t.results.aiPick}
-            </div>
-          </div>
-
-          {/* Title overlay */}
-          <div className="absolute bottom-6 left-6 right-6">
-            <h2
-              className="mb-1"
-              style={{
-                fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
-                fontWeight: '600',
-                textTransform: 'uppercase',
-                fontSize: 'clamp(1.8rem, 5vw, 3rem)',
-                letterSpacing: '0.04em',
-                color: 'var(--pc-overlay-text)',
-                lineHeight: 1,
-                textShadow: 'var(--pc-overlay-shadow)',
-              }}
-            >
-              {movie.localizedName ?? movie.name}
-            </h2>
-            <div
-              className="flex items-center gap-3 flex-wrap"
-              style={{ color: 'var(--pc-t2)', fontSize: '0.82rem' }}
-            >
-              <span>{movie.year}</span>
-              {hasRating && (
-                <>
-                  <span>·</span>
-                  <span
-                    className="px-1.5 py-0.5 rounded"
-                    style={{
-                      border: '1px solid var(--pc-bd3)',
-                      color: 'var(--pc-t2)',
-                    }}
-                  >
-                    {movie.age_rating}
-                  </span>
-                </>
-              )}
-              {(movie.duration ?? 0) > 0 && (
-                <>
-                  <span>·</span>
-                  <span className="flex items-center gap-1">
-                    <Clock size={11} />
-                    {movie.duration} {t.results.minUnit}
-                  </span>
-                </>
-              )}
-              {score > 0 && (
-                <>
-                  <span>·</span>
-                  <span className="flex items-center gap-1">
-                    <Star size={11} fill={palette.gold} stroke="none" />
-                    <span style={{ color: 'var(--pc-gold-text)' }}>{score}</span>/10
-                  </span>
-                </>
-              )}
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Content */}
-      <div className="p-6 pt-4">
-        {!movie.posterURL && (
-          <div className="mb-4">
-            <h2
-              style={{
-                fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
-                fontWeight: '600',
-                textTransform: 'uppercase',
-                fontSize: '2rem',
-                letterSpacing: '0.04em',
-                color: 'var(--pc-t1)',
-              }}
-            >
-              {movie.localizedName ?? movie.name}
-            </h2>
-            <div
-              className="flex items-center gap-3 flex-wrap mt-1"
-              style={{ color: 'var(--pc-t2)', fontSize: '0.82rem' }}
-            >
-              <span>{movie.year}</span>
-              {hasRating && (
-                <>
-                  <span>·</span>
-                  <span>{movie.age_rating}</span>
-                </>
-              )}
-              {(movie.duration ?? 0) > 0 && (
-                <>
-                  <span>·</span>
-                  <span>
-                    {movie.duration} {t.results.minUnit}
-                  </span>
-                </>
-              )}
-            </div>
-          </div>
-        )}
-
-        <div className="flex items-center justify-between flex-wrap gap-3 mb-4">
-          <div className="flex items-center gap-2">
-            <Clapperboard size={13} style={{ color: 'var(--pc-t3)' }} />
-            <span title={matchExactLabel} style={{ color: 'var(--pc-t3)', fontSize: '0.82rem' }}>
-              {movie.year} · {matchLabel}
-            </span>
-          </div>
-          {hasRating && <AgeRatingPill label={movie.age_rating!} />}
-        </div>
-
-        {score > 0 && (
-          <div className="flex items-center gap-2 mb-4">
-            <StarRating score={score} />
-            <span style={{ color: 'var(--pc-t3)', fontSize: '0.78rem' }}>{score}/10</span>
-          </div>
-        )}
-
-        {/* AI description */}
-        {movie.description && (
-          <div
-            className="p-4 rounded-2xl"
-            style={{
-              background: 'var(--pc-ai-bg)',
-              border: '1px solid',
-              borderColor: 'var(--pc-ai-bd)',
-            }}
-          >
-            <div className="flex items-center gap-2 mb-2">
-              <Sparkles size={12} style={{ color: 'var(--pc-gold-text)' }} />
-              <span
-                className="uppercase tracking-widest"
-                style={{ color: 'var(--pc-gold-text)', fontSize: '0.65rem' }}
-              >
-                {isGroup ? t.results.whyThisFilmForGroup : t.results.whyThisFilmForYou}
-              </span>
-            </div>
-            <p
-              style={{
-                color: 'var(--pc-t2)',
-                fontSize: '0.88rem',
-                lineHeight: 1.75,
-              }}
-            >
-              <MarkdownText text={movie.description ?? ''} />
-            </p>
-          </div>
-        )}
-      </div>
+      <MainMovieContent movie={movie} view={view} />
     </motion.div>
+  );
+}
+
+function MainPosterSection({
+  imgLoaded,
+  movie,
+  onImageLoad,
+  view,
+}: {
+  imgLoaded: boolean;
+  movie: MovieRecommendation;
+  onImageLoad: () => void;
+  view: ResultMovieCardViewModel;
+}) {
+  if (!view.hasPoster) return null;
+
+  return (
+    <div className="relative h-72 md:h-96 overflow-hidden">
+      <div
+        className="absolute inset-0 transition-opacity duration-700"
+        style={{ opacity: imgLoaded ? 0 : 1, background: 'var(--pc-surface-deep)' }}
+      />
+      <Image
+        src={view.posterUrl!}
+        alt={movie.name}
+        fill
+        priority
+        sizes="(max-width: 768px) 100vw, 600px"
+        className="object-cover transition-opacity duration-700"
+        style={{ opacity: imgLoaded ? 1 : 0 }}
+        onLoad={onImageLoad}
+      />
+      <div className="absolute inset-0" style={{ background: 'var(--pc-poster-grad)' }} />
+      <div className="absolute top-4 right-4">
+        <SimilarityBadge similarity={movie.similarity} />
+      </div>
+      <AiPickBadge label={view.aiPickLabel} />
+      <MainPosterTitle view={view} />
+    </div>
+  );
+}
+
+function MainMovieContent({
+  movie,
+  view,
+}: {
+  movie: MovieRecommendation;
+  view: ResultMovieCardViewModel;
+}) {
+  return (
+    <div className="p-6 pt-4">
+      <NoPosterHeader view={view} />
+      <MainMatchSummary movie={movie} view={view} />
+      <MainScoreRow view={view} />
+      <MainRationale view={view} />
+    </div>
+  );
+}
+
+function AiPickBadge({ label }: { label: string }) {
+  return (
+    <div className="absolute top-4 left-4">
+      <div
+        className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs"
+        style={{
+          background: 'var(--pc-overlay-bg)',
+          border: `1px solid ${palette.gold}40`,
+          color: 'var(--pc-gold-text)',
+          backdropFilter: 'blur(8px)',
+        }}
+      >
+        <Sparkles size={10} />
+        {label}
+      </div>
+    </div>
+  );
+}
+
+function MainPosterTitle({ view }: { view: ResultMovieCardViewModel }) {
+  return (
+    <div className="absolute bottom-6 left-6 right-6">
+      <h2
+        className="mb-1"
+        style={{
+          fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
+          fontWeight: '600',
+          textTransform: 'uppercase',
+          fontSize: 'clamp(1.8rem, 5vw, 3rem)',
+          letterSpacing: '0.04em',
+          color: 'var(--pc-overlay-text)',
+          lineHeight: 1,
+          textShadow: 'var(--pc-overlay-shadow)',
+        }}
+      >
+        {view.title}
+      </h2>
+      <MetaItems items={view.overlayMetaItems} overlay />
+    </div>
+  );
+}
+
+function NoPosterHeader({ view }: { view: ResultMovieCardViewModel }) {
+  if (view.hasPoster) return null;
+
+  return (
+    <div className="mb-4">
+      <h2
+        style={{
+          fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
+          fontWeight: '600',
+          textTransform: 'uppercase',
+          fontSize: '2rem',
+          letterSpacing: '0.04em',
+          color: 'var(--pc-t1)',
+        }}
+      >
+        {view.title}
+      </h2>
+      <MetaItems className="mt-1" items={view.plainMetaItems} />
+    </div>
+  );
+}
+
+function MainMatchSummary({
+  movie,
+  view,
+}: {
+  movie: MovieRecommendation;
+  view: ResultMovieCardViewModel;
+}) {
+  return (
+    <div className="flex items-center justify-between flex-wrap gap-3 mb-4">
+      <div className="flex items-center gap-2">
+        <Clapperboard size={13} style={{ color: 'var(--pc-t3)' }} />
+        <span title={view.matchExactLabel} style={{ color: 'var(--pc-t3)', fontSize: '0.82rem' }}>
+          {view.year} · {view.matchLabel}
+        </span>
+      </div>
+      <MainAgeRatingPill movie={movie} view={view} />
+    </div>
+  );
+}
+
+function MainAgeRatingPill({
+  movie,
+  view,
+}: {
+  movie: MovieRecommendation;
+  view: ResultMovieCardViewModel;
+}) {
+  if (!view.hasRating) return null;
+  return <AgeRatingPill label={movie.age_rating!} />;
+}
+
+function MainScoreRow({ view }: { view: ResultMovieCardViewModel }) {
+  if (!view.hasScore) return null;
+
+  return (
+    <div className="flex items-center gap-2 mb-4">
+      <StarRating score={view.score} />
+      <span style={{ color: 'var(--pc-t3)', fontSize: '0.78rem' }}>{view.score}/10</span>
+    </div>
+  );
+}
+
+function MetaItems({
+  className,
+  items,
+  overlay = false,
+}: {
+  className?: string;
+  items: ResultMovieMetaItem[];
+  overlay?: boolean;
+}) {
+  return (
+    <div
+      className={`flex items-center gap-3 flex-wrap${className ? ` ${className}` : ''}`}
+      style={{ color: 'var(--pc-t2)', fontSize: '0.82rem' }}
+    >
+      {items.map((item, index) => (
+        <MetaItem
+          key={`${item.kind}-${item.label}`}
+          item={item}
+          showSeparator={index > 0}
+          overlay={overlay}
+        />
+      ))}
+    </div>
+  );
+}
+
+function MetaItem({
+  item,
+  overlay,
+  showSeparator,
+}: {
+  item: ResultMovieMetaItem;
+  overlay: boolean;
+  showSeparator: boolean;
+}) {
+  return (
+    <>
+      {showSeparator && <span>·</span>}
+      <MetaItemValue item={item} overlay={overlay} />
+    </>
+  );
+}
+
+function MetaItemValue({ item, overlay }: { item: ResultMovieMetaItem; overlay: boolean }) {
+  const renderer = MAIN_META_RENDERERS[`${item.kind}:${overlay}`] ?? renderTextMetaItem;
+  return renderer(item);
+}
+
+const MAIN_META_RENDERERS: Record<string, (item: ResultMovieMetaItem) => ReactNode> = {
+  'duration:true': renderOverlayDurationMetaItem,
+  'rating:true': renderOverlayRatingMetaItem,
+  'score:false': renderScoreMetaItem,
+  'score:true': renderScoreMetaItem,
+};
+
+function renderOverlayRatingMetaItem(item: ResultMovieMetaItem): ReactNode {
+  return (
+    <span
+      className="px-1.5 py-0.5 rounded"
+      style={{ border: '1px solid var(--pc-bd3)', color: 'var(--pc-t2)' }}
+    >
+      {item.label}
+    </span>
+  );
+}
+
+function renderOverlayDurationMetaItem(item: ResultMovieMetaItem): ReactNode {
+  return (
+    <span className="flex items-center gap-1">
+      <Clock size={11} />
+      {item.label}
+    </span>
+  );
+}
+
+function renderScoreMetaItem(item: ResultMovieMetaItem): ReactNode {
+  return (
+    <span className="flex items-center gap-1">
+      <Star size={11} fill={palette.gold} stroke="none" />
+      <span style={{ color: 'var(--pc-gold-text)' }}>{item.label.replace('/10', '')}</span>
+      {item.label.endsWith('/10') ? '/10' : null}
+    </span>
+  );
+}
+
+function renderTextMetaItem(item: ResultMovieMetaItem): ReactNode {
+  return <span>{item.label}</span>;
+}
+
+function MainRationale({ view }: { view: ResultMovieCardViewModel }) {
+  if (!view.hasDescription) return null;
+
+  return (
+    <div
+      className="p-4 rounded-2xl"
+      style={{
+        background: 'var(--pc-ai-bg)',
+        border: '1px solid',
+        borderColor: 'var(--pc-ai-bd)',
+      }}
+    >
+      <div className="flex items-center gap-2 mb-2">
+        <Sparkles size={12} style={{ color: 'var(--pc-gold-text)' }} />
+        <span
+          className="uppercase tracking-widest"
+          style={{ color: 'var(--pc-gold-text)', fontSize: '0.65rem' }}
+        >
+          {view.rationaleLabel}
+        </span>
+      </div>
+      <p style={{ color: 'var(--pc-t2)', fontSize: '0.88rem', lineHeight: 1.75 }}>
+        <MarkdownText text={view.description} />
+      </p>
+    </div>
   );
 }

--- a/apps/web/src/app/results/components/SimilarityBadge.tsx
+++ b/apps/web/src/app/results/components/SimilarityBadge.tsx
@@ -3,8 +3,8 @@
 import { Sparkles } from 'lucide-react';
 
 import { useLanguage } from '@/i18n';
-import { palette } from '@/styles/designTokens';
-import { getSimilarityTier } from '@/utils/ui';
+
+import { buildResultMatchViewModel } from './resultMovieCardViewModel';
 
 export function SimilarityBadge({
   similarity,
@@ -14,31 +14,21 @@ export function SimilarityBadge({
   compact?: boolean;
 }) {
   const { t } = useLanguage();
-  const { pct, tier } = getSimilarityTier(similarity);
-  const color =
-    tier === 'strong'
-      ? palette.teal
-      : tier === 'good'
-        ? palette.gold
-        : tier === 'possible'
-          ? palette.amber
-          : palette.purple;
-  const label = t.results.matchTiers[tier];
-  const exactLabel = t.results.matchTierExact.replace('{pct}', String(pct));
+  const match = buildResultMatchViewModel(similarity, t.results);
 
   return (
     <div
       className="flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs"
-      title={exactLabel}
-      aria-label={`${label}. ${exactLabel}`}
+      title={match.exactLabel}
+      aria-label={`${match.label}. ${match.exactLabel}`}
       style={{
-        background: `${color}18`,
-        border: `1px solid ${color}35`,
-        color,
+        background: `${match.color}18`,
+        border: `1px solid ${match.color}35`,
+        color: match.color,
       }}
     >
       {!compact && <Sparkles size={10} />}
-      {label}
+      {match.label}
     </div>
   );
 }

--- a/apps/web/src/app/results/components/SmallSuggestionCard.tsx
+++ b/apps/web/src/app/results/components/SmallSuggestionCard.tsx
@@ -3,11 +3,16 @@
 import { Star } from 'lucide-react';
 import { motion } from 'motion/react';
 import Image from 'next/image';
-import { useState } from 'react';
+import { type KeyboardEvent, useState } from 'react';
 
 import { useLanguage } from '@/i18n';
 import { palette } from '@/styles/designTokens';
-import { getSimilarityTier } from '@/utils/ui';
+
+import {
+  buildResultMovieCardViewModel,
+  type ResultMovieCardViewModel,
+  type ResultMovieMetaItem,
+} from './resultMovieCardViewModel';
 
 import type { MovieRecommendation } from '@/utils/client';
 
@@ -20,11 +25,7 @@ interface SmallSuggestionCardProps {
 export function SmallSuggestionCard({ movie, active, onClick }: SmallSuggestionCardProps) {
   const { t } = useLanguage();
   const [imgLoaded, setImgLoaded] = useState(false);
-  const score = movie.score_rating ?? 0;
-  const { pct, tier } = getSimilarityTier(movie.similarity);
-  const matchLabel = t.results.matchTiers[tier];
-  const matchExactLabel = t.results.matchTierExact.replace('{pct}', String(pct));
-  const hasRating = !!movie.age_rating && movie.age_rating !== 'NR';
+  const view = buildResultMovieCardViewModel(movie, t.results);
 
   return (
     <motion.div
@@ -32,12 +33,7 @@ export function SmallSuggestionCard({ movie, active, onClick }: SmallSuggestionC
       role="button"
       tabIndex={0}
       onClick={onClick}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          onClick();
-        }
-      }}
+      onKeyDown={(event) => handleCardKeyDown(event, onClick)}
       aria-pressed={active}
       aria-label={movie.name}
       className="relative overflow-hidden rounded-2xl cursor-pointer transition-all duration-300"
@@ -52,105 +48,175 @@ export function SmallSuggestionCard({ movie, active, onClick }: SmallSuggestionC
       whileHover={{ y: -4 }}
       whileTap={{ scale: 0.97 }}
     >
-      <div className="relative h-36 overflow-hidden">
-        {movie.posterURL ? (
-          <>
-            <div
-              className="absolute inset-0"
-              style={{
-                background: 'var(--pc-surface-deep)',
-                opacity: imgLoaded ? 0 : 1,
-              }}
-            />
-            <Image
-              src={movie.posterURL}
-              alt={movie.name}
-              fill
-              sizes="260px"
-              className="object-cover"
-              onLoad={() => setImgLoaded(true)}
-              style={{ opacity: imgLoaded ? 1 : 0, transition: 'opacity 0.4s' }}
-            />
-          </>
-        ) : (
-          <div
-            className="w-full h-full flex items-center justify-center text-3xl"
-            style={{ background: 'var(--pc-surface-deep)' }}
-          >
-            🎬
-          </div>
-        )}
-        <div
-          className="absolute inset-0"
-          style={{
-            background: 'linear-gradient(to bottom, transparent 40%, var(--pc-surface) 100%)',
-          }}
-        />
-        <div className="absolute top-2 right-2 flex flex-col items-end gap-1">
-          <div
-            className="text-xs px-2 py-0.5 rounded-full"
-            title={matchExactLabel}
-            aria-label={`${matchLabel}. ${matchExactLabel}`}
-            style={{
-              background: 'rgba(9,9,15,0.85)',
-              border: '1px solid rgba(245,197,24,0.2)',
-              color: palette.gold,
-              backdropFilter: 'blur(6px)',
-            }}
-          >
-            {matchLabel}
-          </div>
-          {movie.fromTMDB && (
-            <div
-              className="text-xs px-2 py-0.5 rounded-full"
-              style={{
-                background: 'rgba(9,9,15,0.85)',
-                border: '1px solid rgba(255,255,255,0.15)',
-                color: 'var(--pc-t3)',
-                backdropFilter: 'blur(6px)',
-              }}
-            >
-              TMDB
-            </div>
-          )}
-        </div>
-      </div>
+      <SmallPoster
+        imgLoaded={imgLoaded}
+        movie={movie}
+        onImageLoad={() => setImgLoaded(true)}
+        view={view}
+      />
 
       <div className="p-3.5">
         <h4
           className="mb-1 truncate"
           style={{ color: 'var(--pc-t1)', fontWeight: 600, fontSize: '0.9rem' }}
         >
-          {movie.localizedName ?? movie.name}
+          {view.title}
         </h4>
-        <div
-          className="flex items-center gap-2 mb-2 flex-wrap"
-          style={{ color: 'var(--pc-t3)', fontSize: '0.75rem' }}
-        >
-          <span>{movie.year}</span>
-          {hasRating && (
-            <>
-              <span>·</span>
-              <span>{movie.age_rating}</span>
-            </>
-          )}
-          {score > 0 && (
-            <>
-              <span>·</span>
-              <span className="flex items-center gap-0.5">
-                <Star size={10} fill={palette.gold} stroke="none" />
-                {score}
-              </span>
-            </>
-          )}
-          {(movie.duration ?? 0) > 0 && (
-            <>
-              <span>·</span>
-              <span>{movie.duration}m</span>
-            </>
-          )}
-        </div>
+        <SmallMetaItems items={view.compactMetaItems} />
       </div>
     </motion.div>
+  );
+}
+
+function handleCardKeyDown(event: KeyboardEvent<HTMLDivElement>, onClick: () => void): void {
+  if (event.key !== 'Enter' && event.key !== ' ') return;
+  event.preventDefault();
+  onClick();
+}
+
+function SmallPoster({
+  imgLoaded,
+  movie,
+  onImageLoad,
+  view,
+}: {
+  imgLoaded: boolean;
+  movie: MovieRecommendation;
+  onImageLoad: () => void;
+  view: ResultMovieCardViewModel;
+}) {
+  return (
+    <div className="relative h-36 overflow-hidden">
+      {view.hasPoster ? (
+        <SmallPosterImage
+          imgLoaded={imgLoaded}
+          movie={movie}
+          onImageLoad={onImageLoad}
+          view={view}
+        />
+      ) : (
+        <SmallPosterFallback />
+      )}
+      <div
+        className="absolute inset-0"
+        style={{
+          background: 'linear-gradient(to bottom, transparent 40%, var(--pc-surface) 100%)',
+        }}
+      />
+      <SmallBadges fromTmdb={Boolean(movie.fromTMDB)} view={view} />
+    </div>
+  );
+}
+
+function SmallPosterImage({
+  imgLoaded,
+  movie,
+  onImageLoad,
+  view,
+}: {
+  imgLoaded: boolean;
+  movie: MovieRecommendation;
+  onImageLoad: () => void;
+  view: ResultMovieCardViewModel;
+}) {
+  return (
+    <>
+      <div
+        className="absolute inset-0"
+        style={{ background: 'var(--pc-surface-deep)', opacity: imgLoaded ? 0 : 1 }}
+      />
+      <Image
+        src={view.posterUrl!}
+        alt={movie.name}
+        fill
+        sizes="260px"
+        className="object-cover"
+        onLoad={onImageLoad}
+        style={{ opacity: imgLoaded ? 1 : 0, transition: 'opacity 0.4s' }}
+      />
+    </>
+  );
+}
+
+function SmallPosterFallback() {
+  return (
+    <div
+      className="w-full h-full flex items-center justify-center text-3xl"
+      style={{ background: 'var(--pc-surface-deep)' }}
+    >
+      🎬
+    </div>
+  );
+}
+
+function SmallBadges({ fromTmdb, view }: { fromTmdb: boolean; view: ResultMovieCardViewModel }) {
+  return (
+    <div className="absolute top-2 right-2 flex flex-col items-end gap-1">
+      <div
+        className="text-xs px-2 py-0.5 rounded-full"
+        title={view.matchExactLabel}
+        aria-label={`${view.matchLabel}. ${view.matchExactLabel}`}
+        style={{
+          background: 'rgba(9,9,15,0.85)',
+          border: '1px solid rgba(245,197,24,0.2)',
+          color: palette.gold,
+          backdropFilter: 'blur(6px)',
+        }}
+      >
+        {view.matchLabel}
+      </div>
+      {fromTmdb && <TmdbBadge />}
+    </div>
+  );
+}
+
+function TmdbBadge() {
+  return (
+    <div
+      className="text-xs px-2 py-0.5 rounded-full"
+      style={{
+        background: 'rgba(9,9,15,0.85)',
+        border: '1px solid rgba(255,255,255,0.15)',
+        color: 'var(--pc-t3)',
+        backdropFilter: 'blur(6px)',
+      }}
+    >
+      TMDB
+    </div>
+  );
+}
+
+function SmallMetaItems({ items }: { items: ResultMovieMetaItem[] }) {
+  return (
+    <div
+      className="flex items-center gap-2 mb-2 flex-wrap"
+      style={{ color: 'var(--pc-t3)', fontSize: '0.75rem' }}
+    >
+      {items.map((item, index) => (
+        <SmallMetaItem key={`${item.kind}-${item.label}`} item={item} showSeparator={index > 0} />
+      ))}
+    </div>
+  );
+}
+
+function SmallMetaItem({
+  item,
+  showSeparator,
+}: {
+  item: ResultMovieMetaItem;
+  showSeparator: boolean;
+}) {
+  return (
+    <>
+      {showSeparator && <span>·</span>}
+      {item.kind === 'score' ? (
+        <span className="flex items-center gap-0.5">
+          <Star size={10} fill={palette.gold} stroke="none" />
+          {item.label}
+        </span>
+      ) : (
+        <span>{item.label}</span>
+      )}
+    </>
   );
 }

--- a/apps/web/src/app/results/components/resultMovieCardViewModel.test.ts
+++ b/apps/web/src/app/results/components/resultMovieCardViewModel.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+
+import { en } from '@/i18n/locales/en';
+
+import {
+  buildResultMatchViewModel,
+  buildResultMovieCardViewModel,
+} from './resultMovieCardViewModel';
+
+import type { MovieRecommendation } from '@/utils/client';
+
+const movie: MovieRecommendation = {
+  id: 101,
+  name: 'Arrival',
+  year: 2016,
+  similarity: 0.91,
+  age_rating: 'PG-13',
+  duration: 116,
+  score_rating: 8.1,
+  posterURL: '/arrival.jpg',
+  description: 'Language, memory, and grief.',
+  localizedName: 'Arrival Localized',
+};
+
+describe('buildResultMovieCardViewModel', () => {
+  it('builds display fields and metadata rows for a fully enriched movie', () => {
+    const view = buildResultMovieCardViewModel(movie, en.results);
+
+    expect(view.title).toBe('Arrival Localized');
+    expect(view.posterUrl).toBe('/arrival.jpg');
+    expect(view.hasPoster).toBe(true);
+    expect(view.hasRating).toBe(true);
+    expect(view.hasDuration).toBe(true);
+    expect(view.hasScore).toBe(true);
+    expect(view.durationWithUnit).toBe('116 min');
+    expect(view.durationShort).toBe('116m');
+    expect(view.rationaleLabel).toBe(en.results.whyThisFilmForYou);
+    expect(view.overlayMetaItems.map((item) => item.kind)).toEqual([
+      'text',
+      'rating',
+      'duration',
+      'score',
+    ]);
+    expect(view.compactMetaItems.map((item) => item.label)).toEqual([
+      '2016',
+      'PG-13',
+      '8.1',
+      '116m',
+    ]);
+  });
+
+  it('omits optional metadata when poster, rating, score, and duration are absent', () => {
+    const view = buildResultMovieCardViewModel(
+      {
+        ...movie,
+        age_rating: 'NR',
+        duration: 0,
+        posterURL: undefined,
+        score_rating: undefined,
+        description: undefined,
+        localizedName: undefined,
+      },
+      en.results,
+    );
+
+    expect(view.title).toBe('Arrival');
+    expect(view.hasPoster).toBe(false);
+    expect(view.hasRating).toBe(false);
+    expect(view.hasDuration).toBe(false);
+    expect(view.hasScore).toBe(false);
+    expect(view.hasDescription).toBe(false);
+    expect(view.plainMetaItems).toEqual([{ kind: 'text', label: '2016' }]);
+  });
+
+  it('uses group and expanded rationale labels where requested', () => {
+    const groupView = buildResultMovieCardViewModel(movie, en.results, { isGroup: true });
+    const expandedView = buildResultMovieCardViewModel(movie, en.results, {
+      rationaleVariant: 'expanded',
+    });
+
+    expect(groupView.rationaleLabel).toBe(en.results.whyThisFilmForGroup);
+    expect(expandedView.rationaleLabel).toBe(en.results.whyThisFilm);
+  });
+});
+
+describe('buildResultMatchViewModel', () => {
+  it('formats accessible match labels from the similarity tier', () => {
+    const match = buildResultMatchViewModel(0.56, en.results);
+
+    expect(match.label).toBe(en.results.matchTiers.strong);
+    expect(match.exactLabel).toContain('90');
+    expect(match.color).toMatch(/^#/);
+  });
+});

--- a/apps/web/src/app/results/components/resultMovieCardViewModel.ts
+++ b/apps/web/src/app/results/components/resultMovieCardViewModel.ts
@@ -1,0 +1,185 @@
+import { palette } from '@/styles/designTokens';
+import { getSimilarityTier } from '@/utils/ui';
+
+import type { Translations } from '@/i18n/locales/en';
+import type { MovieRecommendation } from '@/utils/client';
+
+export type ResultMovieMetaKind = 'text' | 'rating' | 'duration' | 'score';
+
+export interface ResultMovieMetaItem {
+  kind: ResultMovieMetaKind;
+  label: string;
+}
+
+export interface ResultMovieCardViewModel {
+  aiPickLabel: string;
+  description: string;
+  duration: number;
+  durationWithUnit: string;
+  durationShort: string;
+  hasDescription: boolean;
+  hasDuration: boolean;
+  hasPoster: boolean;
+  hasRating: boolean;
+  hasScore: boolean;
+  matchColor: string;
+  matchExactLabel: string;
+  matchLabel: string;
+  posterUrl?: string;
+  rationaleLabel: string;
+  score: number;
+  title: string;
+  year: string | number;
+  compactMetaItems: ResultMovieMetaItem[];
+  expandedMetaItems: ResultMovieMetaItem[];
+  overlayMetaItems: ResultMovieMetaItem[];
+  plainMetaItems: ResultMovieMetaItem[];
+}
+
+type ResultsCopy = Translations['results'];
+
+export interface ResultMatchViewModel {
+  color: string;
+  exactLabel: string;
+  label: string;
+}
+
+const MATCH_TIER_COLORS = {
+  strong: palette.teal,
+  good: palette.gold,
+  possible: palette.amber,
+  wildcard: palette.purple,
+} as const;
+
+export function buildResultMovieCardViewModel(
+  movie: MovieRecommendation,
+  copy: ResultsCopy,
+  options: { isGroup?: boolean; rationaleVariant?: 'main' | 'expanded' } = {},
+): ResultMovieCardViewModel {
+  const score = movie.score_rating ?? 0;
+  const duration = movie.duration ?? 0;
+  const match = buildResultMatchViewModel(movie.similarity, copy);
+  const hasRating = Boolean(movie.age_rating && movie.age_rating !== 'NR');
+  const hasScore = score > 0;
+  const hasDuration = duration > 0;
+  const ratingItem = hasRating ? createMetaItem('rating', movie.age_rating!) : undefined;
+  const durationShort = `${duration}m`;
+  const durationWithUnit = `${duration} ${copy.minUnit}`;
+  const scoreShort = String(score);
+  const title = movie.localizedName ?? movie.name;
+
+  return {
+    aiPickLabel: copy.aiPick,
+    description: movie.description ?? '',
+    duration,
+    durationShort,
+    durationWithUnit,
+    hasDescription: Boolean(movie.description),
+    hasDuration,
+    hasPoster: Boolean(movie.posterURL),
+    hasRating,
+    hasScore,
+    matchColor: match.color,
+    matchExactLabel: match.exactLabel,
+    matchLabel: match.label,
+    posterUrl: movie.posterURL,
+    rationaleLabel: getRationaleLabel(copy, options),
+    score,
+    title,
+    year: movie.year,
+    compactMetaItems: compactMetaItems(
+      movie.year,
+      ratingItem,
+      hasScore,
+      scoreShort,
+      hasDuration,
+      durationShort,
+    ),
+    expandedMetaItems: compactMetaItems(
+      movie.year,
+      ratingItem,
+      hasScore,
+      scoreShort,
+      hasDuration,
+      durationShort,
+    ),
+    overlayMetaItems: overlayMetaItems(
+      movie.year,
+      ratingItem,
+      hasDuration,
+      durationWithUnit,
+      hasScore,
+      `${score}/10`,
+    ),
+    plainMetaItems: plainMetaItems(movie.year, ratingItem, hasDuration, durationWithUnit),
+  };
+}
+
+export function buildResultMatchViewModel(
+  similarity: number,
+  copy: ResultsCopy,
+): ResultMatchViewModel {
+  const { pct, tier } = getSimilarityTier(similarity);
+  return {
+    color: MATCH_TIER_COLORS[tier],
+    exactLabel: copy.matchTierExact.replace('{pct}', String(pct)),
+    label: copy.matchTiers[tier],
+  };
+}
+
+function getRationaleLabel(
+  copy: ResultsCopy,
+  options: { isGroup?: boolean; rationaleVariant?: 'main' | 'expanded' },
+): string {
+  if (options.isGroup) return copy.whyThisFilmForGroup;
+  return options.rationaleVariant === 'expanded' ? copy.whyThisFilm : copy.whyThisFilmForYou;
+}
+
+function createMetaItem(kind: ResultMovieMetaKind, label: string): ResultMovieMetaItem {
+  return { kind, label };
+}
+
+function compactMetaItems(
+  year: string | number,
+  ratingItem: ResultMovieMetaItem | undefined,
+  hasScore: boolean,
+  score: string,
+  hasDuration: boolean,
+  duration: string,
+): ResultMovieMetaItem[] {
+  return [
+    createMetaItem('text', String(year)),
+    ratingItem,
+    hasScore ? createMetaItem('score', score) : undefined,
+    hasDuration ? createMetaItem('duration', duration) : undefined,
+  ].filter(Boolean) as ResultMovieMetaItem[];
+}
+
+function overlayMetaItems(
+  year: string | number,
+  ratingItem: ResultMovieMetaItem | undefined,
+  hasDuration: boolean,
+  duration: string,
+  hasScore: boolean,
+  score: string,
+): ResultMovieMetaItem[] {
+  return [
+    createMetaItem('text', String(year)),
+    ratingItem,
+    hasDuration ? createMetaItem('duration', duration) : undefined,
+    hasScore ? createMetaItem('score', score) : undefined,
+  ].filter(Boolean) as ResultMovieMetaItem[];
+}
+
+function plainMetaItems(
+  year: string | number,
+  ratingItem: ResultMovieMetaItem | undefined,
+  hasDuration: boolean,
+  duration: string,
+): ResultMovieMetaItem[] {
+  return [
+    createMetaItem('text', String(year)),
+    ratingItem,
+    hasDuration ? createMetaItem('duration', duration) : undefined,
+  ].filter(Boolean) as ResultMovieMetaItem[];
+}


### PR DESCRIPTION
## Summary
- Extract shared result movie card display/view-model logic for metadata, match labels, and rationale copy
- Split MainMovieCard, SmallSuggestionCard, ExpandedSuggestion, and SimilarityBadge into smaller render helpers
- Add unit coverage for result card view-model branches

## Fallow impact
- Full health after #751: 104 findings, 19 critical / 31 high / 54 moderate
- This branch: 100 findings, 16 critical / 31 high / 53 moderate
- Changed-code Fallow: health 0, dead-code 0, dupes 0

Part of #743.

## Verification
- npm run test --workspace=apps/web -- src/app/results/components/resultMovieCardViewModel.test.ts
- npm run type-check --workspace=apps/web
- npm run lint:check --workspace=apps/web
- npm run build --workspace=apps/web
- npx fallow health --format json --quiet --changed-since origin/development
- npx fallow dead-code --format json --quiet --changed-since origin/development
- npx fallow dupes --format json --quiet --changed-since origin/development
- pre-push: lint, server tests, production build, Storybook tests