### PR TITLE
Refactor quiz UI complexity

### DIFF
--- a/apps/web/src/app/quiz/components/GroupSetup.tsx
+++ b/apps/web/src/app/quiz/components/GroupSetup.tsx
@@ -15,6 +15,9 @@ interface GroupSetupProps {
   onStart: () => void;
 }
 
+type GroupSetupCopy = ReturnType<typeof useLanguage>['t']['quiz']['groupSetup'];
+type GroupSetupAudience = NonNullable<GroupSetupProps['audience']>;
+
 export function GroupSetup({
   audience = 'group',
   groupNames,
@@ -23,14 +26,8 @@ export function GroupSetup({
   onStart,
 }: GroupSetupProps) {
   const { t } = useLanguage();
-  const isDuo = audience === 'duo';
-  const copy = isDuo ? t.quiz.duoSetup : t.quiz.groupSetup;
-  const maxPeople = isDuo ? 2 : 6;
-  const minPeople = isDuo ? 2 : 3;
-  const visibleNames = isDuo ? groupNames.slice(0, 2) : groupNames;
-  const namedPeople = visibleNames.map((name) => name.trim()).filter(Boolean);
-  const namedPeopleCount = namedPeople.length;
-  const canStart = namedPeopleCount >= minPeople;
+  const state = getGroupSetupState(audience, groupNames);
+  const copy = state.isDuo ? t.quiz.duoSetup : t.quiz.groupSetup;
 
   return (
     <div className="flex-1 flex flex-col items-center justify-center px-5 py-12 min-h-[80vh]">
@@ -40,181 +37,351 @@ export function GroupSetup({
         transition={{ duration: 0.5 }}
         className="w-full max-w-md"
       >
-        <div className="text-center mb-8">
-          <div className="text-4xl mb-4">👥</div>
-          <h2
-            style={{
-              fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
-              fontWeight: '600',
-              textTransform: 'uppercase',
-              fontSize: '2rem',
-              letterSpacing: '0.05em',
-              color: 'var(--pc-t1)',
-            }}
-          >
-            {copy.title}
-          </h2>
-          <p style={{ color: 'var(--pc-t3)', fontSize: '0.85rem', marginTop: 6 }}>
-            {copy.subtitle}
-          </p>
-          <p
-            className="mt-4 inline-flex rounded-full px-3 py-1 text-xs"
-            style={{
-              background: 'var(--pc-gold-wash)',
-              border: '1px solid var(--pc-gold-bd)',
-              color: 'var(--pc-gold-text)',
-              fontWeight: 700,
-            }}
-          >
-            {copy.countLabel.replace('{count}', String(namedPeopleCount))}
-          </p>
-        </div>
-
-        <div className="flex flex-col gap-3 mb-6">
-          {visibleNames.map((name, i) => (
-            <div key={i} className="flex items-center gap-3">
-              <div
-                className="w-8 h-8 rounded-full flex items-center justify-center shrink-0 text-xs"
-                style={{
-                  background: `${palette.purple}33`,
-                  color: palette.purpleLight,
-                  fontWeight: 700,
-                }}
-              >
-                {i + 1}
-              </div>
-              <input
-                value={name}
-                maxLength={PARTICIPANT_NAME_MAX_LENGTH}
-                onChange={(e) =>
-                  onGroupNamesChange(groupNames.map((n, j) => (j === i ? e.target.value : n)))
-                }
-                placeholder={copy.personPlaceholder.replace('{n}', String(i + 1))}
-                className="flex-1 px-4 py-3 rounded-xl outline-none transition-all duration-200"
-                style={{
-                  background: 'var(--pc-surface)',
-                  border: '1px solid var(--pc-bd2)',
-                  color: 'var(--pc-t1)',
-                  fontSize: '0.95rem',
-                }}
-                onFocus={(e) => {
-                  (e.currentTarget as HTMLInputElement).style.borderColor = `${palette.purple}80`;
-                }}
-                onBlur={(e) => {
-                  (e.currentTarget as HTMLInputElement).style.borderColor = 'var(--pc-bd2)';
-                }}
-              />
-              {!isDuo && groupNames.length > 2 && (
-                <button
-                  onClick={() => onGroupNamesChange(groupNames.filter((_, j) => j !== i))}
-                  className="w-8 h-8 rounded-full flex items-center justify-center transition-all duration-200"
-                  style={{ color: 'var(--pc-t3)' }}
-                  onMouseEnter={(e) => {
-                    (e.currentTarget as HTMLElement).style.color = palette.red;
-                    (e.currentTarget as HTMLElement).style.background = `${palette.red}1a`;
-                  }}
-                  onMouseLeave={(e) => {
-                    (e.currentTarget as HTMLElement).style.color = 'var(--pc-t3)';
-                    (e.currentTarget as HTMLElement).style.background = 'transparent';
-                  }}
-                >
-                  <Trash2 size={15} />
-                </button>
-              )}
-            </div>
-          ))}
-        </div>
-
-        {!isDuo && groupNames.length < maxPeople && (
-          <button
-            onClick={() => onGroupNamesChange([...groupNames, ''])}
-            className="w-full flex items-center gap-2 justify-center py-3 rounded-xl mb-6 text-sm transition-all duration-200"
-            style={{
-              border: '1px dashed var(--pc-bd4)',
-              color: 'var(--pc-t3)',
-            }}
-            onMouseEnter={(e) => {
-              (e.currentTarget as HTMLElement).style.color = palette.purpleLight;
-              (e.currentTarget as HTMLElement).style.borderColor = `${palette.purple}66`;
-            }}
-            onMouseLeave={(e) => {
-              (e.currentTarget as HTMLElement).style.color = 'var(--pc-t3)';
-              (e.currentTarget as HTMLElement).style.borderColor = 'var(--pc-bd4)';
-            }}
-          >
-            <Plus size={15} /> {copy.addPerson}
-          </button>
-        )}
-
-        {namedPeople.length > 0 && (
-          <div className="mb-6">
-            <div className="mb-2 flex items-center justify-between gap-3">
-              <p
-                style={{
-                  color: 'var(--pc-t3)',
-                  fontSize: '0.7rem',
-                  fontWeight: 700,
-                  letterSpacing: '0.12em',
-                  textTransform: 'uppercase',
-                }}
-              >
-                {copy.orderTitle}
-              </p>
-              <p style={{ color: 'var(--pc-t4)', fontSize: '0.72rem' }}>{copy.orderHint}</p>
-            </div>
-            <div className="flex flex-wrap gap-2">
-              {namedPeople.map((name, index) => (
-                <span
-                  key={`${name}-${index}`}
-                  className="rounded-full px-3 py-1 text-xs"
-                  style={{
-                    background: index === 0 ? 'var(--pc-gold-wash)' : 'var(--pc-ghost)',
-                    border: index === 0 ? '1px solid var(--pc-gold-bd)' : '1px solid var(--pc-bd2)',
-                    color: index === 0 ? 'var(--pc-gold-text)' : 'var(--pc-t3)',
-                    fontWeight: 700,
-                  }}
-                >
-                  {index + 1}. {name}
-                </span>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {!canStart && (
-          <p className="mb-4 text-center text-xs" style={{ color: 'var(--pc-t4)' }}>
-            {copy.twoNamesHint}
-          </p>
-        )}
-
-        <div className="flex gap-3">
-          <button
-            onClick={onBack}
-            className="flex-1 py-3 rounded-xl text-sm transition-all duration-200"
-            style={{
-              background: 'var(--pc-ghost)',
-              border: '1px solid var(--pc-bd2)',
-              color: 'var(--pc-t2)',
-            }}
-          >
-            {copy.back}
-          </button>
-          <button
-            onClick={onStart}
-            disabled={!canStart}
-            className="flex-1 py-3 rounded-xl text-sm transition-all duration-200"
-            style={{
-              background: 'var(--pc-cta)',
-              color: 'var(--pc-cta-text)',
-              fontWeight: 700,
-              opacity: canStart ? 1 : 0.5,
-              cursor: canStart ? 'pointer' : 'not-allowed',
-            }}
-          >
-            {copy.letsGo}
-          </button>
-        </div>
+        <GroupSetupHeader copy={copy} namedPeopleCount={state.namedPeople.length} />
+        <ParticipantRows
+          copy={copy}
+          groupNames={groupNames}
+          isDuo={state.isDuo}
+          onGroupNamesChange={onGroupNamesChange}
+          visibleNames={state.visibleNames}
+        />
+        <AddParticipantButton
+          copy={copy}
+          groupNames={groupNames}
+          maxPeople={state.maxPeople}
+          onGroupNamesChange={onGroupNamesChange}
+          show={!state.isDuo}
+        />
+        <SpeakingOrderPreview copy={copy} namedPeople={state.namedPeople} />
+        <StartHint canStart={state.canStart} copy={copy} />
+        <GroupSetupActions
+          canStart={state.canStart}
+          copy={copy}
+          onBack={onBack}
+          onStart={onStart}
+        />
       </motion.div>
     </div>
   );
+}
+
+function GroupSetupHeader({
+  copy,
+  namedPeopleCount,
+}: {
+  copy: GroupSetupCopy;
+  namedPeopleCount: number;
+}) {
+  return (
+    <div className="text-center mb-8">
+      <div className="text-4xl mb-4">👥</div>
+      <h2
+        style={{
+          color: 'var(--pc-t1)',
+          fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
+          fontSize: '2rem',
+          fontWeight: '600',
+          letterSpacing: '0.05em',
+          textTransform: 'uppercase',
+        }}
+      >
+        {copy.title}
+      </h2>
+      <p style={{ color: 'var(--pc-t3)', fontSize: '0.85rem', marginTop: 6 }}>{copy.subtitle}</p>
+      <p
+        className="mt-4 inline-flex rounded-full px-3 py-1 text-xs"
+        style={{
+          background: 'var(--pc-gold-wash)',
+          border: '1px solid var(--pc-gold-bd)',
+          color: 'var(--pc-gold-text)',
+          fontWeight: 700,
+        }}
+      >
+        {copy.countLabel.replace('{count}', String(namedPeopleCount))}
+      </p>
+    </div>
+  );
+}
+
+function ParticipantRows({
+  copy,
+  groupNames,
+  isDuo,
+  onGroupNamesChange,
+  visibleNames,
+}: {
+  copy: GroupSetupCopy;
+  groupNames: string[];
+  isDuo: boolean;
+  onGroupNamesChange: (names: string[]) => void;
+  visibleNames: string[];
+}) {
+  return (
+    <div className="flex flex-col gap-3 mb-6">
+      {visibleNames.map((name, index) => (
+        <ParticipantRow
+          key={index}
+          copy={copy}
+          groupNames={groupNames}
+          index={index}
+          isRemovable={!isDuo && groupNames.length > 2}
+          name={name}
+          onGroupNamesChange={onGroupNamesChange}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ParticipantRow({
+  copy,
+  groupNames,
+  index,
+  isRemovable,
+  name,
+  onGroupNamesChange,
+}: {
+  copy: GroupSetupCopy;
+  groupNames: string[];
+  index: number;
+  isRemovable: boolean;
+  name: string;
+  onGroupNamesChange: (names: string[]) => void;
+}) {
+  return (
+    <div className="flex items-center gap-3">
+      <ParticipantIndex index={index} />
+      <input
+        value={name}
+        maxLength={PARTICIPANT_NAME_MAX_LENGTH}
+        onChange={(event) =>
+          onGroupNamesChange(replaceNameAtIndex(groupNames, index, event.target.value))
+        }
+        placeholder={copy.personPlaceholder.replace('{n}', String(index + 1))}
+        className="flex-1 px-4 py-3 rounded-xl outline-none transition-all duration-200"
+        style={{
+          background: 'var(--pc-surface)',
+          border: '1px solid var(--pc-bd2)',
+          color: 'var(--pc-t1)',
+          fontSize: '0.95rem',
+        }}
+        onFocus={(event) => {
+          event.currentTarget.style.borderColor = `${palette.purple}80`;
+        }}
+        onBlur={(event) => {
+          event.currentTarget.style.borderColor = 'var(--pc-bd2)';
+        }}
+      />
+      {isRemovable && (
+        <RemoveParticipantButton
+          onClick={() => onGroupNamesChange(removeNameAtIndex(groupNames, index))}
+        />
+      )}
+    </div>
+  );
+}
+
+function ParticipantIndex({ index }: { index: number }) {
+  return (
+    <div
+      className="w-8 h-8 rounded-full flex items-center justify-center shrink-0 text-xs"
+      style={{
+        background: `${palette.purple}33`,
+        color: palette.purpleLight,
+        fontWeight: 700,
+      }}
+    >
+      {index + 1}
+    </div>
+  );
+}
+
+function RemoveParticipantButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className="w-8 h-8 rounded-full flex items-center justify-center transition-all duration-200"
+      style={{ color: 'var(--pc-t3)' }}
+      onMouseEnter={(event) => {
+        event.currentTarget.style.background = `${palette.red}1a`;
+        event.currentTarget.style.color = palette.red;
+      }}
+      onMouseLeave={(event) => {
+        event.currentTarget.style.background = 'transparent';
+        event.currentTarget.style.color = 'var(--pc-t3)';
+      }}
+    >
+      <Trash2 size={15} />
+    </button>
+  );
+}
+
+function AddParticipantButton({
+  copy,
+  groupNames,
+  maxPeople,
+  onGroupNamesChange,
+  show,
+}: {
+  copy: GroupSetupCopy;
+  groupNames: string[];
+  maxPeople: number;
+  onGroupNamesChange: (names: string[]) => void;
+  show: boolean;
+}) {
+  if (!show || groupNames.length >= maxPeople) {
+    return null;
+  }
+
+  return (
+    <button
+      onClick={() => onGroupNamesChange([...groupNames, ''])}
+      className="w-full flex items-center gap-2 justify-center py-3 rounded-xl mb-6 text-sm transition-all duration-200"
+      style={{
+        border: '1px dashed var(--pc-bd4)',
+        color: 'var(--pc-t3)',
+      }}
+      onMouseEnter={(event) => {
+        event.currentTarget.style.borderColor = `${palette.purple}66`;
+        event.currentTarget.style.color = palette.purpleLight;
+      }}
+      onMouseLeave={(event) => {
+        event.currentTarget.style.borderColor = 'var(--pc-bd4)';
+        event.currentTarget.style.color = 'var(--pc-t3)';
+      }}
+    >
+      <Plus size={15} /> {copy.addPerson}
+    </button>
+  );
+}
+
+function SpeakingOrderPreview({
+  copy,
+  namedPeople,
+}: {
+  copy: GroupSetupCopy;
+  namedPeople: string[];
+}) {
+  if (namedPeople.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mb-6">
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <p
+          style={{
+            color: 'var(--pc-t3)',
+            fontSize: '0.7rem',
+            fontWeight: 700,
+            letterSpacing: '0.12em',
+            textTransform: 'uppercase',
+          }}
+        >
+          {copy.orderTitle}
+        </p>
+        <p style={{ color: 'var(--pc-t4)', fontSize: '0.72rem' }}>{copy.orderHint}</p>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {namedPeople.map((name, index) => (
+          <span
+            key={`${name}-${index}`}
+            className="rounded-full px-3 py-1 text-xs"
+            style={getSpeakingOrderPillStyle(index)}
+          >
+            {index + 1}. {name}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function StartHint({ canStart, copy }: { canStart: boolean; copy: GroupSetupCopy }) {
+  if (canStart) {
+    return null;
+  }
+
+  return (
+    <p className="mb-4 text-center text-xs" style={{ color: 'var(--pc-t4)' }}>
+      {copy.twoNamesHint}
+    </p>
+  );
+}
+
+function GroupSetupActions({
+  canStart,
+  copy,
+  onBack,
+  onStart,
+}: {
+  canStart: boolean;
+  copy: GroupSetupCopy;
+  onBack: () => void;
+  onStart: () => void;
+}) {
+  return (
+    <div className="flex gap-3">
+      <button
+        onClick={onBack}
+        className="flex-1 py-3 rounded-xl text-sm transition-all duration-200"
+        style={{
+          background: 'var(--pc-ghost)',
+          border: '1px solid var(--pc-bd2)',
+          color: 'var(--pc-t2)',
+        }}
+      >
+        {copy.back}
+      </button>
+      <button
+        onClick={onStart}
+        disabled={!canStart}
+        className="flex-1 py-3 rounded-xl text-sm transition-all duration-200"
+        style={{
+          background: 'var(--pc-cta)',
+          color: 'var(--pc-cta-text)',
+          cursor: canStart ? 'pointer' : 'not-allowed',
+          fontWeight: 700,
+          opacity: canStart ? 1 : 0.5,
+        }}
+      >
+        {copy.letsGo}
+      </button>
+    </div>
+  );
+}
+
+function getGroupSetupState(audience: GroupSetupAudience, groupNames: string[]) {
+  const isDuo = audience === 'duo';
+  const maxPeople = isDuo ? 2 : 6;
+  const minPeople = isDuo ? 2 : 3;
+  const visibleNames = isDuo ? groupNames.slice(0, 2) : groupNames;
+  const namedPeople = visibleNames.map((name) => name.trim()).filter(Boolean);
+
+  return {
+    canStart: namedPeople.length >= minPeople,
+    isDuo,
+    maxPeople,
+    namedPeople,
+    visibleNames,
+  };
+}
+
+function getSpeakingOrderPillStyle(index: number) {
+  const isFirst = index === 0;
+
+  return {
+    background: isFirst ? 'var(--pc-gold-wash)' : 'var(--pc-ghost)',
+    border: isFirst ? '1px solid var(--pc-gold-bd)' : '1px solid var(--pc-bd2)',
+    color: isFirst ? 'var(--pc-gold-text)' : 'var(--pc-t3)',
+    fontWeight: 700,
+  };
+}
+
+function replaceNameAtIndex(names: string[], index: number, nextName: string) {
+  return names.map((name, currentIndex) => (currentIndex === index ? nextName : name));
+}
+
+function removeNameAtIndex(names: string[], index: number) {
+  return names.filter((_, currentIndex) => currentIndex !== index);
 }

--- a/apps/web/src/app/quiz/components/QuizNavigation.tsx
+++ b/apps/web/src/app/quiz/components/QuizNavigation.tsx
@@ -14,6 +14,24 @@ interface QuizNavigationProps {
   nextPersonName?: string;
 }
 
+type NavigationCopy = ReturnType<typeof useLanguage>['t']['quiz']['nav'];
+type NextButtonLabelKind = 'continue' | 'handoff' | 'submit' | 'submitting';
+
+const NEXT_BUTTON_STYLE = {
+  disabled: {
+    background: 'var(--pc-bd2)',
+    color: 'var(--pc-t4)',
+    cursor: 'not-allowed',
+    fontWeight: 700,
+  },
+  enabled: {
+    background: 'var(--pc-cta)',
+    color: 'var(--pc-cta-text)',
+    cursor: 'pointer',
+    fontWeight: 700,
+  },
+};
+
 export function QuizNavigation({
   onBack,
   onNext,
@@ -24,9 +42,14 @@ export function QuizNavigation({
   nextPersonName,
 }: QuizNavigationProps) {
   const { t } = useLanguage();
-  const nextPersonLabel = nextPersonName
-    ? t.quiz.nav.handTo.replace('{name}', nextPersonName)
-    : t.quiz.nav.nextPerson;
+  const nextButton = getNextButtonPresentation({
+    canProceed,
+    copy: t.quiz.nav,
+    isLastPerson,
+    isLastStep,
+    isSubmitting,
+    nextPersonName,
+  });
 
   return (
     <div className="px-5 py-6 max-w-xl mx-auto w-full flex gap-3">
@@ -44,29 +67,131 @@ export function QuizNavigation({
 
       <button
         onClick={onNext}
-        disabled={!canProceed || isSubmitting}
+        disabled={nextButton.disabled}
         className="flex-1 flex items-center justify-center gap-2 py-3.5 rounded-2xl text-sm transition-all duration-200 active:scale-[0.98]"
-        style={{
-          background: canProceed && !isSubmitting ? 'var(--pc-cta)' : 'var(--pc-bd2)',
-          color: canProceed && !isSubmitting ? 'var(--pc-cta-text)' : 'var(--pc-t4)',
-          fontWeight: 700,
-          cursor: canProceed && !isSubmitting ? 'pointer' : 'not-allowed',
-        }}
+        style={nextButton.style}
       >
-        {isSubmitting ? (
-          <>{t.quiz.nav.submitting}</>
-        ) : isLastStep && isLastPerson ? (
-          <>{t.quiz.nav.findMyMovie}</>
-        ) : isLastStep ? (
-          <>
-            {nextPersonLabel} <ChevronRight size={16} />
-          </>
-        ) : (
-          <>
-            {t.quiz.nav.continue} <ChevronRight size={16} />
-          </>
-        )}
+        {nextButton.label}
+        {nextButton.showChevron && <ChevronRight size={16} />}
       </button>
     </div>
   );
+}
+
+function getNextButtonPresentation({
+  canProceed,
+  copy,
+  isLastPerson,
+  isLastStep,
+  isSubmitting,
+  nextPersonName,
+}: {
+  canProceed: boolean;
+  copy: NavigationCopy;
+  isLastPerson: boolean;
+  isLastStep: boolean;
+  isSubmitting: boolean;
+  nextPersonName?: string;
+}) {
+  const enabled = canUseNextButton(canProceed, isSubmitting);
+  const label = getNextButtonLabel({
+    copy,
+    isLastPerson,
+    isLastStep,
+    isSubmitting,
+    nextPersonName,
+  });
+
+  return {
+    disabled: !enabled,
+    label: label.text,
+    showChevron: label.showChevron,
+    style: getNextButtonStyle(enabled),
+  };
+}
+
+function getNextButtonLabel({
+  copy,
+  isLastPerson,
+  isLastStep,
+  isSubmitting,
+  nextPersonName,
+}: {
+  copy: NavigationCopy;
+  isLastPerson: boolean;
+  isLastStep: boolean;
+  isSubmitting: boolean;
+  nextPersonName?: string;
+}) {
+  const kind = getNextButtonLabelKind({ isLastPerson, isLastStep, isSubmitting });
+  const text = getNextButtonText({ copy, kind, nextPersonName });
+
+  return { showChevron: shouldShowNextChevron(kind), text };
+}
+
+function getNextPersonLabel(copy: NavigationCopy, nextPersonName?: string) {
+  if (!nextPersonName) {
+    return copy.nextPerson;
+  }
+
+  return copy.handTo.replace('{name}', nextPersonName);
+}
+
+function canUseNextButton(canProceed: boolean, isSubmitting: boolean) {
+  return canProceed && !isSubmitting;
+}
+
+function getNextButtonStyle(enabled: boolean) {
+  return enabled ? NEXT_BUTTON_STYLE.enabled : NEXT_BUTTON_STYLE.disabled;
+}
+
+function getNextButtonLabelKind({
+  isLastPerson,
+  isLastStep,
+  isSubmitting,
+}: {
+  isLastPerson: boolean;
+  isLastStep: boolean;
+  isSubmitting: boolean;
+}): NextButtonLabelKind {
+  if (isSubmitting) {
+    return 'submitting';
+  }
+
+  if (isFinalSubmit(isLastStep, isLastPerson)) {
+    return 'submit';
+  }
+
+  if (isLastStep) {
+    return 'handoff';
+  }
+
+  return 'continue';
+}
+
+function getNextButtonText({
+  copy,
+  kind,
+  nextPersonName,
+}: {
+  copy: NavigationCopy;
+  kind: NextButtonLabelKind;
+  nextPersonName?: string;
+}) {
+  const textByKind = {
+    continue: copy.continue,
+    handoff: getNextPersonLabel(copy, nextPersonName),
+    submit: copy.findMyMovie,
+    submitting: copy.submitting,
+  };
+
+  return textByKind[kind];
+}
+
+function shouldShowNextChevron(kind: NextButtonLabelKind) {
+  return kind === 'continue' || kind === 'handoff';
+}
+
+function isFinalSubmit(isLastStep: boolean, isLastPerson: boolean) {
+  return isLastStep && isLastPerson;
 }

--- a/apps/web/src/app/quiz/components/steps/FastPickSteps.tsx
+++ b/apps/web/src/app/quiz/components/steps/FastPickSteps.tsx
@@ -1,109 +1,49 @@
 'use client';
 
-import { Check, Compass, ShieldOff, Sparkles } from 'lucide-react';
+import { Compass, ShieldOff, Sparkles } from 'lucide-react';
 
 import { useLanguage } from '@/i18n';
 import { palette } from '@/styles/designTokens';
 
 import { FAST_AVOIDS, FAST_DISCOVERY_OPTIONS, FAST_INTENTS } from '../../constants';
 
+import { OptionIcon, SelectableOptionButton, SelectionMark, StepHeader } from './StepPrimitives';
+
 import type { FastAvoid, FastDiscovery, FastIntent, PersonAnswers } from '../../types';
+import type { ReactNode } from 'react';
 
 interface FastPickStepProps {
   person: PersonAnswers;
   onUpdate: (updates: Partial<PersonAnswers>) => void;
 }
 
-function SelectionMark({ color }: { color: string }) {
-  return (
-    <span
-      className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full"
-      style={{ background: color }}
-    >
-      <Check size={12} style={{ color: 'var(--pc-cta-text)' }} />
-    </span>
-  );
-}
+type FastIntentOption = (typeof FAST_INTENTS)[number];
+type FastAvoidOption = (typeof FAST_AVOIDS)[number];
+type FastDiscoveryOption = (typeof FAST_DISCOVERY_OPTIONS)[number];
 
 export function FastIntentStep({ person, onUpdate }: FastPickStepProps) {
   const { t } = useLanguage();
 
   return (
     <div className="flex flex-col gap-5 pt-2">
-      <div className="flex items-center gap-3">
-        <div
-          className="flex h-10 w-10 items-center justify-center rounded-xl"
-          style={{
-            background: 'rgba(245,197,24,0.15)',
-            color: 'var(--pc-gold-text)',
-          }}
-        >
-          <Sparkles size={20} />
-        </div>
-        <div>
-          <h2
-            style={{
-              fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
-              fontWeight: '600',
-              textTransform: 'uppercase',
-              fontSize: '1.8rem',
-              letterSpacing: '0.04em',
-              color: 'var(--pc-t1)',
-              lineHeight: 1.1,
-            }}
-          >
-            {t.quiz.fast.intent.title}
-          </h2>
-          <p style={{ color: 'var(--pc-t3)', fontSize: '0.82rem', marginTop: 2 }}>
-            {t.quiz.fast.intent.hint}
-          </p>
-        </div>
-      </div>
-
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-        {FAST_INTENTS.map((option) => {
-          const selected = person.fastIntent.includes(option.id);
-          const label = t.quiz.fast.intent.options[option.id];
-          const nextIntent = selected
-            ? person.fastIntent.filter((intent) => intent !== option.id)
-            : [...person.fastIntent, option.id as FastIntent].slice(0, 3);
-
-          return (
-            <button
-              key={option.id}
-              type="button"
-              aria-pressed={selected}
-              onClick={() => onUpdate({ fastIntent: nextIntent })}
-              className="flex items-center gap-3 rounded-xl p-3.5 text-left transition-all duration-200 active:scale-[0.97]"
-              style={{
-                background: selected ? `${option.color}18` : 'var(--pc-surface)',
-                border: selected ? `1.5px solid ${option.color}50` : '1px solid var(--pc-bd1)',
-              }}
-            >
-              <span
-                className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg"
-                style={{
-                  background: selected ? `${option.color}25` : 'var(--pc-ghost)',
-                  color: selected ? option.color : 'var(--pc-t3)',
-                }}
-              >
-                <option.icon size={16} />
-              </span>
-              <span
-                className="flex-1"
-                style={{
-                  color: selected ? option.color : 'var(--pc-t2)',
-                  fontWeight: selected ? 600 : 400,
-                  fontSize: '0.9rem',
-                }}
-              >
-                {label}
-              </span>
-              {selected && <SelectionMark color={option.color} />}
-            </button>
-          );
-        })}
-      </div>
+      <StepHeader
+        accentBackground="rgba(245,197,24,0.15)"
+        accentColor="var(--pc-gold-text)"
+        icon={<Sparkles size={20} />}
+        title={t.quiz.fast.intent.title}
+        subtitle={t.quiz.fast.intent.hint}
+      />
+      <FastOptionGrid>
+        {FAST_INTENTS.map((option) => (
+          <FastIntentOptionButton
+            key={option.id}
+            option={option}
+            person={person}
+            label={t.quiz.fast.intent.options[option.id]}
+            onUpdate={onUpdate}
+          />
+        ))}
+      </FastOptionGrid>
     </div>
   );
 }
@@ -113,80 +53,24 @@ export function FastAvoidsStep({ person, onUpdate }: FastPickStepProps) {
 
   return (
     <div className="flex flex-col gap-5 pt-2">
-      <div className="flex items-center gap-3">
-        <div
-          className="flex h-10 w-10 items-center justify-center rounded-xl"
-          style={{
-            background: 'rgba(239,68,68,0.15)',
-            color: palette.red,
-          }}
-        >
-          <ShieldOff size={20} />
-        </div>
-        <div>
-          <h2
-            style={{
-              fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
-              fontWeight: '600',
-              textTransform: 'uppercase',
-              fontSize: '1.8rem',
-              letterSpacing: '0.04em',
-              color: 'var(--pc-t1)',
-              lineHeight: 1.1,
-            }}
-          >
-            {t.quiz.fast.avoids.title}
-          </h2>
-          <p style={{ color: 'var(--pc-t3)', fontSize: '0.82rem', marginTop: 2 }}>
-            {t.quiz.fast.avoids.hint}
-          </p>
-        </div>
-      </div>
-
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-        {FAST_AVOIDS.map((option) => {
-          const selected = person.fastAvoids.includes(option.id);
-          const label = t.quiz.fast.avoids.options[option.id];
-          const nextAvoids = selected
-            ? person.fastAvoids.filter((avoid) => avoid !== option.id)
-            : [...person.fastAvoids, option.id as FastAvoid];
-
-          return (
-            <button
-              key={option.id}
-              type="button"
-              aria-pressed={selected}
-              onClick={() => onUpdate({ fastAvoids: nextAvoids })}
-              className="flex items-center gap-3 rounded-xl p-3.5 text-left transition-all duration-200 active:scale-[0.97]"
-              style={{
-                background: selected ? `${option.color}18` : 'var(--pc-surface)',
-                border: selected ? `1.5px solid ${option.color}50` : '1px solid var(--pc-bd1)',
-              }}
-            >
-              <span
-                className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg"
-                style={{
-                  background: selected ? `${option.color}25` : 'var(--pc-ghost)',
-                  color: selected ? option.color : 'var(--pc-t3)',
-                }}
-              >
-                <option.icon size={16} />
-              </span>
-              <span
-                className="flex-1"
-                style={{
-                  color: selected ? option.color : 'var(--pc-t2)',
-                  fontWeight: selected ? 600 : 400,
-                  fontSize: '0.9rem',
-                }}
-              >
-                {label}
-              </span>
-              {selected && <SelectionMark color={option.color} />}
-            </button>
-          );
-        })}
-      </div>
+      <StepHeader
+        accentBackground="rgba(239,68,68,0.15)"
+        accentColor={palette.red}
+        icon={<ShieldOff size={20} />}
+        title={t.quiz.fast.avoids.title}
+        subtitle={t.quiz.fast.avoids.hint}
+      />
+      <FastOptionGrid>
+        {FAST_AVOIDS.map((option) => (
+          <FastAvoidOptionButton
+            key={option.id}
+            option={option}
+            person={person}
+            label={t.quiz.fast.avoids.options[option.id]}
+            onUpdate={onUpdate}
+          />
+        ))}
+      </FastOptionGrid>
     </div>
   );
 }
@@ -196,74 +80,169 @@ export function FastDiscoveryStep({ person, onUpdate }: FastPickStepProps) {
 
   return (
     <div className="flex flex-col gap-5 pt-2">
-      <div className="flex items-center gap-3">
-        <div
-          className="flex h-10 w-10 items-center justify-center rounded-xl"
-          style={{
-            background: 'rgba(20,184,166,0.15)',
-            color: palette.teal,
-          }}
-        >
-          <Compass size={20} />
-        </div>
-        <h2
-          style={{
-            fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
-            fontWeight: '600',
-            textTransform: 'uppercase',
-            fontSize: '1.8rem',
-            letterSpacing: '0.04em',
-            color: 'var(--pc-t1)',
-            lineHeight: 1.1,
-          }}
-        >
-          {t.quiz.fast.discovery.title}
-        </h2>
-      </div>
-
+      <StepHeader
+        accentBackground="rgba(20,184,166,0.15)"
+        accentColor={palette.teal}
+        icon={<Compass size={20} />}
+        title={t.quiz.fast.discovery.title}
+      />
       <div className="grid grid-cols-1 gap-4">
-        {FAST_DISCOVERY_OPTIONS.map((option) => {
-          const selected = person.fastDiscovery === option.id;
-          const copy = t.quiz.fast.discovery.options[option.id];
-
-          return (
-            <button
-              key={option.id}
-              type="button"
-              aria-pressed={selected}
-              onClick={() => onUpdate({ fastDiscovery: option.id as FastDiscovery })}
-              className="flex items-center gap-4 rounded-2xl p-4 text-left transition-all duration-200 active:scale-[0.98]"
-              style={{
-                background: selected ? `${option.color}18` : 'var(--pc-surface)',
-                border: selected ? `1.5px solid ${option.color}60` : '1px solid var(--pc-bd2)',
-                boxShadow: selected ? `0 0 20px ${option.color}18` : 'none',
-              }}
-            >
-              <span
-                className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl"
-                style={{
-                  background: selected ? `${option.color}25` : 'var(--pc-ghost)',
-                  color: selected ? option.color : 'var(--pc-t3)',
-                }}
-              >
-                <option.icon size={19} />
-              </span>
-              <span className="flex-1">
-                <span
-                  className="block"
-                  style={{ color: selected ? option.color : 'var(--pc-t1)', fontWeight: 600 }}
-                >
-                  {copy.title}
-                </span>
-                <span className="block" style={{ color: 'var(--pc-t3)', fontSize: '0.82rem' }}>
-                  {copy.desc}
-                </span>
-              </span>
-              {selected && <SelectionMark color={option.color} />}
-            </button>
-          );
-        })}
+        {FAST_DISCOVERY_OPTIONS.map((option) => (
+          <FastDiscoveryOptionButton
+            key={option.id}
+            option={option}
+            selected={person.fastDiscovery === option.id}
+            copy={t.quiz.fast.discovery.options[option.id]}
+            onSelect={() => onUpdate({ fastDiscovery: option.id as FastDiscovery })}
+          />
+        ))}
       </div>
     </div>
   );
+}
+
+function FastOptionGrid({ children }: { children: ReactNode }) {
+  return <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">{children}</div>;
+}
+
+function FastIntentOptionButton({
+  label,
+  onUpdate,
+  option,
+  person,
+}: {
+  label: string;
+  onUpdate: (updates: Partial<PersonAnswers>) => void;
+  option: FastIntentOption;
+  person: PersonAnswers;
+}) {
+  const selected = person.fastIntent.includes(option.id);
+  const nextIntent = getNextFastIntent(person.fastIntent, option.id, selected);
+
+  return (
+    <FastSelectableOption
+      color={option.color}
+      icon={<option.icon size={16} />}
+      label={label}
+      selected={selected}
+      onClick={() => onUpdate({ fastIntent: nextIntent })}
+    />
+  );
+}
+
+function FastAvoidOptionButton({
+  label,
+  onUpdate,
+  option,
+  person,
+}: {
+  label: string;
+  onUpdate: (updates: Partial<PersonAnswers>) => void;
+  option: FastAvoidOption;
+  person: PersonAnswers;
+}) {
+  const selected = person.fastAvoids.includes(option.id);
+  const nextAvoids = getNextFastAvoids(person.fastAvoids, option.id, selected);
+
+  return (
+    <FastSelectableOption
+      color={option.color}
+      icon={<option.icon size={16} />}
+      label={label}
+      selected={selected}
+      onClick={() => onUpdate({ fastAvoids: nextAvoids })}
+    />
+  );
+}
+
+function FastDiscoveryOptionButton({
+  copy,
+  onSelect,
+  option,
+  selected,
+}: {
+  copy: { title: string; desc: string };
+  onSelect: () => void;
+  option: FastDiscoveryOption;
+  selected: boolean;
+}) {
+  return (
+    <SelectableOptionButton
+      color={option.color}
+      layout="large-row"
+      selected={selected}
+      onClick={onSelect}
+      selectedBorderAlpha="60"
+      selectedShadow={`0 0 20px ${option.color}18`}
+    >
+      <OptionIcon color={option.color} selected={selected} size="lg">
+        <option.icon size={19} />
+      </OptionIcon>
+      <span className="flex-1">
+        <span
+          className="block"
+          style={{ color: selected ? option.color : 'var(--pc-t1)', fontWeight: 600 }}
+        >
+          {copy.title}
+        </span>
+        <span className="block" style={{ color: 'var(--pc-t3)', fontSize: '0.82rem' }}>
+          {copy.desc}
+        </span>
+      </span>
+      {selected && <SelectionMark color={option.color} />}
+    </SelectableOptionButton>
+  );
+}
+
+function FastSelectableOption({
+  color,
+  icon,
+  label,
+  onClick,
+  selected,
+}: {
+  color: string;
+  icon: ReactNode;
+  label: string;
+  onClick: () => void;
+  selected: boolean;
+}) {
+  return (
+    <SelectableOptionButton color={color} selected={selected} onClick={onClick}>
+      <OptionIcon color={color} selected={selected}>
+        {icon}
+      </OptionIcon>
+      <span
+        className="flex-1"
+        style={{
+          color: selected ? color : 'var(--pc-t2)',
+          fontSize: '0.9rem',
+          fontWeight: selected ? 600 : 400,
+        }}
+      >
+        {label}
+      </span>
+      {selected && <SelectionMark color={color} />}
+    </SelectableOptionButton>
+  );
+}
+
+function getNextFastIntent(
+  currentIntent: FastIntent[],
+  intentId: string,
+  selected: boolean,
+): FastIntent[] {
+  return selected
+    ? currentIntent.filter((intent) => intent !== intentId)
+    : [...currentIntent, intentId as FastIntent].slice(0, 3);
+}
+
+function getNextFastAvoids(
+  currentAvoids: FastAvoid[],
+  avoidId: string,
+  selected: boolean,
+): FastAvoid[] {
+  return selected
+    ? currentAvoids.filter((avoid) => avoid !== avoidId)
+    : [...currentAvoids, avoidId as FastAvoid];
 }

--- a/apps/web/src/app/quiz/components/steps/MoodStep.tsx
+++ b/apps/web/src/app/quiz/components/steps/MoodStep.tsx
@@ -6,6 +6,8 @@ import { useLanguage } from '@/i18n';
 
 import { GENRES } from '../../constants';
 
+import { OptionIcon, SelectableOptionButton, StepHeader } from './StepPrimitives';
+
 import type { PersonAnswers } from '../../types';
 
 const MAX_MOOD_SELECTIONS = 3;
@@ -15,109 +17,95 @@ interface MoodStepProps {
   onUpdate: (updates: Partial<PersonAnswers>) => void;
 }
 
+type MoodOption = (typeof GENRES)[number];
+
 export function MoodStep({ person, onUpdate }: MoodStepProps) {
   const { t } = useLanguage();
 
   return (
     <div className="flex flex-col gap-5 pt-2">
-      <div className="flex items-center gap-3">
-        <div
-          className="w-10 h-10 rounded-xl flex items-center justify-center"
-          style={{
-            background: 'rgba(139,92,246,0.15)',
-            color: '#8B5CF6',
-          }}
-        >
-          <Smile size={20} />
-        </div>
-        <div>
-          <h2
-            style={{
-              fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
-              fontWeight: '600',
-              textTransform: 'uppercase',
-              fontSize: '1.8rem',
-              letterSpacing: '0.04em',
-              color: 'var(--pc-t1)',
-              lineHeight: 1.1,
-            }}
-          >
-            {t.quiz.mood.title}
-          </h2>
-          <p
-            style={{
-              color: 'var(--pc-t3)',
-              fontSize: '0.82rem',
-              marginTop: 2,
-            }}
-          >
-            {t.quiz.mood.pickOne}
-          </p>
-        </div>
-      </div>
+      <StepHeader
+        accentBackground="rgba(139,92,246,0.15)"
+        accentColor="#8B5CF6"
+        icon={<Smile size={20} />}
+        title={t.quiz.mood.title}
+        subtitle={t.quiz.mood.pickOne}
+      />
 
       <div className="grid grid-cols-2 gap-3">
-        {GENRES.map((g) => {
-          const selected = person.moods.includes(g.id);
-          const selectionLimitReached = !selected && person.moods.length >= MAX_MOOD_SELECTIONS;
-          const label = t.genres[g.id as keyof typeof t.genres] ?? g.label;
-          return (
-            <button
-              key={g.id}
-              onClick={() => {
-                if (selectionLimitReached) {
-                  return;
-                }
-                const newMoods = selected
-                  ? person.moods.filter((m) => m !== g.id)
-                  : [...person.moods, g.id];
-                onUpdate({ moods: newMoods });
-              }}
-              disabled={selectionLimitReached}
-              className="flex items-center gap-3 p-3.5 rounded-xl text-left transition-all duration-200 active:scale-[0.97]"
-              style={{
-                background: selected ? `${g.color}18` : 'var(--pc-surface)',
-                border: selected ? `1.5px solid ${g.color}50` : '1px solid var(--pc-bd1)',
-                cursor: selectionLimitReached ? 'not-allowed' : 'pointer',
-                opacity: selectionLimitReached ? 0.45 : 1,
-              }}
-            >
-              <div
-                className="w-8 h-8 rounded-lg flex items-center justify-center shrink-0"
-                style={{
-                  background: selected ? `${g.color}25` : 'var(--pc-ghost)',
-                  color: selected ? g.color : 'var(--pc-t3)',
-                }}
-              >
-                <g.icon size={15} />
-              </div>
-              <span
-                style={{
-                  color: selected ? g.color : 'var(--pc-t2)',
-                  fontWeight: selected ? 600 : 400,
-                  fontSize: '0.88rem',
-                }}
-              >
-                {label}
-              </span>
-            </button>
-          );
-        })}
+        {GENRES.map((genre) => (
+          <MoodOptionButton
+            key={genre.id}
+            genre={genre}
+            label={t.genres[genre.id as keyof typeof t.genres] ?? genre.label}
+            person={person}
+            onUpdate={onUpdate}
+          />
+        ))}
       </div>
 
-      {person.moods.length > 0 && (
-        <p
-          style={{
-            color: 'var(--pc-t3)',
-            fontSize: '0.78rem',
-            textAlign: 'center',
-          }}
-        >
-          {person.moods.length === 1
-            ? t.quiz.mood.selectedSingular.replace('{n}', String(person.moods.length))
-            : t.quiz.mood.selectedPlural.replace('{n}', String(person.moods.length))}
-        </p>
-      )}
+      <MoodSelectionSummary count={person.moods.length} copy={t.quiz.mood} />
     </div>
   );
+}
+
+function MoodOptionButton({
+  genre,
+  label,
+  onUpdate,
+  person,
+}: {
+  genre: MoodOption;
+  label: string;
+  onUpdate: (updates: Partial<PersonAnswers>) => void;
+  person: PersonAnswers;
+}) {
+  const selected = person.moods.includes(genre.id);
+  const selectionLimitReached = !selected && person.moods.length >= MAX_MOOD_SELECTIONS;
+
+  return (
+    <SelectableOptionButton
+      color={genre.color}
+      disabled={selectionLimitReached}
+      selected={selected}
+      onClick={() => onUpdate({ moods: getNextMoodSelection(person.moods, genre.id, selected) })}
+    >
+      <OptionIcon color={genre.color} selected={selected} size="sm">
+        <genre.icon size={15} />
+      </OptionIcon>
+      <span
+        style={{
+          color: selected ? genre.color : 'var(--pc-t2)',
+          fontSize: '0.88rem',
+          fontWeight: selected ? 600 : 400,
+        }}
+      >
+        {label}
+      </span>
+    </SelectableOptionButton>
+  );
+}
+
+function MoodSelectionSummary({
+  count,
+  copy,
+}: {
+  count: number;
+  copy: ReturnType<typeof useLanguage>['t']['quiz']['mood'];
+}) {
+  if (count === 0) return null;
+
+  const template = count === 1 ? copy.selectedSingular : copy.selectedPlural;
+
+  return (
+    <p style={{ color: 'var(--pc-t3)', fontSize: '0.78rem', textAlign: 'center' }}>
+      {template.replace('{n}', String(count))}
+    </p>
+  );
+}
+
+function getNextMoodSelection(currentMoods: string[], moodId: string, selected: boolean): string[] {
+  return selected
+    ? currentMoods.filter((mood) => mood !== moodId)
+    : [...currentMoods, moodId].slice(0, MAX_MOOD_SELECTIONS);
 }

--- a/apps/web/src/app/quiz/components/steps/StepPrimitives.tsx
+++ b/apps/web/src/app/quiz/components/steps/StepPrimitives.tsx
@@ -1,0 +1,237 @@
+'use client';
+
+import { Check } from 'lucide-react';
+
+import type { ReactNode } from 'react';
+
+type StepHeaderProps = {
+  accentBackground: string;
+  accentColor: string;
+  icon: ReactNode;
+  subtitle?: string;
+  title: string;
+};
+
+type SelectableOptionButtonProps = {
+  children: ReactNode;
+  color: string;
+  disabled?: boolean;
+  layout?: 'row' | 'stack' | 'large-row';
+  onClick: () => void;
+  selected: boolean;
+  selectedBackground?: string;
+  selectedBorderAlpha?: '50' | '60';
+  selectedShadow?: string;
+};
+
+type SelectionMarkProps = {
+  color: string;
+};
+
+type SelectableLayout = 'row' | 'stack' | 'large-row';
+type SelectableStyleOptions = {
+  color: string;
+  disabled: boolean;
+  layout: SelectableLayout;
+  selected: boolean;
+  selectedBackground?: string;
+  selectedBorderAlpha: '50' | '60';
+  selectedShadow?: string;
+};
+
+const SELECTABLE_CLASS_BY_LAYOUT: Record<SelectableLayout, string> = {
+  'large-row':
+    'flex items-center gap-4 rounded-2xl p-4 text-left transition-all duration-200 active:scale-[0.98]',
+  row: 'flex items-center gap-3 rounded-xl p-3.5 text-left transition-all duration-200 active:scale-[0.97]',
+  stack:
+    'flex flex-col items-start gap-3 rounded-2xl p-4 text-left transition-all duration-200 active:scale-[0.97]',
+};
+
+const INACTIVE_BORDER_BY_LAYOUT: Record<SelectableLayout, string> = {
+  'large-row': '1px solid var(--pc-bd2)',
+  row: '1px solid var(--pc-bd1)',
+  stack: '1px solid var(--pc-bd1)',
+};
+
+export function StepHeader({
+  accentBackground,
+  accentColor,
+  icon,
+  subtitle,
+  title,
+}: StepHeaderProps) {
+  return (
+    <div className="flex items-center gap-3">
+      <div
+        className="flex h-10 w-10 items-center justify-center rounded-xl"
+        style={{ background: accentBackground, color: accentColor }}
+      >
+        {icon}
+      </div>
+      <div>
+        <h2
+          style={{
+            color: 'var(--pc-t1)',
+            fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
+            fontSize: '1.8rem',
+            fontWeight: '600',
+            letterSpacing: '0.04em',
+            lineHeight: 1.1,
+            textTransform: 'uppercase',
+          }}
+        >
+          {title}
+        </h2>
+        {subtitle && (
+          <p style={{ color: 'var(--pc-t3)', fontSize: '0.82rem', marginTop: 2 }}>{subtitle}</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function SelectableOptionButton({
+  children,
+  color,
+  disabled = false,
+  layout = 'row',
+  onClick,
+  selected,
+  selectedBackground,
+  selectedBorderAlpha = '50',
+  selectedShadow,
+}: SelectableOptionButtonProps) {
+  const presentation = getSelectableOptionPresentation({
+    color,
+    disabled,
+    layout,
+    selected,
+    selectedBackground,
+    selectedBorderAlpha,
+    selectedShadow,
+  });
+
+  return (
+    <button
+      type="button"
+      aria-pressed={selected}
+      disabled={disabled}
+      onClick={onClick}
+      className={presentation.className}
+      style={presentation.style}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function OptionIcon({
+  children,
+  color,
+  selected,
+  size = 'md',
+}: {
+  children: ReactNode;
+  color: string;
+  selected: boolean;
+  size?: 'sm' | 'md' | 'lg';
+}) {
+  const className = {
+    sm: 'flex h-8 w-8 shrink-0 items-center justify-center rounded-lg',
+    md: 'flex h-9 w-9 shrink-0 items-center justify-center rounded-lg',
+    lg: 'flex h-11 w-11 shrink-0 items-center justify-center rounded-xl',
+  }[size];
+
+  return (
+    <span
+      className={className}
+      style={{
+        background: selected ? `${color}25` : 'var(--pc-ghost)',
+        color: selected ? color : 'var(--pc-t3)',
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+export function SelectionMark({ color }: SelectionMarkProps) {
+  return (
+    <span
+      className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full"
+      style={{ background: color }}
+    >
+      <Check size={12} style={{ color: 'var(--pc-cta-text)' }} />
+    </span>
+  );
+}
+
+function getSelectableOptionPresentation({
+  color,
+  disabled,
+  layout,
+  selected,
+  selectedBackground,
+  selectedBorderAlpha,
+  selectedShadow,
+}: SelectableStyleOptions) {
+  return {
+    className: SELECTABLE_CLASS_BY_LAYOUT[layout],
+    style: getSelectableOptionStyle({
+      color,
+      disabled,
+      layout,
+      selected,
+      selectedBackground,
+      selectedBorderAlpha,
+      selectedShadow,
+    }),
+  };
+}
+
+function getSelectableOptionStyle(options: SelectableStyleOptions) {
+  return {
+    background: getSelectableBackground(options),
+    border: getSelectableBorder(options),
+    boxShadow: getSelectableShadow(options),
+    cursor: getSelectableCursor(options.disabled),
+    opacity: getSelectableOpacity(options.disabled),
+  };
+}
+
+function getSelectableBackground({ color, selected, selectedBackground }: SelectableStyleOptions) {
+  if (!selected) {
+    return 'var(--pc-surface)';
+  }
+
+  return selectedBackground ?? `${color}18`;
+}
+
+function getSelectableBorder({
+  color,
+  layout,
+  selected,
+  selectedBorderAlpha,
+}: SelectableStyleOptions) {
+  if (!selected) {
+    return INACTIVE_BORDER_BY_LAYOUT[layout];
+  }
+
+  return `1.5px solid ${color}${selectedBorderAlpha}`;
+}
+
+function getSelectableShadow({ selected, selectedShadow }: SelectableStyleOptions) {
+  if (!selected) {
+    return 'none';
+  }
+
+  return selectedShadow ?? 'none';
+}
+
+function getSelectableCursor(disabled: boolean) {
+  return disabled ? 'not-allowed' : 'pointer';
+}
+
+function getSelectableOpacity(disabled: boolean) {
+  return disabled ? 0.45 : 1;
+}

--- a/apps/web/src/app/quiz/components/steps/ToneStep.tsx
+++ b/apps/web/src/app/quiz/components/steps/ToneStep.tsx
@@ -6,6 +6,8 @@ import { useLanguage } from '@/i18n';
 
 import { TONES } from '../../constants';
 
+import { OptionIcon, SelectableOptionButton, StepHeader } from './StepPrimitives';
+
 import type { PersonAnswers, Tone } from '../../types';
 
 interface ToneStepProps {
@@ -13,85 +15,87 @@ interface ToneStepProps {
   onUpdate: (updates: Partial<PersonAnswers>) => void;
 }
 
+type ToneOption = (typeof TONES)[number];
+
 export function ToneStep({ person, onUpdate }: ToneStepProps) {
   const { t } = useLanguage();
 
   return (
     <div className="flex flex-col gap-5 pt-2">
-      <div className="flex items-center gap-3">
-        <div
-          className="w-10 h-10 rounded-xl flex items-center justify-center"
-          style={{
-            background: 'rgba(245,197,24,0.15)',
-            color: 'var(--pc-gold-text)',
-          }}
-        >
-          <Moon size={20} />
-        </div>
-        <h2
-          style={{
-            fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
-            fontWeight: '600',
-            textTransform: 'uppercase',
-            fontSize: '1.8rem',
-            letterSpacing: '0.04em',
-            color: 'var(--pc-t1)',
-            lineHeight: 1.1,
-          }}
-        >
-          {t.quiz.tone.title}
-        </h2>
-      </div>
+      <StepHeader
+        accentBackground="rgba(245,197,24,0.15)"
+        accentColor="var(--pc-gold-text)"
+        icon={<Moon size={20} />}
+        title={t.quiz.tone.title}
+      />
 
       <div className="grid grid-cols-2 gap-3">
-        {TONES.map((tone) => {
-          const selected = person.tone === tone.id;
-          const toneT = t.tones[tone.id as keyof typeof t.tones];
-          const label = toneT?.label ?? tone.label;
-          const desc = toneT?.desc ?? tone.desc;
-          return (
-            <button
-              key={tone.id}
-              onClick={() => onUpdate({ tone: tone.id as Tone })}
-              className="flex flex-col items-start gap-3 p-4 rounded-2xl text-left transition-all duration-200 active:scale-[0.97]"
-              style={{
-                background: selected ? tone.grad : 'var(--pc-surface)',
-                border: selected ? `1.5px solid ${tone.color}50` : '1px solid var(--pc-bd1)',
-                boxShadow: selected ? `0 0 20px ${tone.color}14` : 'none',
-              }}
-            >
-              <div
-                className="w-9 h-9 rounded-xl flex items-center justify-center"
-                style={{
-                  background: selected ? `${tone.color}20` : 'var(--pc-ghost)',
-                  color: selected ? tone.color : 'var(--pc-t3)',
-                }}
-              >
-                <tone.icon size={16} />
-              </div>
-              <div>
-                <div
-                  style={{
-                    color: selected ? tone.color : 'var(--pc-t1)',
-                    fontWeight: 600,
-                    fontSize: '0.88rem',
-                  }}
-                >
-                  {label}
-                </div>
-                <div
-                  style={{
-                    color: 'var(--pc-t3)',
-                    fontSize: '0.78rem',
-                  }}
-                >
-                  {desc}
-                </div>
-              </div>
-            </button>
-          );
-        })}
+        {TONES.map((tone) => (
+          <ToneOptionButton
+            key={tone.id}
+            option={tone}
+            selected={person.tone === tone.id}
+            toneCopy={t.tones[tone.id as keyof typeof t.tones]}
+            onSelect={() => onUpdate({ tone: tone.id as Tone })}
+          />
+        ))}
       </div>
     </div>
   );
+}
+
+function ToneOptionButton({
+  onSelect,
+  option,
+  selected,
+  toneCopy,
+}: {
+  onSelect: () => void;
+  option: ToneOption;
+  selected: boolean;
+  toneCopy: { label: string; desc: string } | undefined;
+}) {
+  const copy = getToneOptionCopy(option, toneCopy);
+
+  return (
+    <SelectableOptionButton
+      color={option.color}
+      layout="stack"
+      selected={selected}
+      onClick={onSelect}
+      selectedBackground={option.grad}
+      selectedShadow={`0 0 20px ${option.color}14`}
+    >
+      <OptionIcon color={option.color} selected={selected}>
+        <option.icon size={16} />
+      </OptionIcon>
+      <span>
+        <span className="block" style={getToneLabelStyle(selected, option.color)}>
+          {copy.label}
+        </span>
+        <span className="block" style={{ color: 'var(--pc-t3)', fontSize: '0.78rem' }}>
+          {copy.desc}
+        </span>
+      </span>
+    </SelectableOptionButton>
+  );
+}
+
+function getToneOptionCopy(
+  option: ToneOption,
+  toneCopy: { label: string; desc: string } | undefined,
+) {
+  if (!toneCopy) {
+    return { desc: option.desc, label: option.label };
+  }
+
+  return toneCopy;
+}
+
+function getToneLabelStyle(selected: boolean, color: string) {
+  return {
+    color: selected ? color : 'var(--pc-t1)',
+    fontSize: '0.88rem',
+    fontWeight: 600,
+  };
 }


### PR DESCRIPTION
## Summary
- split quiz setup/navigation rendering into smaller focused components and helpers
- add shared quiz step primitives for headers, selectable option buttons, icons, and selection marks
- preserve existing selected-state styling while removing Fallow changed-code complexity findings

## Validation
- npm run lint:check --workspace=apps/web
- npm run type-check --workspace=apps/web
- npm run test --workspace=apps/web -- src/app/quiz/quiz.machine.test.ts src/app/quiz/constants.test.ts
- pre-commit: shared build + web/backoffice type-check
- pre-push: lint, server tests, production build, Storybook tests
- npx fallow health --changed-since origin/development --format json --quiet
- npx fallow dead-code --changed-since origin/development --format json --quiet
- npx fallow dupes --changed-since origin/development --format json --quiet

Fallow changed-code result: health 0 findings, dead-code 0 issues, dupes 0 clone groups.

Part of #717.