### PR TITLE
Split repair batch action view models

### DIFF
--- a/apps/backoffice/src/app/repair-batches/[id]/actions/route.test.ts
+++ b/apps/backoffice/src/app/repair-batches/[id]/actions/route.test.ts
@@ -105,4 +105,27 @@ describe('repair batch action route', () => {
       expect.any(Headers),
     );
   });
+
+  it('maps unavailable retry results to the JSON failure contract', async () => {
+    mocks.retryCatalogRepairBatchItem.mockResolvedValue({
+      batchId: 'batch-1',
+      issueKey: 'missing_poster_url',
+      item: { batchId: 'batch-1', id: 'item-1', status: 'unavailable' },
+      job: null,
+      status: 'unavailable',
+    });
+
+    const response = await POST(createRetryRequest() as never, {
+      params: Promise.resolve({ id: 'batch-1' }),
+    });
+
+    await expectBackofficeActionJson(response, {
+      body: expect.objectContaining({
+        message: 'Queue is unavailable; retry item remains unresolved.',
+        ok: false,
+        status: 'unavailable',
+      }),
+      status: 503,
+    });
+  });
 });

--- a/apps/backoffice/src/app/repair-batches/[id]/actions/route.ts
+++ b/apps/backoffice/src/app/repair-batches/[id]/actions/route.ts
@@ -16,6 +16,8 @@ type RepairBatchActionContext = {
   params: Promise<{ id: string }>;
 };
 
+type RepairBatchRetryResult = Awaited<ReturnType<typeof retryCatalogRepairBatchItem>>;
+
 function buildRepairBatchRedirectUrl({
   request,
   returnPath,
@@ -30,58 +32,98 @@ function buildRepairBatchRedirectUrl({
   return url;
 }
 
+function buildRepairBatchActionRedirect({
+  request,
+  returnPath,
+  status,
+}: {
+  request: NextRequest;
+  returnPath: string;
+  status: string;
+}) {
+  return NextResponse.redirect(buildRepairBatchRedirectUrl({ request, returnPath, status }), 303);
+}
+
+function ensureRepairBatchFormBatchId(formData: FormData, batchId: string): void {
+  const formBatchId = formData.get('batch_id');
+  if (typeof formBatchId !== 'string' || formBatchId.trim() === '') {
+    formData.set('batch_id', batchId);
+  }
+}
+
+function getRepairBatchRetryMessage(status: RepairBatchRetryResult['status']): string {
+  if (status === 'unavailable') return 'Queue is unavailable; retry item remains unresolved.';
+  if (status === 'failed') return 'Retry failed before the item could be queued.';
+  return 'Repair batch item retry queued.';
+}
+
+function getRepairBatchRetryStatusCode(status: RepairBatchRetryResult['status']): number {
+  if (status === 'unavailable') return 503;
+  if (status === 'failed') return 500;
+  return 200;
+}
+
+function buildRepairBatchRetryJsonResponse(result: RepairBatchRetryResult, returnPath: string) {
+  const ok = result.status === 'queued' || result.status === 'deduped';
+
+  return NextResponse.json(
+    {
+      ok,
+      status: result.status,
+      message: getRepairBatchRetryMessage(result.status),
+      batchId: result.batchId,
+      issueKey: result.issueKey,
+      item: result.item,
+      job: result.job,
+      redirectTo: returnPath,
+    },
+    { status: getRepairBatchRetryStatusCode(result.status) },
+  );
+}
+
+function buildRepairBatchForbiddenResponse(request: NextRequest, returnPath: string) {
+  if (wantsBackofficeJsonResponse(request)) {
+    return backofficeActionFailureResponse('Forbidden.', 403);
+  }
+
+  return buildRepairBatchActionRedirect({ request, returnPath, status: 'forbidden' });
+}
+
+async function handleRepairBatchRetryRequest({
+  batchId,
+  request,
+  returnPath,
+}: {
+  batchId: string;
+  request: NextRequest;
+  returnPath: string;
+}) {
+  const formData = await request.formData();
+  ensureRepairBatchFormBatchId(formData, batchId);
+  const parsedReturnPath = parseBackofficeReturnPath(formData.get('return_to')) || returnPath;
+  const result = await retryCatalogRepairBatchItem(formData, request.headers);
+
+  if (wantsBackofficeJsonResponse(request)) {
+    return buildRepairBatchRetryJsonResponse(result, parsedReturnPath);
+  }
+
+  return buildRepairBatchActionRedirect({
+    request,
+    returnPath: parsedReturnPath,
+    status: result.status,
+  });
+}
+
 export async function POST(request: NextRequest, context: RepairBatchActionContext) {
   const { id } = await context.params;
   let returnPath = `/repair-batches/${encodeURIComponent(id)}`;
 
   try {
     if (!isSameOriginRequest(request)) {
-      if (wantsBackofficeJsonResponse(request)) {
-        return backofficeActionFailureResponse('Forbidden.', 403);
-      }
-
-      return NextResponse.redirect(
-        buildRepairBatchRedirectUrl({ request, returnPath, status: 'forbidden' }),
-        303,
-      );
+      return buildRepairBatchForbiddenResponse(request, returnPath);
     }
 
-    const formData = await request.formData();
-    const batchId = formData.get('batch_id');
-    if (typeof batchId !== 'string' || batchId.trim() === '') {
-      formData.set('batch_id', id);
-    }
-    returnPath = parseBackofficeReturnPath(formData.get('return_to')) || returnPath;
-    const result = await retryCatalogRepairBatchItem(formData, request.headers);
-    const ok = result.status === 'queued' || result.status === 'deduped';
-
-    if (wantsBackofficeJsonResponse(request)) {
-      return NextResponse.json(
-        {
-          ok,
-          status: result.status,
-          message:
-            result.status === 'unavailable'
-              ? 'Queue is unavailable; retry item remains unresolved.'
-              : result.status === 'failed'
-                ? 'Retry failed before the item could be queued.'
-                : 'Repair batch item retry queued.',
-          batchId: result.batchId,
-          issueKey: result.issueKey,
-          item: result.item,
-          job: result.job,
-          redirectTo: returnPath,
-        },
-        {
-          status: result.status === 'unavailable' ? 503 : result.status === 'failed' ? 500 : 200,
-        },
-      );
-    }
-
-    return NextResponse.redirect(
-      buildRepairBatchRedirectUrl({ request, returnPath, status: result.status }),
-      303,
-    );
+    return await handleRepairBatchRetryRequest({ batchId: id, request, returnPath });
   } catch (error) {
     logBackofficeError('Failed to retry catalog repair batch item', error);
     if (wantsBackofficeJsonResponse(request)) {
@@ -91,9 +133,6 @@ export async function POST(request: NextRequest, context: RepairBatchActionConte
       );
     }
 
-    return NextResponse.redirect(
-      buildRepairBatchRedirectUrl({ request, returnPath, status: 'failed' }),
-      303,
-    );
+    return buildRepairBatchActionRedirect({ request, returnPath, status: 'failed' });
   }
 }

--- a/apps/backoffice/src/components/repair-batches/detailSections.tsx
+++ b/apps/backoffice/src/components/repair-batches/detailSections.tsx
@@ -3,39 +3,18 @@ import type { CatalogRepairBatch, CatalogRepairBatchItem } from '@pop-choice/sha
 import { formatBackofficeDateTime } from '../../lib/backoffice';
 import { RepairStatusBadge, repairStatusLabel } from '../catalog-repair-status';
 import { CatalogStat, PanelHeader, TableEmptyRow } from '../shared';
-import {
-  getRepairBatchProgress,
-  issueHref,
-  movieHref,
-  repairItemPressureLabel,
-  resultValue,
-  snapshotValue,
-  truncateText,
-} from './helpers';
+import { getRepairBatchProgress, issueHref } from './helpers';
+import { getRepairBatchItemRowView, type RepairBatchItemRowView } from './viewModels';
 
-const RETRIABLE_ITEM_STATUSES = new Set<CatalogRepairBatchItem['status']>([
-  'failed',
-  'enqueue_failed',
-  'unavailable',
-]);
-
-function canRetryRepairBatchItem(item: CatalogRepairBatchItem): boolean {
-  return RETRIABLE_ITEM_STATUSES.has(item.status);
-}
-
-function RepairBatchItemAction({ item }: { item: CatalogRepairBatchItem }) {
-  if (!canRetryRepairBatchItem(item)) return <span className="muted">Inspect</span>;
+function RepairBatchItemAction({ action }: { action: RepairBatchItemRowView['action'] }) {
+  if (action.type === 'inspect') return <span className="muted">Inspect</span>;
 
   return (
-    <form action={`/repair-batches/${encodeURIComponent(item.batchId)}/actions`} method="post">
+    <form action={`/repair-batches/${encodeURIComponent(action.batchId)}/actions`} method="post">
       <input type="hidden" name="action" value="retry_item" />
-      <input type="hidden" name="batch_id" value={item.batchId} />
-      <input type="hidden" name="item_id" value={item.id} />
-      <input
-        type="hidden"
-        name="return_to"
-        value={`/repair-batches/${encodeURIComponent(item.batchId)}?status=needs_review`}
-      />
+      <input type="hidden" name="batch_id" value={action.batchId} />
+      <input type="hidden" name="item_id" value={action.itemId} />
+      <input type="hidden" name="return_to" value={action.returnTo} />
       <button className="button small secondary" type="submit">
         Retry item
       </button>
@@ -50,62 +29,58 @@ export function RepairBatchItemRows({ items }: { items: CatalogRepairBatchItem[]
     );
   }
 
+  const rows = items.map(getRepairBatchItemRowView);
+
   return (
     <>
-      {items.map((item) => {
-        const name = snapshotValue(item.movieSnapshot, 'name');
-        const year = snapshotValue(item.movieSnapshot, 'year');
-        const attempts =
-          resultValue(item.result, 'attemptsMade') ??
-          resultValue(item.result, 'attempts') ??
-          resultValue(item.result, 'attempt');
-
-        return (
-          <tr key={item.id}>
-            <td>#{item.id}</td>
-            <td>
-              <a href={issueHref(item.issueKey)}>{item.issueKey}</a>
-            </td>
-            <td>
-              <div className="movie-title">
-                <strong>
-                  <a href={movieHref(item.movieId)}>{name ?? `Movie ${item.movieId}`}</a>
-                </strong>
-                <span className="muted">
-                  #{item.movieId}
-                  {year === null || year === undefined ? '' : ` · ${year}`}
-                </span>
-              </div>
-            </td>
-            <td>
-              <RepairStatusBadge status={item.status} />
-            </td>
-            <td>
-              <div className="queue-metadata">
-                <strong>{item.jobId ?? '-'}</strong>
-                <span>{item.queueName ?? 'queue unknown'}</span>
-                <span>{item.jobName ?? 'job unknown'}</span>
-              </div>
-            </td>
-            <td>{item.reason ?? '-'}</td>
-            <td>{item.language ?? '-'}</td>
-            <td>
-              <span title={item.errorMessage ?? undefined}>{truncateText(item.errorMessage)}</span>
-            </td>
-            <td>
-              <div className="queue-metadata">
-                <strong>{repairItemPressureLabel(item)}</strong>
-                <span>{attempts === null ? 'attempts unknown' : `${attempts} attempts`}</span>
-              </div>
-            </td>
-            <td>{formatBackofficeDateTime(item.updatedAt)}</td>
-            <td>
-              <RepairBatchItemAction item={item} />
-            </td>
-          </tr>
-        );
-      })}
+      {rows.map((row) => (
+        <RepairBatchItemRow key={row.id} row={row} />
+      ))}
     </>
+  );
+}
+
+function RepairBatchItemRow({ row }: { row: RepairBatchItemRowView }) {
+  return (
+    <tr>
+      <td>#{row.id}</td>
+      <td>
+        <a href={row.issueHref}>{row.issueKey}</a>
+      </td>
+      <td>
+        <div className="movie-title">
+          <strong>
+            <a href={row.movieHref}>{row.movieLabel}</a>
+          </strong>
+          <span className="muted">{row.movieMeta}</span>
+        </div>
+      </td>
+      <td>
+        <RepairStatusBadge status={row.status} />
+      </td>
+      <td>
+        <div className="queue-metadata">
+          <strong>{row.jobIdLabel}</strong>
+          <span>{row.queueNameLabel}</span>
+          <span>{row.jobNameLabel}</span>
+        </div>
+      </td>
+      <td>{row.reasonLabel}</td>
+      <td>{row.languageLabel}</td>
+      <td>
+        <span title={row.errorTitle}>{row.errorLabel}</span>
+      </td>
+      <td>
+        <div className="queue-metadata">
+          <strong>{row.pressureLabel}</strong>
+          <span>{row.attemptsLabel}</span>
+        </div>
+      </td>
+      <td>{row.updatedAtLabel}</td>
+      <td>
+        <RepairBatchItemAction action={row.action} />
+      </td>
+    </tr>
   );
 }
 

--- a/apps/backoffice/src/components/repair-batches/viewModels.test.ts
+++ b/apps/backoffice/src/components/repair-batches/viewModels.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { catalogRepairBatchItem } from '../../test/backofficeFixtures';
+import { canRetryRepairBatchItem, getRepairBatchItemRowView } from './viewModels';
+
+describe('repair batch view models', () => {
+  it('marks only retryable item statuses as retry actions', () => {
+    expect(canRetryRepairBatchItem(catalogRepairBatchItem({ status: 'failed' }))).toBe(true);
+    expect(canRetryRepairBatchItem(catalogRepairBatchItem({ status: 'enqueue_failed' }))).toBe(
+      true,
+    );
+    expect(canRetryRepairBatchItem(catalogRepairBatchItem({ status: 'unavailable' }))).toBe(true);
+    expect(
+      canRetryRepairBatchItem(catalogRepairBatchItem({ status: 'completed_unresolved' })),
+    ).toBe(false);
+  });
+
+  it('builds stable display labels for a repair batch item row', () => {
+    const view = getRepairBatchItemRowView(
+      catalogRepairBatchItem({
+        batchId: 'batch:7',
+        id: 'item-7',
+        movieId: '99',
+        movieSnapshot: { name: 'Primer', year: 2004 },
+        result: { attemptsMade: 3 },
+        status: 'failed',
+      }),
+    );
+
+    expect(view).toMatchObject({
+      action: {
+        batchId: 'batch:7',
+        itemId: 'item-7',
+        returnTo: '/repair-batches/batch%3A7?status=needs_review',
+        type: 'retry',
+      },
+      attemptsLabel: '3 attempts',
+      issueHref: '/#issue-missing_poster_url',
+      movieHref: '/movies/99',
+      movieLabel: 'Primer',
+      movieMeta: '#99 · 2004',
+      pressureLabel: 'Retry pressure: high',
+    });
+  });
+});

--- a/apps/backoffice/src/components/repair-batches/viewModels.ts
+++ b/apps/backoffice/src/components/repair-batches/viewModels.ts
@@ -1,0 +1,101 @@
+import type { CatalogRepairBatchItem } from '@pop-choice/shared';
+
+import { formatBackofficeDateTime } from '../../lib/backoffice';
+import {
+  issueHref,
+  movieHref,
+  repairItemPressureLabel,
+  resultValue,
+  snapshotValue,
+  truncateText,
+} from './helpers';
+
+const RETRIABLE_ITEM_STATUSES = new Set<CatalogRepairBatchItem['status']>([
+  'failed',
+  'enqueue_failed',
+  'unavailable',
+]);
+
+export type RepairBatchItemRowView = {
+  action:
+    | {
+        batchId: string;
+        itemId: string;
+        returnTo: string;
+        type: 'retry';
+      }
+    | { type: 'inspect' };
+  attemptsLabel: string;
+  errorLabel: string;
+  errorTitle?: string;
+  id: string;
+  issueHref: string;
+  issueKey: string;
+  jobIdLabel: string;
+  jobNameLabel: string;
+  languageLabel: string;
+  movieHref: string;
+  movieLabel: string;
+  movieMeta: string;
+  pressureLabel: string;
+  queueNameLabel: string;
+  reasonLabel: string;
+  status: CatalogRepairBatchItem['status'];
+  updatedAtLabel: string;
+};
+
+export function canRetryRepairBatchItem(item: Pick<CatalogRepairBatchItem, 'status'>): boolean {
+  return RETRIABLE_ITEM_STATUSES.has(item.status);
+}
+
+export function getRepairBatchItemRowView(item: CatalogRepairBatchItem): RepairBatchItemRowView {
+  const attempts =
+    resultValue(item.result, 'attemptsMade') ??
+    resultValue(item.result, 'attempts') ??
+    resultValue(item.result, 'attempt');
+  const movieName = snapshotValue(item.movieSnapshot, 'name');
+  const movieYear = snapshotValue(item.movieSnapshot, 'year');
+
+  return {
+    action: getRepairBatchItemActionView(item),
+    attemptsLabel: attempts === null ? 'attempts unknown' : `${attempts} attempts`,
+    errorLabel: truncateText(item.errorMessage),
+    errorTitle: item.errorMessage ?? undefined,
+    id: item.id,
+    issueHref: issueHref(item.issueKey),
+    issueKey: item.issueKey,
+    jobIdLabel: item.jobId ?? '-',
+    jobNameLabel: item.jobName ?? 'job unknown',
+    languageLabel: item.language ?? '-',
+    movieHref: movieHref(item.movieId),
+    movieLabel:
+      movieName === null || movieName === undefined ? `Movie ${item.movieId}` : String(movieName),
+    movieMeta: getRepairBatchItemMovieMeta(item.movieId, movieYear),
+    pressureLabel: repairItemPressureLabel(item),
+    queueNameLabel: item.queueName ?? 'queue unknown',
+    reasonLabel: item.reason ?? '-',
+    status: item.status,
+    updatedAtLabel: formatBackofficeDateTime(item.updatedAt),
+  };
+}
+
+function getRepairBatchItemActionView(
+  item: CatalogRepairBatchItem,
+): RepairBatchItemRowView['action'] {
+  if (!canRetryRepairBatchItem(item)) return { type: 'inspect' };
+
+  return {
+    batchId: item.batchId,
+    itemId: item.id,
+    returnTo: `/repair-batches/${encodeURIComponent(item.batchId)}?status=needs_review`,
+    type: 'retry',
+  };
+}
+
+function getRepairBatchItemMovieMeta(
+  movieId: string,
+  year: string | number | null | undefined,
+): string {
+  const yearLabel = year === null || year === undefined ? '' : ` · ${year}`;
+  return `#${movieId}${yearLabel}`;
+}


### PR DESCRIPTION
## Summary
- Extract repair batch item row display/action state into a pure view-model helper with unit coverage.
- Simplify the repair batch item table renderer to consume derived row state.
- Split the repair batch retry action route into focused helpers for redirects, form normalization, JSON contracts, and forbidden/error responses.

## Fallow
- Baseline after #757: 80 health findings, 12 critical / 25 high / 43 moderate; backoffice 11.
- This branch: 78 health findings, 12 critical / 25 high / 41 moderate; backoffice 9.
- Changed-code Fallow: health 0, dead-code 0, dupes 0.

## Validation
- npm run test --workspace=apps/backoffice -- src/components/repair-batches/viewModels.test.ts src/components/repair-batches/detailSections.test.tsx 'src/app/repair-batches/[id]/actions/route.test.ts'
- npm run type-check --workspace=apps/backoffice
- npm run lint:check
- npm run build --workspace=apps/backoffice
- git diff --check
- pre-push: lint, server tests, production build; Storybook skipped (no Storybook-relevant changes)

Part of #744.