### PR TITLE
Split backoffice queue realtime view models

### DIFF
--- a/apps/backoffice/src/components/catalog-queue/realtime.tsx
+++ b/apps/backoffice/src/components/catalog-queue/realtime.tsx
@@ -16,6 +16,11 @@ import {
   type QueueRealtimeConnectionState,
 } from './helpers';
 import { QueueCommandStrip, QueueJobsPanel, QueueRealtimeStatus } from './realtimeSections';
+import {
+  buildQueueFingerprint,
+  getConnectionStateAfterSnapshotRefresh,
+  loadQueueSnapshotRefresh,
+} from './realtimeViewModel';
 
 async function fetchCatalogMaintenanceQueue(
   search: string,
@@ -54,16 +59,14 @@ export function CatalogMaintenanceQueueRealtime({
   const [lastEventAt, setLastEventAt] = useState<string | null>(initialJobPage.updatedAt);
   const [nowMs, setNowMs] = useState(Date.now());
   const refreshRequestId = useRef(0);
-  const initialFingerprint = useRef(
-    `${initialJobPage.state}:${initialJobPage.offset}:${initialJobPage.limit}:${initialJobPage.updatedAt}`,
-  );
+  const initialFingerprint = useRef(buildQueueFingerprint(initialJobPage));
   const search = useMemo(() => {
     const serialized = searchParams.toString();
     return serialized ? `?${serialized}` : '';
   }, [searchParams]);
 
   useEffect(() => {
-    const nextFingerprint = `${initialJobPage.state}:${initialJobPage.offset}:${initialJobPage.limit}:${initialJobPage.updatedAt}`;
+    const nextFingerprint = buildQueueFingerprint(initialJobPage);
     if (initialFingerprint.current === nextFingerprint) return;
 
     initialFingerprint.current = nextFingerprint;
@@ -77,22 +80,21 @@ export function CatalogMaintenanceQueueRealtime({
     const requestId = ++refreshRequestId.current;
     setIsFallbackFetching(true);
 
-    try {
-      const nextJobPage = await fetchCatalogMaintenanceQueue(search);
-      if (requestId !== refreshRequestId.current) return;
+    const result = await loadQueueSnapshotRefresh({
+      fetchQueue: fetchCatalogMaintenanceQueue,
+      search,
+    });
+    if (requestId !== refreshRequestId.current) return;
 
-      setJobPage(nextJobPage);
-      setLastEventAt(nextJobPage.updatedAt);
-      setNowMs(Date.now());
-      setConnectionState((current) => (current === 'connected' ? current : 'fallback'));
-    } catch {
-      if (requestId === refreshRequestId.current) {
-        setConnectionState('reconnecting');
-        setNowMs(Date.now());
-      }
-    } finally {
-      if (requestId === refreshRequestId.current) setIsFallbackFetching(false);
+    if (result.kind === 'success') {
+      setJobPage(result.jobPage);
+      setLastEventAt(result.jobPage.updatedAt);
+      setConnectionState(getConnectionStateAfterSnapshotRefresh);
+    } else {
+      setConnectionState('reconnecting');
     }
+    setNowMs(result.nowMs);
+    setIsFallbackFetching(false);
   }, [search]);
 
   useEffect(() => {

--- a/apps/backoffice/src/components/catalog-queue/realtimeSections.tsx
+++ b/apps/backoffice/src/components/catalog-queue/realtimeSections.tsx
@@ -3,21 +3,23 @@ import type {
   CatalogMaintenanceQueueJobState,
   CatalogMaintenanceQueueJobSummary,
 } from '../../catalogMaintenanceQueue';
-import { formatLiveSyncTime } from '../liveRefreshTime';
 import { PanelHeader, SimplePaginationControls, TableEmptyRow, TableScroll } from '../shared';
 import {
   buildQueueHref,
   getLastQueueEvent,
-  getQueueHealth,
   getQueueJobLinks,
   getQueueStateClass,
   getQueueStateCount,
-  queueRealtimeDetailCopy,
   QUEUE_STATES,
-  queueRealtimeCopy,
   STATE_LABELS,
   type QueueRealtimeStatus as QueueRealtimeStatusValue,
 } from './helpers';
+import {
+  buildQueueCommandStripViewModel,
+  buildQueueRealtimeStatusViewModel,
+} from './realtimeViewModel';
+
+const QUEUE_JOB_COLUMNS = ['Job', 'State', 'Details', 'Attempts', 'Last update', 'Links'] as const;
 
 export function QueueCommandStrip({
   bullBoardUrl,
@@ -26,48 +28,30 @@ export function QueueCommandStrip({
   bullBoardUrl?: string;
   jobPage: CatalogMaintenanceQueueJobPage;
 }) {
-  const health = getQueueHealth(jobPage);
+  const view = buildQueueCommandStripViewModel({ bullBoardUrl, jobPage });
 
   return (
-    <section className={`queue-command-strip ${health.state}`}>
+    <section className={`queue-command-strip ${view.state}`}>
       <div className="queue-command-main">
-        <span
-          className={`queue-dot ${health.state === 'healthy' ? '' : health.state === 'active' ? 'neutral' : 'warning'}`}
-          aria-hidden="true"
-        />
+        <span className={view.dotClassName} aria-hidden="true" />
         <div>
-          <h2>{health.title}</h2>
-          <p>{health.copy}</p>
+          <h2>{view.title}</h2>
+          <p>{view.copy}</p>
         </div>
       </div>
       <div className="queue-command-metrics" aria-label="Queue health metrics">
-        <span>
-          <strong>{jobPage.openJobs}</strong> open
-        </span>
-        <span className={jobPage.counts.failed > 0 ? 'warn' : ''}>
-          <strong>{jobPage.counts.failed}</strong> failed
-        </span>
-        <span>
-          <strong>{jobPage.counts.waiting}</strong> waiting
-        </span>
-        <span>
-          <strong>{jobPage.counts.delayed}</strong> scheduled
-        </span>
+        {view.metrics.map((metric) => (
+          <span key={metric.label} className={metric.className}>
+            <strong>{metric.value}</strong> {metric.label}
+          </span>
+        ))}
       </div>
       <div className="queue-command-actions">
-        {jobPage.counts.failed > 0 && jobPage.state !== 'failed' ? (
-          <a
-            className="button secondary small"
-            href={buildQueueHref({ page: 1, pageSize: jobPage.limit, state: 'failed' })}
-          >
-            Review failed
+        {view.actions.map((action) => (
+          <a key={action.href} className={action.className} href={action.href}>
+            {action.label}
           </a>
-        ) : null}
-        {bullBoardUrl ? (
-          <a className="button small" href={bullBoardUrl}>
-            Open Bull Board
-          </a>
-        ) : null}
+        ))}
       </div>
     </section>
   );
@@ -108,12 +92,9 @@ export function QueueJobsPanel({ jobPage }: { jobPage: CatalogMaintenanceQueueJo
         <table className="queue-jobs-table">
           <thead>
             <tr>
-              <th>Job</th>
-              <th>State</th>
-              <th>Details</th>
-              <th>Attempts</th>
-              <th>Last update</th>
-              <th>Links</th>
+              {QUEUE_JOB_COLUMNS.map((column) => (
+                <th key={column}>{column}</th>
+              ))}
             </tr>
           </thead>
           <tbody>
@@ -289,29 +270,27 @@ export function QueueRealtimeStatus({
   onRefresh?: () => void;
   status: QueueRealtimeStatusValue;
 }) {
-  const copy = queueRealtimeCopy(status);
-  const detailCopy = queueRealtimeDetailCopy(status);
-  const lastEvent = lastEventAt ? formatLiveSyncTime(lastEventAt) : null;
-  const dotState =
-    status === 'connecting' || isRefreshing ? 'pending' : status === 'connected' ? '' : 'error';
-  const showFallbackControls = status !== 'connected' && status !== 'connecting';
+  const view = buildQueueRealtimeStatusViewModel({
+    isRefreshing,
+    lastEventAt,
+    onRefreshAvailable: Boolean(onRefresh),
+    status,
+  });
 
   return (
     <div className={`live-refresh realtime-refresh ${status}`} aria-live="polite">
-      <span className={`live-refresh-dot ${dotState}`} aria-hidden="true" />
-      <span>{copy}</span>
-      <span className="live-refresh-meta">
-        {lastEvent ? `Updated ${lastEvent}` : 'Waiting for the first update'}
-      </span>
-      {detailCopy ? <span className="live-refresh-error">{detailCopy}</span> : null}
-      {showFallbackControls && onRefresh ? (
+      <span className={`live-refresh-dot ${view.dotState}`} aria-hidden="true" />
+      <span>{view.copy}</span>
+      <span className="live-refresh-meta">{view.lastEventLabel}</span>
+      {view.detailCopy ? <span className="live-refresh-error">{view.detailCopy}</span> : null}
+      {view.refreshButton && onRefresh ? (
         <button
           className="button small quiet"
-          disabled={isRefreshing}
+          disabled={view.refreshButton.disabled}
           onClick={onRefresh}
           type="button"
         >
-          {isRefreshing ? 'Refreshing' : 'Refresh'}
+          {view.refreshButton.label}
         </button>
       ) : null}
     </div>

--- a/apps/backoffice/src/components/catalog-queue/realtimeViewModel.test.ts
+++ b/apps/backoffice/src/components/catalog-queue/realtimeViewModel.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import { catalogMaintenanceQueueJobPage } from '../../test/backofficeFixtures';
+import {
+  buildQueueCommandStripViewModel,
+  buildQueueFingerprint,
+  buildQueueRealtimeStatusViewModel,
+  getConnectionStateAfterSnapshotRefresh,
+  loadQueueSnapshotRefresh,
+} from './realtimeViewModel';
+
+describe('catalog queue realtime view models', () => {
+  it('builds command strip metrics and actions for failed queue work', () => {
+    const view = buildQueueCommandStripViewModel({
+      bullBoardUrl: 'https://bull.example.test',
+      jobPage: catalogMaintenanceQueueJobPage({
+        counts: {
+          active: 0,
+          completed: 10,
+          delayed: 2,
+          failed: 3,
+          prioritized: 0,
+          waiting: 4,
+          waitingChildren: 0,
+        },
+        openJobs: 6,
+      }),
+    });
+
+    expect(view.state).toBe('warning');
+    expect(view.dotClassName).toBe('queue-dot warning');
+    expect(view.metrics).toEqual([
+      { label: 'open', value: 6 },
+      { className: 'warn', label: 'failed', value: 3 },
+      { label: 'waiting', value: 4 },
+      { label: 'scheduled', value: 2 },
+    ]);
+    expect(view.actions).toEqual([
+      {
+        className: 'button secondary small',
+        href: '/queue?state=failed&page=1&pageSize=25',
+        label: 'Review failed',
+      },
+      { className: 'button small', href: 'https://bull.example.test', label: 'Open Bull Board' },
+    ]);
+  });
+
+  it('hides failed review action while already filtering failed jobs', () => {
+    const view = buildQueueCommandStripViewModel({
+      jobPage: catalogMaintenanceQueueJobPage({
+        counts: {
+          active: 0,
+          completed: 0,
+          delayed: 0,
+          failed: 1,
+          prioritized: 0,
+          waiting: 0,
+          waitingChildren: 0,
+        },
+        state: 'failed',
+      }),
+    });
+
+    expect(view.actions).toEqual([]);
+  });
+
+  it('builds realtime status copy and fallback refresh controls', () => {
+    expect(
+      buildQueueRealtimeStatusViewModel({
+        lastEventAt: '2026-06-02T12:00:00.000Z',
+        onRefreshAvailable: true,
+        status: 'connected',
+      }),
+    ).toMatchObject({
+      copy: 'Queue updates are live',
+      dotState: '',
+      refreshButton: null,
+    });
+
+    expect(
+      buildQueueRealtimeStatusViewModel({
+        isRefreshing: true,
+        lastEventAt: null,
+        onRefreshAvailable: true,
+        status: 'stale',
+      }),
+    ).toMatchObject({
+      dotState: 'pending',
+      lastEventLabel: 'Waiting for the first update',
+      refreshButton: { disabled: true, label: 'Refreshing' },
+    });
+  });
+
+  it('keeps stable fingerprints and refresh connection transitions', async () => {
+    const page = catalogMaintenanceQueueJobPage();
+
+    expect(buildQueueFingerprint(page)).toBe('waiting:0:25:2026-06-02T12:00:00.000Z');
+    expect(getConnectionStateAfterSnapshotRefresh('connected')).toBe('connected');
+    expect(getConnectionStateAfterSnapshotRefresh('reconnecting')).toBe('fallback');
+
+    await expect(
+      loadQueueSnapshotRefresh({
+        fetchQueue: async () => page,
+        now: () => 123,
+        search: '?state=waiting',
+      }),
+    ).resolves.toEqual({ jobPage: page, kind: 'success', nowMs: 123 });
+    await expect(
+      loadQueueSnapshotRefresh({
+        fetchQueue: async () => {
+          throw new Error('network');
+        },
+        now: () => 456,
+        search: '',
+      }),
+    ).resolves.toEqual({ kind: 'error', nowMs: 456 });
+  });
+});

--- a/apps/backoffice/src/components/catalog-queue/realtimeViewModel.ts
+++ b/apps/backoffice/src/components/catalog-queue/realtimeViewModel.ts
@@ -1,0 +1,160 @@
+import type { CatalogMaintenanceQueueJobPage } from '../../catalogMaintenanceQueue';
+import { formatLiveSyncTime } from '../liveRefreshTime';
+import {
+  buildQueueHref,
+  getQueueHealth,
+  queueRealtimeCopy,
+  queueRealtimeDetailCopy,
+  type QueueRealtimeConnectionState,
+  type QueueRealtimeStatus,
+} from './helpers';
+
+export interface QueueCommandMetricViewModel {
+  className?: string;
+  label: string;
+  value: number;
+}
+
+export interface QueueCommandActionViewModel {
+  className: string;
+  href: string;
+  label: string;
+}
+
+export interface QueueCommandStripViewModel {
+  actions: QueueCommandActionViewModel[];
+  copy: string;
+  dotClassName: string;
+  metrics: QueueCommandMetricViewModel[];
+  state: ReturnType<typeof getQueueHealth>['state'];
+  title: string;
+}
+
+export interface QueueRealtimeStatusViewModel {
+  copy: string;
+  detailCopy: string | null;
+  dotState: string;
+  lastEventLabel: string;
+  refreshButton: { disabled: boolean; label: string } | null;
+}
+
+export type QueueSnapshotRefreshResult =
+  | { jobPage: CatalogMaintenanceQueueJobPage; kind: 'success'; nowMs: number }
+  | { kind: 'error'; nowMs: number };
+
+export function buildQueueCommandStripViewModel({
+  bullBoardUrl,
+  jobPage,
+}: {
+  bullBoardUrl?: string;
+  jobPage: CatalogMaintenanceQueueJobPage;
+}): QueueCommandStripViewModel {
+  const health = getQueueHealth(jobPage);
+
+  return {
+    actions: buildQueueCommandActions(jobPage, bullBoardUrl),
+    copy: health.copy,
+    dotClassName: getQueueHealthDotClassName(health.state),
+    metrics: [
+      { label: 'open', value: jobPage.openJobs },
+      {
+        className: jobPage.counts.failed > 0 ? 'warn' : undefined,
+        label: 'failed',
+        value: jobPage.counts.failed,
+      },
+      { label: 'waiting', value: jobPage.counts.waiting },
+      { label: 'scheduled', value: jobPage.counts.delayed },
+    ],
+    state: health.state,
+    title: health.title,
+  };
+}
+
+export function buildQueueRealtimeStatusViewModel({
+  isRefreshing = false,
+  lastEventAt,
+  onRefreshAvailable,
+  status,
+}: {
+  isRefreshing?: boolean;
+  lastEventAt: string | null;
+  onRefreshAvailable: boolean;
+  status: QueueRealtimeStatus;
+}): QueueRealtimeStatusViewModel {
+  const showFallbackControls = status !== 'connected' && status !== 'connecting';
+
+  return {
+    copy: queueRealtimeCopy(status),
+    detailCopy: queueRealtimeDetailCopy(status),
+    dotState: getQueueRealtimeDotState(status, isRefreshing),
+    lastEventLabel: lastEventAt
+      ? `Updated ${formatLiveSyncTime(lastEventAt)}`
+      : 'Waiting for the first update',
+    refreshButton:
+      showFallbackControls && onRefreshAvailable
+        ? { disabled: isRefreshing, label: isRefreshing ? 'Refreshing' : 'Refresh' }
+        : null,
+  };
+}
+
+export function buildQueueFingerprint(jobPage: CatalogMaintenanceQueueJobPage): string {
+  return `${jobPage.state}:${jobPage.offset}:${jobPage.limit}:${jobPage.updatedAt}`;
+}
+
+export function getConnectionStateAfterSnapshotRefresh(
+  current: QueueRealtimeConnectionState,
+): QueueRealtimeConnectionState {
+  return current === 'connected' ? current : 'fallback';
+}
+
+export async function loadQueueSnapshotRefresh({
+  fetchQueue,
+  now = Date.now,
+  search,
+}: {
+  fetchQueue: (search: string) => Promise<CatalogMaintenanceQueueJobPage>;
+  now?: () => number;
+  search: string;
+}): Promise<QueueSnapshotRefreshResult> {
+  try {
+    const jobPage = await fetchQueue(search);
+    return { jobPage, kind: 'success', nowMs: now() };
+  } catch {
+    return { kind: 'error', nowMs: now() };
+  }
+}
+
+function buildQueueCommandActions(
+  jobPage: CatalogMaintenanceQueueJobPage,
+  bullBoardUrl?: string,
+): QueueCommandActionViewModel[] {
+  const actions: QueueCommandActionViewModel[] = [];
+
+  if (jobPage.counts.failed > 0 && jobPage.state !== 'failed') {
+    actions.push({
+      className: 'button secondary small',
+      href: buildQueueHref({ page: 1, pageSize: jobPage.limit, state: 'failed' }),
+      label: 'Review failed',
+    });
+  }
+  if (bullBoardUrl) {
+    actions.push({
+      className: 'button small',
+      href: bullBoardUrl,
+      label: 'Open Bull Board',
+    });
+  }
+
+  return actions;
+}
+
+function getQueueHealthDotClassName(state: QueueCommandStripViewModel['state']): string {
+  if (state === 'healthy') return 'queue-dot';
+  if (state === 'active') return 'queue-dot neutral';
+  return 'queue-dot warning';
+}
+
+function getQueueRealtimeDotState(status: QueueRealtimeStatus, isRefreshing: boolean): string {
+  if (status === 'connecting' || isRefreshing) return 'pending';
+  return status === 'connected' ? '' : 'error';
+}


### PR DESCRIPTION
## Summary
- Extract catalog maintenance queue realtime status, command strip, fingerprint, and snapshot refresh helpers into a focused view-model module
- Simplify queue realtime components so TSX mostly renders derived view data
- Add unit coverage for queue command actions, realtime status controls, fingerprints, and refresh transitions

## Fallow impact
- Baseline after #754: 89 findings, 14 critical / 29 high / 46 moderate
- This branch: 86 findings, 13 critical / 28 high / 45 moderate
- Backoffice findings: 20 -> 17
- Changed-code Fallow: health 0, dead-code 0, dupes 0

Part of #744.

## Verification
- npm run test --workspace=apps/backoffice -- src/components/catalog-queue/realtimeViewModel.test.ts src/components/catalog-queue/helpers.test.ts
- npm run type-check --workspace=apps/backoffice
- npm run lint:check
- npm run build --workspace=apps/backoffice
- npx fallow health --format json --quiet --changed-since origin/development
- npx fallow dead-code --format json --quiet --changed-since origin/development
- npx fallow dupes --format json --quiet --changed-since origin/development
- pre-push: lint, server tests, production build, Storybook tests