### PR TITLE
Split recommendation eval action responses

### DIFF
--- a/apps/backoffice/src/app/api/recommendation-evals/route.test.ts
+++ b/apps/backoffice/src/app/api/recommendation-evals/route.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  ensureBackofficeReady: vi.fn(),
+  isSameOriginRequest: vi.fn(),
+  listRecommendationEvalRunPage: vi.fn(),
+  logBackofficeError: vi.fn(),
+  parseRecommendationEvalListParams: vi.fn(),
+  performRecommendationEvalAction: vi.fn(),
+}));
+
+vi.mock('@pop-choice/shared', () => ({
+  listRecommendationEvalRunPage: mocks.listRecommendationEvalRunPage,
+}));
+
+vi.mock('../../../lib/backoffice', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../lib/backoffice')>();
+  return {
+    ...actual,
+    ensureBackofficeReady: mocks.ensureBackofficeReady,
+    logBackofficeError: mocks.logBackofficeError,
+    parseRecommendationEvalListParams: mocks.parseRecommendationEvalListParams,
+    performRecommendationEvalAction: mocks.performRecommendationEvalAction,
+  };
+});
+
+vi.mock('../../../lib/sameOriginRequest', () => ({
+  isSameOriginRequest: mocks.isSameOriginRequest,
+}));
+
+import { GET, POST } from './route';
+
+function createJsonRequest(body: unknown = {}) {
+  return new Request('https://backoffice.test/api/recommendation-evals', {
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json', 'x-csrf-token': 'token' },
+    method: 'POST',
+  });
+}
+
+describe('recommendation eval API route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.ensureBackofficeReady.mockResolvedValue({ redisUrl: 'redis://example.test' });
+    mocks.isSameOriginRequest.mockReturnValue(true);
+    mocks.parseRecommendationEvalListParams.mockReturnValue({ limit: 25, offset: 0 });
+  });
+
+  it('returns a no-store eval run page JSON response', async () => {
+    const runPage = { limit: 25, offset: 0, runs: [], totalCount: 0 };
+    mocks.listRecommendationEvalRunPage.mockResolvedValue(runPage);
+
+    const response = await GET(new Request('https://backoffice.test/api/recommendation-evals'));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    await expect(response.json()).resolves.toEqual(runPage);
+    expect(mocks.listRecommendationEvalRunPage).toHaveBeenCalledWith({ limit: 25, offset: 0 });
+  });
+
+  it('rejects cross-origin action requests', async () => {
+    mocks.isSameOriginRequest.mockReturnValue(false);
+
+    const response = await POST(createJsonRequest({ mode: 'mock' }) as never);
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      message: 'Forbidden.',
+      ok: false,
+      status: 'failed',
+    });
+    expect(mocks.performRecommendationEvalAction).not.toHaveBeenCalled();
+  });
+
+  it('maps JSON bodies into the shared eval action response contract', async () => {
+    mocks.performRecommendationEvalAction.mockResolvedValue({
+      jobId: 'job-1',
+      mode: 'live',
+      runId: 'run-1',
+      status: 'queued',
+    });
+
+    const response = await POST(
+      createJsonRequest({
+        acknowledgeLiveCost: true,
+        liveConfirmation: 'RUN LIVE RECOMMENDATION EVAL',
+        mode: 'live',
+      }) as never,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      jobId: 'job-1',
+      mode: 'live',
+      ok: true,
+      runId: 'run-1',
+      status: 'queued',
+    });
+
+    const formData = mocks.performRecommendationEvalAction.mock.calls[0]?.[0] as FormData;
+    expect(formData.get('mode')).toBe('live');
+    expect(formData.get('acknowledge_live_cost')).toBe('yes');
+    expect(formData.get('live_confirmation')).toBe('RUN LIVE RECOMMENDATION EVAL');
+  });
+
+  it('returns unavailable action results with a 503 JSON contract', async () => {
+    mocks.performRecommendationEvalAction.mockResolvedValue({
+      errorMessage: 'queue unavailable',
+      mode: 'mock',
+      runId: 'run-2',
+      status: 'unavailable',
+    });
+
+    const response = await POST(createJsonRequest({ mode: 'mock' }) as never);
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({
+      errorMessage: 'queue unavailable',
+      ok: false,
+      status: 'unavailable',
+    });
+  });
+});

--- a/apps/backoffice/src/app/api/recommendation-evals/route.ts
+++ b/apps/backoffice/src/app/api/recommendation-evals/route.ts
@@ -3,26 +3,32 @@ import { NextResponse, type NextRequest } from 'next/server';
 
 import {
   ensureBackofficeReady,
+  buildRecommendationEvalActionBody,
+  buildRecommendationEvalFormDataFromJsonBody,
+  getRecommendationEvalActionStatusCode,
   getBackofficeErrorStatus,
   logBackofficeError,
   parseRecommendationEvalListParams,
   performRecommendationEvalAction,
-  recommendationEvalMessage,
 } from '../../../lib/backoffice';
 import { isSameOriginRequest } from '../../../lib/sameOriginRequest';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
+async function readRecommendationEvalRunPage(request: Request) {
+  const searchParams = Object.fromEntries(new URL(request.url).searchParams.entries());
+  const pagination = parseRecommendationEvalListParams(searchParams);
+  return listRecommendationEvalRunPage({
+    limit: pagination.limit,
+    offset: pagination.offset,
+  });
+}
+
 export async function GET(request: Request) {
   try {
     await ensureBackofficeReady();
-    const searchParams = Object.fromEntries(new URL(request.url).searchParams.entries());
-    const pagination = parseRecommendationEvalListParams(searchParams);
-    const runPage = await listRecommendationEvalRunPage({
-      limit: pagination.limit,
-      offset: pagination.offset,
-    });
+    const runPage = await readRecommendationEvalRunPage(request);
 
     return NextResponse.json(runPage, {
       headers: {
@@ -47,37 +53,14 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
-    const formData = new FormData();
-    if (typeof body.mode === 'string') {
-      formData.set('mode', body.mode);
-    }
-    if (body.acknowledgeLiveCost === true || body.acknowledge_live_cost === 'yes') {
-      formData.set('acknowledge_live_cost', 'yes');
-    }
-    if (typeof body.liveConfirmation === 'string') {
-      formData.set('live_confirmation', body.liveConfirmation);
-    }
-    if (typeof body.live_confirmation === 'string') {
-      formData.set('live_confirmation', body.live_confirmation);
-    }
+    const formData = buildRecommendationEvalFormDataFromJsonBody(
+      (await request.json().catch(() => ({}))) as Record<string, unknown>,
+    );
     const result = await performRecommendationEvalAction(formData, request.headers);
 
-    return NextResponse.json(
-      {
-        ok: result.status === 'queued',
-        message: recommendationEvalMessage(result.status),
-        mode: result.mode,
-        runId: result.runId,
-        status: result.status,
-        ...(result.status === 'queued'
-          ? { jobId: result.jobId }
-          : { errorMessage: result.errorMessage }),
-      },
-      {
-        status: result.status === 'unavailable' ? 503 : result.status === 'failed' ? 500 : 200,
-      },
-    );
+    return NextResponse.json(buildRecommendationEvalActionBody(result), {
+      status: getRecommendationEvalActionStatusCode(result.status),
+    });
   } catch (error) {
     logBackofficeError('Failed to enqueue recommendation eval run', error);
     return NextResponse.json(

--- a/apps/backoffice/src/app/recommendation-evals/actions/route.test.ts
+++ b/apps/backoffice/src/app/recommendation-evals/actions/route.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createBackofficeFormRequest,
+  expectBackofficeActionFailureJson,
+  expectBackofficeActionJson,
+} from '../../../test/backofficeActionRoute';
+
+const mocks = vi.hoisted(() => ({
+  getBackofficeErrorStatus: vi.fn(),
+  isSameOriginRequest: vi.fn(),
+  logBackofficeError: vi.fn(),
+  performRecommendationEvalAction: vi.fn(),
+}));
+
+vi.mock('../../../lib/backoffice', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../lib/backoffice')>();
+  return {
+    ...actual,
+    getBackofficeErrorStatus: mocks.getBackofficeErrorStatus,
+    logBackofficeError: mocks.logBackofficeError,
+    performRecommendationEvalAction: mocks.performRecommendationEvalAction,
+  };
+});
+
+vi.mock('../../../lib/sameOriginRequest', () => ({
+  isSameOriginRequest: mocks.isSameOriginRequest,
+}));
+
+import { POST } from './route';
+
+function createEvalActionRequest({
+  fetch = true,
+  fields = { mode: 'mock' },
+}: {
+  fetch?: boolean;
+  fields?: Record<string, string>;
+} = {}) {
+  return createBackofficeFormRequest({
+    fetch,
+    fields,
+    url: 'https://backoffice.test/recommendation-evals/actions',
+  });
+}
+
+describe('recommendation eval form action route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getBackofficeErrorStatus.mockReturnValue(500);
+    mocks.isSameOriginRequest.mockReturnValue(true);
+  });
+
+  it('returns the JSON forbidden contract for cross-origin fetches', async () => {
+    mocks.isSameOriginRequest.mockReturnValue(false);
+
+    const response = await POST(createEvalActionRequest() as never);
+
+    await expectBackofficeActionFailureJson(response, { message: 'Forbidden.', status: 403 });
+    expect(mocks.performRecommendationEvalAction).not.toHaveBeenCalled();
+  });
+
+  it('returns the shared queued JSON contract for fetch requests', async () => {
+    mocks.performRecommendationEvalAction.mockResolvedValue({
+      jobId: 'job-1',
+      mode: 'mock',
+      runId: 'run-1',
+      status: 'queued',
+    });
+
+    const response = await POST(createEvalActionRequest() as never);
+
+    await expectBackofficeActionJson(response, {
+      body: expect.objectContaining({
+        jobId: 'job-1',
+        mode: 'mock',
+        ok: true,
+        runId: 'run-1',
+        status: 'queued',
+      }),
+      status: 200,
+    });
+    expect(mocks.performRecommendationEvalAction).toHaveBeenCalledWith(
+      expect.any(FormData),
+      expect.any(Headers),
+    );
+  });
+
+  it('redirects non-fetch form posts with the eval status', async () => {
+    mocks.performRecommendationEvalAction.mockResolvedValue({
+      errorMessage: 'queue unavailable',
+      mode: 'mock',
+      runId: 'run-2',
+      status: 'unavailable',
+    });
+
+    const response = await POST(createEvalActionRequest({ fetch: false }) as never);
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get('location')).toBe(
+      'https://backoffice.test/recommendation-evals?eval=unavailable',
+    );
+  });
+
+  it('returns the JSON error contract when the action throws', async () => {
+    const error = new Error('boom');
+    mocks.getBackofficeErrorStatus.mockReturnValue(422);
+    mocks.performRecommendationEvalAction.mockRejectedValue(error);
+
+    const response = await POST(createEvalActionRequest() as never);
+
+    await expectBackofficeActionJson(response, {
+      body: {
+        message: 'Recommendation eval action failed. Check backoffice logs for details.',
+        ok: false,
+        status: 'failed',
+      },
+      status: 422,
+    });
+    expect(mocks.logBackofficeError).toHaveBeenCalledWith(
+      'Failed to apply recommendation eval action',
+      error,
+    );
+  });
+});

--- a/apps/backoffice/src/app/recommendation-evals/actions/route.ts
+++ b/apps/backoffice/src/app/recommendation-evals/actions/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse, type NextRequest } from 'next/server';
 
 import {
+  buildRecommendationEvalActionBody,
+  getRecommendationEvalActionStatusCode,
   getBackofficeErrorStatus,
   logBackofficeError,
   performRecommendationEvalAction,
-  recommendationEvalMessage,
 } from '../../../lib/backoffice';
 import { isSameOriginRequest } from '../../../lib/sameOriginRequest';
 
@@ -36,21 +37,9 @@ export async function POST(request: NextRequest) {
     const result = await performRecommendationEvalAction(formData, request.headers);
 
     if (wantsJsonResponse(request)) {
-      return NextResponse.json(
-        {
-          ok: result.status === 'queued',
-          message: recommendationEvalMessage(result.status),
-          mode: result.mode,
-          runId: result.runId,
-          status: result.status,
-          ...(result.status === 'queued'
-            ? { jobId: result.jobId }
-            : { errorMessage: result.errorMessage }),
-        },
-        {
-          status: result.status === 'unavailable' ? 503 : result.status === 'failed' ? 500 : 200,
-        },
-      );
+      return NextResponse.json(buildRecommendationEvalActionBody(result), {
+        status: getRecommendationEvalActionStatusCode(result.status),
+      });
     }
 
     return NextResponse.redirect(

--- a/apps/backoffice/src/lib/backoffice.test.ts
+++ b/apps/backoffice/src/lib/backoffice.test.ts
@@ -8,6 +8,9 @@ import {
   MAX_QUEUE_JOB_PAGE_SIZE,
   MAX_RECOMMENDATION_EVAL_PAGE_SIZE,
   MAX_REPAIR_BATCH_PAGE_SIZE,
+  buildRecommendationEvalActionBody,
+  buildRecommendationEvalFormDataFromJsonBody,
+  getRecommendationEvalActionStatusCode,
   parseCatalogMaintenanceQueueParams,
   parseRecommendationEvalListParams,
   parseRecommendationEvalMode,
@@ -150,5 +153,55 @@ describe('recommendation eval params and actions', () => {
     accepted.set('live_confirmation', 'RUN LIVE RECOMMENDATION EVAL');
 
     expect(parseRecommendationEvalMode(accepted)).toBe('live');
+  });
+
+  it('builds recommendation eval action JSON contracts and status codes', () => {
+    expect(
+      buildRecommendationEvalActionBody({
+        jobId: 'job-1',
+        mode: 'mock',
+        runId: 'run-1',
+        status: 'queued',
+      }),
+    ).toMatchObject({
+      jobId: 'job-1',
+      ok: true,
+      status: 'queued',
+    });
+    expect(getRecommendationEvalActionStatusCode('queued')).toBe(200);
+
+    expect(
+      buildRecommendationEvalActionBody({
+        errorMessage: 'redis down',
+        mode: 'real-data',
+        runId: 'run-2',
+        status: 'unavailable',
+      }),
+    ).toMatchObject({
+      errorMessage: 'redis down',
+      ok: false,
+      status: 'unavailable',
+    });
+    expect(getRecommendationEvalActionStatusCode('unavailable')).toBe(503);
+    expect(getRecommendationEvalActionStatusCode('failed')).toBe(500);
+  });
+
+  it('maps recommendation eval JSON API bodies into action form data', () => {
+    const formData = buildRecommendationEvalFormDataFromJsonBody({
+      acknowledgeLiveCost: true,
+      liveConfirmation: 'RUN LIVE RECOMMENDATION EVAL',
+      mode: 'live',
+    });
+
+    expect(formData.get('mode')).toBe('live');
+    expect(formData.get('acknowledge_live_cost')).toBe('yes');
+    expect(formData.get('live_confirmation')).toBe('RUN LIVE RECOMMENDATION EVAL');
+
+    const snakeCase = buildRecommendationEvalFormDataFromJsonBody({
+      acknowledge_live_cost: 'yes',
+      live_confirmation: 'RUN LIVE RECOMMENDATION EVAL',
+    });
+    expect(snakeCase.get('acknowledge_live_cost')).toBe('yes');
+    expect(snakeCase.get('live_confirmation')).toBe('RUN LIVE RECOMMENDATION EVAL');
   });
 });

--- a/apps/backoffice/src/lib/recommendationEvalActions.ts
+++ b/apps/backoffice/src/lib/recommendationEvalActions.ts
@@ -54,9 +54,7 @@ export type RecommendationEvalActionResult =
       errorMessage: string;
     };
 
-export function recommendationEvalMessage(
-  status: RecommendationEvalActionResult['status'],
-): string {
+function recommendationEvalMessage(status: RecommendationEvalActionResult['status']): string {
   if (status === 'queued') {
     return 'Recommendation eval job queued. Workers will persist results when it finishes.';
   }
@@ -64,6 +62,49 @@ export function recommendationEvalMessage(
     return 'Recommendation eval queue is unavailable. Check REDIS_URL and worker status.';
   }
   return 'Recommendation eval failed to enqueue. Check backoffice logs before retrying.';
+}
+
+export function getRecommendationEvalActionStatusCode(
+  status: RecommendationEvalActionResult['status'],
+): number {
+  if (status === 'unavailable') return 503;
+  if (status === 'failed') return 500;
+  return 200;
+}
+
+export function buildRecommendationEvalActionBody(result: RecommendationEvalActionResult) {
+  return {
+    ok: result.status === 'queued',
+    message: recommendationEvalMessage(result.status),
+    mode: result.mode,
+    runId: result.runId,
+    status: result.status,
+    ...(result.status === 'queued'
+      ? { jobId: result.jobId }
+      : { errorMessage: result.errorMessage }),
+  };
+}
+
+export function buildRecommendationEvalFormDataFromJsonBody(
+  body: Record<string, unknown>,
+): FormData {
+  const formData = new FormData();
+  if (typeof body.mode === 'string') {
+    formData.set('mode', body.mode);
+  }
+  if (body.acknowledgeLiveCost === true || body.acknowledge_live_cost === 'yes') {
+    formData.set('acknowledge_live_cost', 'yes');
+  }
+  const liveConfirmation =
+    typeof body.liveConfirmation === 'string'
+      ? body.liveConfirmation
+      : typeof body.live_confirmation === 'string'
+        ? body.live_confirmation
+        : null;
+  if (liveConfirmation !== null) {
+    formData.set('live_confirmation', liveConfirmation);
+  }
+  return formData;
 }
 
 export async function performRecommendationEvalAction(


### PR DESCRIPTION
## Summary
- Add shared recommendation eval action response/status helpers and JSON body normalization.
- Reuse the shared contract in both the API POST and form action POST routes.
- Add focused route/helper tests for queued, forbidden, unavailable, redirect, and error contracts.

## Fallow
- Baseline after #759: 72 health findings, 12 critical / 21 high / 39 moderate; backoffice 3.
- This branch: 70 health findings, 11 critical / 20 high / 39 moderate; backoffice 1.
- Changed-code Fallow: health 0, dead-code 0, dupes 0.

## Validation
- npm run test --workspace=apps/backoffice -- src/lib/backoffice.test.ts src/app/api/recommendation-evals/route.test.ts src/app/recommendation-evals/actions/route.test.ts
- npm run type-check --workspace=apps/backoffice
- npm run lint:check
- npm run build --workspace=apps/backoffice
- git diff --check
- pre-push: lint, server tests, production build; Storybook skipped (no Storybook-relevant changes)

Part of #744.