### PR TITLE
Split catalog health repair action responses

### DIFF
--- a/apps/backoffice/src/app/catalog-health/actions/route.test.ts
+++ b/apps/backoffice/src/app/catalog-health/actions/route.test.ts
@@ -9,7 +9,9 @@ import {
 const mocks = vi.hoisted(() => ({
   backofficeActionErrorResponse: vi.fn(),
   backofficeActionFailureResponse: vi.fn(),
-  catalogRepairMessage: vi.fn(),
+  buildCatalogRepairActionBody: vi.fn(),
+  getCatalogRepairActionStatusCode: vi.fn(),
+  getCatalogRepairRedirectStatus: vi.fn(),
   getBackofficeErrorStatus: vi.fn(),
   isSameOriginRequest: vi.fn(),
   logBackofficeError: vi.fn(),
@@ -21,7 +23,9 @@ const mocks = vi.hoisted(() => ({
 vi.mock('../../../lib/backoffice', () => ({
   backofficeActionErrorResponse: mocks.backofficeActionErrorResponse,
   backofficeActionFailureResponse: mocks.backofficeActionFailureResponse,
-  catalogRepairMessage: mocks.catalogRepairMessage,
+  buildCatalogRepairActionBody: mocks.buildCatalogRepairActionBody,
+  getCatalogRepairActionStatusCode: mocks.getCatalogRepairActionStatusCode,
+  getCatalogRepairRedirectStatus: mocks.getCatalogRepairRedirectStatus,
   getBackofficeErrorStatus: mocks.getBackofficeErrorStatus,
   logBackofficeError: mocks.logBackofficeError,
   parseBackofficeReturnPath: mocks.parseBackofficeReturnPath,
@@ -62,7 +66,34 @@ function createRepairRequest({
 describe('catalog health repair action route', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.catalogRepairMessage.mockImplementation((status: string) => `message:${status}`);
+    mocks.buildCatalogRepairActionBody.mockImplementation((result) => ({
+      ok:
+        result.status === 'queued' ||
+        result.status === 'deduped' ||
+        result.status === 'orchestration_queued',
+      mode: result.mode,
+      status: result.status,
+      message: `message:${result.status}`,
+      issueKey: result.issueKey,
+      ...(result.mode === 'single'
+        ? { movieId: result.movieId, job: result.job }
+        : { summary: result.summary }),
+    }));
+    mocks.getCatalogRepairActionStatusCode.mockImplementation((status: string) => {
+      if (status === 'unavailable') return 503;
+      if (status === 'failed') return 500;
+      if (status === 'partial') return 207;
+      return 200;
+    });
+    mocks.getCatalogRepairRedirectStatus.mockImplementation((result) => {
+      if (result.status === 'queued') return result.mode === 'bulk' ? 'bulk-queued' : 'queued';
+      if (result.status === 'deduped') return 'deduped';
+      if (result.status === 'orchestration_queued') return 'bulk-orchestration-queued';
+      if (result.status === 'partial') return 'bulk-partial';
+      if (result.status === 'empty') return 'empty';
+      if (result.status === 'failed') return 'failed';
+      return 'unavailable';
+    });
     mocks.getBackofficeErrorStatus.mockReturnValue(500);
     mocks.isSameOriginRequest.mockReturnValue(true);
     mocks.parseBackofficeReturnPath.mockImplementation((value: FormDataEntryValue | null) =>

--- a/apps/backoffice/src/app/catalog-health/actions/route.ts
+++ b/apps/backoffice/src/app/catalog-health/actions/route.ts
@@ -3,7 +3,9 @@ import { NextResponse, type NextRequest } from 'next/server';
 import {
   backofficeActionErrorResponse,
   backofficeActionFailureResponse,
-  catalogRepairMessage,
+  buildCatalogRepairActionBody,
+  getCatalogRepairActionStatusCode,
+  getCatalogRepairRedirectStatus,
   logBackofficeError,
   parseBackofficeReturnPath,
   performCatalogRepairAction,
@@ -12,16 +14,6 @@ import {
 import { isSameOriginRequest } from '../../../lib/sameOriginRequest';
 
 export const dynamic = 'force-dynamic';
-
-function repairRedirectStatus(result: Awaited<ReturnType<typeof performCatalogRepairAction>>) {
-  if (result.status === 'queued') return result.mode === 'bulk' ? 'bulk-queued' : 'queued';
-  if (result.status === 'deduped') return 'deduped';
-  if (result.status === 'orchestration_queued') return 'bulk-orchestration-queued';
-  if (result.status === 'partial') return 'bulk-partial';
-  if (result.status === 'empty') return 'empty';
-  if (result.status === 'failed') return 'failed';
-  return 'unavailable';
-}
 
 function buildRepairRedirectUrl({
   request,
@@ -54,39 +46,16 @@ export async function POST(request: NextRequest) {
     const result = await performCatalogRepairAction(formData, request.headers);
 
     if (wantsBackofficeJsonResponse(request)) {
-      const ok =
-        result.status === 'queued' ||
-        result.status === 'deduped' ||
-        result.status === 'orchestration_queued';
-      return NextResponse.json(
-        {
-          ok,
-          mode: result.mode,
-          status: result.status,
-          message: catalogRepairMessage(result.status),
-          issueKey: result.issueKey,
-          ...(result.mode === 'single'
-            ? { movieId: result.movieId, job: result.job }
-            : { summary: result.summary }),
-        },
-        {
-          status:
-            result.status === 'unavailable'
-              ? 503
-              : result.status === 'failed'
-                ? 500
-                : result.status === 'partial'
-                  ? 207
-                  : 200,
-        },
-      );
+      return NextResponse.json(buildCatalogRepairActionBody(result), {
+        status: getCatalogRepairActionStatusCode(result.status),
+      });
     }
 
     return NextResponse.redirect(
       buildRepairRedirectUrl({
         request,
         returnPath,
-        repairStatus: repairRedirectStatus(result),
+        repairStatus: getCatalogRepairRedirectStatus(result),
       }),
       303,
     );

--- a/apps/backoffice/src/lib/backoffice.ts
+++ b/apps/backoffice/src/lib/backoffice.ts
@@ -4,6 +4,7 @@ export * from './backofficeActionLog';
 export * from './backofficeMetrics';
 export * from './backofficeRuntime';
 export * from './catalogRepairActions';
+export * from './catalogRepairActionResponse';
 export * from './catalogRepairBatchActions';
 export * from './recommendationEvalActions';
 export * from './tmdbReviewActions';

--- a/apps/backoffice/src/lib/catalogRepairActionResponse.ts
+++ b/apps/backoffice/src/lib/catalogRepairActionResponse.ts
@@ -1,0 +1,38 @@
+import { catalogRepairMessage } from './catalogRepairActionHelpers';
+
+import type { CatalogRepairActionStatus } from './catalogRepairActionHelpers';
+import type { CatalogRepairActionResult } from './catalogRepairActions';
+
+function isCatalogRepairActionOk(status: CatalogRepairActionStatus): boolean {
+  return status === 'queued' || status === 'deduped' || status === 'orchestration_queued';
+}
+
+export function getCatalogRepairActionStatusCode(status: CatalogRepairActionStatus): number {
+  if (status === 'unavailable') return 503;
+  if (status === 'failed') return 500;
+  if (status === 'partial') return 207;
+  return 200;
+}
+
+export function getCatalogRepairRedirectStatus(result: CatalogRepairActionResult): string {
+  if (result.status === 'queued') return result.mode === 'bulk' ? 'bulk-queued' : 'queued';
+  if (result.status === 'deduped') return 'deduped';
+  if (result.status === 'orchestration_queued') return 'bulk-orchestration-queued';
+  if (result.status === 'partial') return 'bulk-partial';
+  if (result.status === 'empty') return 'empty';
+  if (result.status === 'failed') return 'failed';
+  return 'unavailable';
+}
+
+export function buildCatalogRepairActionBody(result: CatalogRepairActionResult) {
+  return {
+    ok: isCatalogRepairActionOk(result.status),
+    mode: result.mode,
+    status: result.status,
+    message: catalogRepairMessage(result.status),
+    issueKey: result.issueKey,
+    ...(result.mode === 'single'
+      ? { movieId: result.movieId, job: result.job }
+      : { summary: result.summary }),
+  };
+}

--- a/apps/backoffice/src/lib/catalogRepairActions.test.ts
+++ b/apps/backoffice/src/lib/catalogRepairActions.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import { catalogRepairMessage, REPAIRABLE_CATALOG_ISSUE_KEYS } from './catalogRepairActions';
 import { getBackfillReasonForIssue, getBulkRepairStatus } from './catalogRepairActionHelpers';
+import {
+  buildCatalogRepairActionBody,
+  getCatalogRepairActionStatusCode,
+  getCatalogRepairRedirectStatus,
+} from './catalogRepairActionResponse';
 
 describe('catalog repair actions', () => {
   it('keeps every known automatic repair issue registered as repairable', () => {
@@ -51,5 +56,101 @@ describe('catalog repair actions', () => {
     expect(getBulkRepairStatus({ ...base, failed: 1, queued: 4 })).toBe('partial');
     expect(getBulkRepairStatus({ ...base, failed: 1 })).toBe('failed');
     expect(getBulkRepairStatus({ ...base, unavailable: 10 })).toBe('unavailable');
+  });
+
+  it('builds catalog repair JSON contracts and response status codes', () => {
+    expect(
+      buildCatalogRepairActionBody({
+        issueKey: 'missing_poster_url',
+        job: {
+          jobId: 'backfill-42',
+          jobName: 'catalog-backfill-movie',
+          language: 'en-US',
+          queueName: 'catalog-maintenance',
+          status: 'queued',
+        },
+        mode: 'single',
+        movieId: '42',
+        status: 'queued',
+      }),
+    ).toMatchObject({
+      issueKey: 'missing_poster_url',
+      job: {
+        jobId: 'backfill-42',
+        jobName: 'catalog-backfill-movie',
+        language: 'en-US',
+        queueName: 'catalog-maintenance',
+        status: 'queued',
+      },
+      mode: 'single',
+      movieId: '42',
+      ok: true,
+      status: 'queued',
+    });
+    expect(getCatalogRepairActionStatusCode('queued')).toBe(200);
+
+    expect(
+      buildCatalogRepairActionBody({
+        issueKey: 'missing_poster_url',
+        mode: 'bulk',
+        status: 'partial',
+        summary: {
+          attempted: 2,
+          deduped: 0,
+          failed: 1,
+          issueKey: 'missing_poster_url',
+          jobs: [],
+          limit: 2,
+          movieIds: ['42'],
+          queued: 1,
+          totalCandidates: 2,
+          unavailable: 0,
+        },
+      }),
+    ).toMatchObject({
+      mode: 'bulk',
+      ok: false,
+      status: 'partial',
+    });
+    expect(getCatalogRepairActionStatusCode('partial')).toBe(207);
+    expect(getCatalogRepairActionStatusCode('unavailable')).toBe(503);
+    expect(getCatalogRepairActionStatusCode('failed')).toBe(500);
+  });
+
+  it('maps catalog repair results into redirect status flags', () => {
+    expect(
+      getCatalogRepairRedirectStatus({
+        issueKey: 'missing_poster_url',
+        job: {
+          jobId: 'backfill-42',
+          jobName: 'catalog-backfill-movie',
+          language: 'en-US',
+          queueName: 'catalog-maintenance',
+          status: 'queued',
+        },
+        mode: 'single',
+        movieId: '42',
+        status: 'queued',
+      }),
+    ).toBe('queued');
+    expect(
+      getCatalogRepairRedirectStatus({
+        issueKey: 'missing_poster_url',
+        mode: 'bulk',
+        status: 'orchestration_queued',
+        summary: {
+          attempted: 0,
+          deduped: 0,
+          failed: 0,
+          issueKey: 'missing_poster_url',
+          jobs: [],
+          limit: 10,
+          movieIds: [],
+          queued: 0,
+          totalCandidates: 10,
+          unavailable: 0,
+        },
+      }),
+    ).toBe('bulk-orchestration-queued');
   });
 });


### PR DESCRIPTION
## Summary
- move catalog-health repair JSON/status/redirect mapping into catalog repair helpers
- keep the action route focused on origin checks, response mode, and redirects
- add helper coverage for JSON body/status codes and redirect status flags

## Fallow / Quality
- Changed-code Fallow: health 0, dead-code 0, dupes 0
- Full Fallow health after this branch: 69 total findings; 11 critical / 20 high / 38 moderate
- Backoffice health findings: 0
- Full dead-code: 0

## Validation
- npm run test --workspace=apps/backoffice -- src/lib/catalogRepairActions.test.ts src/app/catalog-health/actions/route.test.ts
- npm run type-check --workspace=apps/backoffice
- npm run build --workspace=apps/backoffice
- npm run lint:check
- npm run test:server
- npm run build

Part of #744.