### PR TITLE
Add movie detail backoffice coverage

### DIFF
--- a/apps/backoffice/src/app/movies/[id]/page.test.tsx
+++ b/apps/backoffice/src/app/movies/[id]/page.test.tsx
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { catalogMovieDetail } from '../../../test/backofficeFixtures';
+
+const mocks = vi.hoisted(() => ({
+  BackofficeErrorPage: vi.fn(),
+  CatalogMovieDetailPage: vi.fn(),
+  ensureBackofficeReady: vi.fn(),
+  getCatalogMovieDetail: vi.fn(),
+  logBackofficeError: vi.fn(),
+  notFound: vi.fn(() => {
+    throw new Error('NEXT_NOT_FOUND');
+  }),
+}));
+
+vi.mock('@pop-choice/shared', () => ({
+  getCatalogMovieDetail: mocks.getCatalogMovieDetail,
+}));
+
+vi.mock('next/navigation', () => ({
+  notFound: mocks.notFound,
+}));
+
+vi.mock('../../../components/backoffice', () => ({
+  BackofficeErrorPage: mocks.BackofficeErrorPage,
+  CatalogMovieDetailPage: mocks.CatalogMovieDetailPage,
+}));
+
+vi.mock('../../../lib/backoffice', () => ({
+  ensureBackofficeReady: mocks.ensureBackofficeReady,
+  logBackofficeError: mocks.logBackofficeError,
+}));
+
+import CatalogMovieDetailRoute from './page';
+
+describe('CatalogMovieDetailRoute', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('loads movie detail with config-driven stale age and normalized repair status', async () => {
+    const detail = catalogMovieDetail();
+    mocks.ensureBackofficeReady.mockResolvedValue({ catalogHealthStaleDays: 11 });
+    mocks.getCatalogMovieDetail.mockResolvedValue({ detail, status: 'found' });
+
+    const element = await CatalogMovieDetailRoute({
+      params: Promise.resolve({ id: '42' }),
+      searchParams: Promise.resolve({ repair: ['queued', 'failed'] }),
+    });
+
+    expect(mocks.getCatalogMovieDetail).toHaveBeenCalledWith({
+      movieId: '42',
+      staleAfterDays: 11,
+    });
+    expect(element.type).toBe(mocks.CatalogMovieDetailPage);
+    expect(element.props).toMatchObject({ detail, repairStatus: 'queued' });
+  });
+
+  it('renders the backoffice error page when detail loading fails', async () => {
+    const error = new Error('database unavailable');
+    mocks.ensureBackofficeReady.mockRejectedValue(error);
+
+    const element = await CatalogMovieDetailRoute({
+      params: Promise.resolve({ id: 'movie:42' }),
+      searchParams: Promise.resolve({}),
+    });
+
+    expect(mocks.logBackofficeError).toHaveBeenCalledWith(
+      'Failed to render catalog movie detail',
+      error,
+    );
+    expect(element.type).toBe(mocks.BackofficeErrorPage);
+    expect(element.props).toMatchObject({
+      active: 'health',
+      error,
+      retryHref: '/movies/movie%3A42',
+    });
+  });
+
+  it('delegates not-found results to Next navigation', async () => {
+    mocks.ensureBackofficeReady.mockResolvedValue({ catalogHealthStaleDays: 7 });
+    mocks.getCatalogMovieDetail.mockResolvedValue({ movieId: '404', status: 'not_found' });
+
+    await expect(
+      CatalogMovieDetailRoute({
+        params: Promise.resolve({ id: '404' }),
+      }),
+    ).rejects.toThrow('NEXT_NOT_FOUND');
+    expect(mocks.notFound).toHaveBeenCalled();
+  });
+});

--- a/apps/backoffice/src/components/movie-detail/identityPanel.test.tsx
+++ b/apps/backoffice/src/components/movie-detail/identityPanel.test.tsx
@@ -1,0 +1,44 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { catalogMovieDetail, catalogMovieDetailHealthFlag } from '../../test/backofficeFixtures';
+import { MovieIdentityPanel } from './identityPanel';
+
+describe('MovieIdentityPanel', () => {
+  it('renders active issue, poster fallback, localized title, and TMDB metadata', () => {
+    const html = renderToStaticMarkup(<MovieIdentityPanel detail={catalogMovieDetail()} />);
+
+    expect(html).toContain('Movie #42');
+    expect(html).toContain('1 active issue(s)');
+    expect(html).toContain('No poster');
+    expect(html).toContain('Fuego contra fuego');
+    expect(html).toContain('2h 50m');
+    expect(html).toContain('href="https://www.themoviedb.org/movie/949"');
+    expect(html).toContain('92%');
+    expect(html).toContain('manual_review');
+  });
+
+  it('renders the healthy state and local fallbacks when metadata is missing', () => {
+    const detail = catalogMovieDetail({
+      healthFlags: [catalogMovieDetailHealthFlag({ isActive: false })],
+      movie: {
+        ...catalogMovieDetail().movie,
+        ageRating: '',
+        description: '',
+        localizedName: null,
+        posterUrl: 'https://image.test/poster.jpg',
+        tmdbId: null,
+        tmdbMatchConfidence: null,
+        tmdbMatchSource: null,
+      },
+    });
+
+    const html = renderToStaticMarkup(<MovieIdentityPanel detail={detail} />);
+
+    expect(html).toContain('Healthy');
+    expect(html).toContain('src="https://image.test/poster.jpg"');
+    expect(html).toContain('Heat poster');
+    expect(html).toContain('No local description stored.');
+    expect(html).toContain('<span class="data-pill neutral">-</span>');
+  });
+});

--- a/apps/backoffice/src/components/movie-detail/repairPanel.test.tsx
+++ b/apps/backoffice/src/components/movie-detail/repairPanel.test.tsx
@@ -1,0 +1,46 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { catalogMovieDetail, catalogMovieDetailHealthFlag } from '../../test/backofficeFixtures';
+import { MovieRepairPanel } from './repairPanel';
+
+describe('MovieRepairPanel', () => {
+  it('renders the focused repair form for repairable active flags', () => {
+    const html = renderToStaticMarkup(
+      <MovieRepairPanel detail={catalogMovieDetail()} repairStatus="queued" />,
+    );
+
+    expect(html).toContain('1 repairable');
+    expect(html).toContain('repair-message accepted');
+    expect(html).toContain('name="action" value="enqueue_backfill"');
+    expect(html).toContain('name="movie_id" value="42"');
+    expect(html).toContain('name="issue_key"');
+    expect(html).toContain('Missing poster');
+    expect(html).toContain('Queue focused repair');
+  });
+
+  it('renders manual-review copy for active non-repairable flags', () => {
+    const detail = catalogMovieDetail({
+      healthFlags: [catalogMovieDetailHealthFlag({ key: 'duplicate_tmdb_id', label: 'Duplicate' })],
+    });
+
+    const html = renderToStaticMarkup(<MovieRepairPanel detail={detail} repairStatus="failed" />);
+
+    expect(html).toContain('No action');
+    expect(html).toContain('repair-message warn');
+    expect(html).toContain('manual review or duplicate-merge tooling');
+    expect(html).not.toContain('Queue focused repair');
+  });
+
+  it('renders the no-active-flags copy for healthy movies', () => {
+    const detail = catalogMovieDetail({
+      healthFlags: [catalogMovieDetailHealthFlag({ isActive: false })],
+    });
+
+    const html = renderToStaticMarkup(<MovieRepairPanel detail={detail} repairStatus={null} />);
+
+    expect(html).toContain('No action');
+    expect(html).toContain('No active catalog-health flags need repair for this movie.');
+    expect(html).not.toContain('repair-message');
+  });
+});

--- a/apps/backoffice/src/components/movie-detail/taxonomyPanels.test.tsx
+++ b/apps/backoffice/src/components/movie-detail/taxonomyPanels.test.tsx
@@ -1,0 +1,52 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import {
+  catalogMovieDetailPersonCredit,
+  catalogMovieDetailTaxonomyItem,
+} from '../../test/backofficeFixtures';
+import { PeopleTable, TaxonomyList } from './taxonomyPanels';
+
+describe('movie detail taxonomy panels', () => {
+  it('renders taxonomy chips and empty taxonomy states', () => {
+    expect(
+      renderToStaticMarkup(
+        <TaxonomyList emptyLabel="No genres stored" items={[catalogMovieDetailTaxonomyItem()]} />,
+      ),
+    ).toContain('Crime');
+
+    expect(
+      renderToStaticMarkup(<TaxonomyList emptyLabel="No genres stored" items={[]} />),
+    ).toContain('No genres stored');
+  });
+
+  it('renders people rows with role, TMDB, order, and fallback fields', () => {
+    const html = renderToStaticMarkup(
+      <PeopleTable
+        emptyLabel="No people stored"
+        people={[
+          catalogMovieDetailPersonCredit(),
+          catalogMovieDetailPersonCredit({
+            billingOrder: null,
+            characterName: null,
+            id: 'credit-2',
+            job: 'Director',
+            name: 'Michael Mann',
+            role: 'director',
+            tmdbId: null,
+          }),
+        ]}
+      />,
+    );
+
+    expect(html).toContain('Robert De Niro');
+    expect(html).toContain('Neil McCauley');
+    expect(html).toContain('380');
+    expect(html).toContain('Michael Mann');
+    expect(html).toContain('Director');
+    expect(html).toContain('<td>-</td>');
+    expect(
+      renderToStaticMarkup(<PeopleTable emptyLabel="No people stored" people={[]} />),
+    ).toContain('No people stored');
+  });
+});

--- a/apps/backoffice/src/test/backofficeFixtures.ts
+++ b/apps/backoffice/src/test/backofficeFixtures.ts
@@ -1,5 +1,9 @@
 import type {
   CatalogHealthIssue,
+  CatalogMovieDetail,
+  CatalogMovieDetailHealthFlag,
+  CatalogMovieDetailPersonCredit,
+  CatalogMovieDetailTaxonomyItem,
   CatalogMovieSample,
   CatalogRepairBatch,
   CatalogRepairBatchItem,
@@ -25,6 +29,98 @@ export function catalogMovieSample(
     tmdb_id: null,
     tmdb_matched_at: null,
     year: 1995,
+    ...overrides,
+  };
+}
+
+export function catalogMovieDetailHealthFlag(
+  overrides: Partial<CatalogMovieDetailHealthFlag> = {},
+): CatalogMovieDetailHealthFlag {
+  return {
+    isActive: true,
+    key: 'missing_poster_url',
+    label: 'Missing poster',
+    ...overrides,
+  };
+}
+
+export function catalogMovieDetailPersonCredit(
+  overrides: Partial<CatalogMovieDetailPersonCredit> = {},
+): CatalogMovieDetailPersonCredit {
+  return {
+    billingOrder: 1,
+    characterName: 'Neil McCauley',
+    department: null,
+    id: 'credit-1',
+    job: null,
+    name: 'Robert De Niro',
+    personId: 'person-1',
+    popularity: 12,
+    profilePath: null,
+    rawMetadata: {},
+    role: 'cast',
+    tmdbCreditId: 'credit-tmdb-1',
+    tmdbId: 380,
+    ...overrides,
+  };
+}
+
+export function catalogMovieDetailTaxonomyItem(
+  overrides: Partial<CatalogMovieDetailTaxonomyItem> = {},
+): CatalogMovieDetailTaxonomyItem {
+  return {
+    id: 'genre-1',
+    name: 'Crime',
+    rawMetadata: {},
+    source: 'tmdb',
+    tmdbId: 80,
+    ...overrides,
+  };
+}
+
+export function catalogMovieDetail(
+  overrides: Partial<CatalogMovieDetail> = {},
+): CatalogMovieDetail {
+  return {
+    cast: [catalogMovieDetailPersonCredit()],
+    directors: [
+      catalogMovieDetailPersonCredit({
+        billingOrder: null,
+        characterName: null,
+        id: 'credit-director-1',
+        job: 'Director',
+        name: 'Michael Mann',
+        personId: 'person-director-1',
+        role: 'director',
+        tmdbId: 638,
+      }),
+    ],
+    duplicateContext: {
+      normalizedTitleYearPeers: [],
+      tmdbIdPeers: [],
+    },
+    genres: [catalogMovieDetailTaxonomyItem()],
+    healthFlags: [catalogMovieDetailHealthFlag()],
+    keywords: [catalogMovieDetailTaxonomyItem({ id: 'keyword-1', name: 'heist', tmdbId: 100 })],
+    movie: {
+      ageRating: 'R',
+      description: 'A crew and a detective move through Los Angeles.',
+      duration: 170,
+      id: '42',
+      localizedName: 'Fuego contra fuego',
+      name: 'Heat',
+      posterUrl: null,
+      scoreRating: 8.3,
+      tmdbId: 949,
+      tmdbMatchConfidence: 0.92,
+      tmdbMatchSource: 'manual_review',
+      tmdbMatchedAt: '2026-06-02T12:00:00.000Z',
+      tmdbMetadata: {},
+      tmdbMetadataRefreshedAt: '2026-06-03T12:00:00.000Z',
+      year: 1995,
+    },
+    relatedReviews: [],
+    repairAudit: [],
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary
- Add reusable catalog movie detail fixtures for backoffice tests.
- Cover movie detail identity, repair, taxonomy, and route branches with focused unit/component tests.
- Remove the movie-detail Fallow health findings via coverage without changing UI behavior.

## Fallow
- Baseline after #758: 78 health findings, 12 critical / 25 high / 41 moderate; backoffice 9.
- This branch: 72 health findings, 12 critical / 21 high / 39 moderate; backoffice 3.
- Changed-code Fallow: health 0, dead-code 0, dupes 0.

## Validation
- npm run test --workspace=apps/backoffice -- 'src/app/movies/[id]/page.test.tsx' src/components/movie-detail/identityPanel.test.tsx src/components/movie-detail/repairPanel.test.tsx src/components/movie-detail/taxonomyPanels.test.tsx
- npm run type-check --workspace=apps/backoffice
- npm run lint:check
- npm run build --workspace=apps/backoffice
- git diff --check
- pre-push: lint, server tests, production build; Storybook skipped (no Storybook-relevant changes)

Part of #744.