### PR TITLE
Split auth page form complexity

### DIFF
--- a/apps/web/src/app/authFormLogic.ts
+++ b/apps/web/src/app/authFormLogic.ts
@@ -18,6 +18,22 @@ export type ResetPasswordFormState = {
   confirmPassword: string;
 };
 
+export type EmailPasswordFormState = {
+  email: string;
+  password: string;
+};
+
+export type EmailErrorCopy = {
+  emailRequired: string;
+  emailInvalid: string;
+  generic: string;
+};
+
+export type EmailPasswordErrorCopy = EmailErrorCopy & {
+  invalidCredentials: string;
+  passwordRequired: string;
+};
+
 export type RegisterErrorCopy = {
   emailRequired: string;
   emailInvalid: string;
@@ -45,6 +61,15 @@ export type SubmitResult = {
 
 type ErrorResponse = {
   error?: string;
+};
+
+type ForgotPasswordResponse = {
+  resetUrl?: string;
+};
+
+type AuthPostResponse<TData> = {
+  data: TData;
+  status: number;
 };
 
 type ErrorRule<TForm, TField extends keyof AuthFieldErrors> = {
@@ -138,6 +163,38 @@ export function validateResetPasswordForm(
   ]);
 }
 
+export function validateEmailForm(email: string, messages: EmailErrorCopy): AuthFieldErrors {
+  const trimmedEmail = email.trim();
+
+  return collectErrors({ email: trimmedEmail }, [
+    { field: 'email', message: messages.emailRequired, when: (value) => !value.email },
+    {
+      field: 'email',
+      message: messages.emailInvalid,
+      when: (value) => Boolean(value.email) && !EMAIL_PATTERN.test(value.email),
+    },
+  ]);
+}
+
+export function validateEmailPasswordForm(
+  form: EmailPasswordFormState,
+  messages: EmailPasswordErrorCopy,
+): AuthFieldErrors {
+  return collectErrors({ ...form, email: form.email.trim() }, [
+    { field: 'email', message: messages.emailRequired, when: (value) => !value.email },
+    {
+      field: 'email',
+      message: messages.emailInvalid,
+      when: (value) => Boolean(value.email) && !EMAIL_PATTERN.test(value.email),
+    },
+    {
+      field: 'password',
+      message: messages.passwordRequired,
+      when: (value) => !value.password,
+    },
+  ]);
+}
+
 export function registerErrorsForResponse(
   status: number,
   data: ErrorResponse,
@@ -158,6 +215,16 @@ export function resetPasswordErrorsForResponse(
     : { general: messages.generic };
 }
 
+function credentialsErrorsForResponse(
+  status: number,
+  data: ErrorResponse,
+  messages: EmailPasswordErrorCopy,
+): AuthFieldErrors {
+  return status === 401 || data.error === 'invalid_credentials'
+    ? { general: messages.invalidCredentials }
+    : { general: messages.generic };
+}
+
 export function applyAuthSubmitResult(
   result: SubmitResult,
   fallbackMessage: string,
@@ -174,6 +241,51 @@ export function applyAuthSubmitResult(
 
 async function readErrorResponse(response: Response): Promise<ErrorResponse> {
   return (await response.json().catch(() => ({}))) as ErrorResponse;
+}
+
+async function postAuthJson<TData>(url: string, body: unknown): Promise<AuthPostResponse<TData>> {
+  const response = await fetch(url, {
+    body: JSON.stringify(body),
+    credentials: 'same-origin',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRF-Token': getCsrfToken(),
+    },
+    method: 'POST',
+  });
+
+  return { data: (await response.json().catch(() => ({}))) as TData, status: response.status };
+}
+
+async function submitEmailPasswordAuthForm({
+  form,
+  messages,
+  onSuccess,
+  url,
+}: {
+  form: EmailPasswordFormState;
+  messages: EmailPasswordErrorCopy;
+  onSuccess: () => Promise<unknown>;
+  url: string;
+}): Promise<SubmitResult> {
+  try {
+    const response = await postAuthJson<ErrorResponse>(url, {
+      email: form.email.trim(),
+      password: form.password,
+    });
+
+    if (response.status === 200) {
+      await onSuccess();
+      return { success: true };
+    }
+
+    return {
+      errors: credentialsErrorsForResponse(response.status, response.data, messages),
+      success: false,
+    };
+  } catch {
+    return { errors: { general: messages.generic }, success: false };
+  }
 }
 
 export async function submitRegisterForm(
@@ -204,6 +316,49 @@ export async function submitRegisterForm(
     };
   } catch {
     return { errors: { general: messages.generic }, success: false };
+  }
+}
+
+export function submitLoginForm(
+  form: EmailPasswordFormState,
+  messages: EmailPasswordErrorCopy,
+  refreshSession: () => Promise<unknown>,
+): Promise<SubmitResult> {
+  return submitEmailPasswordAuthForm({
+    form,
+    messages,
+    onSuccess: refreshSession,
+    url: '/api/auth/login',
+  });
+}
+
+export function submitDeleteAccountForm(
+  form: EmailPasswordFormState,
+  messages: EmailPasswordErrorCopy,
+  refreshSession: () => Promise<unknown>,
+): Promise<SubmitResult> {
+  return submitEmailPasswordAuthForm({
+    form,
+    messages,
+    onSuccess: refreshSession,
+    url: '/api/auth/delete-account',
+  });
+}
+
+export async function submitForgotPasswordForm(
+  email: string,
+  fallbackMessage: string,
+): Promise<SubmitResult & ForgotPasswordResponse> {
+  try {
+    const response = await postAuthJson<ForgotPasswordResponse>('/api/auth/forgot-password', {
+      email: email.trim(),
+    });
+
+    return response.status === 202
+      ? { resetUrl: response.data.resetUrl, success: true }
+      : { errors: { general: fallbackMessage }, success: false };
+  } catch {
+    return { errors: { general: fallbackMessage }, success: false };
   }
 }
 

--- a/apps/web/src/app/authFormUi.tsx
+++ b/apps/web/src/app/authFormUi.tsx
@@ -6,8 +6,14 @@ import Link from 'next/link';
 
 import { palette } from '@/styles/designTokens';
 
-import type { AuthFieldErrors, ResetPasswordFormState } from './authFormLogic';
-import type { ReactNode } from 'react';
+import type {
+  AuthFieldErrors,
+  EmailPasswordFormState,
+  ResetPasswordFormState,
+} from './authFormLogic';
+import type { FormEvent, ReactNode } from 'react';
+
+type AuthTone = 'gold' | 'red';
 
 type AuthPanelProps = {
   children: ReactNode;
@@ -18,6 +24,7 @@ type AuthHeaderProps = {
   icon: ReactNode;
   subtitle: string;
   title: string;
+  tone?: AuthTone;
 };
 
 type AuthSuccessPanelProps = {
@@ -34,11 +41,13 @@ type AuthTextFieldProps = {
   label: string;
   onChange: (value: string) => void;
   placeholder: string;
+  trailingLabel?: ReactNode;
   type: 'email' | 'password';
   value: string;
 };
 
 type AuthSubmitButtonProps = {
+  danger?: boolean;
   disabled?: boolean;
   label: string;
   submitting: boolean;
@@ -73,6 +82,48 @@ type AuthLoginLinkProps = {
   linkLabel: string;
 };
 
+type EmailPasswordCopy = {
+  emailLabel: string;
+  emailPlaceholder: string;
+  passwordLabel: string;
+  passwordPlaceholder: string;
+};
+
+type AuthEmailPasswordFieldsProps<TForm extends EmailPasswordFormState> = {
+  copy: EmailPasswordCopy;
+  errors: AuthFieldErrors;
+  form: TForm;
+  passwordTrailingLabel?: ReactNode;
+  setForm: (next: TForm) => void;
+};
+
+type AuthEmailPasswordFormProps<TForm extends EmailPasswordFormState> = {
+  copy: EmailPasswordCopy & { submitButton: string; submitting: string };
+  danger?: boolean;
+  errors: AuthFieldErrors;
+  footer?: ReactNode;
+  form: TForm;
+  header: ReactNode;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  passwordTrailingLabel?: ReactNode;
+  setForm: (next: TForm) => void;
+  submitting: boolean;
+};
+
+const titleStyle = {
+  color: 'var(--pc-t1)',
+  fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
+  fontSize: '2rem',
+  fontWeight: '600',
+  letterSpacing: '0.05em',
+  textTransform: 'uppercase',
+} as const;
+
+const authToneColor: Record<AuthTone, string> = {
+  gold: 'var(--pc-gold-text)',
+  red: palette.red,
+};
+
 export function AuthPanel({ children, mode = 'form' }: AuthPanelProps) {
   return (
     <div className="flex flex-col items-center justify-center flex-1 px-5 py-16">
@@ -92,26 +143,18 @@ export function AuthPanel({ children, mode = 'form' }: AuthPanelProps) {
   );
 }
 
-export function AuthHeader({ icon, subtitle, title }: AuthHeaderProps) {
+export function AuthHeader({ icon, subtitle, title, tone = 'gold' }: AuthHeaderProps) {
+  const color = authToneColor[tone];
+
   return (
     <div className="text-center mb-8">
       <div
         className="w-12 h-12 rounded-xl flex items-center justify-center mx-auto mb-4"
-        style={{ background: `${palette.gold}20`, color: 'var(--pc-gold-text)' }}
+        style={{ background: `${color}20`, color }}
       >
         {icon}
       </div>
-      <h1
-        className="mb-2"
-        style={{
-          color: 'var(--pc-t1)',
-          fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
-          fontSize: '2rem',
-          fontWeight: '600',
-          letterSpacing: '0.05em',
-          textTransform: 'uppercase',
-        }}
-      >
+      <h1 className="mb-2" style={titleStyle}>
         {title}
       </h1>
       <p style={{ color: 'var(--pc-t3)', fontSize: '0.9rem' }}>{subtitle}</p>
@@ -128,17 +171,7 @@ export function AuthSuccessPanel({ body, ctaHref, ctaLabel, title }: AuthSuccess
       >
         <CheckCircle size={32} />
       </div>
-      <h1
-        className="mb-3"
-        style={{
-          color: 'var(--pc-t1)',
-          fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
-          fontSize: '2rem',
-          fontWeight: '600',
-          letterSpacing: '0.05em',
-          textTransform: 'uppercase',
-        }}
-      >
+      <h1 className="mb-3" style={titleStyle}>
         {title}
       </h1>
       <p style={{ color: 'var(--pc-t2)', marginBottom: '2rem' }}>{body}</p>
@@ -179,14 +212,18 @@ export function AuthTextField({
   label,
   onChange,
   placeholder,
+  trailingLabel,
   type,
   value,
 }: AuthTextFieldProps) {
   return (
     <div className="flex flex-col gap-1.5">
-      <label htmlFor={id} className="text-sm font-medium" style={{ color: 'var(--pc-t2)' }}>
-        {label}
-      </label>
+      <div className="flex items-center justify-between gap-3">
+        <label htmlFor={id} className="text-sm font-medium" style={{ color: 'var(--pc-t2)' }}>
+          {label}
+        </label>
+        {trailingLabel}
+      </div>
       <input
         id={id}
         type={type}
@@ -207,6 +244,76 @@ export function AuthTextField({
         </p>
       )}
     </div>
+  );
+}
+
+function AuthEmailPasswordFields<TForm extends EmailPasswordFormState>({
+  copy,
+  errors,
+  form,
+  passwordTrailingLabel,
+  setForm,
+}: AuthEmailPasswordFieldsProps<TForm>) {
+  return (
+    <>
+      <AuthTextField
+        autoComplete="email"
+        error={errors.email}
+        id="email"
+        label={copy.emailLabel}
+        onChange={(email) => setForm({ ...form, email })}
+        placeholder={copy.emailPlaceholder}
+        type="email"
+        value={form.email}
+      />
+      <AuthTextField
+        autoComplete="current-password"
+        error={errors.password}
+        id="password"
+        label={copy.passwordLabel}
+        onChange={(password) => setForm({ ...form, password })}
+        placeholder={copy.passwordPlaceholder}
+        trailingLabel={passwordTrailingLabel}
+        type="password"
+        value={form.password}
+      />
+    </>
+  );
+}
+
+export function AuthEmailPasswordForm<TForm extends EmailPasswordFormState>({
+  copy,
+  danger,
+  errors,
+  footer,
+  form,
+  header,
+  onSubmit,
+  passwordTrailingLabel,
+  setForm,
+  submitting,
+}: AuthEmailPasswordFormProps<TForm>) {
+  return (
+    <>
+      {header}
+      <form onSubmit={onSubmit} noValidate className="flex flex-col gap-5">
+        <AuthGeneralError errors={errors} />
+        <AuthEmailPasswordFields
+          copy={copy}
+          errors={errors}
+          form={form}
+          passwordTrailingLabel={passwordTrailingLabel}
+          setForm={setForm}
+        />
+        <AuthSubmitButton
+          danger={danger}
+          label={copy.submitButton}
+          submitting={submitting}
+          submittingLabel={copy.submitting}
+        />
+      </form>
+      {footer}
+    </>
   );
 }
 
@@ -243,6 +350,7 @@ export function AuthPasswordConfirmationFields<TForm extends ResetPasswordFormSt
 }
 
 export function getAuthSubmitButtonPresentation({
+  danger,
   disabled,
   label,
   submitting,
@@ -268,6 +376,16 @@ export function getAuthSubmitButtonPresentation({
     };
   }
 
+  if (danger) {
+    return {
+      background: palette.red,
+      color: '#F8F8FF',
+      cursor: 'pointer',
+      disabled: false,
+      text: label,
+    };
+  }
+
   return {
     background: 'var(--pc-cta)',
     color: 'var(--pc-cta-text)',
@@ -278,12 +396,14 @@ export function getAuthSubmitButtonPresentation({
 }
 
 export function AuthSubmitButton({
+  danger,
   disabled,
   label,
   submitting,
   submittingLabel,
 }: AuthSubmitButtonProps) {
   const presentation = getAuthSubmitButtonPresentation({
+    danger,
     disabled,
     label,
     submitting,
@@ -302,6 +422,75 @@ export function AuthSubmitButton({
       }}
     >
       {presentation.text}
+    </button>
+  );
+}
+
+export function AuthPrimaryLink({
+  fullWidth,
+  href,
+  label,
+}: {
+  fullWidth?: boolean;
+  href: string;
+  label: string;
+}) {
+  return (
+    <Link
+      href={href}
+      className={`${fullWidth ? 'block w-full text-center' : 'inline-block'} px-6 py-3 rounded-xl text-sm font-semibold transition-colors duration-200`}
+      style={{ background: 'var(--pc-cta)', color: 'var(--pc-cta-text)' }}
+    >
+      {label}
+    </Link>
+  );
+}
+
+export function AuthInlineLink({ href, label }: { href: string; label: string }) {
+  return (
+    <Link
+      href={href}
+      className="font-medium transition-colors duration-200"
+      style={{ color: 'var(--pc-gold-text)' }}
+    >
+      {label}
+    </Link>
+  );
+}
+
+export function AuthStandaloneTextLink({ href, label }: { href: string; label: string }) {
+  return (
+    <Link
+      href={href}
+      className="text-center text-sm font-semibold transition-colors duration-200"
+      style={{ color: 'var(--pc-gold-text)' }}
+    >
+      {label}
+    </Link>
+  );
+}
+
+export function AuthTrailingLink({ href, label }: { href: string; label: string }) {
+  return (
+    <Link
+      href={href}
+      className="text-xs font-medium transition-colors duration-200"
+      style={{ color: 'var(--pc-gold-text)' }}
+    >
+      {label}
+    </Link>
+  );
+}
+
+export function AuthTextButton({ label, onClick }: { label: string; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="text-center text-sm font-semibold transition-colors duration-200"
+      style={{ color: 'var(--pc-gold-text)' }}
+    >
+      {label}
     </button>
   );
 }

--- a/apps/web/src/app/delete-account/page.tsx
+++ b/apps/web/src/app/delete-account/page.tsx
@@ -1,253 +1,61 @@
 'use client';
 
-import { CheckCircle, Trash2 } from 'lucide-react';
-import { motion } from 'motion/react';
-import Link from 'next/link';
-import { useState, type FormEvent } from 'react';
+import { Trash2 } from 'lucide-react';
 
 import { useAuth } from '@/components/AuthProvider';
 import { useLanguage } from '@/i18n';
-import { getCsrfToken } from '@/lib/csrfClient';
-import { palette } from '@/styles/designTokens';
 
-interface FormState {
-  email: string;
-  password: string;
-}
-
-interface FieldErrors {
-  email?: string;
-  password?: string;
-  general?: string;
-}
+import { submitDeleteAccountForm } from '../authFormLogic';
+import { AuthEmailPasswordForm, AuthHeader, AuthPanel, AuthSuccessPanel } from '../authFormUi';
+import { useEmailPasswordAuthPage } from '../useAuthPageForms';
 
 export default function DeleteAccountPage() {
   const { refreshSession } = useAuth();
   const { t } = useLanguage();
-  const d = t.deleteAccount;
+  const copy = t.deleteAccount;
+  const page = useEmailPasswordAuthPage({
+    errors: copy.errors,
+    submit: (form) => submitDeleteAccountForm(form, copy.errors, refreshSession),
+  });
 
-  const [form, setForm] = useState<FormState>({ email: '', password: '' });
-  const [errors, setErrors] = useState<FieldErrors>({});
-  const [submitting, setSubmitting] = useState(false);
-  const [success, setSuccess] = useState(false);
-
-  function validate(): FieldErrors {
-    const errs: FieldErrors = {};
-    if (!form.email.trim()) {
-      errs.email = d.errors.emailRequired;
-    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email.trim())) {
-      errs.email = d.errors.emailInvalid;
-    }
-    if (!form.password) {
-      errs.password = d.errors.passwordRequired;
-    }
-    return errs;
-  }
-
-  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
-    e.preventDefault();
-    const errs = validate();
-    if (Object.keys(errs).length > 0) {
-      setErrors(errs);
-      return;
-    }
-    setErrors({});
-    setSubmitting(true);
-
-    try {
-      const res = await fetch('/api/auth/delete-account', {
-        method: 'POST',
-        credentials: 'same-origin',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRF-Token': getCsrfToken(),
-        },
-        body: JSON.stringify({ email: form.email.trim(), password: form.password }),
-      });
-
-      if (res.status === 200) {
-        await refreshSession();
-        setSuccess(true);
-        return;
-      }
-
-      const data = (await res.json()) as { error?: string };
-      if (res.status === 401 || data.error === 'invalid_credentials') {
-        setErrors({ general: d.errors.invalidCredentials });
-      } else {
-        setErrors({ general: d.errors.generic });
-      }
-    } catch {
-      setErrors({ general: d.errors.generic });
-    } finally {
-      setSubmitting(false);
-    }
-  }
-
-  if (success) {
-    return (
-      <div className="flex flex-col items-center justify-center flex-1 px-5 py-16">
-        <motion.div
-          initial={{ opacity: 0, scale: 0.9 }}
-          animate={{ opacity: 1, scale: 1 }}
-          transition={{ duration: 0.4 }}
-          className="w-full max-w-sm text-center"
-        >
-          <div
-            className="w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-6"
-            style={{ background: `${palette.green}20`, color: palette.green }}
-          >
-            <CheckCircle size={32} />
-          </div>
-          <h1
-            className="mb-3"
-            style={{
-              fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
-              fontWeight: '600',
-              textTransform: 'uppercase',
-              fontSize: '2rem',
-              letterSpacing: '0.05em',
-              color: 'var(--pc-t1)',
-            }}
-          >
-            {d.successTitle}
-          </h1>
-          <p style={{ color: 'var(--pc-t2)', marginBottom: '2rem' }}>{d.successMessage}</p>
-          <Link
-            href="/"
-            className="inline-block px-6 py-3 rounded-xl text-sm font-semibold transition-colors duration-200"
-            style={{ background: 'var(--pc-cta)', color: 'var(--pc-cta-text)' }}
-          >
-            {d.backToHome}
-          </Link>
-        </motion.div>
-      </div>
-    );
+  if (page.success) {
+    return <DeleteAccountSuccess copy={copy} />;
   }
 
   return (
-    <div className="flex flex-col items-center justify-center flex-1 px-5 py-16">
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.4 }}
-        className="w-full max-w-sm"
-      >
-        {/* Header */}
-        <div className="text-center mb-8">
-          <div
-            className="w-12 h-12 rounded-xl flex items-center justify-center mx-auto mb-4"
-            style={{ background: `${palette.red}20`, color: palette.red }}
-          >
-            <Trash2 size={22} />
-          </div>
-          <h1
-            className="mb-2"
-            style={{
-              fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
-              fontWeight: '600',
-              textTransform: 'uppercase',
-              fontSize: '2rem',
-              letterSpacing: '0.05em',
-              color: 'var(--pc-t1)',
-            }}
-          >
-            {d.title}
-          </h1>
-          <p style={{ color: 'var(--pc-t3)', fontSize: '0.9rem' }}>{d.subtitle}</p>
-        </div>
+    <AuthPanel>
+      <AuthEmailPasswordForm
+        copy={copy}
+        danger
+        errors={page.errors}
+        form={page.form}
+        header={
+          <AuthHeader
+            icon={<Trash2 size={22} />}
+            subtitle={copy.subtitle}
+            title={copy.title}
+            tone="red"
+          />
+        }
+        onSubmit={page.handleSubmit}
+        setForm={page.setForm}
+        submitting={page.submitting}
+      />
+    </AuthPanel>
+  );
+}
 
-        {/* Form */}
-        <form onSubmit={handleSubmit} noValidate className="flex flex-col gap-5">
-          {/* General error */}
-          {errors.general && (
-            <p
-              className="text-sm px-4 py-3 rounded-xl"
-              style={{
-                background: `${palette.red}18`,
-                border: `1px solid ${palette.red}40`,
-                color: palette.red,
-              }}
-            >
-              {errors.general}
-            </p>
-          )}
-
-          {/* Email */}
-          <div className="flex flex-col gap-1.5">
-            <label
-              htmlFor="email"
-              className="text-sm font-medium"
-              style={{ color: 'var(--pc-t2)' }}
-            >
-              {d.emailLabel}
-            </label>
-            <input
-              id="email"
-              type="email"
-              autoComplete="email"
-              value={form.email}
-              onChange={(e) => setForm((f) => ({ ...f, email: e.target.value }))}
-              placeholder={d.emailPlaceholder}
-              className="w-full px-4 py-3 rounded-xl text-sm transition-colors duration-200 outline-none"
-              style={{
-                background: 'var(--pc-input-bg, rgba(255,255,255,0.05))',
-                border: `1px solid ${errors.email ? palette.red : 'var(--pc-bd2)'}`,
-                color: 'var(--pc-t1)',
-              }}
-            />
-            {errors.email && (
-              <p className="text-xs" style={{ color: palette.red }}>
-                {errors.email}
-              </p>
-            )}
-          </div>
-
-          {/* Password */}
-          <div className="flex flex-col gap-1.5">
-            <label
-              htmlFor="password"
-              className="text-sm font-medium"
-              style={{ color: 'var(--pc-t2)' }}
-            >
-              {d.passwordLabel}
-            </label>
-            <input
-              id="password"
-              type="password"
-              autoComplete="current-password"
-              value={form.password}
-              onChange={(e) => setForm((f) => ({ ...f, password: e.target.value }))}
-              placeholder={d.passwordPlaceholder}
-              className="w-full px-4 py-3 rounded-xl text-sm transition-colors duration-200 outline-none"
-              style={{
-                background: 'var(--pc-input-bg, rgba(255,255,255,0.05))',
-                border: `1px solid ${errors.password ? palette.red : 'var(--pc-bd2)'}`,
-                color: 'var(--pc-t1)',
-              }}
-            />
-            {errors.password && (
-              <p className="text-xs" style={{ color: palette.red }}>
-                {errors.password}
-              </p>
-            )}
-          </div>
-
-          {/* Submit */}
-          <button
-            type="submit"
-            disabled={submitting}
-            className="w-full px-4 py-3 rounded-xl text-sm font-semibold transition-all duration-200 mt-1"
-            style={{
-              background: submitting ? 'var(--pc-ghost)' : `${palette.red}`,
-              color: submitting ? 'var(--pc-t3)' : '#F8F8FF',
-              cursor: submitting ? 'not-allowed' : 'pointer',
-            }}
-          >
-            {submitting ? d.submitting : d.submitButton}
-          </button>
-        </form>
-      </motion.div>
-    </div>
+function DeleteAccountSuccess({
+  copy,
+}: {
+  copy: ReturnType<typeof useLanguage>['t']['deleteAccount'];
+}) {
+  return (
+    <AuthSuccessPanel
+      body={copy.successMessage}
+      ctaHref="/"
+      ctaLabel={copy.backToHome}
+      title={copy.successTitle}
+    />
   );
 }

--- a/apps/web/src/app/forgot-password/page.tsx
+++ b/apps/web/src/app/forgot-password/page.tsx
@@ -1,219 +1,143 @@
 'use client';
 
 import { CheckCircle, Mail } from 'lucide-react';
-import { motion } from 'motion/react';
-import Link from 'next/link';
-import { useState, type FormEvent } from 'react';
 
 import { useLanguage } from '@/i18n';
-import { getCsrfToken } from '@/lib/csrfClient';
-import { palette } from '@/styles/designTokens';
 
-interface FieldErrors {
-  email?: string;
-  general?: string;
-}
+import {
+  AuthGeneralError,
+  AuthHeader,
+  AuthInlineLink,
+  AuthPanel,
+  AuthPrimaryLink,
+  AuthStandaloneTextLink,
+  AuthSubmitButton,
+  AuthTextButton,
+  AuthTextField,
+} from '../authFormUi';
+import { useForgotPasswordRequest } from '../useAuthPageForms';
+
+import type { AuthFieldErrors } from '../authFormLogic';
+import type { FormEvent } from 'react';
 
 export default function ForgotPasswordPage() {
   const { t } = useLanguage();
-  const l = t.forgotPassword;
-  const [email, setEmail] = useState('');
-  const [errors, setErrors] = useState<FieldErrors>({});
-  const [submitting, setSubmitting] = useState(false);
-  const [submitted, setSubmitted] = useState(false);
-  const [devResetUrl, setDevResetUrl] = useState<string | null>(null);
+  const copy = t.forgotPassword;
+  const request = useForgotPasswordRequest(copy.errors);
 
-  function resetRequestForm() {
-    setEmail('');
-    setErrors({});
-    setSubmitting(false);
-    setSubmitted(false);
-    setDevResetUrl(null);
+  return (
+    <AuthPanel>
+      <ForgotPasswordHeader labels={copy} submitted={request.submitted} />
+      <ForgotPasswordBody labels={copy} request={request} />
+    </AuthPanel>
+  );
+}
+
+function ForgotPasswordHeader({
+  labels,
+  submitted,
+}: {
+  labels: ReturnType<typeof useLanguage>['t']['forgotPassword'];
+  submitted: boolean;
+}) {
+  if (submitted) {
+    return (
+      <AuthHeader
+        icon={<CheckCircle size={22} />}
+        title={labels.sentTitle}
+        subtitle={labels.sentBody}
+      />
+    );
   }
 
-  function validate(): FieldErrors {
-    const errs: FieldErrors = {};
-    if (!email.trim()) {
-      errs.email = l.errors.emailRequired;
-    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim())) {
-      errs.email = l.errors.emailInvalid;
-    }
-    return errs;
-  }
+  return <AuthHeader icon={<Mail size={22} />} title={labels.title} subtitle={labels.subtitle} />;
+}
 
-  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
-    e.preventDefault();
-    const errs = validate();
-    if (Object.keys(errs).length > 0) {
-      setErrors(errs);
-      return;
-    }
-
-    setErrors({});
-    setSubmitting(true);
-    setDevResetUrl(null);
-
-    try {
-      const res = await fetch('/api/auth/forgot-password', {
-        method: 'POST',
-        credentials: 'same-origin',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRF-Token': getCsrfToken(),
-        },
-        body: JSON.stringify({ email: email.trim() }),
-      });
-
-      if (res.status === 202) {
-        const data = (await res.json()) as { resetUrl?: string };
-        setDevResetUrl(data.resetUrl ?? null);
-        setSubmitted(true);
-        return;
-      }
-
-      if (res.status === 422) {
-        setErrors({ general: l.errors.generic });
-      } else {
-        setErrors({ general: l.errors.generic });
-      }
-    } catch {
-      setErrors({ general: l.errors.generic });
-    } finally {
-      setSubmitting(false);
-    }
+function ForgotPasswordBody({
+  labels,
+  request,
+}: {
+  labels: ReturnType<typeof useLanguage>['t']['forgotPassword'];
+  request: ReturnType<typeof useForgotPasswordRequest>;
+}) {
+  if (request.submitted) {
+    return (
+      <ForgotPasswordSubmitted
+        labels={labels}
+        devResetUrl={request.devResetUrl}
+        onResetRequest={request.resetRequestForm}
+      />
+    );
   }
 
   return (
-    <div className="flex flex-col items-center justify-center flex-1 px-5 py-16">
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.4 }}
-        className="w-full max-w-sm"
-      >
-        <div className="text-center mb-8">
-          <div
-            className="w-12 h-12 rounded-xl flex items-center justify-center mx-auto mb-4"
-            style={{ background: `${palette.gold}20`, color: 'var(--pc-gold-text)' }}
-          >
-            {submitted ? <CheckCircle size={22} /> : <Mail size={22} />}
-          </div>
-          <h1
-            className="mb-2"
-            style={{
-              fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
-              fontWeight: '600',
-              textTransform: 'uppercase',
-              fontSize: '2rem',
-              letterSpacing: '0.05em',
-              color: 'var(--pc-t1)',
-            }}
-          >
-            {submitted ? l.sentTitle : l.title}
-          </h1>
-          <p style={{ color: 'var(--pc-t3)', fontSize: '0.9rem' }}>
-            {submitted ? l.sentBody : l.subtitle}
-          </p>
-        </div>
+    <ForgotPasswordForm
+      email={request.email}
+      errors={request.errors}
+      labels={labels}
+      onEmailChange={request.setEmail}
+      onSubmit={request.handleSubmit}
+      submitting={request.submitting}
+    />
+  );
+}
 
-        {submitted ? (
-          <div className="flex flex-col gap-4">
-            {devResetUrl && (
-              <Link
-                href={devResetUrl}
-                className="text-center text-sm font-semibold transition-colors duration-200"
-                style={{ color: 'var(--pc-gold-text)' }}
-              >
-                {l.devResetLink}
-              </Link>
-            )}
-            <Link
-              href="/login"
-              className="w-full px-4 py-3 rounded-xl text-sm font-semibold text-center transition-all duration-200"
-              style={{ background: 'var(--pc-cta)', color: 'var(--pc-cta-text)' }}
-            >
-              {l.backToLogin}
-            </Link>
-            <button
-              type="button"
-              onClick={resetRequestForm}
-              className="text-center text-sm font-semibold transition-colors duration-200"
-              style={{ color: 'var(--pc-gold-text)' }}
-            >
-              {l.requestAnother}
-            </button>
-          </div>
-        ) : (
-          <form onSubmit={handleSubmit} noValidate className="flex flex-col gap-5">
-            {errors.general && (
-              <p
-                className="text-sm px-4 py-3 rounded-xl"
-                style={{
-                  background: `${palette.red}18`,
-                  border: `1px solid ${palette.red}40`,
-                  color: palette.red,
-                }}
-              >
-                {errors.general}
-              </p>
-            )}
-
-            <div className="flex flex-col gap-1.5">
-              <label
-                htmlFor="email"
-                className="text-sm font-medium"
-                style={{ color: 'var(--pc-t2)' }}
-              >
-                {l.emailLabel}
-              </label>
-              <input
-                id="email"
-                type="email"
-                autoComplete="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                placeholder={l.emailPlaceholder}
-                className="w-full px-4 py-3 rounded-xl text-sm transition-colors duration-200 outline-none"
-                style={{
-                  background: 'var(--pc-input-bg, rgba(255,255,255,0.05))',
-                  border: `1px solid ${errors.email ? palette.red : 'var(--pc-bd2)'}`,
-                  color: 'var(--pc-t1)',
-                }}
-              />
-              {errors.email && (
-                <p className="text-xs" style={{ color: palette.red }}>
-                  {errors.email}
-                </p>
-              )}
-            </div>
-
-            <button
-              type="submit"
-              disabled={submitting}
-              className="w-full px-4 py-3 rounded-xl text-sm font-semibold transition-all duration-200 mt-1"
-              style={{
-                background: submitting ? 'var(--pc-ghost)' : 'var(--pc-cta)',
-                color: submitting ? 'var(--pc-t3)' : 'var(--pc-cta-text)',
-                cursor: submitting ? 'not-allowed' : 'pointer',
-              }}
-            >
-              {submitting ? l.submitting : l.submitButton}
-            </button>
-          </form>
-        )}
-
-        {!submitted && (
-          <p className="text-center text-sm mt-6" style={{ color: 'var(--pc-t3)' }}>
-            <Link
-              href="/login"
-              className="font-medium transition-colors duration-200"
-              style={{ color: 'var(--pc-gold-text)' }}
-            >
-              {l.backToLogin}
-            </Link>
-          </p>
-        )}
-      </motion.div>
+function ForgotPasswordSubmitted({
+  labels,
+  devResetUrl,
+  onResetRequest,
+}: {
+  labels: ReturnType<typeof useLanguage>['t']['forgotPassword'];
+  devResetUrl: string | null;
+  onResetRequest: () => void;
+}) {
+  return (
+    <div className="flex flex-col gap-4">
+      {devResetUrl && <AuthStandaloneTextLink href={devResetUrl} label={labels.devResetLink} />}
+      <AuthPrimaryLink href="/login" label={labels.backToLogin} fullWidth />
+      <AuthTextButton onClick={onResetRequest} label={labels.requestAnother} />
     </div>
+  );
+}
+
+function ForgotPasswordForm({
+  email,
+  errors,
+  labels,
+  onEmailChange,
+  onSubmit,
+  submitting,
+}: {
+  email: string;
+  errors: AuthFieldErrors;
+  labels: ReturnType<typeof useLanguage>['t']['forgotPassword'];
+  onEmailChange: (email: string) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  submitting: boolean;
+}) {
+  return (
+    <>
+      <form onSubmit={onSubmit} noValidate className="flex flex-col gap-5">
+        <AuthGeneralError errors={errors} />
+        <AuthTextField
+          autoComplete="email"
+          error={errors.email}
+          id="email"
+          label={labels.emailLabel}
+          onChange={onEmailChange}
+          placeholder={labels.emailPlaceholder}
+          type="email"
+          value={email}
+        />
+        <AuthSubmitButton
+          label={labels.submitButton}
+          submitting={submitting}
+          submittingLabel={labels.submitting}
+        />
+      </form>
+      <p className="text-center text-sm mt-6" style={{ color: 'var(--pc-t3)' }}>
+        <AuthInlineLink href="/login" label={labels.backToLogin} />
+      </p>
+    </>
   );
 }

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,276 +1,66 @@
 'use client';
 
-import { CheckCircle, LogIn } from 'lucide-react';
-import { motion } from 'motion/react';
-import Link from 'next/link';
-import { useState, type FormEvent } from 'react';
+import { LogIn } from 'lucide-react';
 
 import { useAuth } from '@/components/AuthProvider';
 import { useLanguage } from '@/i18n';
-import { getCsrfToken } from '@/lib/csrfClient';
-import { palette } from '@/styles/designTokens';
 
-interface FormState {
-  email: string;
-  password: string;
-}
-
-interface FieldErrors {
-  email?: string;
-  password?: string;
-  general?: string;
-}
+import { submitLoginForm } from '../authFormLogic';
+import {
+  AuthEmailPasswordForm,
+  AuthHeader,
+  AuthInlineLink,
+  AuthPanel,
+  AuthSuccessPanel,
+  AuthTrailingLink,
+} from '../authFormUi';
+import { useEmailPasswordAuthPage } from '../useAuthPageForms';
 
 export default function LoginPage() {
   const { isAuthenticated, refreshSession } = useAuth();
   const { t } = useLanguage();
-  const l = t.login;
+  const copy = t.login;
+  const page = useEmailPasswordAuthPage({
+    errors: copy.errors,
+    submit: (form) => submitLoginForm(form, copy.errors, refreshSession),
+  });
 
-  const [form, setForm] = useState<FormState>({ email: '', password: '' });
-  const [errors, setErrors] = useState<FieldErrors>({});
-  const [submitting, setSubmitting] = useState(false);
-  const [success, setSuccess] = useState(false);
-
-  function validate(): FieldErrors {
-    const errs: FieldErrors = {};
-    if (!form.email.trim()) {
-      errs.email = l.errors.emailRequired;
-    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email.trim())) {
-      errs.email = l.errors.emailInvalid;
-    }
-    if (!form.password) {
-      errs.password = l.errors.passwordRequired;
-    }
-    return errs;
-  }
-
-  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
-    e.preventDefault();
-    const errs = validate();
-    if (Object.keys(errs).length > 0) {
-      setErrors(errs);
-      return;
-    }
-    setErrors({});
-    setSubmitting(true);
-
-    try {
-      const res = await fetch('/api/auth/login', {
-        method: 'POST',
-        credentials: 'same-origin',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRF-Token': getCsrfToken(),
-        },
-        body: JSON.stringify({ email: form.email.trim(), password: form.password }),
-      });
-
-      if (res.status === 200) {
-        await refreshSession();
-        setSuccess(true);
-        return;
-      }
-
-      const data = (await res.json()) as { error?: string };
-      if (res.status === 401 || data.error === 'invalid_credentials') {
-        setErrors({ general: l.errors.invalidCredentials });
-      } else if (res.status === 422) {
-        setErrors({ general: l.errors.generic });
-      } else {
-        setErrors({ general: l.errors.generic });
-      }
-    } catch {
-      setErrors({ general: l.errors.generic });
-    } finally {
-      setSubmitting(false);
-    }
-  }
-
-  if (success || isAuthenticated) {
-    return (
-      <div className="flex flex-col items-center justify-center flex-1 px-5 py-16">
-        <motion.div
-          initial={{ opacity: 0, scale: 0.9 }}
-          animate={{ opacity: 1, scale: 1 }}
-          transition={{ duration: 0.4 }}
-          className="w-full max-w-sm text-center"
-        >
-          <div
-            className="w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-6"
-            style={{ background: `${palette.green}20`, color: palette.green }}
-          >
-            <CheckCircle size={32} />
-          </div>
-          <h1
-            className="mb-3"
-            style={{
-              fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
-              fontWeight: '600',
-              textTransform: 'uppercase',
-              fontSize: '2rem',
-              letterSpacing: '0.05em',
-              color: 'var(--pc-t1)',
-            }}
-          >
-            {l.successTitle}
-          </h1>
-          <p style={{ color: 'var(--pc-t2)', marginBottom: '2rem' }}>{l.successMessage}</p>
-          <Link
-            href="/"
-            className="inline-block px-6 py-3 rounded-xl text-sm font-semibold transition-colors duration-200"
-            style={{ background: 'var(--pc-cta)', color: 'var(--pc-cta-text)' }}
-          >
-            {l.backToHome}
-          </Link>
-        </motion.div>
-      </div>
-    );
+  if (page.success || isAuthenticated) {
+    return <LoginSuccess copy={copy} />;
   }
 
   return (
-    <div className="flex flex-col items-center justify-center flex-1 px-5 py-16">
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.4 }}
-        className="w-full max-w-sm"
-      >
-        {/* Header */}
-        <div className="text-center mb-8">
-          <div
-            className="w-12 h-12 rounded-xl flex items-center justify-center mx-auto mb-4"
-            style={{ background: `${palette.gold}20`, color: 'var(--pc-gold-text)' }}
-          >
-            <LogIn size={22} />
-          </div>
-          <h1
-            className="mb-2"
-            style={{
-              fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
-              fontWeight: '600',
-              textTransform: 'uppercase',
-              fontSize: '2rem',
-              letterSpacing: '0.05em',
-              color: 'var(--pc-t1)',
-            }}
-          >
-            {l.title}
-          </h1>
-          <p style={{ color: 'var(--pc-t3)', fontSize: '0.9rem' }}>{l.subtitle}</p>
-        </div>
+    <AuthPanel>
+      <AuthEmailPasswordForm
+        copy={copy}
+        errors={page.errors}
+        form={page.form}
+        header={
+          <AuthHeader icon={<LogIn size={22} />} subtitle={copy.subtitle} title={copy.title} />
+        }
+        onSubmit={page.handleSubmit}
+        passwordTrailingLabel={
+          <AuthTrailingLink href="/forgot-password" label={copy.forgotPassword} />
+        }
+        setForm={page.setForm}
+        submitting={page.submitting}
+        footer={
+          <p className="text-center text-sm mt-6" style={{ color: 'var(--pc-t3)' }}>
+            {copy.noAccount} <AuthInlineLink href="/register" label={copy.signUp} />
+          </p>
+        }
+      />
+    </AuthPanel>
+  );
+}
 
-        {/* Form */}
-        <form onSubmit={handleSubmit} noValidate className="flex flex-col gap-5">
-          {/* General error */}
-          {errors.general && (
-            <p
-              className="text-sm px-4 py-3 rounded-xl"
-              style={{
-                background: `${palette.red}18`,
-                border: `1px solid ${palette.red}40`,
-                color: palette.red,
-              }}
-            >
-              {errors.general}
-            </p>
-          )}
-
-          {/* Email */}
-          <div className="flex flex-col gap-1.5">
-            <label
-              htmlFor="email"
-              className="text-sm font-medium"
-              style={{ color: 'var(--pc-t2)' }}
-            >
-              {l.emailLabel}
-            </label>
-            <input
-              id="email"
-              type="email"
-              autoComplete="email"
-              value={form.email}
-              onChange={(e) => setForm((f) => ({ ...f, email: e.target.value }))}
-              placeholder={l.emailPlaceholder}
-              className="w-full px-4 py-3 rounded-xl text-sm transition-colors duration-200 outline-none"
-              style={{
-                background: 'var(--pc-input-bg, rgba(255,255,255,0.05))',
-                border: `1px solid ${errors.email ? palette.red : 'var(--pc-bd2)'}`,
-                color: 'var(--pc-t1)',
-              }}
-            />
-            {errors.email && (
-              <p className="text-xs" style={{ color: palette.red }}>
-                {errors.email}
-              </p>
-            )}
-          </div>
-
-          {/* Password */}
-          <div className="flex flex-col gap-1.5">
-            <div className="flex items-center justify-between gap-3">
-              <label
-                htmlFor="password"
-                className="text-sm font-medium"
-                style={{ color: 'var(--pc-t2)' }}
-              >
-                {l.passwordLabel}
-              </label>
-              <Link
-                href="/forgot-password"
-                className="text-xs font-medium transition-colors duration-200"
-                style={{ color: 'var(--pc-gold-text)' }}
-              >
-                {l.forgotPassword}
-              </Link>
-            </div>
-            <input
-              id="password"
-              type="password"
-              autoComplete="current-password"
-              value={form.password}
-              onChange={(e) => setForm((f) => ({ ...f, password: e.target.value }))}
-              placeholder={l.passwordPlaceholder}
-              className="w-full px-4 py-3 rounded-xl text-sm transition-colors duration-200 outline-none"
-              style={{
-                background: 'var(--pc-input-bg, rgba(255,255,255,0.05))',
-                border: `1px solid ${errors.password ? palette.red : 'var(--pc-bd2)'}`,
-                color: 'var(--pc-t1)',
-              }}
-            />
-            {errors.password && (
-              <p className="text-xs" style={{ color: palette.red }}>
-                {errors.password}
-              </p>
-            )}
-          </div>
-
-          {/* Submit */}
-          <button
-            type="submit"
-            disabled={submitting}
-            className="w-full px-4 py-3 rounded-xl text-sm font-semibold transition-all duration-200 mt-1"
-            style={{
-              background: submitting ? 'var(--pc-ghost)' : 'var(--pc-cta)',
-              color: submitting ? 'var(--pc-t3)' : 'var(--pc-cta-text)',
-              cursor: submitting ? 'not-allowed' : 'pointer',
-            }}
-          >
-            {submitting ? l.submitting : l.submitButton}
-          </button>
-        </form>
-
-        {/* Link to register */}
-        <p className="text-center text-sm mt-6" style={{ color: 'var(--pc-t3)' }}>
-          {l.noAccount}{' '}
-          <Link
-            href="/register"
-            className="font-medium transition-colors duration-200"
-            style={{ color: 'var(--pc-gold-text)' }}
-          >
-            {l.signUp}
-          </Link>
-        </p>
-      </motion.div>
-    </div>
+function LoginSuccess({ copy }: { copy: ReturnType<typeof useLanguage>['t']['login'] }) {
+  return (
+    <AuthSuccessPanel
+      body={copy.successMessage}
+      ctaHref="/"
+      ctaLabel={copy.backToHome}
+      title={copy.successTitle}
+    />
   );
 }

--- a/apps/web/src/app/useAuthPageForms.ts
+++ b/apps/web/src/app/useAuthPageForms.ts
@@ -1,0 +1,135 @@
+'use client';
+
+import { useState, type FormEvent } from 'react';
+
+import {
+  type AuthFieldErrors,
+  type EmailErrorCopy,
+  type EmailPasswordErrorCopy,
+  type EmailPasswordFormState,
+  type SubmitResult,
+  applyAuthSubmitResult,
+  hasAuthFieldErrors,
+  submitForgotPasswordForm,
+  validateEmailForm,
+  validateEmailPasswordForm,
+} from './authFormLogic';
+
+const EMPTY_EMAIL_PASSWORD_FORM: EmailPasswordFormState = {
+  email: '',
+  password: '',
+};
+
+type EmailPasswordAuthPageOptions = {
+  errors: EmailPasswordErrorCopy;
+  onSuccess?: () => void;
+  submit: (form: EmailPasswordFormState) => Promise<SubmitResult>;
+};
+
+export function useEmailPasswordAuthPage({
+  errors: errorCopy,
+  onSuccess,
+  submit,
+}: EmailPasswordAuthPageOptions) {
+  const state = useEmailPasswordAuthState();
+  const { form, setErrors, setSubmitting, setSuccess } = state;
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const validationErrors = validateEmailPasswordForm(form, errorCopy);
+    if (rejectInvalidSubmit(validationErrors, setErrors)) return;
+
+    setErrors({});
+    setSubmitting(true);
+    const result = await submit(form);
+    setSubmitting(false);
+    applyAuthSubmitResult(
+      result,
+      errorCopy.generic,
+      () => {
+        setSuccess(true);
+        onSuccess?.();
+      },
+      setErrors,
+    );
+  }
+
+  return { ...state, handleSubmit };
+}
+
+export function useForgotPasswordRequest(errorCopy: EmailErrorCopy) {
+  const [email, setEmail] = useState('');
+  const [errors, setErrors] = useState<AuthFieldErrors>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [devResetUrl, setDevResetUrl] = useState<string | null>(null);
+
+  function resetRequestForm() {
+    setEmail('');
+    setErrors({});
+    setSubmitting(false);
+    setSubmitted(false);
+    setDevResetUrl(null);
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const validationErrors = validateEmailForm(email, errorCopy);
+    if (rejectInvalidSubmit(validationErrors, setErrors)) return;
+
+    setErrors({});
+    setSubmitting(true);
+    setDevResetUrl(null);
+    const result = await submitForgotPasswordForm(email, errorCopy.generic);
+    setSubmitting(false);
+    applyAuthSubmitResult(
+      result,
+      errorCopy.generic,
+      () => {
+        setDevResetUrl(result.resetUrl ?? null);
+        setSubmitted(true);
+      },
+      setErrors,
+    );
+  }
+
+  return {
+    devResetUrl,
+    email,
+    errors,
+    handleSubmit,
+    resetRequestForm,
+    setEmail,
+    submitted,
+    submitting,
+  };
+}
+
+function rejectInvalidSubmit(
+  validationErrors: AuthFieldErrors,
+  setErrors: (errors: AuthFieldErrors) => void,
+): boolean {
+  if (!hasAuthFieldErrors(validationErrors)) return false;
+  setErrors(validationErrors);
+  return true;
+}
+
+function useEmailPasswordAuthState() {
+  const formState = useState<EmailPasswordFormState>(EMPTY_EMAIL_PASSWORD_FORM);
+  const errorState = useState<AuthFieldErrors>({});
+  const submittingState = useState(false);
+  const successState = useState(false);
+
+  return {
+    errors: errorState[0],
+    form: formState[0],
+    setErrors: errorState[1],
+    setForm: formState[1],
+    setSubmitting: submittingState[1],
+    setSuccess: successState[1],
+    submitting: submittingState[0],
+    success: successState[0],
+  };
+}


### PR DESCRIPTION
## Summary
- reuse and extend the existing auth form UI/logic primitives for login, forgot-password, and delete-account pages
- move shared email/password submit state into a small hook and keep page components focused on view selection
- keep auth page behavior and endpoints unchanged while clearing the #745 page complexity findings

Part of #745.

## Validation
- npm run test --workspace=apps/web -- src/app/api/auth/login/route.test.ts src/app/api/auth/forgot-password/route.test.ts src/app/api/auth/delete-account/route.test.ts
- npm run type-check --workspace=apps/web
- npm run build --workspace=apps/web
- npx fallow health --changed-since origin/development --format json --quiet: 0 findings
- npx fallow dead-code --changed-since origin/development --format json --quiet: 0 issues
- npx fallow dupes --changed-since origin/development --format json --quiet: 0 clone groups
- git diff --check
- pre-push: npm run lint:check
- pre-push: npm run test:server (80 files, 1146 tests)
- pre-push: npm run build
