### PR TITLE
Split auth guard complexity

### DIFF
--- a/apps/web/src/lib/apiAuth.ts
+++ b/apps/web/src/lib/apiAuth.ts
@@ -25,65 +25,19 @@ let cachedValidKeys: { rawKeys: string; hashBuffers: Buffer[] } | null = null;
 
 export async function validateApiKey(req: Request): Promise<string | null> {
   const rawKeys = process.env.VALID_API_KEYS;
+  const configuredKeys = rawKeys?.trim() ? rawKeys : null;
 
-  // Development mode: auth is disabled when VALID_API_KEYS is not configured.
-  if (!rawKeys || rawKeys.trim() === '') {
-    if (process.env.NODE_ENV !== 'production') {
-      if (!hasLoggedMissingKeysWarning) {
-        logger.warn(
-          'VALID_API_KEYS is not set — API authentication is disabled. Set this variable in production.',
-        );
-        hasLoggedMissingKeysWarning = true;
-      }
-      return 'dev-unauthenticated';
-    }
-    // In production with no keys configured, deny all requests to prevent an
-    // accidentally open API from consuming quota.
-    if (!hasLoggedMissingKeysError) {
-      logger.error(
-        'VALID_API_KEYS is not configured in production — all API requests will be rejected.',
-      );
-      hasLoggedMissingKeysError = true;
-    }
-    return null;
-  }
+  if (!configuredKeys) return resolveMissingApiKeysClientId();
 
-  const validHashBuffers = getValidHashBuffers(rawKeys);
-
+  const validHashBuffers = getValidHashBuffers(configuredKeys);
   const derivationSecret = getConfiguredDerivationSecret();
+
   if (!derivationSecret) {
-    if (!hasLoggedMissingSecretError) {
-      logger.error(
-        'API_KEY_HMAC_SECRET must be set when VALID_API_KEYS is configured — rejecting API requests.',
-      );
-      hasLoggedMissingSecretError = true;
-    }
+    logMissingDerivationSecret();
     return null;
   }
 
-  // Extract the raw key from the request headers.
-  const authHeader = req.headers.get('authorization');
-  const apiKeyHeader = req.headers.get('x-api-key');
-
-  let candidateKey: string | null = null;
-
-  if (authHeader) {
-    const parts = authHeader.split(' ');
-    if (parts.length === 2 && parts[0].toLowerCase() === 'bearer') {
-      const bearerToken = parts[1].trim();
-      if (bearerToken) {
-        candidateKey = bearerToken;
-      }
-    }
-  }
-
-  if (!candidateKey && apiKeyHeader) {
-    const trimmedApiKeyHeader = apiKeyHeader.trim();
-    if (trimmedApiKeyHeader) {
-      candidateKey = trimmedApiKeyHeader;
-    }
-  }
-
+  const candidateKey = extractCandidateApiKey(req.headers);
   if (!candidateKey) {
     logger.warn({ ip: getRequestIp(req) }, 'API auth failed: no key provided');
     return null;
@@ -94,16 +48,7 @@ export async function validateApiKey(req: Request): Promise<string | null> {
   const candidateHash = await hashApiKeyWithSecretAsync(candidateKey, derivationSecret);
   const candidateHashBuf = Buffer.from(candidateHash, 'hex');
 
-  const matched = validHashBuffers.some((storedHashBuf) => {
-    if (storedHashBuf.length !== candidateHashBuf.length) return false;
-    try {
-      return timingSafeEqual(storedHashBuf, candidateHashBuf);
-    } catch {
-      return false;
-    }
-  });
-
-  if (!matched) {
+  if (!hasMatchingApiKeyHash(validHashBuffers, candidateHashBuf)) {
     // Log the first 8 characters of the hash (not the key itself) for audit trail.
     logger.warn(
       { keyPrefix: candidateHash.substring(0, 8), ip: getRequestIp(req) },
@@ -116,6 +61,70 @@ export async function validateApiKey(req: Request): Promise<string | null> {
   const clientId = `client:${candidateHash.substring(0, 12)}`;
   logger.debug({ clientId }, 'API auth succeeded');
   return clientId;
+}
+
+function resolveMissingApiKeysClientId(): string | null {
+  if (process.env.NODE_ENV !== 'production') {
+    logMissingKeysWarning();
+    return 'dev-unauthenticated';
+  }
+
+  logMissingKeysProductionError();
+  return null;
+}
+
+function logMissingKeysWarning() {
+  if (hasLoggedMissingKeysWarning) return;
+  logger.warn(
+    'VALID_API_KEYS is not set — API authentication is disabled. Set this variable in production.',
+  );
+  hasLoggedMissingKeysWarning = true;
+}
+
+function logMissingKeysProductionError() {
+  if (hasLoggedMissingKeysError) return;
+  logger.error(
+    'VALID_API_KEYS is not configured in production — all API requests will be rejected.',
+  );
+  hasLoggedMissingKeysError = true;
+}
+
+function logMissingDerivationSecret() {
+  if (hasLoggedMissingSecretError) return;
+  logger.error(
+    'API_KEY_HMAC_SECRET must be set when VALID_API_KEYS is configured — rejecting API requests.',
+  );
+  hasLoggedMissingSecretError = true;
+}
+
+function extractCandidateApiKey(headers: Headers): string | null {
+  return extractBearerToken(headers.get('authorization')) ?? extractApiKeyHeader(headers);
+}
+
+function extractBearerToken(authHeader: string | null): string | null {
+  if (!authHeader) return null;
+
+  const parts = authHeader.split(' ');
+  if (parts.length !== 2 || parts[0].toLowerCase() !== 'bearer') return null;
+
+  return parts[1].trim() || null;
+}
+
+function extractApiKeyHeader(headers: Headers): string | null {
+  return headers.get('x-api-key')?.trim() || null;
+}
+
+function hasMatchingApiKeyHash(storedHashes: Buffer[], candidateHash: Buffer): boolean {
+  return storedHashes.some((storedHash) => isSameHash(storedHash, candidateHash));
+}
+
+function isSameHash(storedHash: Buffer, candidateHash: Buffer): boolean {
+  if (storedHash.length !== candidateHash.length) return false;
+  try {
+    return timingSafeEqual(storedHash, candidateHash);
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/apps/web/src/lib/withAuth.ts
+++ b/apps/web/src/lib/withAuth.ts
@@ -7,6 +7,11 @@ import logger from '@/lib/logger';
 type RouteHandler = (req: NextRequest, clientId: string) => Promise<Response> | Response;
 const CSRF_COOKIE = '__csrf';
 
+type CsrfCredentials = {
+  cookie: string | undefined;
+  header: string | null;
+};
+
 /**
  * Higher-order function that wraps a Next.js API route handler with authentication.
  *
@@ -37,60 +42,88 @@ const CSRF_COOKIE = '__csrf';
 export function withAuth(handler: RouteHandler) {
   return async function authMiddleware(req: NextRequest): Promise<Response> {
     // 1. Validate CSRF pair whenever either CSRF artifact is present.
-    const csrfHeader = req.headers.get('x-csrf-token');
-    const csrfCookie = req.cookies.get(CSRF_COOKIE)?.value;
-    if (csrfHeader || csrfCookie) {
-      if (!csrfHeader || !csrfCookie || csrfHeader !== csrfCookie) {
-        logger.warn('Auth failed: invalid CSRF header/cookie pair');
-        return NextResponse.json({ error: 'Unauthorized: invalid CSRF token.' }, { status: 401 });
-      }
+    const csrf = readCsrfCredentials(req);
+    if (hasInvalidCsrfPair(csrf)) {
+      logger.warn('Auth failed: invalid CSRF header/cookie pair');
+      return invalidCsrfResponse();
     }
-
-    const hasApiKeyCredential = Boolean(
-      req.headers.get('authorization') || req.headers.get('x-api-key'),
-    );
 
     // 2. Prefer API key auth for external/service callers when a key is actually supplied.
-    if (hasApiKeyCredential) {
-      const clientId = await validateApiKey(req);
-      if (clientId !== null) {
-        return handler(req, clientId);
-      }
-    }
+    const apiKeyResponse = await tryApiKeyAuth(req, handler);
+    if (apiKeyResponse) return apiKeyResponse;
 
     // 3. Same-origin browser fallback with a valid CSRF pair.
-    if (csrfHeader && csrfCookie && isSameOriginBrowserRequest(req)) {
-      const session = getSessionFromRequest(req);
-      if (session) {
-        logger.debug({ userId: session.sub }, 'Auth succeeded via browser session');
-        return handler(req, `user:${session.sub}`);
-      }
+    const browserResponse = tryBrowserCsrfAuth(req, handler, csrf);
+    if (browserResponse) return browserResponse;
 
-      logger.debug('Auth succeeded via same-origin CSRF browser fallback');
-      return handler(req, 'browser-csrf');
-    }
-
-    if (csrfHeader || csrfCookie) {
+    if (hasCsrfCredential(csrf)) {
       logger.warn('Auth failed: cross-origin CSRF fallback attempt');
-      return NextResponse.json({ error: 'Unauthorized: invalid CSRF token.' }, { status: 401 });
+      return invalidCsrfResponse();
     }
-
-    const shouldUseDevAuthBypass =
-      process.env.NODE_ENV !== 'production' && !process.env.VALID_API_KEYS;
 
     // 4. Development-only unauthenticated API fallback when no credentials were supplied.
-    if (shouldUseDevAuthBypass) {
-      const clientId = await validateApiKey(req);
-      if (clientId !== null) {
-        return handler(req, clientId);
-      }
-    }
+    const devBypassResponse = await tryDevAuthBypass(req, handler);
+    if (devBypassResponse) return devBypassResponse;
 
     return NextResponse.json(
       { error: 'Unauthorized: valid API key or same-origin CSRF token is required.' },
       { status: 401 },
     );
   };
+}
+
+function readCsrfCredentials(req: NextRequest): CsrfCredentials {
+  return {
+    cookie: req.cookies.get(CSRF_COOKIE)?.value,
+    header: req.headers.get('x-csrf-token'),
+  };
+}
+
+function hasCsrfCredential(csrf: CsrfCredentials): boolean {
+  return Boolean(csrf.header || csrf.cookie);
+}
+
+function hasInvalidCsrfPair(csrf: CsrfCredentials): boolean {
+  return hasCsrfCredential(csrf) && (!csrf.header || !csrf.cookie || csrf.header !== csrf.cookie);
+}
+
+function invalidCsrfResponse(): Response {
+  return NextResponse.json({ error: 'Unauthorized: invalid CSRF token.' }, { status: 401 });
+}
+
+function hasApiKeyCredential(req: NextRequest): boolean {
+  return Boolean(req.headers.get('authorization') || req.headers.get('x-api-key'));
+}
+
+async function tryApiKeyAuth(req: NextRequest, handler: RouteHandler): Promise<Response | null> {
+  if (!hasApiKeyCredential(req)) return null;
+
+  const clientId = await validateApiKey(req);
+  return clientId === null ? null : handler(req, clientId);
+}
+
+function tryBrowserCsrfAuth(
+  req: NextRequest,
+  handler: RouteHandler,
+  csrf: CsrfCredentials,
+): Response | Promise<Response> | null {
+  if (!csrf.header || !csrf.cookie || !isSameOriginBrowserRequest(req)) return null;
+
+  const session = getSessionFromRequest(req);
+  if (session) {
+    logger.debug({ userId: session.sub }, 'Auth succeeded via browser session');
+    return handler(req, `user:${session.sub}`);
+  }
+
+  logger.debug('Auth succeeded via same-origin CSRF browser fallback');
+  return handler(req, 'browser-csrf');
+}
+
+async function tryDevAuthBypass(req: NextRequest, handler: RouteHandler): Promise<Response | null> {
+  if (process.env.NODE_ENV === 'production' || process.env.VALID_API_KEYS) return null;
+
+  const clientId = await validateApiKey(req);
+  return clientId === null ? null : handler(req, clientId);
 }
 
 /**


### PR DESCRIPTION
## Summary
- split API key env handling, header extraction, and timing-safe hash matching out of validateApiKey
- split withAuth into explicit API-key, browser CSRF/session, and development bypass paths
- keeps auth behavior unchanged while removing changed-code Fallow health findings for the guard slice of #745

Part of #745.

## Validation
- npm run test --workspace=apps/web -- src/lib/apiAuth.test.ts src/lib/withAuth.test.ts
- npm run type-check --workspace=apps/web
- npx fallow health --changed-since origin/development --format json --quiet: 0 findings
- npx fallow dead-code --changed-since origin/development --format json --quiet: 0 issues
- npx fallow dupes --changed-since origin/development --format json --quiet: 0 clone groups
- git diff --check
- pre-push: npm run lint:check
- pre-push: npm run test:server (80 files, 1146 tests)
- pre-push: npm run build
