### PR TITLE
Split backoffice catalog health realtime view models

### DIFF
--- a/apps/backoffice/src/components/catalogHealthLiveRefresh.tsx
+++ b/apps/backoffice/src/components/catalogHealthLiveRefresh.tsx
@@ -9,27 +9,18 @@ import {
   type CatalogHealthLiveData,
 } from '../lib/catalogHealthLive';
 import { CATALOG_HEALTH_REFRESH_EVENT } from './catalogHealthRefreshEvent';
-import { formatLiveSyncTime } from './liveRefreshTime';
+import {
+  buildLiveRefreshStatusViewModel,
+  refreshCatalogHealthSnapshot,
+  type LiveConnectionState,
+  type LiveSnapshotTrigger,
+} from './catalogHealthLiveRefreshViewModel';
 
-type LiveConnectionState = 'connecting' | 'connected' | 'fallback';
 type StreamConnectionMessage = {
   mode?: unknown;
 };
 
 const FALLBACK_REFRESH_SECONDS = 60;
-
-async function fetchCatalogHealthLive(search: string): Promise<CatalogHealthLiveData> {
-  const response = await fetch(`/api/catalog-health${search}`, {
-    cache: 'no-store',
-    headers: { Accept: 'application/json' },
-  });
-
-  if (!response.ok) {
-    throw new Error('Failed to fetch live catalog health state.');
-  }
-
-  return (await response.json()) as CatalogHealthLiveData;
-}
 
 function parseStreamConnectionMessage(event: MessageEvent<string>): StreamConnectionMessage {
   try {
@@ -56,9 +47,7 @@ export function CatalogHealthLiveRefresh({
   const [isFallbackFetching, setIsFallbackFetching] = useState(false);
   const [isStreamError, setIsStreamError] = useState(false);
   const [lastSnapshotAt, setLastSnapshotAt] = useState(initialData.report.generatedAt);
-  const [lastSnapshotTrigger, setLastSnapshotTrigger] = useState<
-    'connected' | 'queue-event' | 'redis-unavailable'
-  >('connected');
+  const [lastSnapshotTrigger, setLastSnapshotTrigger] = useState<LiveSnapshotTrigger>('connected');
   const initialFingerprint = useMemo(
     () => catalogHealthLiveFingerprint(initialData),
     [initialData],
@@ -87,21 +76,21 @@ export function CatalogHealthLiveRefresh({
   }, [initialData, initialFingerprint, onSnapshot, search]);
 
   useEffect(() => {
-    const refresh = async () => {
+    const applyData = (nextData: CatalogHealthLiveData) => {
+      setData(nextData);
+      onSnapshot?.(nextData);
+      setLastSnapshotAt(nextData.report.generatedAt);
+      setIsStreamError(false);
+    };
+    const refresh = () => {
       const requestId = ++refreshRequestId.current;
-      setIsFallbackFetching(true);
-      try {
-        const nextData = await fetchCatalogHealthLive(search);
-        if (requestId !== refreshRequestId.current) return;
-        setData(nextData);
-        onSnapshot?.(nextData);
-        setLastSnapshotAt(nextData.report.generatedAt);
-        setIsStreamError(false);
-      } catch {
-        if (requestId === refreshRequestId.current) setIsStreamError(true);
-      } finally {
-        if (requestId === refreshRequestId.current) setIsFallbackFetching(false);
-      }
+      void refreshCatalogHealthSnapshot({
+        applyData,
+        isCurrent: () => requestId === refreshRequestId.current,
+        onError: () => setIsStreamError(true),
+        onFetchingChange: setIsFallbackFetching,
+        search,
+      });
     };
 
     const onVisibilityChange = () => {
@@ -164,22 +153,22 @@ export function CatalogHealthLiveRefresh({
     if (connectionState !== 'fallback') return;
 
     let cancelled = false;
-    const refresh = async () => {
-      setIsFallbackFetching(true);
-      try {
-        const nextData = await fetchCatalogHealthLive(search);
-        if (cancelled) return;
-        setData(nextData);
-        onSnapshot?.(nextData);
-        setLastSnapshotAt(nextData.report.generatedAt);
-      } catch {
-        if (!cancelled) setIsStreamError(true);
-      } finally {
-        if (!cancelled) setIsFallbackFetching(false);
-      }
+    const applyData = (nextData: CatalogHealthLiveData) => {
+      setData(nextData);
+      onSnapshot?.(nextData);
+      setLastSnapshotAt(nextData.report.generatedAt);
+    };
+    const refresh = () => {
+      void refreshCatalogHealthSnapshot({
+        applyData,
+        isCurrent: () => !cancelled,
+        onError: () => setIsStreamError(true),
+        onFetchingChange: setIsFallbackFetching,
+        search,
+      });
     };
 
-    void refresh();
+    refresh();
     const interval = window.setInterval(refresh, refreshSeconds * 1000);
 
     return () => {
@@ -200,31 +189,26 @@ export function CatalogHealthLiveRefresh({
     });
   }, [data, router]);
 
-  const lastSnapshot = formatLiveSyncTime(lastSnapshotAt);
   const isBusy = isPending || isFallbackFetching;
-  const statusCopy = isBusy
-    ? 'Updating catalog status'
-    : connectionState === 'connected'
-      ? 'Catalog and queue updates are live'
-      : connectionState === 'connecting'
-        ? 'Connecting to live updates'
-        : 'Live updates are reconnecting';
-  const metaCopy =
-    lastSnapshotTrigger === 'queue-event'
-      ? `Queue changed ${lastSnapshot}`
-      : `Updated ${lastSnapshot}`;
+  const status = buildLiveRefreshStatusViewModel({
+    connectionState,
+    isBusy,
+    isStreamError,
+    lastSnapshotAt,
+    lastSnapshotTrigger,
+  });
 
   return (
     <div className={`live-refresh ${connectionState}`} aria-live="polite">
-      <span
-        className={`live-refresh-dot ${isBusy || connectionState === 'connecting' ? 'pending' : connectionState === 'fallback' ? 'error' : ''}`}
-        aria-hidden="true"
-      />
-      <span>{statusCopy}</span>
-      <span className="live-refresh-meta">{metaCopy}</span>
-      {isStreamError ? (
-        <span className="live-refresh-error">Live updates are recovering</span>
-      ) : null}
+      <span className={status.dotClassName} aria-hidden="true" />
+      <span>{status.statusCopy}</span>
+      <span className="live-refresh-meta">{status.metaCopy}</span>
+      <LiveRefreshError text={status.errorText} />
     </div>
   );
+}
+
+function LiveRefreshError({ text }: { text: string | null }) {
+  if (!text) return null;
+  return <span className="live-refresh-error">{text}</span>;
 }

--- a/apps/backoffice/src/components/catalogHealthLiveRefreshViewModel.ts
+++ b/apps/backoffice/src/components/catalogHealthLiveRefreshViewModel.ts
@@ -1,0 +1,89 @@
+import { formatLiveSyncTime } from './liveRefreshTime';
+
+import type { CatalogHealthLiveData } from '../lib/catalogHealthLive';
+
+export type LiveConnectionState = 'connecting' | 'connected' | 'fallback';
+export type LiveSnapshotTrigger = 'connected' | 'queue-event' | 'redis-unavailable';
+
+export interface LiveRefreshStatusViewModel {
+  dotClassName: string;
+  errorText: string | null;
+  metaCopy: string;
+  statusCopy: string;
+}
+
+export interface RefreshCatalogHealthOptions {
+  applyData: (data: CatalogHealthLiveData) => void;
+  isCurrent: () => boolean;
+  onError: () => void;
+  onFetchingChange: (isFetching: boolean) => void;
+  search: string;
+}
+
+const STATUS_COPY: Record<LiveConnectionState, string> = {
+  connected: 'Catalog and queue updates are live',
+  connecting: 'Connecting to live updates',
+  fallback: 'Live updates are reconnecting',
+};
+
+export function buildLiveRefreshStatusViewModel({
+  connectionState,
+  isBusy,
+  isStreamError,
+  lastSnapshotAt,
+  lastSnapshotTrigger,
+}: {
+  connectionState: LiveConnectionState;
+  isBusy: boolean;
+  isStreamError: boolean;
+  lastSnapshotAt: string;
+  lastSnapshotTrigger: LiveSnapshotTrigger;
+}): LiveRefreshStatusViewModel {
+  const lastSnapshot = formatLiveSyncTime(lastSnapshotAt);
+
+  return {
+    dotClassName: `live-refresh-dot ${liveRefreshDotState(connectionState, isBusy)}`,
+    errorText: isStreamError ? 'Live updates are recovering' : null,
+    metaCopy:
+      lastSnapshotTrigger === 'queue-event'
+        ? `Queue changed ${lastSnapshot}`
+        : `Updated ${lastSnapshot}`,
+    statusCopy: isBusy ? 'Updating catalog status' : STATUS_COPY[connectionState],
+  };
+}
+
+export async function refreshCatalogHealthSnapshot({
+  applyData,
+  isCurrent,
+  onError,
+  onFetchingChange,
+  search,
+}: RefreshCatalogHealthOptions): Promise<void> {
+  onFetchingChange(true);
+  try {
+    const nextData = await fetchCatalogHealthLive(search);
+    if (isCurrent()) applyData(nextData);
+  } catch {
+    if (isCurrent()) onError();
+  } finally {
+    if (isCurrent()) onFetchingChange(false);
+  }
+}
+
+async function fetchCatalogHealthLive(search: string): Promise<CatalogHealthLiveData> {
+  const response = await fetch(`/api/catalog-health${search}`, {
+    cache: 'no-store',
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch live catalog health state.');
+  }
+
+  return (await response.json()) as CatalogHealthLiveData;
+}
+
+function liveRefreshDotState(connectionState: LiveConnectionState, isBusy: boolean): string {
+  if (isBusy || connectionState === 'connecting') return 'pending';
+  return connectionState === 'fallback' ? 'error' : '';
+}

--- a/apps/backoffice/src/components/catalogHealthRealtimeOverview.tsx
+++ b/apps/backoffice/src/components/catalogHealthRealtimeOverview.tsx
@@ -2,51 +2,32 @@
 
 import { useEffect, useState } from 'react';
 
-import type { CatalogMaintenanceQueueSnapshot } from '../catalogMaintenanceQueue';
-import type { CatalogHealthLiveData } from '../lib/catalogHealthLive';
 import { CatalogHealthLiveRefresh } from './catalogHealthLiveRefresh';
-import { formatLiveSyncTime } from './liveRefreshTime';
+import { buildCatalogHealthOverviewViewModel } from './catalogHealthRealtimeViewModel';
 import { CatalogStat } from './shared';
 
-function CatalogStatusStrip({
-  activeIssues,
-  duplicateGroups,
-  queueSnapshot,
-}: {
-  activeIssues: number;
-  duplicateGroups: number;
-  queueSnapshot: CatalogMaintenanceQueueSnapshot;
-}) {
-  const isHealthy = activeIssues === 0 && duplicateGroups === 0;
+import type { CatalogHealthLiveData } from '../lib/catalogHealthLive';
+import type {
+  CatalogQueueStatusViewModel,
+  CatalogStatusStripViewModel,
+} from './catalogHealthRealtimeViewModel';
 
+function CatalogStatusStrip({ status }: { status: CatalogStatusStripViewModel }) {
   return (
-    <section
-      className={`catalog-status ${isHealthy ? 'healthy' : 'needs-work'}`}
-      aria-label="Catalog health status"
-    >
+    <section className={status.className} aria-label="Catalog health status">
       <div>
         <div className="status-heading">
           <span className="status-dot" aria-hidden="true" />
-          <span>{isHealthy ? 'Catalog is clear' : 'Catalog needs operator attention'}</span>
+          <span>{status.heading}</span>
         </div>
-        <p className="status-copy">
-          {isHealthy
-            ? 'No active issue categories or duplicate groups are currently reported.'
-            : 'Work the highest-count repairable panels first, then review duplicates before manual merges.'}
-        </p>
+        <p className="status-copy">{status.copy}</p>
       </div>
       <div className="status-metrics" aria-label="Open catalog signals">
-        <span className={`pill ${activeIssues > 0 ? 'warning' : 'good'}`}>
-          {activeIssues} active issue categories
-        </span>
-        <span className={`pill ${duplicateGroups > 0 ? 'warning' : 'good'}`}>
-          {duplicateGroups} duplicate groups
-        </span>
-        <span className={`pill ${queueSnapshot.available ? 'good' : 'warning'}`}>
-          {queueSnapshot.available
-            ? `${queueSnapshot.openJobs} catalog queue open`
-            : 'Catalog queue unavailable'}
-        </span>
+        {status.metrics.map((metric) => (
+          <span key={metric.label} className={metric.className}>
+            {metric.label}
+          </span>
+        ))}
       </div>
     </section>
   );
@@ -90,65 +71,63 @@ function ManualRepairForm({ repairableIssueKeys }: { repairableIssueKeys: string
 function CatalogQueueStatus({
   bullBoardUrl,
   repairableIssueKeys,
-  snapshot,
+  queue,
 }: {
   bullBoardUrl?: string;
+  queue: CatalogQueueStatusViewModel;
   repairableIssueKeys: string[];
-  snapshot: CatalogMaintenanceQueueSnapshot;
 }) {
-  const state = !snapshot.available ? 'warning' : snapshot.openJobs > 0 ? 'neutral' : 'healthy';
-
   return (
     <section className="queue-status" aria-label="Catalog maintenance queue status">
       <div className="queue-status-main">
         <div>
           <div className="queue-status-title">
-            <span className={`queue-dot ${state}`} aria-hidden="true" />
+            <span className={queue.dotClassName} aria-hidden="true" />
             <span>Catalog maintenance queue</span>
           </div>
-          <p>
-            {snapshot.available
-              ? `Queue updated ${formatLiveSyncTime(snapshot.updatedAt)}.`
-              : 'Queue data is unavailable, so backoffice cannot read repair job state.'}
-          </p>
+          <p>{queue.statusCopy}</p>
         </div>
         <div className="queue-status-actions">
-          {bullBoardUrl ? (
-            <a className="button small" href={bullBoardUrl} target="_blank" rel="noreferrer">
-              Open Bull Board
-            </a>
-          ) : (
-            <span className="button small disabled" aria-disabled="true">
-              Queue dashboard unavailable
-            </span>
-          )}
+          <BullBoardAction action={queue.bullBoardAction} bullBoardUrl={bullBoardUrl} />
           <a className="button small" href="/repair-batches">
             Repair batches
           </a>
         </div>
       </div>
       <div className="queue-counts">
-        <span>
-          <strong>{snapshot.counts.waiting}</strong> waiting
-        </span>
-        <span>
-          <strong>{snapshot.counts.active}</strong> active
-        </span>
-        <span>
-          <strong>{snapshot.counts.delayed + snapshot.counts.prioritized}</strong> scheduled
-        </span>
-        <span>
-          <strong>{snapshot.counts.failed}</strong> failed
-        </span>
-        <span>
-          <strong>{snapshot.counts.completed}</strong> completed
-        </span>
+        {queue.counts.map((count) => (
+          <span key={count.label}>
+            <strong>{count.value}</strong> {count.label}
+          </span>
+        ))}
       </div>
       <details className="manual-repair">
         <summary>Manually queue a movie</summary>
         <ManualRepairForm repairableIssueKeys={repairableIssueKeys} />
       </details>
     </section>
+  );
+}
+
+function BullBoardAction({
+  action,
+  bullBoardUrl,
+}: {
+  action: CatalogQueueStatusViewModel['bullBoardAction'];
+  bullBoardUrl?: string;
+}) {
+  if (action === 'link') {
+    return (
+      <a className="button small" href={bullBoardUrl} target="_blank" rel="noreferrer">
+        Open Bull Board
+      </a>
+    );
+  }
+
+  return (
+    <span className="button small disabled" aria-disabled="true">
+      Queue dashboard unavailable
+    </span>
   );
 }
 
@@ -162,8 +141,7 @@ export function CatalogHealthRealtimeOverview({
   repairableIssueKeys: string[];
 }) {
   const [data, setData] = useState(initialData);
-  const activeIssues = data.report.activeIssues;
-  const duplicateGroups = data.report.duplicateGroups;
+  const view = buildCatalogHealthOverviewViewModel(data, bullBoardUrl);
 
   useEffect(() => {
     setData(initialData);
@@ -172,35 +150,16 @@ export function CatalogHealthRealtimeOverview({
   return (
     <>
       <CatalogHealthLiveRefresh initialData={initialData} onSnapshot={setData} />
-      <CatalogStatusStrip
-        activeIssues={activeIssues}
-        duplicateGroups={duplicateGroups}
-        queueSnapshot={data.queueSnapshot}
-      />
+      <CatalogStatusStrip status={view.status} />
       <CatalogQueueStatus
         bullBoardUrl={bullBoardUrl}
+        queue={view.queue}
         repairableIssueKeys={repairableIssueKeys}
-        snapshot={data.queueSnapshot}
       />
       <section className="summary" aria-label="Catalog health summary">
-        <CatalogStat label="Movies" value={data.report.totalMovies} meta="Catalog rows tracked" />
-        <CatalogStat
-          label="Issue categories"
-          value={activeIssues}
-          meta={activeIssues === 0 ? 'No active categories' : 'Categories with affected rows'}
-          state={activeIssues === 0 ? 'healthy' : 'warning'}
-        />
-        <CatalogStat
-          label="Duplicate groups"
-          value={duplicateGroups}
-          meta={duplicateGroups === 0 ? 'No duplicate groups' : 'Groups awaiting review'}
-          state={duplicateGroups === 0 ? 'healthy' : 'warning'}
-        />
-        <CatalogStat
-          label="Stale threshold"
-          value={`${data.report.staleAfterDays}d`}
-          meta="TMDB metadata refresh window"
-        />
+        {view.summary.map((stat) => (
+          <CatalogStat key={stat.label} {...stat} />
+        ))}
       </section>
     </>
   );

--- a/apps/backoffice/src/components/catalogHealthRealtimeViewModel.test.ts
+++ b/apps/backoffice/src/components/catalogHealthRealtimeViewModel.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildLiveRefreshStatusViewModel } from './catalogHealthLiveRefreshViewModel';
+import { buildCatalogHealthOverviewViewModel } from './catalogHealthRealtimeViewModel';
+
+import type { CatalogHealthLiveData } from '../lib/catalogHealthLive';
+
+const liveData: CatalogHealthLiveData = {
+  auditPage: {
+    limit: 25,
+    offset: 0,
+    totalCount: 3,
+  },
+  issueMoviePage: {
+    issueKey: 'missing_poster_url',
+    limit: 25,
+    offset: 0,
+    totalCount: 12,
+  },
+  queueSnapshot: {
+    available: true,
+    counts: {
+      active: 1,
+      completed: 10,
+      delayed: 2,
+      failed: 0,
+      prioritized: 1,
+      waiting: 2,
+      waitingChildren: 0,
+    },
+    openJobs: 6,
+    queueName: 'catalog-maintenance',
+    updatedAt: '2026-06-02T12:00:00.000Z',
+  },
+  report: {
+    activeIssues: 2,
+    duplicateGroups: 1,
+    generatedAt: '2026-06-02T12:00:00.000Z',
+    issueCounts: {
+      missing_poster_url: 12,
+      missing_runtime: 4,
+    },
+    staleAfterDays: 180,
+    totalMovies: 351,
+  },
+};
+
+describe('buildCatalogHealthOverviewViewModel', () => {
+  it('builds warning status, queue action, counts, and summary stats', () => {
+    const view = buildCatalogHealthOverviewViewModel(liveData, 'https://bull.example.test');
+
+    expect(view.status.className).toBe('catalog-status needs-work');
+    expect(view.status.heading).toBe('Catalog needs operator attention');
+    expect(view.status.metrics.map((metric) => metric.label)).toEqual([
+      '2 active issue categories',
+      '1 duplicate groups',
+      '6 catalog queue open',
+    ]);
+    expect(view.queue.bullBoardAction).toBe('link');
+    expect(view.queue.dotClassName).toBe('queue-dot neutral');
+    expect(view.queue.counts.find((count) => count.label === 'scheduled')?.value).toBe(3);
+    expect(view.summary.map((stat) => stat.label)).toEqual([
+      'Movies',
+      'Issue categories',
+      'Duplicate groups',
+      'Stale threshold',
+    ]);
+  });
+
+  it('builds healthy and unavailable queue states', () => {
+    const view = buildCatalogHealthOverviewViewModel({
+      ...liveData,
+      queueSnapshot: {
+        ...liveData.queueSnapshot,
+        available: false,
+        openJobs: 0,
+      },
+      report: {
+        ...liveData.report,
+        activeIssues: 0,
+        duplicateGroups: 0,
+      },
+    });
+
+    expect(view.status.className).toBe('catalog-status healthy');
+    expect(view.status.heading).toBe('Catalog is clear');
+    expect(view.queue.bullBoardAction).toBe('disabled');
+    expect(view.queue.dotClassName).toBe('queue-dot warning');
+  });
+});
+
+describe('buildLiveRefreshStatusViewModel', () => {
+  it('formats busy, fallback, and queue-event status copy', () => {
+    const status = buildLiveRefreshStatusViewModel({
+      connectionState: 'fallback',
+      isBusy: true,
+      isStreamError: true,
+      lastSnapshotAt: '2026-06-02T12:00:00.000Z',
+      lastSnapshotTrigger: 'queue-event',
+    });
+
+    expect(status.statusCopy).toBe('Updating catalog status');
+    expect(status.dotClassName).toContain('pending');
+    expect(status.errorText).toBe('Live updates are recovering');
+    expect(status.metaCopy).toContain('Queue changed');
+  });
+});

--- a/apps/backoffice/src/components/catalogHealthRealtimeViewModel.ts
+++ b/apps/backoffice/src/components/catalogHealthRealtimeViewModel.ts
@@ -1,0 +1,148 @@
+import { formatLiveSyncTime } from './liveRefreshTime';
+
+import type { CatalogMaintenanceQueueSnapshot } from '../catalogMaintenanceQueue';
+import type { CatalogHealthLiveData } from '../lib/catalogHealthLive';
+
+type CatalogStatState = 'healthy' | 'warning';
+type QueueState = 'healthy' | 'neutral' | 'warning';
+
+export interface CatalogMetricPill {
+  className: string;
+  label: string;
+}
+
+export interface CatalogStatusStripViewModel {
+  className: string;
+  copy: string;
+  heading: string;
+  metrics: CatalogMetricPill[];
+}
+
+export interface CatalogQueueStatusViewModel {
+  bullBoardAction: 'link' | 'disabled';
+  counts: Array<{ label: string; value: number }>;
+  dotClassName: string;
+  statusCopy: string;
+}
+
+export interface CatalogSummaryStatViewModel {
+  label: string;
+  meta: string;
+  state?: CatalogStatState;
+  value: number | string;
+}
+
+export interface CatalogHealthOverviewViewModel {
+  activeIssues: number;
+  duplicateGroups: number;
+  queueSnapshot: CatalogMaintenanceQueueSnapshot;
+  status: CatalogStatusStripViewModel;
+  queue: CatalogQueueStatusViewModel;
+  summary: CatalogSummaryStatViewModel[];
+}
+
+export function buildCatalogHealthOverviewViewModel(
+  data: CatalogHealthLiveData,
+  bullBoardUrl?: string,
+): CatalogHealthOverviewViewModel {
+  const { activeIssues, duplicateGroups } = data.report;
+
+  return {
+    activeIssues,
+    duplicateGroups,
+    queueSnapshot: data.queueSnapshot,
+    queue: buildCatalogQueueStatusViewModel(data.queueSnapshot, bullBoardUrl),
+    status: buildCatalogStatusStripViewModel(activeIssues, duplicateGroups, data.queueSnapshot),
+    summary: buildCatalogSummaryStats(data),
+  };
+}
+
+function buildCatalogStatusStripViewModel(
+  activeIssues: number,
+  duplicateGroups: number,
+  queueSnapshot: CatalogMaintenanceQueueSnapshot,
+): CatalogStatusStripViewModel {
+  const isHealthy = activeIssues === 0 && duplicateGroups === 0;
+
+  return {
+    className: `catalog-status ${isHealthy ? 'healthy' : 'needs-work'}`,
+    copy: isHealthy
+      ? 'No active issue categories or duplicate groups are currently reported.'
+      : 'Work the highest-count repairable panels first, then review duplicates before manual merges.',
+    heading: isHealthy ? 'Catalog is clear' : 'Catalog needs operator attention',
+    metrics: [
+      buildMetricPill(activeIssues, 'active issue categories'),
+      buildMetricPill(duplicateGroups, 'duplicate groups'),
+      buildQueueMetricPill(queueSnapshot),
+    ],
+  };
+}
+
+function buildCatalogQueueStatusViewModel(
+  snapshot: CatalogMaintenanceQueueSnapshot,
+  bullBoardUrl?: string,
+): CatalogQueueStatusViewModel {
+  return {
+    bullBoardAction: bullBoardUrl ? 'link' : 'disabled',
+    counts: [
+      { label: 'waiting', value: snapshot.counts.waiting },
+      { label: 'active', value: snapshot.counts.active },
+      { label: 'scheduled', value: snapshot.counts.delayed + snapshot.counts.prioritized },
+      { label: 'failed', value: snapshot.counts.failed },
+      { label: 'completed', value: snapshot.counts.completed },
+    ],
+    dotClassName: `queue-dot ${queueState(snapshot)}`,
+    statusCopy: snapshot.available
+      ? `Queue updated ${formatLiveSyncTime(snapshot.updatedAt)}.`
+      : 'Queue data is unavailable, so backoffice cannot read repair job state.',
+  };
+}
+
+function buildCatalogSummaryStats(data: CatalogHealthLiveData): CatalogSummaryStatViewModel[] {
+  return [
+    { label: 'Movies', value: data.report.totalMovies, meta: 'Catalog rows tracked' },
+    {
+      label: 'Issue categories',
+      value: data.report.activeIssues,
+      meta:
+        data.report.activeIssues === 0 ? 'No active categories' : 'Categories with affected rows',
+      state: statState(data.report.activeIssues),
+    },
+    {
+      label: 'Duplicate groups',
+      value: data.report.duplicateGroups,
+      meta: data.report.duplicateGroups === 0 ? 'No duplicate groups' : 'Groups awaiting review',
+      state: statState(data.report.duplicateGroups),
+    },
+    {
+      label: 'Stale threshold',
+      value: `${data.report.staleAfterDays}d`,
+      meta: 'TMDB metadata refresh window',
+    },
+  ];
+}
+
+function buildMetricPill(count: number, label: string): CatalogMetricPill {
+  return {
+    className: `pill ${count > 0 ? 'warning' : 'good'}`,
+    label: `${count} ${label}`,
+  };
+}
+
+function buildQueueMetricPill(queueSnapshot: CatalogMaintenanceQueueSnapshot): CatalogMetricPill {
+  return {
+    className: `pill ${queueSnapshot.available ? 'good' : 'warning'}`,
+    label: queueSnapshot.available
+      ? `${queueSnapshot.openJobs} catalog queue open`
+      : 'Catalog queue unavailable',
+  };
+}
+
+function queueState(snapshot: CatalogMaintenanceQueueSnapshot): QueueState {
+  if (!snapshot.available) return 'warning';
+  return snapshot.openJobs > 0 ? 'neutral' : 'healthy';
+}
+
+function statState(count: number): CatalogStatState {
+  return count === 0 ? 'healthy' : 'warning';
+}


### PR DESCRIPTION
## Summary
- Extract catalog health live refresh status/refresh helpers into a focused view-model module
- Extract realtime overview status, queue, and summary derivation into a focused view-model module
- Add unit coverage for catalog health realtime view-model branches

## Fallow impact
- Full health after #753: 95 findings, 15 critical / 30 high / 50 moderate
- This branch: 89 findings, 14 critical / 29 high / 46 moderate
- Backoffice findings: 26 -> 20
- Changed-code Fallow: health 0, dead-code 0, dupes 0

Part of #744.

## Verification
- npm run test --workspace=apps/backoffice -- src/components/catalogHealthRealtimeViewModel.test.ts
- npm run type-check --workspace=apps/backoffice
- npm run lint:check
- npm run build --workspace=apps/backoffice
- npx fallow health --format json --quiet --changed-since origin/development
- npx fallow dead-code --format json --quiet --changed-since origin/development
- npx fallow dupes --format json --quiet --changed-since origin/development
- pre-push: lint, server tests, production build, Storybook tests