### PR TITLE
Split backoffice TMDB review view models

### DIFF
--- a/apps/backoffice/src/components/tmdb-reviews/detail.tsx
+++ b/apps/backoffice/src/components/tmdb-reviews/detail.tsx
@@ -12,10 +12,9 @@ import { ReviewActionSubmitButton } from './actionSubmitButton';
 import { AuditRows } from './auditRows';
 import {
   buildReviewPageHref,
-  canApplyCandidate,
-  getCandidateWarning,
+  buildCandidateCardViewModel,
+  buildStatusActionViewModel,
   getReviewRiskSummary,
-  isCurrentCandidate,
 } from './helpers';
 import {
   ConfidenceMeter,
@@ -34,51 +33,36 @@ function CandidateCard({
   candidate: TMDBReviewCandidate;
   index: number;
 }) {
-  const canApply = canApplyCandidate({ candidate, review });
-  const isBest = index === 0;
-  const isCurrent = isCurrentCandidate({ candidate, review });
-  const warning = getCandidateWarning({ candidate, review });
+  const view = buildCandidateCardViewModel({ candidate, index, review });
 
   return (
-    <article className={`candidate ${isBest ? 'best' : ''} ${isCurrent ? 'current' : ''}`}>
+    <article className={view.className}>
       <div>
         <div className="candidate-title">
-          <h3>{candidate.title}</h3>
+          <h3>{view.title}</h3>
           <div className="candidate-flags">
-            {isBest ? <span className="pill good">Best candidate</span> : null}
-            {isCurrent ? <span className="pill repairable">Current TMDB</span> : null}
-            {warning ? <span className="pill warning">Needs check</span> : null}
+            {view.flags.map((flag) => (
+              <span key={flag.label} className={flag.className}>
+                {flag.label}
+              </span>
+            ))}
           </div>
         </div>
         <dl>
-          <div>
-            <dt>TMDB</dt>
-            <dd>{candidate.id ?? '-'}</dd>
-          </div>
-          <div>
-            <dt>Original</dt>
-            <dd>{candidate.originalTitle ?? '-'}</dd>
-          </div>
-          <div>
-            <dt>Year</dt>
-            <dd>{candidate.releaseYear ?? '-'}</dd>
-          </div>
-          <div>
-            <dt>Confidence</dt>
-            <dd>{formatPercent(candidate.confidence)}</dd>
-          </div>
+          {view.facts.map((fact) => (
+            <div key={fact.label}>
+              <dt>{fact.label}</dt>
+              <dd>{fact.value}</dd>
+            </div>
+          ))}
         </dl>
-        <ConfidenceMeter confidence={candidate.confidence} />
-        {warning ? <p className="candidate-warning">{warning}</p> : null}
+        <ConfidenceMeter confidence={view.confidence} />
+        {view.warning ? <p className="candidate-warning">{view.warning}</p> : null}
       </div>
-      {canApply ? (
-        <form
-          className="action-form apply-action"
-          method="post"
-          action={`/tmdb-reviews/${encodeURIComponent(review.id)}/actions`}
-        >
+      {view.applyCandidateId ? (
+        <form className="action-form apply-action" method="post" action={view.actionHref}>
           <input type="hidden" name="action" value="apply_candidate" />
-          <input type="hidden" name="candidate_id" value={String(candidate.id)} />
+          <input type="hidden" name="candidate_id" value={view.applyCandidateId} />
           <label>
             Decision note
             <input name="note" maxLength={500} placeholder="Why this candidate is correct" />
@@ -112,61 +96,41 @@ function StatusActionForm({
   action: Exclude<TMDBMatchReviewAction, 'apply_candidate'>;
   label: string;
 }) {
-  const disabled =
-    review.status === 'resolved' ||
-    (action === 'reject' && review.status === 'ignored') ||
-    (action === 'defer' && review.status === 'deferred') ||
-    (action === 'reopen' && review.status === 'open');
-  const details = {
-    defer: {
-      buttonClass: 'secondary',
-      className: 'defer',
-      description: 'Keep it out of the active queue until more catalog context exists.',
-    },
-    reject: {
-      buttonClass: 'danger',
-      className: 'reject',
-      description: 'Mark this review as ignored when candidates are wrong or not useful.',
-    },
-    reopen: {
-      buttonClass: 'quiet',
-      className: 'reopen',
-      description: 'Move a deferred or ignored review back into active operator work.',
-    },
-  }[action];
+  const view = buildStatusActionViewModel({ action, review });
 
   return (
-    <article className={`decision-card ${details.className}`}>
+    <article className={`decision-card ${view.className}`}>
       <div className="decision-card-header">
         <span className="decision-title">{label}</span>
-        <span className="small-note">{details.description}</span>
+        <span className="small-note">{view.description}</span>
       </div>
-      <form
-        className="action-form"
-        method="post"
-        action={`/tmdb-reviews/${encodeURIComponent(review.id)}/actions`}
-      >
+      <form className="action-form" method="post" action={view.formAction}>
         <input type="hidden" name="action" value={action} />
         <label>
           Decision note
-          <input name="note" maxLength={500} placeholder="Optional rationale" disabled={disabled} />
+          <input
+            name="note"
+            maxLength={500}
+            placeholder="Optional rationale"
+            disabled={view.disabled}
+          />
         </label>
         <ReviewActionSubmitButton
-          buttonClass={details.buttonClass}
-          disabled={disabled}
+          buttonClass={view.buttonClass}
+          disabled={view.disabled}
           label={label}
           pendingLabel="Saving..."
         />
-        {action === 'reopen' ? null : (
+        {view.includeNextAction ? (
           <ReviewActionSubmitButton
             buttonClass="secondary"
-            disabled={disabled}
+            disabled={view.disabled}
             label={`${label} + next`}
             name="next_review"
             pendingLabel="Saving..."
             value="1"
           />
-        )}
+        ) : null}
       </form>
     </article>
   );

--- a/apps/backoffice/src/components/tmdb-reviews/helpers.ts
+++ b/apps/backoffice/src/components/tmdb-reviews/helpers.ts
@@ -7,3 +7,9 @@ export {
 export { buildReviewDetailHref, buildReviewPageHref } from './navigation';
 export type { ReviewFilters } from './navigation';
 export { getReviewRiskSummary } from './riskSummary';
+export {
+  buildCandidateCardViewModel,
+  buildCandidateSummaryViewModel,
+  buildReviewPaginationViewModel,
+  buildStatusActionViewModel,
+} from './viewModels';

--- a/apps/backoffice/src/components/tmdb-reviews/list.tsx
+++ b/apps/backoffice/src/components/tmdb-reviews/list.tsx
@@ -2,7 +2,7 @@ import type { TMDBMatchReview, TMDBReviewCandidate } from '@pop-choice/shared';
 
 import { formatBackofficeDateTime } from '../../lib/backoffice';
 import { BackofficeLayout } from '../backoffice-layout';
-import { PanelHeader, TableEmptyRow, TableScroll, formatPercent } from '../shared';
+import { PanelHeader, TableEmptyRow, TableScroll } from '../shared';
 import {
   ConfidenceMeter,
   CurrentTMDBValue,
@@ -11,7 +11,22 @@ import {
   renderStatus,
   StatusBadge,
 } from './reviewPresentation';
-import { buildReviewPageHref, candidateConfidenceGap, type ReviewFilters } from './helpers';
+import {
+  buildCandidateSummaryViewModel,
+  buildReviewPaginationViewModel,
+  type ReviewFilters,
+} from './helpers';
+
+const REVIEW_TABLE_COLUMNS = [
+  'ID',
+  'Local movie',
+  'Reason',
+  'Status',
+  'Candidates',
+  'Current TMDB',
+  'Updated',
+  '',
+] as const;
 
 function ReviewFilterSummary({ filters }: { filters: ReviewFilters }) {
   return (
@@ -38,27 +53,14 @@ function PaginationControls({
   pageSize: number;
   totalCount: number;
 }) {
-  const totalPages = Math.max(Math.ceil(totalCount / pageSize), 1);
-  const currentPage = Math.max(page, 1);
-  const firstItem =
-    totalCount === 0 || currentPage > totalPages ? 0 : (currentPage - 1) * pageSize + 1;
-  const lastItem = currentPage > totalPages ? 0 : Math.min(currentPage * pageSize, totalCount);
+  const view = buildReviewPaginationViewModel({ filters, page, pageSize, totalCount });
 
   return (
     <nav className="pagination" aria-label="Review queue pagination">
-      <span className="pagination-summary">
-        {totalCount === 0
-          ? 'No reviews'
-          : currentPage > totalPages
-            ? `Page ${currentPage} is past ${totalCount} matching reviews`
-            : `Showing ${firstItem}-${lastItem} of ${totalCount} reviews`}
-      </span>
+      <span className="pagination-summary">{view.summary}</span>
       <div className="pagination-actions">
-        {currentPage > 1 ? (
-          <a
-            className="button small"
-            href={buildReviewPageHref({ filters, page: currentPage - 1, pageSize })}
-          >
+        {view.previousHref ? (
+          <a className="button small" href={view.previousHref}>
             Previous
           </a>
         ) : (
@@ -67,13 +69,10 @@ function PaginationControls({
           </span>
         )}
         <span className="pagination-page">
-          Page {currentPage} / {totalPages}
+          Page {view.currentPage} / {view.totalPages}
         </span>
-        {currentPage < totalPages ? (
-          <a
-            className="button small"
-            href={buildReviewPageHref({ filters, page: currentPage + 1, pageSize })}
-          >
+        {view.nextHref ? (
+          <a className="button small" href={view.nextHref}>
             Next
           </a>
         ) : (
@@ -87,26 +86,17 @@ function PaginationControls({
 }
 
 function CandidateSummary({ candidates }: { candidates: TMDBReviewCandidate[] }) {
-  if (candidates.length === 0) return <span className="muted">No candidates captured</span>;
-
-  const [best] = candidates;
-  const gap = candidateConfidenceGap(candidates);
+  const view = buildCandidateSummaryViewModel(candidates);
+  if (view.emptyText) return <span className="muted">{view.emptyText}</span>;
 
   return (
     <div className="candidate-summary">
       <div className="candidate-headline">
-        <strong>
-          {best?.title}
-          {best?.releaseYear === null || best?.releaseYear === undefined
-            ? null
-            : ` (${best.releaseYear})`}
-        </strong>
-        <span className="pill">{formatPercent(best?.confidence ?? null)}</span>
+        <strong>{view.headline}</strong>
+        <span className="pill">{view.confidenceLabel}</span>
       </div>
-      <ConfidenceMeter confidence={best?.confidence ?? null} />
-      <div className="muted">
-        {candidates.length} candidate(s){gap === null ? '' : `, gap ${formatPercent(gap)}`}
-      </div>
+      <ConfidenceMeter confidence={view.confidence} />
+      <div className="muted">{view.meta}</div>
     </div>
   );
 }
@@ -224,14 +214,9 @@ export function ReviewListPage({
           <table className="review-table">
             <thead>
               <tr>
-                <th>ID</th>
-                <th>Local movie</th>
-                <th>Reason</th>
-                <th>Status</th>
-                <th>Candidates</th>
-                <th>Current TMDB</th>
-                <th>Updated</th>
-                <th />
+                {REVIEW_TABLE_COLUMNS.map((column, index) => (
+                  <th key={`${column}-${index}`}>{column}</th>
+                ))}
               </tr>
             </thead>
             <tbody>

--- a/apps/backoffice/src/components/tmdb-reviews/viewModels.test.ts
+++ b/apps/backoffice/src/components/tmdb-reviews/viewModels.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+
+import { tmdbMatchReview } from '../../test/backofficeFixtures';
+import {
+  buildCandidateCardViewModel,
+  buildCandidateSummaryViewModel,
+  buildReviewPaginationViewModel,
+  buildStatusActionViewModel,
+} from './viewModels';
+
+const filters = { reason: 'all', sort: 'highest_risk', status: 'open' } as const;
+
+describe('tmdb review view models', () => {
+  it('builds pagination summaries and disabled link states', () => {
+    expect(
+      buildReviewPaginationViewModel({ filters, page: 1, pageSize: 25, totalCount: 0 }),
+    ).toMatchObject({
+      currentPage: 1,
+      nextHref: null,
+      previousHref: null,
+      summary: 'No reviews',
+      totalPages: 1,
+    });
+
+    expect(
+      buildReviewPaginationViewModel({ filters, page: 2, pageSize: 25, totalCount: 60 }),
+    ).toMatchObject({
+      nextHref: '/tmdb-reviews?status=open&reason=all&sort=highest_risk&page=3&pageSize=25',
+      previousHref: '/tmdb-reviews?status=open&reason=all&sort=highest_risk&page=1&pageSize=25',
+      summary: 'Showing 26-50 of 60 reviews',
+      totalPages: 3,
+    });
+
+    expect(
+      buildReviewPaginationViewModel({ filters, page: 5, pageSize: 25, totalCount: 60 }).summary,
+    ).toBe('Page 5 is past 60 matching reviews');
+  });
+
+  it('summarizes candidates using order-preserving best and confidence gap', () => {
+    const review = tmdbMatchReview();
+
+    expect(buildCandidateSummaryViewModel([])).toMatchObject({
+      emptyText: 'No candidates captured',
+      headline: null,
+    });
+    expect(buildCandidateSummaryViewModel(review.candidates)).toMatchObject({
+      confidenceLabel: '62%',
+      headline: 'Heat (1994)',
+      meta: '2 candidate(s), gap 3%',
+    });
+  });
+
+  it('builds candidate card state, facts, and apply controls', () => {
+    const review = tmdbMatchReview();
+    const view = buildCandidateCardViewModel({
+      candidate: review.candidates[0]!,
+      index: 0,
+      review,
+    });
+
+    expect(view.className).toBe('candidate best');
+    expect(view.flags.map((flag) => flag.label)).toEqual(['Best candidate', 'Needs check']);
+    expect(view.facts).toContainEqual({ label: 'TMDB', value: '42' });
+    expect(view.applyCandidateId).toBe('42');
+    expect(view.actionHref).toBe('/tmdb-reviews/review-1/actions');
+
+    expect(
+      buildCandidateCardViewModel({
+        candidate: { ...review.candidates[0]!, id: null },
+        index: 0,
+        review,
+      }).applyCandidateId,
+    ).toBeNull();
+    expect(
+      buildCandidateCardViewModel({
+        candidate: review.candidates[0]!,
+        index: 0,
+        review: { ...review, status: 'resolved' },
+      }).applyCandidateId,
+    ).toBeNull();
+  });
+
+  it('builds status action disabled states and next action availability', () => {
+    const review = tmdbMatchReview();
+
+    expect(buildStatusActionViewModel({ action: 'reject', review })).toMatchObject({
+      buttonClass: 'danger',
+      disabled: false,
+      includeNextAction: true,
+    });
+    expect(
+      buildStatusActionViewModel({ action: 'reject', review: { ...review, status: 'ignored' } })
+        .disabled,
+    ).toBe(true);
+    expect(
+      buildStatusActionViewModel({ action: 'defer', review: { ...review, status: 'deferred' } })
+        .disabled,
+    ).toBe(true);
+    expect(
+      buildStatusActionViewModel({ action: 'reopen', review: { ...review, status: 'open' } }),
+    ).toMatchObject({ disabled: true, includeNextAction: false });
+    expect(
+      buildStatusActionViewModel({ action: 'defer', review: { ...review, status: 'resolved' } })
+        .disabled,
+    ).toBe(true);
+  });
+});

--- a/apps/backoffice/src/components/tmdb-reviews/viewModels.ts
+++ b/apps/backoffice/src/components/tmdb-reviews/viewModels.ts
@@ -1,0 +1,213 @@
+import type {
+  TMDBMatchReview,
+  TMDBMatchReviewAction,
+  TMDBReviewCandidate,
+} from '@pop-choice/shared';
+
+import { formatPercent } from '../shared';
+import {
+  canApplyCandidate,
+  candidateConfidenceGap,
+  getCandidateWarning,
+  isCurrentCandidate,
+} from './candidateReview';
+import { buildReviewPageHref, type ReviewFilters } from './navigation';
+
+export interface ReviewPaginationViewModel {
+  currentPage: number;
+  nextHref: string | null;
+  previousHref: string | null;
+  summary: string;
+  totalPages: number;
+}
+
+export interface CandidateSummaryViewModel {
+  confidence: number | null;
+  confidenceLabel: string;
+  emptyText: string | null;
+  headline: string | null;
+  meta: string | null;
+}
+
+export interface CandidateCardViewModel {
+  actionHref: string;
+  applyCandidateId: string | null;
+  className: string;
+  confidence: number | null;
+  facts: Array<{ label: string; value: string }>;
+  flags: Array<{ className: string; label: string }>;
+  title: string;
+  warning: string | null;
+}
+
+export interface StatusActionViewModel {
+  buttonClass: string;
+  className: string;
+  description: string;
+  disabled: boolean;
+  formAction: string;
+  includeNextAction: boolean;
+}
+
+export function buildReviewPaginationViewModel({
+  filters,
+  page,
+  pageSize,
+  totalCount,
+}: {
+  filters: ReviewFilters;
+  page: number;
+  pageSize: number;
+  totalCount: number;
+}): ReviewPaginationViewModel {
+  const totalPages = Math.max(Math.ceil(totalCount / pageSize), 1);
+  const currentPage = Math.max(page, 1);
+  const isPastLastPage = currentPage > totalPages;
+  const firstItem = totalCount === 0 || isPastLastPage ? 0 : (currentPage - 1) * pageSize + 1;
+  const lastItem = isPastLastPage ? 0 : Math.min(currentPage * pageSize, totalCount);
+
+  return {
+    currentPage,
+    nextHref:
+      currentPage < totalPages
+        ? buildReviewPageHref({ filters, page: currentPage + 1, pageSize })
+        : null,
+    previousHref:
+      currentPage > 1 ? buildReviewPageHref({ filters, page: currentPage - 1, pageSize }) : null,
+    summary: getPaginationSummary({ currentPage, firstItem, isPastLastPage, lastItem, totalCount }),
+    totalPages,
+  };
+}
+
+export function buildCandidateSummaryViewModel(
+  candidates: TMDBReviewCandidate[],
+): CandidateSummaryViewModel {
+  if (candidates.length === 0) {
+    return {
+      confidence: null,
+      confidenceLabel: formatPercent(null),
+      emptyText: 'No candidates captured',
+      headline: null,
+      meta: null,
+    };
+  }
+
+  const [best] = candidates;
+  const gap = candidateConfidenceGap(candidates);
+
+  return {
+    confidence: best?.confidence ?? null,
+    confidenceLabel: formatPercent(best?.confidence ?? null),
+    emptyText: null,
+    headline: buildCandidateTitle(best),
+    meta: `${candidates.length} candidate(s)${gap === null ? '' : `, gap ${formatPercent(gap)}`}`,
+  };
+}
+
+export function buildCandidateCardViewModel({
+  candidate,
+  index,
+  review,
+}: {
+  candidate: TMDBReviewCandidate;
+  index: number;
+  review: TMDBMatchReview;
+}): CandidateCardViewModel {
+  const isBest = index === 0;
+  const isCurrent = isCurrentCandidate({ candidate, review });
+  const warning = getCandidateWarning({ candidate, review });
+  const canApply = canApplyCandidate({ candidate, review });
+
+  return {
+    actionHref: `/tmdb-reviews/${encodeURIComponent(review.id)}/actions`,
+    applyCandidateId: canApply ? String(candidate.id) : null,
+    className: ['candidate', isBest ? 'best' : '', isCurrent ? 'current' : '']
+      .filter(Boolean)
+      .join(' '),
+    confidence: candidate.confidence,
+    facts: [
+      { label: 'TMDB', value: formatNullableValue(candidate.id) },
+      { label: 'Original', value: candidate.originalTitle ?? '-' },
+      { label: 'Year', value: formatNullableValue(candidate.releaseYear) },
+      { label: 'Confidence', value: formatPercent(candidate.confidence) },
+    ],
+    flags: [
+      isBest ? { className: 'pill good', label: 'Best candidate' } : null,
+      isCurrent ? { className: 'pill repairable', label: 'Current TMDB' } : null,
+      warning ? { className: 'pill warning', label: 'Needs check' } : null,
+    ].filter((flag): flag is { className: string; label: string } => Boolean(flag)),
+    title: candidate.title,
+    warning,
+  };
+}
+
+export function buildStatusActionViewModel({
+  action,
+  review,
+}: {
+  action: Exclude<TMDBMatchReviewAction, 'apply_candidate'>;
+  review: Pick<TMDBMatchReview, 'id' | 'status'>;
+}): StatusActionViewModel {
+  const details = STATUS_ACTION_DETAILS[action];
+
+  return {
+    ...details,
+    disabled:
+      review.status === 'resolved' ||
+      (action === 'reject' && review.status === 'ignored') ||
+      (action === 'defer' && review.status === 'deferred') ||
+      (action === 'reopen' && review.status === 'open'),
+    formAction: `/tmdb-reviews/${encodeURIComponent(review.id)}/actions`,
+    includeNextAction: action !== 'reopen',
+  };
+}
+
+const STATUS_ACTION_DETAILS = {
+  defer: {
+    buttonClass: 'secondary',
+    className: 'defer',
+    description: 'Keep it out of the active queue until more catalog context exists.',
+  },
+  reject: {
+    buttonClass: 'danger',
+    className: 'reject',
+    description: 'Mark this review as ignored when candidates are wrong or not useful.',
+  },
+  reopen: {
+    buttonClass: 'quiet',
+    className: 'reopen',
+    description: 'Move a deferred or ignored review back into active operator work.',
+  },
+} satisfies Record<
+  Exclude<TMDBMatchReviewAction, 'apply_candidate'>,
+  Pick<StatusActionViewModel, 'buttonClass' | 'className' | 'description'>
+>;
+
+function buildCandidateTitle(candidate: TMDBReviewCandidate | undefined): string {
+  if (!candidate) return '';
+  return candidate.releaseYear === null || candidate.releaseYear === undefined
+    ? candidate.title
+    : `${candidate.title} (${candidate.releaseYear})`;
+}
+
+function formatNullableValue(value: number | string | null | undefined): string {
+  return value === null || value === undefined ? '-' : String(value);
+}
+
+function getPaginationSummary({
+  currentPage,
+  firstItem,
+  isPastLastPage,
+  lastItem,
+  totalCount,
+}: {
+  currentPage: number;
+  firstItem: number;
+  isPastLastPage: boolean;
+  lastItem: number;
+  totalCount: number;
+}): string {
+  if (totalCount === 0) return 'No reviews';
+  if (isPastLastPage) return `Page ${currentPage} is past ${totalCount} matching reviews`;
+  return `Showing ${firstItem}-${lastItem} of ${totalCount} reviews`;
+}


### PR DESCRIPTION
## Summary
- Extract TMDB review pagination, candidate summary/card, and status action derivation into pure view-model helpers
- Simplify review list/detail components to render derived view data without embedded branch-heavy logic
- Add unit coverage for pagination edge cases, candidate apply guards, order-preserving summaries, and status action disabled states

## Fallow impact
- Baseline after #755: 86 findings, 13 critical / 28 high / 45 moderate
- This branch: 83 findings, 12 critical / 27 high / 44 moderate
- Backoffice findings: 17 -> 14
- Changed-code Fallow: health 0, dead-code 0, dupes 0

Part of #744.

## Verification
- npm run test --workspace=apps/backoffice -- src/components/tmdb-reviews/viewModels.test.ts src/components/tmdb-reviews/helpers.test.ts
- npm run type-check --workspace=apps/backoffice
- npm run lint:check
- npm run build --workspace=apps/backoffice
- npx fallow health --format json --quiet --changed-since origin/development
- npx fallow dead-code --format json --quiet --changed-since origin/development
- npx fallow dupes --format json --quiet --changed-since origin/development
- pre-push: lint, server tests, production build, Storybook tests