### PR TITLE
Split results brief and layout navigation

### DIFF
--- a/apps/web/src/app/results/components/GroupMatchBrief.tsx
+++ b/apps/web/src/app/results/components/GroupMatchBrief.tsx
@@ -6,75 +6,16 @@ import { motion } from 'motion/react';
 import { useLanguage } from '@/i18n';
 import { palette } from '@/styles/designTokens';
 
-import type {
-  GroupParticipantProfile,
-  GroupResultInsights,
-} from '@/features/recommendation/groupResultInsights';
+import {
+  buildGroupMatchBriefViewModel,
+  type GroupMatchBriefViewModel,
+  type GroupParticipantSignalViewModel,
+} from './groupMatchBriefViewModel';
+
+import type { GroupResultInsights } from '@/features/recommendation/groupResultInsights';
 import type { ReactNode } from 'react';
 
-function joinList(values: string[], locale: string): string {
-  return new Intl.ListFormat(locale, { style: 'short', type: 'conjunction' }).format(values);
-}
-
 type TranslationCopy = ReturnType<typeof useLanguage>['t'];
-
-function normalizeChoice(value: string): string {
-  return value
-    .trim()
-    .toLowerCase()
-    .replace(/&/g, 'and')
-    .replace(/[^a-z0-9]+/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
-}
-
-function translateMood(value: string, t: TranslationCopy): string {
-  const moodKey = normalizeChoice(value).replace(/\s+/g, '');
-  const aliases: Record<string, keyof typeof t.genres> = {
-    action: 'action',
-    adventure: 'adventure',
-    animation: 'animation',
-    comedy: 'comedy',
-    documentary: 'documentary',
-    drama: 'drama',
-    horror: 'horror',
-    romance: 'romance',
-    scifi: 'scifi',
-    sciencefiction: 'scifi',
-    thriller: 'thriller',
-  };
-  const key = aliases[moodKey];
-  return key ? t.genres[key] : value;
-}
-
-function translateTone(value: string, t: TranslationCopy): string {
-  const normalized = normalizeChoice(value);
-  const aliases: Record<string, keyof typeof t.tones> = {
-    balanced: 'balanced',
-    dark: 'dark',
-    'dark and intense': 'dark',
-    light: 'light',
-    'light and fun': 'light',
-    serious: 'serious',
-    'serious and thought provoking': 'serious',
-  };
-  const key = aliases[normalized];
-  return key ? t.tones[key].label : value;
-}
-
-function translateEra(value: string, t: TranslationCopy): string {
-  const normalized = normalizeChoice(value);
-  const aliases: Record<string, keyof Omit<typeof t.quiz.era, 'title'>> = {
-    both: 'both',
-    'both new and classic': 'both',
-    classic: 'classic',
-    'timeless classics': 'classic',
-    new: 'new',
-    'new releases': 'new',
-  };
-  const key = aliases[normalized];
-  return key ? t.quiz.era[key].title : value;
-}
 
 function BriefRow({ icon, label, value }: { icon: ReactNode; label: string; value: string }) {
   return (
@@ -102,30 +43,14 @@ function BriefRow({ icon, label, value }: { icon: ReactNode; label: string; valu
 }
 
 function ParticipantSignal({
-  profile,
+  participant,
   t,
-  locale,
   hasDivider,
 }: {
-  profile: GroupParticipantProfile;
+  participant: GroupParticipantSignalViewModel;
   t: TranslationCopy;
-  locale: string;
   hasDivider: boolean;
 }) {
-  const moodValue =
-    profile.moodPreferences.length > 0
-      ? joinList(
-          profile.moodPreferences.map((mood) => translateMood(mood, t)),
-          locale,
-        )
-      : t.results.groupBriefMissingSignal;
-  const toneValue = profile.tonePreference
-    ? translateTone(profile.tonePreference, t)
-    : t.results.groupBriefMissingSignal;
-  const eraValue = profile.eraPreference
-    ? translateEra(profile.eraPreference, t)
-    : t.results.groupBriefMissingSignal;
-
   return (
     <li
       className="grid gap-2 py-3 sm:grid-cols-[minmax(6rem,0.8fr)_1fr] sm:gap-4"
@@ -144,7 +69,7 @@ function ParticipantSignal({
           <Ticket size={13} />
         </div>
         <span style={{ color: 'var(--pc-t1)', fontSize: '0.9rem', fontWeight: 700 }}>
-          {profile.name}
+          {participant.name}
         </span>
       </div>
 
@@ -152,63 +77,52 @@ function ParticipantSignal({
         className="flex flex-wrap gap-x-3 gap-y-1.5"
         style={{ color: 'var(--pc-t3)', fontSize: '0.78rem', lineHeight: 1.5 }}
       >
-        {profile.favoriteMovie && (
-          <span>
-            <strong style={{ color: 'var(--pc-t2)', fontWeight: 700 }}>
-              {t.results.groupBriefFavorite}
-            </strong>{' '}
-            {profile.favoriteMovie}
-          </span>
-        )}
+        <FavoriteMovieSignal participant={participant} t={t} />
         <span>
           <strong style={{ color: 'var(--pc-t2)', fontWeight: 700 }}>
             {t.results.groupBriefMoodSignal}
           </strong>{' '}
-          {moodValue}
+          {participant.moodValue}
         </span>
         <span>
           <strong style={{ color: 'var(--pc-t2)', fontWeight: 700 }}>
             {t.results.groupBriefToneSignal}
           </strong>{' '}
-          {toneValue}
+          {participant.toneValue}
         </span>
         <span>
           <strong style={{ color: 'var(--pc-t2)', fontWeight: 700 }}>
             {t.results.groupBriefEraSignal}
           </strong>{' '}
-          {eraValue}
+          {participant.eraValue}
         </span>
       </div>
     </li>
   );
 }
 
+function FavoriteMovieSignal({
+  participant,
+  t,
+}: {
+  participant: GroupParticipantSignalViewModel;
+  t: TranslationCopy;
+}) {
+  if (!participant.favoriteMovie) return null;
+
+  return (
+    <span>
+      <strong style={{ color: 'var(--pc-t2)', fontWeight: 700 }}>
+        {t.results.groupBriefFavorite}
+      </strong>{' '}
+      {participant.favoriteMovie}
+    </span>
+  );
+}
+
 export function GroupMatchBrief({ insights }: { insights: GroupResultInsights }) {
   const { t, locale } = useLanguage();
-  const names = joinList(insights.participantNames, locale);
-  const sharedMoods =
-    insights.sharedMoods.length > 0
-      ? joinList(
-          insights.sharedMoods.map((mood) => translateMood(mood, t)),
-          locale,
-        )
-      : t.results.groupBriefNoSharedMoods;
-  const tones =
-    insights.tonePreferences.length > 0
-      ? joinList(
-          insights.tonePreferences.map((tone) => translateTone(tone, t)),
-          locale,
-        )
-      : t.results.groupBriefMixedSignals;
-  const eras =
-    insights.eraPreferences.length > 0
-      ? joinList(
-          insights.eraPreferences.map((era) => translateEra(era, t)),
-          locale,
-        )
-      : t.results.groupBriefMixedSignals;
-  const actors =
-    insights.favoriteActors.length > 0 ? joinList(insights.favoriteActors, locale) : null;
+  const view = buildGroupMatchBriefViewModel(insights, t, locale);
 
   return (
     <motion.section
@@ -243,64 +157,69 @@ export function GroupMatchBrief({ insights }: { insights: GroupResultInsights })
         <BriefRow
           icon={<Users size={14} />}
           label={t.results.groupBriefPeople}
-          value={t.results.groupBriefPeopleValue
-            .replace(
-              '{count}',
-              new Intl.NumberFormat(locale).format(insights.participantNames.length),
-            )
-            .replace('{names}', names)}
+          value={view.peopleValue}
         />
         <BriefRow
           icon={<Smile size={14} />}
           label={t.results.groupBriefSharedMood}
-          value={sharedMoods}
+          value={view.sharedMoods}
         />
-        <BriefRow icon={<Film size={14} />} label={t.results.groupBriefTone} value={tones} />
-        <BriefRow icon={<Sparkles size={14} />} label={t.results.groupBriefEra} value={eras} />
+        <BriefRow icon={<Film size={14} />} label={t.results.groupBriefTone} value={view.tones} />
+        <BriefRow icon={<Sparkles size={14} />} label={t.results.groupBriefEra} value={view.eras} />
       </div>
 
-      {actors && (
-        <div
-          className="mt-4 rounded-xl px-4 py-3"
-          style={{
-            background: `${palette.purple}16`,
-            border: `1px solid ${palette.purple}30`,
-            color: 'var(--pc-t3)',
-            fontSize: '0.82rem',
-            lineHeight: 1.55,
-          }}
-        >
-          {t.results.groupBriefActors.replace('{actors}', actors)}
-        </div>
-      )}
-
-      {insights.participantProfiles.length > 0 && (
-        <div
-          className="mt-5 rounded-xl px-4 py-3"
-          style={{
-            background: 'var(--pc-surface-hover)',
-            border: '1px solid var(--pc-bd1)',
-          }}
-        >
-          <div
-            className="mb-1 uppercase tracking-widest"
-            style={{ color: 'var(--pc-t4)', fontSize: '0.62rem' }}
-          >
-            {t.results.groupBriefParticipantSignals}
-          </div>
-          <ul>
-            {insights.participantProfiles.map((profile, index) => (
-              <ParticipantSignal
-                key={`${profile.name}-${profile.favoriteMovie ?? profile.tonePreference ?? ''}-${index}`}
-                profile={profile}
-                t={t}
-                locale={locale}
-                hasDivider={index > 0}
-              />
-            ))}
-          </ul>
-        </div>
-      )}
+      <ActorsBrief view={view} />
+      <ParticipantSignals t={t} view={view} />
     </motion.section>
+  );
+}
+
+function ActorsBrief({ view }: { view: GroupMatchBriefViewModel }) {
+  if (!view.hasActors) return null;
+
+  return (
+    <div
+      className="mt-4 rounded-xl px-4 py-3"
+      style={{
+        background: `${palette.purple}16`,
+        border: `1px solid ${palette.purple}30`,
+        color: 'var(--pc-t3)',
+        fontSize: '0.82rem',
+        lineHeight: 1.55,
+      }}
+    >
+      {view.actorsText}
+    </div>
+  );
+}
+
+function ParticipantSignals({ t, view }: { t: TranslationCopy; view: GroupMatchBriefViewModel }) {
+  if (!view.hasParticipantSignals) return null;
+
+  return (
+    <div
+      className="mt-5 rounded-xl px-4 py-3"
+      style={{
+        background: 'var(--pc-surface-hover)',
+        border: '1px solid var(--pc-bd1)',
+      }}
+    >
+      <div
+        className="mb-1 uppercase tracking-widest"
+        style={{ color: 'var(--pc-t4)', fontSize: '0.62rem' }}
+      >
+        {t.results.groupBriefParticipantSignals}
+      </div>
+      <ul>
+        {view.participants.map((participant, index) => (
+          <ParticipantSignal
+            key={participant.key}
+            participant={participant}
+            t={t}
+            hasDivider={index > 0}
+          />
+        ))}
+      </ul>
+    </div>
   );
 }

--- a/apps/web/src/app/results/components/MarkdownText.tsx
+++ b/apps/web/src/app/results/components/MarkdownText.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import type { ReactNode } from 'react';
+
 /**
  * Renders a string containing `**bold**` or `*italic*` markdown as React elements.
  * Double asterisks → <strong>, single asterisks → <em>.
@@ -8,17 +10,26 @@
 export function MarkdownText({ text, style }: { text: string; style?: React.CSSProperties }) {
   // Split on **bold** first, then *italic* within plain segments.
   const parts = text.split(/(\*\*[^*]+\*\*|\*[^*]+\*)/g);
-  return (
-    <span style={style}>
-      {parts.map((part, i) => {
-        if (part.startsWith('**') && part.endsWith('**')) {
-          return <strong key={i}>{part.slice(2, -2)}</strong>;
-        }
-        if (part.startsWith('*') && part.endsWith('*')) {
-          return <em key={i}>{part.slice(1, -1)}</em>;
-        }
-        return part;
-      })}
-    </span>
-  );
+  return <span style={style}>{parts.map((part, index) => renderMarkdownPart(part, index))}</span>;
+}
+
+type MarkdownPartKind = 'bold' | 'italic' | 'text';
+
+const MARKDOWN_RENDERERS: Record<MarkdownPartKind, (part: string, index: number) => ReactNode> = {
+  bold: (part, index) => <strong key={index}>{part.slice(2, -2)}</strong>,
+  italic: (part, index) => <em key={index}>{part.slice(1, -1)}</em>,
+  text: (part) => part,
+};
+
+const MARKDOWN_PATTERNS: Array<{ kind: MarkdownPartKind; pattern: RegExp }> = [
+  { kind: 'bold', pattern: /^\*\*[^*]+\*\*$/ },
+  { kind: 'italic', pattern: /^\*[^*]+\*$/ },
+];
+
+function renderMarkdownPart(part: string, index: number): ReactNode {
+  return MARKDOWN_RENDERERS[getMarkdownPartKind(part)](part, index);
+}
+
+function getMarkdownPartKind(part: string): MarkdownPartKind {
+  return MARKDOWN_PATTERNS.find(({ pattern }) => pattern.test(part))?.kind ?? 'text';
 }

--- a/apps/web/src/app/results/components/groupMatchBriefViewModel.test.ts
+++ b/apps/web/src/app/results/components/groupMatchBriefViewModel.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import { en } from '@/i18n/locales/en';
+
+import { buildGroupMatchBriefViewModel } from './groupMatchBriefViewModel';
+
+import type { GroupResultInsights } from '@/features/recommendation/groupResultInsights';
+
+const insights: GroupResultInsights = {
+  participantNames: ['Ada', 'Grace'],
+  participantProfiles: [
+    {
+      name: 'Ada',
+      favoriteMovie: 'Arrival',
+      moodPreferences: ['science fiction', 'drama'],
+      tonePreference: 'light and fun',
+      eraPreference: 'new releases',
+    },
+    {
+      name: 'Grace',
+      favoriteMovie: null,
+      moodPreferences: [],
+      tonePreference: null,
+      eraPreference: null,
+    },
+  ],
+  sharedMoods: ['science fiction'],
+  tonePreferences: ['dark and intense', 'balanced'],
+  eraPreferences: ['timeless classics'],
+  favoriteActors: ['Sigourney Weaver', 'Oscar Isaac'],
+};
+
+describe('buildGroupMatchBriefViewModel', () => {
+  it('localizes joined group signals and participant rows', () => {
+    const view = buildGroupMatchBriefViewModel(insights, en, 'en');
+
+    expect(view.peopleValue).toContain('2');
+    expect(view.peopleValue).toContain('Ada');
+    expect(view.sharedMoods).toBe(en.genres.scifi);
+    expect(view.tones).toContain(en.tones.dark.label);
+    expect(view.tones).toContain(en.tones.balanced.label);
+    expect(view.eras).toBe(en.quiz.era.classic.title);
+    expect(view.actorsText).toContain('Sigourney Weaver');
+    expect(view.hasActors).toBe(true);
+    expect(view.hasParticipantSignals).toBe(true);
+    expect(view.participants[0]).toMatchObject({
+      name: 'Ada',
+      favoriteMovie: 'Arrival',
+      moodValue: `${en.genres.scifi} & ${en.genres.drama}`,
+      toneValue: en.tones.light.label,
+      eraValue: en.quiz.era.new.title,
+    });
+  });
+
+  it('uses translated fallbacks for missing optional group signals', () => {
+    const view = buildGroupMatchBriefViewModel(
+      {
+        participantNames: ['Solo'],
+        participantProfiles: [],
+        sharedMoods: [],
+        tonePreferences: [],
+        eraPreferences: [],
+        favoriteActors: [],
+      },
+      en,
+      'en',
+    );
+
+    expect(view.sharedMoods).toBe(en.results.groupBriefNoSharedMoods);
+    expect(view.tones).toBe(en.results.groupBriefMixedSignals);
+    expect(view.eras).toBe(en.results.groupBriefMixedSignals);
+    expect(view.actorsText).toBeNull();
+    expect(view.hasActors).toBe(false);
+    expect(view.hasParticipantSignals).toBe(false);
+  });
+});

--- a/apps/web/src/app/results/components/groupMatchBriefViewModel.ts
+++ b/apps/web/src/app/results/components/groupMatchBriefViewModel.ts
@@ -1,0 +1,178 @@
+import type {
+  GroupParticipantProfile,
+  GroupResultInsights,
+} from '@/features/recommendation/groupResultInsights';
+import type { Translations } from '@/i18n/locales/en';
+
+type TranslationCopy = Translations;
+
+export interface GroupParticipantSignalViewModel {
+  eraValue: string;
+  favoriteMovie: string | null;
+  key: string;
+  moodValue: string;
+  name: string;
+  toneValue: string;
+}
+
+export interface GroupMatchBriefViewModel {
+  actorsText: string | null;
+  eras: string;
+  hasActors: boolean;
+  hasParticipantSignals: boolean;
+  participants: GroupParticipantSignalViewModel[];
+  peopleValue: string;
+  sharedMoods: string;
+  tones: string;
+}
+
+const MOOD_ALIASES: Record<string, keyof TranslationCopy['genres']> = {
+  action: 'action',
+  adventure: 'adventure',
+  animation: 'animation',
+  comedy: 'comedy',
+  documentary: 'documentary',
+  drama: 'drama',
+  horror: 'horror',
+  romance: 'romance',
+  scifi: 'scifi',
+  sciencefiction: 'scifi',
+  thriller: 'thriller',
+};
+
+const TONE_ALIASES: Record<string, keyof TranslationCopy['tones']> = {
+  balanced: 'balanced',
+  dark: 'dark',
+  'dark and intense': 'dark',
+  light: 'light',
+  'light and fun': 'light',
+  serious: 'serious',
+  'serious and thought provoking': 'serious',
+};
+
+const ERA_ALIASES: Record<string, keyof Omit<TranslationCopy['quiz']['era'], 'title'>> = {
+  both: 'both',
+  'both new and classic': 'both',
+  classic: 'classic',
+  'timeless classics': 'classic',
+  new: 'new',
+  'new releases': 'new',
+};
+
+export function buildGroupMatchBriefViewModel(
+  insights: GroupResultInsights,
+  t: TranslationCopy,
+  locale: string,
+): GroupMatchBriefViewModel {
+  const names = joinList(insights.participantNames, locale);
+  const actors = optionalJoinedValue(insights.favoriteActors, locale);
+
+  return {
+    actorsText: actors ? t.results.groupBriefActors.replace('{actors}', actors) : null,
+    eras: translatedOrFallback(
+      insights.eraPreferences,
+      locale,
+      t.results.groupBriefMixedSignals,
+      (era) => translateEra(era, t),
+    ),
+    hasActors: Boolean(actors),
+    hasParticipantSignals: insights.participantProfiles.length > 0,
+    participants: insights.participantProfiles.map((profile, index) =>
+      buildParticipantSignalViewModel(profile, index, t, locale),
+    ),
+    peopleValue: t.results.groupBriefPeopleValue
+      .replace('{count}', new Intl.NumberFormat(locale).format(insights.participantNames.length))
+      .replace('{names}', names),
+    sharedMoods: translatedOrFallback(
+      insights.sharedMoods,
+      locale,
+      t.results.groupBriefNoSharedMoods,
+      (mood) => translateMood(mood, t),
+    ),
+    tones: translatedOrFallback(
+      insights.tonePreferences,
+      locale,
+      t.results.groupBriefMixedSignals,
+      (tone) => translateTone(tone, t),
+    ),
+  };
+}
+
+function buildParticipantSignalViewModel(
+  profile: GroupParticipantProfile,
+  index: number,
+  t: TranslationCopy,
+  locale: string,
+): GroupParticipantSignalViewModel {
+  return {
+    eraValue: optionalTranslatedValue(
+      profile.eraPreference,
+      t.results.groupBriefMissingSignal,
+      (era) => translateEra(era, t),
+    ),
+    favoriteMovie: profile.favoriteMovie,
+    key: `${profile.name}-${profile.favoriteMovie ?? profile.tonePreference ?? ''}-${index}`,
+    moodValue: translatedOrFallback(
+      profile.moodPreferences,
+      locale,
+      t.results.groupBriefMissingSignal,
+      (mood) => translateMood(mood, t),
+    ),
+    name: profile.name,
+    toneValue: optionalTranslatedValue(
+      profile.tonePreference,
+      t.results.groupBriefMissingSignal,
+      (tone) => translateTone(tone, t),
+    ),
+  };
+}
+
+function joinList(values: string[], locale: string): string {
+  return new Intl.ListFormat(locale, { style: 'short', type: 'conjunction' }).format(values);
+}
+
+function translatedOrFallback(
+  values: string[],
+  locale: string,
+  fallback: string,
+  translate: (value: string) => string,
+): string {
+  return values.length > 0 ? joinList(values.map(translate), locale) : fallback;
+}
+
+function optionalJoinedValue(values: string[], locale: string): string | null {
+  return values.length > 0 ? joinList(values, locale) : null;
+}
+
+function optionalTranslatedValue(
+  value: string | null,
+  fallback: string,
+  translate: (value: string) => string,
+): string {
+  return value ? translate(value) : fallback;
+}
+
+function normalizeChoice(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/&/g, 'and')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function translateMood(value: string, t: TranslationCopy): string {
+  const key = MOOD_ALIASES[normalizeChoice(value).replace(/\s+/g, '')];
+  return key ? t.genres[key] : value;
+}
+
+function translateTone(value: string, t: TranslationCopy): string {
+  const key = TONE_ALIASES[normalizeChoice(value)];
+  return key ? t.tones[key].label : value;
+}
+
+function translateEra(value: string, t: TranslationCopy): string {
+  const key = ERA_ALIASES[normalizeChoice(value)];
+  return key ? t.quiz.era[key].title : value;
+}

--- a/apps/web/src/components/PCLayout/PCLayout.tsx
+++ b/apps/web/src/components/PCLayout/PCLayout.tsx
@@ -38,6 +38,13 @@ type LayoutNavigationProps = {
   toggle: () => void;
 };
 
+type FreshQuizLinkProps = {
+  label: string;
+  onStart: (event: React.MouseEvent<HTMLAnchorElement>) => void;
+  show: boolean;
+  variant: 'desktop' | 'mobile';
+};
+
 function ThemeToggleButton({
   isDark,
   toggle,
@@ -68,6 +75,283 @@ function ThemeToggleButton({
   );
 }
 
+function DesktopNavigationBar({
+  currentPath,
+  isAuthenticated,
+  isDark,
+  logout,
+  navLinks,
+  showFreshQuizLink,
+  startFreshQuiz,
+  t,
+  toggle,
+}: LayoutNavigationProps & {
+  currentPath: string;
+  showFreshQuizLink: boolean;
+  startFreshQuiz?: (event: React.MouseEvent<HTMLAnchorElement>) => void;
+}) {
+  return (
+    <nav className="hidden md:flex items-center gap-1">
+      <DesktopNavLinks currentPath={currentPath} navLinks={navLinks} />
+      <DesktopLogoutButton isAuthenticated={isAuthenticated} label={t.nav.logOut} logout={logout} />
+      <LanguageSwitcher />
+      <ThemeToggleButton
+        isDark={isDark}
+        toggle={toggle}
+        label={t.nav.toggleTheme}
+        className="ml-1 w-9 h-9 rounded-xl flex items-center justify-center transition-colors duration-200"
+      />
+      <FreshQuizLink
+        label={t.nav.findAMovie}
+        onStart={startFreshQuiz ?? preventFreshQuizFallback}
+        show={showFreshQuizLink}
+        variant="desktop"
+      />
+    </nav>
+  );
+}
+
+function DesktopNavLinks({ currentPath, navLinks }: { currentPath: string; navLinks: NavLink[] }) {
+  return (
+    <>
+      {navLinks.map((link) => (
+        <Link
+          key={link.href}
+          href={link.href}
+          className="px-3 py-2 rounded-xl text-sm transition-colors duration-200"
+          style={desktopNavLinkStyle(currentPath.startsWith(link.href))}
+        >
+          {link.label}
+        </Link>
+      ))}
+    </>
+  );
+}
+
+function DesktopLogoutButton({
+  isAuthenticated,
+  label,
+  logout,
+}: {
+  isAuthenticated: boolean;
+  label: string;
+  logout: () => Promise<void>;
+}) {
+  if (!isAuthenticated) return null;
+
+  return (
+    <button
+      onClick={() => {
+        void logout();
+      }}
+      className="px-3 py-2 rounded-xl text-sm transition-colors duration-200"
+      style={{ color: 'var(--pc-t3)', background: 'transparent' }}
+    >
+      {label}
+    </button>
+  );
+}
+
+function MobileNavigationControls({
+  isDark,
+  mobileMenuOpen,
+  setMobileMenuOpen,
+  t,
+  toggle,
+}: Pick<
+  LayoutNavigationProps,
+  'isDark' | 'mobileMenuOpen' | 'setMobileMenuOpen' | 't' | 'toggle'
+>) {
+  return (
+    <div className="flex md:hidden items-center gap-1">
+      <ThemeToggleButton
+        isDark={isDark}
+        toggle={toggle}
+        label={t.nav.toggleTheme}
+        className="w-9 h-9 rounded-xl flex items-center justify-center transition-colors duration-200"
+      />
+
+      <button
+        onClick={() => setMobileMenuOpen((prev) => !prev)}
+        className="w-9 h-9 rounded-xl flex items-center justify-center transition-colors duration-200"
+        style={mobileMenuButtonStyle(mobileMenuOpen)}
+        aria-label={mobileMenuOpen ? t.nav.closeMenu : t.nav.openMenu}
+        aria-expanded={mobileMenuOpen}
+        aria-controls="mobile-nav-drawer"
+      >
+        <MobileMenuIcon open={mobileMenuOpen} />
+      </button>
+    </div>
+  );
+}
+
+function MobileMenuIcon({ open }: { open: boolean }) {
+  return open ? (
+    <X size={16} style={{ color: 'var(--pc-t2)' }} />
+  ) : (
+    <Menu size={16} style={{ color: 'var(--pc-t2)' }} />
+  );
+}
+
+function MobileNavigationDrawer({
+  currentPath,
+  isAuthenticated,
+  isOpen,
+  logout,
+  navLinks,
+  setMobileMenuOpen,
+  showFreshQuizLink,
+  startFreshQuiz,
+  t,
+}: Pick<
+  LayoutNavigationProps,
+  'isAuthenticated' | 'logout' | 'navLinks' | 'setMobileMenuOpen' | 't'
+> & {
+  currentPath: string;
+  isOpen: boolean;
+  showFreshQuizLink: boolean;
+  startFreshQuiz: (event: React.MouseEvent<HTMLAnchorElement>) => void;
+}) {
+  if (!isOpen) return null;
+
+  return (
+    <nav
+      id="mobile-nav-drawer"
+      className="md:hidden z-40 flex flex-col gap-1 px-4 py-3"
+      style={{
+        background: 'var(--pc-header-bg)',
+        backdropFilter: 'blur(16px)',
+        borderBottom: '1px solid var(--pc-bd1)',
+      }}
+    >
+      <MobileNavLinks
+        currentPath={currentPath}
+        navLinks={navLinks}
+        onNavigate={() => setMobileMenuOpen(false)}
+      />
+      <MobileLogoutButton
+        isAuthenticated={isAuthenticated}
+        label={t.nav.logOut}
+        logout={logout}
+        onNavigate={() => setMobileMenuOpen(false)}
+      />
+      <div className="flex items-center gap-2 pt-1">
+        <LanguageSwitcher />
+        <FreshQuizLink
+          label={t.nav.findAMovie}
+          onStart={startFreshQuiz}
+          show={showFreshQuizLink}
+          variant="mobile"
+        />
+      </div>
+    </nav>
+  );
+}
+
+function MobileNavLinks({
+  currentPath,
+  navLinks,
+  onNavigate,
+}: {
+  currentPath: string;
+  navLinks: NavLink[];
+  onNavigate: () => void;
+}) {
+  return (
+    <>
+      {navLinks.map((link) => (
+        <Link
+          key={link.href}
+          href={link.href}
+          onClick={onNavigate}
+          className="px-3 py-2.5 rounded-xl text-sm transition-colors duration-200"
+          style={mobileNavLinkStyle(currentPath.startsWith(link.href))}
+        >
+          {link.label}
+        </Link>
+      ))}
+    </>
+  );
+}
+
+function MobileLogoutButton({
+  isAuthenticated,
+  label,
+  logout,
+  onNavigate,
+}: {
+  isAuthenticated: boolean;
+  label: string;
+  logout: () => Promise<void>;
+  onNavigate: () => void;
+}) {
+  if (!isAuthenticated) return null;
+
+  return (
+    <button
+      onClick={() => {
+        onNavigate();
+        void logout();
+      }}
+      className="px-3 py-2.5 rounded-xl text-sm text-left transition-colors duration-200"
+      style={{ color: 'var(--pc-t2)', background: 'transparent' }}
+    >
+      {label}
+    </button>
+  );
+}
+
+function FreshQuizLink({ label, onStart, show, variant }: FreshQuizLinkProps) {
+  if (!show) return null;
+
+  return (
+    <Link
+      href="/quiz"
+      onClick={onStart}
+      className={freshQuizLinkClassName(variant)}
+      style={{
+        background: 'var(--pc-cta)',
+        color: 'var(--pc-cta-text)',
+        fontWeight: 600,
+      }}
+    >
+      {label}
+    </Link>
+  );
+}
+
+function preventFreshQuizFallback(event: React.MouseEvent<HTMLAnchorElement>) {
+  event.preventDefault();
+}
+
+function desktopNavLinkStyle(isActive: boolean): React.CSSProperties {
+  return {
+    color: isActive ? 'var(--pc-gold-text)' : 'var(--pc-t3)',
+    background: isActive ? 'var(--pc-gold-subtle)' : 'transparent',
+  };
+}
+
+function mobileNavLinkStyle(isActive: boolean): React.CSSProperties {
+  return {
+    color: isActive ? 'var(--pc-gold-text)' : 'var(--pc-t2)',
+    background: isActive ? 'var(--pc-gold-subtle)' : 'transparent',
+    fontWeight: isActive ? 600 : 400,
+  };
+}
+
+function mobileMenuButtonStyle(isOpen: boolean): React.CSSProperties {
+  return {
+    background: isOpen ? 'var(--pc-gold-subtle)' : 'var(--pc-ghost)',
+    border: '1px solid var(--pc-bd2)',
+  };
+}
+
+function freshQuizLinkClassName(variant: FreshQuizLinkProps['variant']): string {
+  return variant === 'desktop'
+    ? 'ml-1 px-3 py-2 rounded-xl text-sm'
+    : 'flex-1 text-center px-3 py-2.5 rounded-xl text-sm';
+}
+
 function LayoutNavigationFallback({
   isAuthenticated,
   isDark,
@@ -80,69 +364,25 @@ function LayoutNavigationFallback({
 }: LayoutNavigationProps) {
   return (
     <>
-      <nav className="hidden md:flex items-center gap-1">
-        {navLinks.map((link) => (
-          <Link
-            key={link.href}
-            href={link.href}
-            className="px-3 py-2 rounded-xl text-sm transition-colors duration-200"
-            style={{
-              color: 'var(--pc-t3)',
-              background: 'transparent',
-            }}
-          >
-            {link.label}
-          </Link>
-        ))}
-
-        {isAuthenticated && (
-          <button
-            onClick={() => {
-              void logout();
-            }}
-            className="px-3 py-2 rounded-xl text-sm transition-colors duration-200"
-            style={{ color: 'var(--pc-t3)', background: 'transparent' }}
-          >
-            {t.nav.logOut}
-          </button>
-        )}
-
-        <LanguageSwitcher />
-
-        <ThemeToggleButton
-          isDark={isDark}
-          toggle={toggle}
-          label={t.nav.toggleTheme}
-          className="ml-1 w-9 h-9 rounded-xl flex items-center justify-center transition-colors duration-200"
-        />
-      </nav>
-
-      <div className="flex md:hidden items-center gap-1">
-        <ThemeToggleButton
-          isDark={isDark}
-          toggle={toggle}
-          label={t.nav.toggleTheme}
-          className="w-9 h-9 rounded-xl flex items-center justify-center transition-colors duration-200"
-        />
-
-        <button
-          onClick={() => setMobileMenuOpen((prev) => !prev)}
-          className="w-9 h-9 rounded-xl flex items-center justify-center transition-colors duration-200"
-          style={{
-            background: mobileMenuOpen ? 'var(--pc-gold-subtle)' : 'var(--pc-ghost)',
-            border: '1px solid var(--pc-bd2)',
-          }}
-          aria-label={mobileMenuOpen ? t.nav.closeMenu : t.nav.openMenu}
-          aria-expanded={mobileMenuOpen}
-          aria-controls="mobile-nav-drawer"
-        >
-          {mobileMenuOpen ? (
-            <X size={16} style={{ color: 'var(--pc-t2)' }} />
-          ) : (
-            <Menu size={16} style={{ color: 'var(--pc-t2)' }} />
-          )}
-        </button>
-      </div>
+      <DesktopNavigationBar
+        currentPath=""
+        isAuthenticated={isAuthenticated}
+        isDark={isDark}
+        logout={logout}
+        mobileMenuOpen={mobileMenuOpen}
+        navLinks={navLinks}
+        setMobileMenuOpen={setMobileMenuOpen}
+        showFreshQuizLink={false}
+        t={t}
+        toggle={toggle}
+      />
+      <MobileNavigationControls
+        isDark={isDark}
+        mobileMenuOpen={mobileMenuOpen}
+        setMobileMenuOpen={setMobileMenuOpen}
+        t={t}
+        toggle={toggle}
+      />
     </>
   );
 }
@@ -174,157 +414,43 @@ function LayoutNavigation({
 
   return (
     <>
-      <nav className="hidden md:flex items-center gap-1">
-        {navLinks.map((link) => {
-          const isActive = currentPath.startsWith(link.href);
-
-          return (
-            <Link
-              key={link.href}
-              href={link.href}
-              className="px-3 py-2 rounded-xl text-sm transition-colors duration-200"
-              style={{
-                color: isActive ? 'var(--pc-gold-text)' : 'var(--pc-t3)',
-                background: isActive ? 'var(--pc-gold-subtle)' : 'transparent',
-              }}
-            >
-              {link.label}
-            </Link>
-          );
-        })}
-
-        {isAuthenticated && (
-          <button
-            onClick={() => {
-              void logout();
-            }}
-            className="px-3 py-2 rounded-xl text-sm transition-colors duration-200"
-            style={{ color: 'var(--pc-t3)', background: 'transparent' }}
-          >
-            {t.nav.logOut}
-          </button>
-        )}
-
-        <LanguageSwitcher />
-
-        <ThemeToggleButton
-          isDark={isDark}
-          toggle={toggle}
-          label={t.nav.toggleTheme}
-          className="ml-1 w-9 h-9 rounded-xl flex items-center justify-center transition-colors duration-200"
-        />
-
-        {!isLanding && (
-          <Link
-            href="/quiz"
-            onClick={(event) => {
-              event.preventDefault();
-              startFreshQuiz();
-            }}
-            className="ml-1 px-3 py-2 rounded-xl text-sm"
-            style={{
-              background: 'var(--pc-cta)',
-              color: 'var(--pc-cta-text)',
-              fontWeight: 600,
-            }}
-          >
-            {t.nav.findAMovie}
-          </Link>
-        )}
-      </nav>
-
-      <div className="flex md:hidden items-center gap-1">
-        <ThemeToggleButton
-          isDark={isDark}
-          toggle={toggle}
-          label={t.nav.toggleTheme}
-          className="w-9 h-9 rounded-xl flex items-center justify-center transition-colors duration-200"
-        />
-
-        <button
-          onClick={() => setMobileMenuOpen((prev) => !prev)}
-          className="w-9 h-9 rounded-xl flex items-center justify-center transition-colors duration-200"
-          style={{
-            background: mobileMenuOpen ? 'var(--pc-gold-subtle)' : 'var(--pc-ghost)',
-            border: '1px solid var(--pc-bd2)',
-          }}
-          aria-label={mobileMenuOpen ? t.nav.closeMenu : t.nav.openMenu}
-          aria-expanded={mobileMenuOpen}
-          aria-controls="mobile-nav-drawer"
-        >
-          {mobileMenuOpen ? (
-            <X size={16} style={{ color: 'var(--pc-t2)' }} />
-          ) : (
-            <Menu size={16} style={{ color: 'var(--pc-t2)' }} />
-          )}
-        </button>
-      </div>
-
-      {mobileMenuOpen && (
-        <nav
-          id="mobile-nav-drawer"
-          className="md:hidden z-40 flex flex-col gap-1 px-4 py-3"
-          style={{
-            background: 'var(--pc-header-bg)',
-            backdropFilter: 'blur(16px)',
-            borderBottom: '1px solid var(--pc-bd1)',
-          }}
-        >
-          {navLinks.map((link) => {
-            const isActive = currentPath.startsWith(link.href);
-
-            return (
-              <Link
-                key={link.href}
-                href={link.href}
-                onClick={() => setMobileMenuOpen(false)}
-                className="px-3 py-2.5 rounded-xl text-sm transition-colors duration-200"
-                style={{
-                  color: isActive ? 'var(--pc-gold-text)' : 'var(--pc-t2)',
-                  background: isActive ? 'var(--pc-gold-subtle)' : 'transparent',
-                  fontWeight: isActive ? 600 : 400,
-                }}
-              >
-                {link.label}
-              </Link>
-            );
-          })}
-
-          {isAuthenticated && (
-            <button
-              onClick={() => {
-                setMobileMenuOpen(false);
-                void logout();
-              }}
-              className="px-3 py-2.5 rounded-xl text-sm text-left transition-colors duration-200"
-              style={{ color: 'var(--pc-t2)', background: 'transparent' }}
-            >
-              {t.nav.logOut}
-            </button>
-          )}
-
-          <div className="flex items-center gap-2 pt-1">
-            <LanguageSwitcher />
-            {!isLanding && (
-              <Link
-                href="/quiz"
-                onClick={(event) => {
-                  event.preventDefault();
-                  startFreshQuiz();
-                }}
-                className="flex-1 text-center px-3 py-2.5 rounded-xl text-sm"
-                style={{
-                  background: 'var(--pc-cta)',
-                  color: 'var(--pc-cta-text)',
-                  fontWeight: 600,
-                }}
-              >
-                {t.nav.findAMovie}
-              </Link>
-            )}
-          </div>
-        </nav>
-      )}
+      <DesktopNavigationBar
+        currentPath={currentPath}
+        isAuthenticated={isAuthenticated}
+        isDark={isDark}
+        logout={logout}
+        mobileMenuOpen={mobileMenuOpen}
+        navLinks={navLinks}
+        setMobileMenuOpen={setMobileMenuOpen}
+        showFreshQuizLink={!isLanding}
+        startFreshQuiz={(event) => {
+          event.preventDefault();
+          startFreshQuiz();
+        }}
+        t={t}
+        toggle={toggle}
+      />
+      <MobileNavigationControls
+        isDark={isDark}
+        mobileMenuOpen={mobileMenuOpen}
+        setMobileMenuOpen={setMobileMenuOpen}
+        t={t}
+        toggle={toggle}
+      />
+      <MobileNavigationDrawer
+        currentPath={currentPath}
+        isAuthenticated={isAuthenticated}
+        isOpen={mobileMenuOpen}
+        logout={logout}
+        navLinks={navLinks}
+        setMobileMenuOpen={setMobileMenuOpen}
+        showFreshQuizLink={!isLanding}
+        startFreshQuiz={(event) => {
+          event.preventDefault();
+          startFreshQuiz();
+        }}
+        t={t}
+      />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Extract group match brief copy/signal derivation into a pure view-model with unit coverage
- Split group brief participant/actor rendering and markdown token rendering into smaller helpers
- Split PCLayout navigation into focused desktop/mobile/link/button helpers while preserving active link and fresh quiz behavior

## Fallow impact
- Full health after #752: 100 findings, 16 critical / 31 high / 53 moderate
- This branch: 95 findings, 15 critical / 30 high / 50 moderate
- Remaining Fallow findings in results components / PCLayout: 0
- Changed-code Fallow: health 0, dead-code 0, dupes 0

Closes #743.

## Verification
- npm run test --workspace=apps/web -- src/app/results/components/groupMatchBriefViewModel.test.ts src/app/results/components/resultMovieCardViewModel.test.ts
- npm run type-check --workspace=apps/web
- npm run lint:check --workspace=apps/web
- npm run build --workspace=apps/web
- npx fallow health --format json --quiet --changed-since origin/development
- npx fallow dead-code --format json --quiet --changed-since origin/development
- npx fallow dupes --format json --quiet --changed-since origin/development
- pre-push: lint, server tests, production build, Storybook tests