### PR TITLE
Split catalog health panel view models

### DIFF
--- a/apps/backoffice/src/components/catalog-health/index.tsx
+++ b/apps/backoffice/src/components/catalog-health/index.tsx
@@ -15,73 +15,12 @@ import { formatLiveSyncTime } from '../liveRefreshTime';
 import { CountPill, SimplePaginationControls } from '../shared';
 import { buildRepairAuditPageHref } from '../shared/hrefs';
 import { CatalogIssuePanel } from './issuePanel';
+import { buildDuplicateReportViewModel, buildRepairFlashViewModel } from './viewModels';
 
 function RepairFlash({ repairStatus }: { repairStatus: string | null }) {
-  if (repairStatus === 'queued') {
-    return (
-      <div className="notice neutral">
-        Catalog backfill work accepted. This row is not resolved yet; workers will process it
-        through the existing rate-limited TMDB path.
-      </div>
-    );
-  }
+  const view = buildRepairFlashViewModel(repairStatus);
 
-  if (repairStatus === 'deduped') {
-    return (
-      <div className="notice neutral">
-        Catalog backfill work was already queued. Workers will process the existing job through the
-        rate-limited TMDB path.
-      </div>
-    );
-  }
-
-  if (repairStatus === 'bulk-queued') {
-    return (
-      <div className="notice neutral">
-        Catalog repair batch accepted. Issues stay open until workers update the catalog and the
-        next health report clears them.
-      </div>
-    );
-  }
-
-  if (repairStatus === 'bulk-orchestration-queued') {
-    return (
-      <div className="notice neutral">
-        Catalog repair orchestration accepted. A durable batch was created; workers will add repair
-        items and queue backfill jobs in chunks.
-      </div>
-    );
-  }
-
-  if (repairStatus === 'bulk-partial') {
-    return (
-      <div className="notice warn">
-        Catalog repair batch partially queued. Check the recent repair audit before retrying.
-      </div>
-    );
-  }
-
-  if (repairStatus === 'unavailable') {
-    return (
-      <div className="notice warn">
-        Catalog repair queue is unavailable. Check REDIS_URL and the backoffice logs.
-      </div>
-    );
-  }
-
-  if (repairStatus === 'empty') {
-    return <div className="notice warn">No affected movies are currently available to queue.</div>;
-  }
-
-  if (repairStatus === 'failed') {
-    return (
-      <div className="notice warn">
-        Catalog repair action failed. Check backoffice logs for details.
-      </div>
-    );
-  }
-
-  return null;
+  return view ? <div className={`notice ${view.tone}`}>{view.copy}</div> : null;
 }
 
 function DuplicateGroup({ group }: { group: DuplicateIdentityGroup }) {
@@ -113,28 +52,26 @@ function DuplicateReport({
   title: string;
   report: CatalogHealthReport['duplicateTmdbIds'];
 }) {
-  const state = report.totalGroups > 0 ? 'warning' : 'healthy';
+  const view = buildDuplicateReportViewModel(report);
 
   return (
-    <section
-      className={`panel duplicate-panel ${report.totalGroups > 0 ? 'needs-work' : 'healthy'}`}
-    >
+    <section className={view.panelClassName}>
       <div className="panel-header">
         <div className="issue-title">
           <div className="issue-title-row">
             <h2>{title}</h2>
-            <span className={`pill ${state}`}>{report.totalGroups > 0 ? 'Review' : 'Healthy'}</span>
+            <span className={`pill ${view.state}`}>{view.pillLabel}</span>
           </div>
           <div className="issue-hint">
             Potential identity collisions that should be reviewed before merge automation.
           </div>
         </div>
-        <CountPill count={report.totalGroups} state={state} />
+        <CountPill count={report.totalGroups} state={view.state} />
       </div>
-      {report.groups.length === 0 ? (
+      {view.groups.length === 0 ? (
         <p className="empty">No duplicate groups found.</p>
       ) : (
-        report.groups.map((group) => <DuplicateGroup key={group.identityKey} group={group} />)
+        view.groups.map((group) => <DuplicateGroup key={group.identityKey} group={group} />)
       )}
     </section>
   );

--- a/apps/backoffice/src/components/catalog-health/issuePanel.tsx
+++ b/apps/backoffice/src/components/catalog-health/issuePanel.tsx
@@ -5,9 +5,7 @@ import type {
 } from '@pop-choice/shared';
 
 import {
-  DEFAULT_BULK_REPAIR_LIMIT,
   DEFAULT_CATALOG_ISSUE_PAGE_SIZE,
-  MAX_ASYNC_BULK_REPAIR_LIMIT,
   REPAIRABLE_CATALOG_ISSUE_KEYS,
 } from '../../lib/backoffice';
 import {
@@ -17,26 +15,26 @@ import {
   SimplePaginationControls,
 } from '../shared';
 import { buildCatalogIssuePageHref } from '../shared/hrefs';
-
-export function catalogIssueHint(issueKey: string): string {
-  const hints: Record<string, string> = {
-    missing_age_rating: 'Age-rating gaps reduce safety and household filtering quality.',
-    missing_cast_metadata: 'Cast gaps limit actor-aware recommendation features.',
-    missing_director_metadata: 'Director gaps limit creator-aware recommendation features.',
-    missing_genre_metadata: 'Genre gaps weaken discovery and future filters.',
-    missing_keyword_metadata: 'Keyword gaps reduce nuance for ranking and search.',
-    missing_localized_name: 'Localized names improve non-English operator and user views.',
-    missing_poster_url: 'Poster coverage affects result cards and catalog browsing.',
-    missing_runtime: 'Runtime gaps make fit and pacing recommendations weaker.',
-    missing_tmdb_id: 'Identity gaps block richer TMDB refreshes and joins.',
-    missing_tmdb_matched_at: 'Matched rows need timestamps for stale-data decisions.',
-    stale_tmdb_metadata: 'Refresh candidates through the rate-limited TMDB path.',
-  };
-
-  return hints[issueKey] ?? 'Review affected catalog records.';
-}
+import {
+  buildCatalogIssuePanelViewModel,
+  catalogIssueHint,
+  type BulkRepairActionViewModel,
+} from './viewModels';
 
 export { buildCatalogIssuePageHref };
+export { catalogIssueHint };
+
+const SAMPLE_TABLE_COLUMNS = [
+  'ID',
+  'Movie',
+  'Year',
+  'TMDB',
+  'Poster',
+  'Localized',
+  'Runtime',
+  'Age',
+  'Matched',
+] as const;
 
 function SampleRows({
   emptyLabel = 'No sample records returned.',
@@ -56,15 +54,9 @@ function SampleRows({
       <table className="sample-table">
         <thead>
           <tr>
-            <th>ID</th>
-            <th>Movie</th>
-            <th>Year</th>
-            <th>TMDB</th>
-            <th>Poster</th>
-            <th>Localized</th>
-            <th>Runtime</th>
-            <th>Age</th>
-            <th>Matched</th>
+            {SAMPLE_TABLE_COLUMNS.map((column) => (
+              <th key={column}>{column}</th>
+            ))}
             {canRepair ? <th>Repair</th> : null}
           </tr>
         </thead>
@@ -125,46 +117,40 @@ function SampleRows({
 }
 
 function BulkRepairForm({ issue }: { issue: CatalogHealthIssue }) {
-  const batchLimit = Math.min(issue.count, DEFAULT_BULK_REPAIR_LIMIT);
-  const allLimit = Math.min(issue.count, MAX_ASYNC_BULK_REPAIR_LIMIT);
-  const allLabel =
-    issue.count > MAX_ASYNC_BULK_REPAIR_LIMIT ? `Queue first ${allLimit}` : `Queue all ${allLimit}`;
+  const { bulkActions } = buildCatalogIssuePanelViewModel({ issue, issuePage: null });
 
   return (
     <div className="bulk-repair-actions">
-      <form
-        className="bulk-repair-form"
-        method="post"
-        action="/catalog-health/actions"
-        data-bulk-repair-form
-        data-confirm-message={`Queue up to ${batchLimit} repair jobs for ${issue.label}? Workers will keep the existing TMDB/OpenAI pacing.`}
-      >
-        <input type="hidden" name="action" value="bulk_enqueue_backfill" />
-        <input type="hidden" name="issue_key" value={issue.key} />
-        <input type="hidden" name="batch_limit" value={batchLimit} />
-        <button className="button secondary small" type="submit" data-repair-submit>
-          Queue next {batchLimit}
-        </button>
-        <span className="repair-message" aria-live="polite" data-repair-message />
-      </form>
-      {allLimit > batchLimit ? (
-        <form
-          className="bulk-repair-form"
-          method="post"
-          action="/catalog-health/actions"
-          data-bulk-repair-form
-          data-confirm-message={`${allLabel} repair jobs for ${issue.label}? Backoffice will create a durable batch now, then workers will add repair jobs in chunks.`}
-        >
-          <input type="hidden" name="action" value="bulk_enqueue_backfill_async" />
-          <input type="hidden" name="issue_key" value={issue.key} />
-          <input type="hidden" name="batch_limit" value={allLimit} />
-          <button className="button quiet small" type="submit" data-repair-submit>
-            {allLabel}
-          </button>
-          <span className="repair-message" aria-live="polite" data-repair-message />
-        </form>
-      ) : null}
+      {bulkActions.map((action) => (
+        <BulkRepairActionForm key={action.action} action={action} issueKey={issue.key} />
+      ))}
     </div>
+  );
+}
+
+function BulkRepairActionForm({
+  action,
+  issueKey,
+}: {
+  action: BulkRepairActionViewModel;
+  issueKey: string;
+}) {
+  return (
+    <form
+      className="bulk-repair-form"
+      method="post"
+      action="/catalog-health/actions"
+      data-bulk-repair-form
+      data-confirm-message={action.confirmMessage}
+    >
+      <input type="hidden" name="action" value={action.action} />
+      <input type="hidden" name="issue_key" value={issueKey} />
+      <input type="hidden" name="batch_limit" value={action.batchLimit} />
+      <button className={action.buttonClassName} type="submit" data-repair-submit>
+        {action.label}
+      </button>
+      <span className="repair-message" aria-live="polite" data-repair-message />
+    </form>
   );
 }
 
@@ -203,78 +189,51 @@ export function CatalogIssuePanel({
   issue: CatalogHealthIssue;
   issuePage: CatalogHealthIssueMoviePage | null;
 }) {
-  const severity = issue.count > 0 ? 'needs-work' : 'healthy';
-  const canRepair = REPAIRABLE_CATALOG_ISSUE_KEYS.has(issue.key);
-  const state = issue.count === 0 ? 'healthy' : canRepair ? 'repairable' : 'warning';
-  const activePage = issuePage?.issueKey === issue.key ? issuePage : null;
-  const rows = activePage ? activePage.movies : issue.samples;
+  const view = buildCatalogIssuePanelViewModel({ issue, issuePage });
 
   return (
-    <section
-      id={`issue-${issue.key}`}
-      className={`panel issue-panel ${severity} ${canRepair && issue.count > 0 ? 'repairable' : ''}`}
-    >
+    <section id={`issue-${issue.key}`} className={view.panelClassName}>
       <div className="panel-header issue-panel-header">
         <div className="issue-title">
           <div className="issue-title-row">
             <h2>{issue.label}</h2>
-            <span className={`pill ${state}`}>
-              {issue.count === 0 ? 'Healthy' : canRepair ? 'Repairable' : 'Review'}
-            </span>
+            <span className={`pill ${view.countState}`}>{view.pillLabel}</span>
           </div>
-          <div className="issue-hint">{catalogIssueHint(issue.key)}</div>
+          <div className="issue-hint">{view.hint}</div>
         </div>
         <div className="issue-panel-controls">
           <div className="issue-panel-row-actions">
-            <CountPill count={issue.count} state={state} />
-            {issue.count > 0 ? (
-              <a
-                className={`button small ${activePage ? 'quiet' : ''}`}
-                href={buildCatalogIssuePageHref({
-                  issueKey: issue.key,
-                  page: 1,
-                  pageSize: activePage?.limit ?? DEFAULT_CATALOG_ISSUE_PAGE_SIZE,
-                })}
-              >
-                {activePage ? 'Browsing rows' : 'Browse rows'}
+            <CountPill count={issue.count} state={view.countState} />
+            {view.browseAction ? (
+              <a className={view.browseAction.className} href={view.browseAction.href}>
+                {view.browseAction.label}
               </a>
             ) : null}
           </div>
-          {canRepair && issue.count > 0 ? <BulkRepairForm issue={issue} /> : null}
+          {view.canRepair && issue.count > 0 ? <BulkRepairForm issue={issue} /> : null}
         </div>
       </div>
-      {issue.count === 0 ? (
+      {view.showHealthyEmpty ? (
         <p className="empty">No affected movies.</p>
       ) : (
         <>
-          {activePage ? (
+          {view.activePage ? (
             <CatalogIssuePagination
               ariaLabel={`${issue.label} affected movie pagination`}
               issue={issue}
-              page={activePage}
+              page={view.activePage}
             />
           ) : null}
-          <SampleRows
-            issueKey={issue.key}
-            samples={rows}
-            emptyLabel={activePage ? 'No affected movies on this page.' : undefined}
-          />
-          {activePage ? (
+          <SampleRows issueKey={issue.key} samples={view.rows} emptyLabel={view.emptyLabel} />
+          {view.activePage ? (
             <CatalogIssuePagination
               ariaLabel={`${issue.label} affected movie pagination bottom`}
               issue={issue}
-              page={activePage}
+              page={view.activePage}
             />
-          ) : issue.count > issue.samples.length ? (
+          ) : view.footerBrowseHref ? (
             <div className="panel-footer">
-              <a
-                className="button small"
-                href={buildCatalogIssuePageHref({
-                  issueKey: issue.key,
-                  page: 1,
-                  pageSize: DEFAULT_CATALOG_ISSUE_PAGE_SIZE,
-                })}
-              >
+              <a className="button small" href={view.footerBrowseHref}>
                 Browse all {issue.count} rows
               </a>
             </div>

--- a/apps/backoffice/src/components/catalog-health/viewModels.test.ts
+++ b/apps/backoffice/src/components/catalog-health/viewModels.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import { catalogHealthIssue, catalogMovieSample } from '../../test/backofficeFixtures';
+import {
+  buildCatalogIssuePanelViewModel,
+  buildDuplicateReportViewModel,
+  buildRepairFlashViewModel,
+  catalogIssueHint,
+} from './viewModels';
+
+describe('catalog health view models', () => {
+  it('builds repair flash messages by action status', () => {
+    expect(buildRepairFlashViewModel('queued')).toMatchObject({ tone: 'neutral' });
+    expect(buildRepairFlashViewModel('bulk-partial')).toMatchObject({ tone: 'warn' });
+    expect(buildRepairFlashViewModel('unknown')).toBeNull();
+  });
+
+  it('builds healthy, repairable, and paged issue panel state', () => {
+    expect(catalogIssueHint('missing_poster_url')).toContain('Poster coverage');
+    expect(
+      buildCatalogIssuePanelViewModel({
+        issue: catalogHealthIssue({ count: 0 }),
+        issuePage: null,
+      }),
+    ).toMatchObject({
+      countState: 'healthy',
+      pillLabel: 'Healthy',
+      showHealthyEmpty: true,
+    });
+
+    const issue = catalogHealthIssue({
+      count: 140,
+      key: 'missing_poster_url',
+      samples: [catalogMovieSample({ id: '1' })],
+    });
+    const view = buildCatalogIssuePanelViewModel({
+      issue,
+      issuePage: {
+        issueKey: 'missing_poster_url',
+        label: 'Missing poster_url',
+        limit: 25,
+        movies: [catalogMovieSample({ id: '2' })],
+        offset: 25,
+        totalCount: 140,
+      },
+    });
+
+    expect(view.countState).toBe('repairable');
+    expect(view.rows).toEqual([catalogMovieSample({ id: '2' })]);
+    expect(view.bulkActions.map((action) => action.action)).toEqual([
+      'bulk_enqueue_backfill',
+      'bulk_enqueue_backfill_async',
+    ]);
+    expect(view.browseAction).toMatchObject({ label: 'Browsing rows' });
+  });
+
+  it('builds duplicate report state', () => {
+    expect(buildDuplicateReportViewModel({ groups: [], totalGroups: 0 })).toMatchObject({
+      pillLabel: 'Healthy',
+      state: 'healthy',
+    });
+    expect(
+      buildDuplicateReportViewModel({
+        groups: [
+          {
+            count: 2,
+            identityKey: 'tmdb:42',
+            movies: [catalogMovieSample({ id: '1' }), catalogMovieSample({ id: '2' })],
+          },
+        ],
+        totalGroups: 1,
+      }),
+    ).toMatchObject({
+      panelClassName: 'panel duplicate-panel needs-work',
+      pillLabel: 'Review',
+      state: 'warning',
+    });
+  });
+});

--- a/apps/backoffice/src/components/catalog-health/viewModels.ts
+++ b/apps/backoffice/src/components/catalog-health/viewModels.ts
@@ -1,0 +1,217 @@
+import type {
+  CatalogHealthIssue,
+  CatalogHealthIssueMoviePage,
+  CatalogHealthReport,
+  CatalogMovieSample,
+} from '@pop-choice/shared';
+
+import {
+  DEFAULT_BULK_REPAIR_LIMIT,
+  DEFAULT_CATALOG_ISSUE_PAGE_SIZE,
+  MAX_ASYNC_BULK_REPAIR_LIMIT,
+  REPAIRABLE_CATALOG_ISSUE_KEYS,
+} from '../../lib/backoffice';
+import { buildCatalogIssuePageHref } from '../shared/hrefs';
+
+export interface RepairFlashViewModel {
+  copy: string;
+  tone: 'neutral' | 'warn';
+}
+
+export interface CatalogIssuePanelViewModel {
+  activePage: CatalogHealthIssueMoviePage | null;
+  browseAction: { className: string; href: string; label: string } | null;
+  bulkActions: BulkRepairActionViewModel[];
+  canRepair: boolean;
+  countState: 'healthy' | 'repairable' | 'warning';
+  emptyLabel: string;
+  footerBrowseHref: string | null;
+  hint: string;
+  panelClassName: string;
+  pillLabel: string;
+  rows: CatalogMovieSample[];
+  showHealthyEmpty: boolean;
+}
+
+export interface BulkRepairActionViewModel {
+  action: 'bulk_enqueue_backfill' | 'bulk_enqueue_backfill_async';
+  batchLimit: number;
+  buttonClassName: string;
+  confirmMessage: string;
+  label: string;
+}
+
+export interface DuplicateReportViewModel {
+  groups: CatalogHealthReport['duplicateTmdbIds']['groups'];
+  panelClassName: string;
+  pillLabel: 'Healthy' | 'Review';
+  state: 'healthy' | 'warning';
+}
+
+export function catalogIssueHint(issueKey: string): string {
+  return CATALOG_ISSUE_HINTS[issueKey] ?? 'Review affected catalog records.';
+}
+
+export function buildRepairFlashViewModel(
+  repairStatus: string | null,
+): RepairFlashViewModel | null {
+  return repairStatus ? (REPAIR_FLASH_MESSAGES[repairStatus] ?? null) : null;
+}
+
+export function buildCatalogIssuePanelViewModel({
+  issue,
+  issuePage,
+}: {
+  issue: CatalogHealthIssue;
+  issuePage: CatalogHealthIssueMoviePage | null;
+}): CatalogIssuePanelViewModel {
+  const canRepair = REPAIRABLE_CATALOG_ISSUE_KEYS.has(issue.key);
+  const activePage = issuePage?.issueKey === issue.key ? issuePage : null;
+  const countState = getIssueCountState(issue, canRepair);
+  const rows = activePage ? activePage.movies : issue.samples;
+
+  return {
+    activePage,
+    browseAction: buildIssueBrowseAction(issue, activePage),
+    bulkActions: canRepair && issue.count > 0 ? buildBulkRepairActions(issue) : [],
+    canRepair,
+    countState,
+    emptyLabel: activePage ? 'No affected movies on this page.' : 'No sample records returned.',
+    footerBrowseHref:
+      !activePage && issue.count > issue.samples.length
+        ? buildCatalogIssuePageHref({
+            issueKey: issue.key,
+            page: 1,
+            pageSize: DEFAULT_CATALOG_ISSUE_PAGE_SIZE,
+          })
+        : null,
+    hint: catalogIssueHint(issue.key),
+    panelClassName: [
+      'panel issue-panel',
+      issue.count > 0 ? 'needs-work' : 'healthy',
+      canRepair && issue.count > 0 ? 'repairable' : '',
+    ]
+      .filter(Boolean)
+      .join(' '),
+    pillLabel: issue.count === 0 ? 'Healthy' : canRepair ? 'Repairable' : 'Review',
+    rows,
+    showHealthyEmpty: issue.count === 0,
+  };
+}
+
+export function buildDuplicateReportViewModel(
+  report: CatalogHealthReport['duplicateTmdbIds'],
+): DuplicateReportViewModel {
+  const state = report.totalGroups > 0 ? 'warning' : 'healthy';
+
+  return {
+    groups: report.groups,
+    panelClassName: `panel duplicate-panel ${report.totalGroups > 0 ? 'needs-work' : 'healthy'}`,
+    pillLabel: report.totalGroups > 0 ? 'Review' : 'Healthy',
+    state,
+  };
+}
+
+function buildIssueBrowseAction(
+  issue: CatalogHealthIssue,
+  activePage: CatalogHealthIssueMoviePage | null,
+): CatalogIssuePanelViewModel['browseAction'] {
+  if (issue.count === 0) return null;
+
+  return {
+    className: `button small ${activePage ? 'quiet' : ''}`,
+    href: buildCatalogIssuePageHref({
+      issueKey: issue.key,
+      page: 1,
+      pageSize: activePage?.limit ?? DEFAULT_CATALOG_ISSUE_PAGE_SIZE,
+    }),
+    label: activePage ? 'Browsing rows' : 'Browse rows',
+  };
+}
+
+function buildBulkRepairActions(issue: CatalogHealthIssue): BulkRepairActionViewModel[] {
+  const batchLimit = Math.min(issue.count, DEFAULT_BULK_REPAIR_LIMIT);
+  const allLimit = Math.min(issue.count, MAX_ASYNC_BULK_REPAIR_LIMIT);
+  const actions: BulkRepairActionViewModel[] = [
+    {
+      action: 'bulk_enqueue_backfill',
+      batchLimit,
+      buttonClassName: 'button secondary small',
+      confirmMessage: `Queue up to ${batchLimit} repair jobs for ${issue.label}? Workers will keep the existing TMDB/OpenAI pacing.`,
+      label: `Queue next ${batchLimit}`,
+    },
+  ];
+
+  if (allLimit > batchLimit) {
+    const allLabel =
+      issue.count > MAX_ASYNC_BULK_REPAIR_LIMIT
+        ? `Queue first ${allLimit}`
+        : `Queue all ${allLimit}`;
+    actions.push({
+      action: 'bulk_enqueue_backfill_async',
+      batchLimit: allLimit,
+      buttonClassName: 'button quiet small',
+      confirmMessage: `${allLabel} repair jobs for ${issue.label}? Backoffice will create a durable batch now, then workers will add repair jobs in chunks.`,
+      label: allLabel,
+    });
+  }
+
+  return actions;
+}
+
+function getIssueCountState(
+  issue: CatalogHealthIssue,
+  canRepair: boolean,
+): CatalogIssuePanelViewModel['countState'] {
+  if (issue.count === 0) return 'healthy';
+  return canRepair ? 'repairable' : 'warning';
+}
+
+const CATALOG_ISSUE_HINTS: Record<string, string> = {
+  missing_age_rating: 'Age-rating gaps reduce safety and household filtering quality.',
+  missing_cast_metadata: 'Cast gaps limit actor-aware recommendation features.',
+  missing_director_metadata: 'Director gaps limit creator-aware recommendation features.',
+  missing_genre_metadata: 'Genre gaps weaken discovery and future filters.',
+  missing_keyword_metadata: 'Keyword gaps reduce nuance for ranking and search.',
+  missing_localized_name: 'Localized names improve non-English operator and user views.',
+  missing_poster_url: 'Poster coverage affects result cards and catalog browsing.',
+  missing_runtime: 'Runtime gaps make fit and pacing recommendations weaker.',
+  missing_tmdb_id: 'Identity gaps block richer TMDB refreshes and joins.',
+  missing_tmdb_matched_at: 'Matched rows need timestamps for stale-data decisions.',
+  stale_tmdb_metadata: 'Refresh candidates through the rate-limited TMDB path.',
+};
+
+const REPAIR_FLASH_MESSAGES: Record<string, RepairFlashViewModel> = {
+  'bulk-orchestration-queued': {
+    copy: 'Catalog repair orchestration accepted. A durable batch was created; workers will add repair items and queue backfill jobs in chunks.',
+    tone: 'neutral',
+  },
+  'bulk-partial': {
+    copy: 'Catalog repair batch partially queued. Check the recent repair audit before retrying.',
+    tone: 'warn',
+  },
+  'bulk-queued': {
+    copy: 'Catalog repair batch accepted. Issues stay open until workers update the catalog and the next health report clears them.',
+    tone: 'neutral',
+  },
+  deduped: {
+    copy: 'Catalog backfill work was already queued. Workers will process the existing job through the rate-limited TMDB path.',
+    tone: 'neutral',
+  },
+  empty: {
+    copy: 'No affected movies are currently available to queue.',
+    tone: 'warn',
+  },
+  failed: {
+    copy: 'Catalog repair action failed. Check backoffice logs for details.',
+    tone: 'warn',
+  },
+  queued: {
+    copy: 'Catalog backfill work accepted. This row is not resolved yet; workers will process it through the existing rate-limited TMDB path.',
+    tone: 'neutral',
+  },
+  unavailable: {
+    copy: 'Catalog repair queue is unavailable. Check REDIS_URL and the backoffice logs.',
+    tone: 'warn',
+  },
+};


### PR DESCRIPTION
## Summary
- Extract catalog health repair flash, issue panel, bulk repair action, and duplicate report display state into pure view-model helpers
- Simplify catalog health panels to render derived state instead of branching through UI conditions
- Add unit coverage for repair flash status mapping, repairable/paged issue state, and duplicate report state

## Fallow impact
- Baseline after #756: 83 findings, 12 critical / 27 high / 44 moderate
- This branch: 80 findings, 12 critical / 25 high / 43 moderate
- Backoffice findings: 14 -> 11
- Changed-code Fallow: health 0, dead-code 0, dupes 0

Part of #744.

## Verification
- npm run test --workspace=apps/backoffice -- src/components/catalog-health/viewModels.test.ts
- npm run type-check --workspace=apps/backoffice
- npm run lint:check
- npm run build --workspace=apps/backoffice
- npx fallow health --format json --quiet --changed-since origin/development
- npx fallow dead-code --format json --quiet --changed-since origin/development
- npx fallow dupes --format json --quiet --changed-since origin/development
- pre-push: lint, server tests, production build, Storybook tests