### PR TITLE
Refactor Fallow complexity hotspots

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -29,7 +29,13 @@
     "maxCyclomatic": 20,
     "maxCognitive": 15,
     "maxCrap": 30,
-    "ignore": ["**/*.stories.*", "**/*.test.*", "**/*.spec.*", "**/e2e/**"],
+    "ignore": [
+      "**/*.stories.*",
+      "**/*.test.*",
+      "**/*.spec.*",
+      "**/e2e/**",
+      "apps/web/public/mockServiceWorker.js",
+    ],
   },
   "audit": {
     "gate": "new-only",

--- a/apps/web/scripts/analyze-movies.ts
+++ b/apps/web/scripts/analyze-movies.ts
@@ -17,32 +17,52 @@ function main() {
   // Get file path from command line argument or use default
   const filePath = process.argv[2] || './movies.txt';
 
-  console.log('🎬 Starting movie chunk analysis...');
-  console.log(`📁 Analyzing file: ${filePath}`);
-  console.log('='.repeat(80));
+  printAnalysisHeader(filePath);
 
   try {
     const movieChunks = analyzeMovieChunks(filePath);
-
-    console.log('\n' + '='.repeat(80));
-    console.log('✅ Analysis completed successfully!');
-    console.log(`📊 Processed ${movieChunks.length} movie entries`);
-
-    if (movieChunks.length > 0) {
-      const avgChunkSize = Math.round(
-        movieChunks.reduce((sum, chunk) => sum + chunk.chunkSize, 0) / movieChunks.length,
-      );
-      const maxChunkSize = Math.max(...movieChunks.map((chunk) => chunk.chunkSize));
-      const minChunkSize = Math.min(...movieChunks.map((chunk) => chunk.chunkSize));
-
-      console.log(`📈 Average chunk size: ${avgChunkSize} characters`);
-      console.log(`📊 Size range: ${minChunkSize} - ${maxChunkSize} characters`);
-    }
+    printAnalysisReport(movieChunks);
   } catch (error) {
-    console.error('\n❌ Analysis failed:');
-    console.error(error instanceof Error ? error.message : String(error));
-    process.exit(1);
+    exitWithAnalysisError(error);
   }
+}
+
+function printAnalysisHeader(filePath: string) {
+  console.log('🎬 Starting movie chunk analysis...');
+  console.log(`📁 Analyzing file: ${filePath}`);
+  console.log('='.repeat(80));
+}
+
+function printAnalysisReport(movieChunks: ReturnType<typeof analyzeMovieChunks>) {
+  console.log('\n' + '='.repeat(80));
+  console.log('✅ Analysis completed successfully!');
+  console.log(`📊 Processed ${movieChunks.length} movie entries`);
+  printChunkSizeStats(movieChunks);
+}
+
+function printChunkSizeStats(movieChunks: ReturnType<typeof analyzeMovieChunks>) {
+  if (movieChunks.length === 0) {
+    return;
+  }
+
+  const stats = getChunkSizeStats(movieChunks);
+  console.log(`📈 Average chunk size: ${stats.average} characters`);
+  console.log(`📊 Size range: ${stats.min} - ${stats.max} characters`);
+}
+
+function getChunkSizeStats(movieChunks: ReturnType<typeof analyzeMovieChunks>) {
+  const chunkSizes = movieChunks.map((chunk) => chunk.chunkSize);
+  return {
+    average: Math.round(chunkSizes.reduce((sum, size) => sum + size, 0) / chunkSizes.length),
+    max: Math.max(...chunkSizes),
+    min: Math.min(...chunkSizes),
+  };
+}
+
+function exitWithAnalysisError(error: unknown) {
+  console.error('\n❌ Analysis failed:');
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
 }
 
 // Run the script

--- a/apps/web/scripts/calibrate-similarity.ts
+++ b/apps/web/scripts/calibrate-similarity.ts
@@ -50,6 +50,12 @@ const QUERIES = [
 
 const MATCH_COUNT = 5;
 
+type MatchMovieRow = {
+  name: string;
+  year?: number | null;
+  similarity: number;
+};
+
 // ---------------------------------------------------------------------------
 
 function printSeparator() {
@@ -65,89 +71,170 @@ async function embedQuery(text: string): Promise<number[]> {
 }
 
 async function main() {
-  // Validate env
-  if (!process.env.OPENAI_API_KEY) {
-    console.error('❌ Missing required environment variable: OPENAI_API_KEY');
-    process.exit(1);
-  }
-  if (!process.env.DATABASE_URL) {
-    console.error('❌ Missing required environment variable: DATABASE_URL');
-    process.exit(1);
-  }
+  validateEnvironment();
 
   const db = createPgDbClient();
+  printCalibrationHeader();
 
+  const bestScores = await collectBestScores(db);
+  printSummary(bestScores);
+  console.log('');
+}
+
+async function collectBestScores(db: ReturnType<typeof createPgDbClient>) {
+  const bestScores: number[] = [];
+  for (const query of QUERIES) {
+    const bestScore = await runCalibrationQuery(db, query);
+    appendBestScore(bestScores, bestScore);
+  }
+
+  return bestScores;
+}
+
+async function runCalibrationQuery(
+  db: ReturnType<typeof createPgDbClient>,
+  query: (typeof QUERIES)[number],
+) {
+  printQueryHeader(query);
+
+  const embedding = await tryEmbedQuery(query.text);
+  if (!embedding) {
+    return null;
+  }
+
+  const rows = await findMatches(db, embedding);
+  if (!rows) {
+    return null;
+  }
+
+  if (rows.length === 0) {
+    printNoResults();
+    return null;
+  }
+
+  printRows(rows);
+  return rows[0].similarity;
+}
+
+function validateEnvironment() {
+  requireEnvironmentVariable('OPENAI_API_KEY');
+  requireEnvironmentVariable('DATABASE_URL');
+}
+
+function requireEnvironmentVariable(name: string) {
+  if (process.env[name]) {
+    return;
+  }
+
+  console.error(`❌ Missing required environment variable: ${name}`);
+  process.exit(1);
+}
+
+function printCalibrationHeader() {
   console.log('\n🎬 PopChoice — Similarity Threshold Calibration');
   printSeparator();
   console.log(`Model : text-embedding-3-large`);
   console.log(`Top-N : ${MATCH_COUNT} results per query`);
   console.log(`Queries: ${QUERIES.length}`);
   printSeparator();
+}
 
-  const bestScores: number[] = [];
+function printQueryHeader(query: (typeof QUERIES)[number]) {
+  console.log(`\nQuery: ${query.label}`);
+  console.log(`  "${query.text}"`);
+}
 
-  for (const query of QUERIES) {
-    console.log(`\nQuery: ${query.label}`);
-    console.log(`  "${query.text}"`);
+async function tryEmbedQuery(text: string) {
+  try {
+    return await embedQuery(text);
+  } catch (err) {
+    console.error(`  ❌ Embedding failed: ${(err as Error).message}`);
+    return null;
+  }
+}
 
-    let embedding: number[];
-    try {
-      embedding = await embedQuery(query.text);
-    } catch (err) {
-      console.error(`  ❌ Embedding failed: ${(err as Error).message}`);
-      continue;
-    }
+async function findMatches(db: ReturnType<typeof createPgDbClient>, embedding: number[]) {
+  const { data, error } = await db.rpc('match_movies', {
+    match_count: MATCH_COUNT,
+    match_threshold: LOCAL_VECTOR_MATCH_THRESHOLD,
+    query_embedding: embedding,
+  });
 
-    const { data, error } = await db.rpc('match_movies', {
-      query_embedding: embedding,
-      match_threshold: LOCAL_VECTOR_MATCH_THRESHOLD,
-      match_count: MATCH_COUNT,
-    });
-
-    if (error || !data) {
-      console.error(`  ❌ DB query failed: ${error?.message ?? 'no data'}`);
-      continue;
-    }
-
-    if (data.length === 0) {
-      console.log(`  (no results above match_threshold = ${LOCAL_VECTOR_MATCH_THRESHOLD})`);
-      continue;
-    }
-
-    const rows = data as { name: string; year?: number | null; similarity: number }[];
-    const best = rows[0].similarity;
-    bestScores.push(best);
-
-    rows.forEach((row, i) => {
-      const marker = i === 0 ? ' ← ceiling' : '';
-      const year = row.year ? ` (${row.year})` : '';
-      console.log(`  ${row.similarity.toFixed(4)}  ${row.name}${year}${marker}`);
-    });
+  if (hasMatchQueryError(error, data)) {
+    printMatchQueryError(error);
+    return null;
   }
 
-  // Summary
-  if (bestScores.length > 0) {
-    const ceiling = Math.max(...bestScores);
-    const suggested = Math.round(((ceiling * 2) / 3) * 100) / 100;
+  return data as MatchMovieRow[];
+}
 
-    printSeparator();
-    console.log('\nSummary');
-    console.log(`  Highest observed score : ${ceiling.toFixed(4)}`);
-    console.log(`  Suggested threshold    : ~${suggested.toFixed(2)}  (≈ 2/3 of ceiling)`);
-    console.log(
-      `  Current threshold      : ${SIMILARITY_THRESHOLD.toFixed(2)}  (SIMILARITY_THRESHOLD in src/features/recommendation/config.ts)`,
-    );
+function hasMatchQueryError(error: unknown, data: unknown) {
+  return Boolean(error) || !data;
+}
 
-    if (Math.abs(suggested - SIMILARITY_THRESHOLD) >= 0.05) {
-      console.log(`\n⚠️  Suggested threshold differs from current by ≥ 0.05.`);
-      console.log(`   Consider updating src/features/recommendation/config.ts`);
-      console.log(`   and the calibration table in docs/SERVICES.md.`);
-    } else {
-      console.log(`\n✅ Current threshold looks appropriate.`);
-    }
+function printMatchQueryError(error: { message?: string } | null) {
+  console.error(`  ❌ DB query failed: ${getMatchQueryErrorMessage(error)}`);
+}
+
+function getMatchQueryErrorMessage(error: { message?: string } | null) {
+  return error?.message ?? 'no data';
+}
+
+function printNoResults() {
+  console.log(`  (no results above match_threshold = ${LOCAL_VECTOR_MATCH_THRESHOLD})`);
+}
+
+function printRows(rows: MatchMovieRow[]) {
+  rows.forEach((row, index) => {
+    console.log(formatRow(row, index));
+  });
+}
+
+function formatRow(row: MatchMovieRow, index: number) {
+  const marker = index === 0 ? ' ← ceiling' : '';
+  const year = row.year ? ` (${row.year})` : '';
+  return `  ${row.similarity.toFixed(4)}  ${row.name}${year}${marker}`;
+}
+
+function appendBestScore(bestScores: number[], bestScore: number | null) {
+  if (bestScore !== null) {
+    bestScores.push(bestScore);
+  }
+}
+
+function printSummary(bestScores: number[]) {
+  if (bestScores.length === 0) {
+    return;
   }
 
-  console.log('');
+  const threshold = getSuggestedThreshold(bestScores);
+
+  printSeparator();
+  console.log('\nSummary');
+  console.log(`  Highest observed score : ${threshold.ceiling.toFixed(4)}`);
+  console.log(`  Suggested threshold    : ~${threshold.suggested.toFixed(2)}  (≈ 2/3 of ceiling)`);
+  console.log(
+    `  Current threshold      : ${SIMILARITY_THRESHOLD.toFixed(2)}  (SIMILARITY_THRESHOLD in src/features/recommendation/config.ts)`,
+  );
+  printThresholdAdvice(threshold.suggested);
+}
+
+function getSuggestedThreshold(bestScores: number[]) {
+  const ceiling = Math.max(...bestScores);
+  const suggested = Math.round(((ceiling * 2) / 3) * 100) / 100;
+
+  return { ceiling, suggested };
+}
+
+function printThresholdAdvice(suggested: number) {
+  if (Math.abs(suggested - SIMILARITY_THRESHOLD) < 0.05) {
+    console.log(`\n✅ Current threshold looks appropriate.`);
+    return;
+  }
+
+  console.log(`\n⚠️  Suggested threshold differs from current by ≥ 0.05.`);
+  console.log(`   Consider updating src/features/recommendation/config.ts`);
+  console.log(`   and the calibration table in docs/SERVICES.md.`);
 }
 
 main().catch((err) => {

--- a/apps/web/scripts/enqueue-catalog-maintenance.ts
+++ b/apps/web/scripts/enqueue-catalog-maintenance.ts
@@ -26,47 +26,22 @@ function parsePositiveFloat(value: string | undefined, fallback: number): number
 }
 
 function parseSources(): TMDBDiscoverySource[] {
-  const rawSources = process.env.TMDB_SOURCES?.split(',').map((source) => source.trim()) ?? [];
-  const filtered = rawSources.filter((source): source is TMDBDiscoverySource =>
-    VALID_SOURCES.includes(source as TMDBDiscoverySource),
-  );
-  if (rawSources.length > 0 && filtered.length === 0) {
+  const rawSources = parseRawSources();
+  const filtered = rawSources.filter(isValidSource);
+  if (hasOnlyInvalidSources(rawSources, filtered)) {
     throw new Error(`TMDB_SOURCES must include one of: ${VALID_SOURCES.join(', ')}`);
   }
-  return rawSources.length > 0 ? filtered : VALID_SOURCES;
+  return rawSources.length > 0 ? filtered : [...VALID_SOURCES];
 }
 
 async function enqueueDiscovery(): Promise<void> {
-  const sources = parseSources();
-  const maxPagesPerSource = parsePositiveInt(process.env.MAX_PAGES_PER_SOURCE, 3);
-  const minVoteCount = parsePositiveInt(process.env.MIN_VOTE_COUNT, 500);
-  const minVoteAverage = parsePositiveFloat(process.env.MIN_VOTE_AVERAGE, 6.5);
-  const maxMoviesPerPage = parsePositiveInt(process.env.MAX_MOVIES_PER_PAGE, 20);
-  const language = process.env.TMDB_LANGUAGE?.trim() || 'en-US';
-
-  let queued = 0;
-  for (const source of sources) {
-    for (let page = 1; page <= maxPagesPerSource; page++) {
-      const didQueue = await enqueueCatalogDiscoverTMDBSourcePage({
-        source,
-        page,
-        language,
-        minVoteCount,
-        minVoteAverage,
-        maxMoviesPerPage,
-      });
-      if (didQueue) queued++;
-    }
-  }
-
+  const queued = await enqueueDiscoveryPages(getDiscoveryOptions());
   console.log(`Queued ${queued} catalog discovery page jobs.`);
 }
 
 async function enqueueBackfill(): Promise<void> {
   const db = getDbClient();
-  if (!db.isConfigured() || !db.query) {
-    throw new Error('DATABASE_URL is required to enqueue catalog backfill jobs');
-  }
+  assertBackfillDbConfigured(db);
 
   const limit = parsePositiveInt(process.env.MAX_MOVIES, 100);
   const result = await db.query<{ id: string }>(
@@ -83,17 +58,84 @@ async function enqueueBackfill(): Promise<void> {
     [limit],
   );
 
+  const queued = await enqueueBackfillRows(result.rows);
+  console.log(`Queued ${queued} catalog backfill jobs.`);
+}
+
+function parseRawSources() {
+  return process.env.TMDB_SOURCES?.split(',').map((source) => source.trim()) ?? [];
+}
+
+function isValidSource(source: string): source is TMDBDiscoverySource {
+  return VALID_SOURCES.includes(source as TMDBDiscoverySource);
+}
+
+function hasOnlyInvalidSources(rawSources: string[], filtered: TMDBDiscoverySource[]) {
+  return rawSources.length > 0 && filtered.length === 0;
+}
+
+function getDiscoveryOptions() {
+  return {
+    language: process.env.TMDB_LANGUAGE?.trim() || 'en-US',
+    maxMoviesPerPage: parsePositiveInt(process.env.MAX_MOVIES_PER_PAGE, 20),
+    maxPagesPerSource: parsePositiveInt(process.env.MAX_PAGES_PER_SOURCE, 3),
+    minVoteAverage: parsePositiveFloat(process.env.MIN_VOTE_AVERAGE, 6.5),
+    minVoteCount: parsePositiveInt(process.env.MIN_VOTE_COUNT, 500),
+    sources: parseSources(),
+  };
+}
+
+async function enqueueDiscoveryPages(options: ReturnType<typeof getDiscoveryOptions>) {
   let queued = 0;
-  for (const row of result.rows) {
-    const didQueue = await enqueueCatalogBackfillMovie({
-      movieId: row.id,
-      reason: 'missing_metadata',
-      language: process.env.TMDB_LANGUAGE?.trim() || 'en-US',
+  for (const source of options.sources) {
+    queued += await enqueueDiscoverySource(source, options);
+  }
+
+  return queued;
+}
+
+async function enqueueDiscoverySource(
+  source: TMDBDiscoverySource,
+  options: ReturnType<typeof getDiscoveryOptions>,
+) {
+  let queued = 0;
+  for (let page = 1; page <= options.maxPagesPerSource; page++) {
+    const didQueue = await enqueueCatalogDiscoverTMDBSourcePage({
+      language: options.language,
+      maxMoviesPerPage: options.maxMoviesPerPage,
+      minVoteAverage: options.minVoteAverage,
+      minVoteCount: options.minVoteCount,
+      page,
+      source,
     });
     if (didQueue) queued++;
   }
 
-  console.log(`Queued ${queued} catalog backfill jobs.`);
+  return queued;
+}
+
+function assertBackfillDbConfigured(db: ReturnType<typeof getDbClient>): asserts db is ReturnType<
+  typeof getDbClient
+> & {
+  query: NonNullable<ReturnType<typeof getDbClient>['query']>;
+} {
+  if (!db.isConfigured() || !db.query) {
+    throw new Error('DATABASE_URL is required to enqueue catalog backfill jobs');
+  }
+}
+
+async function enqueueBackfillRows(rows: Array<{ id: string }>) {
+  let queued = 0;
+  for (const row of rows) {
+    const didQueue = await enqueueCatalogBackfillMovie({
+      language: process.env.TMDB_LANGUAGE?.trim() || 'en-US',
+      movieId: row.id,
+      reason: 'missing_metadata',
+    });
+    if (didQueue) queued++;
+  }
+
+  return queued;
 }
 
 async function main(): Promise<void> {

--- a/apps/web/scripts/evaluate-recommendations.ts
+++ b/apps/web/scripts/evaluate-recommendations.ts
@@ -21,6 +21,16 @@ type EvalCliOptions = {
   outputPath: string;
 };
 
+type CliArgHandler = (argv: string[], index: number, options: EvalCliOptions) => number;
+
+const CLI_ARG_HANDLERS: Record<string, CliArgHandler> = {
+  '--help': handleHelpArgument,
+  '--live': handleLiveArgument,
+  '--output': handleOutputArgument,
+  '--real-data': handleRealDataArgument,
+  '-h': handleHelpArgument,
+};
+
 function printUsage(): void {
   console.log(`Usage: npm run eval:recommendations -- [--real-data] [--live] [--output <path>]
 
@@ -30,58 +40,101 @@ Use --live only for explicit manual runs against configured providers and databa
 }
 
 function parseCliOptions(argv: string[]): EvalCliOptions {
-  let mode: RecommendationEvalRunMode = 'mock';
-  let outputPath = defaultOutputPath;
+  const options: EvalCliOptions = { mode: 'mock', outputPath: defaultOutputPath };
 
   for (let index = 0; index < argv.length; index += 1) {
-    const arg = argv[index];
-    if (arg === '--help' || arg === '-h') {
-      printUsage();
-      process.exit(0);
-    }
-    if (arg === '--live') {
-      mode = 'live';
-      continue;
-    }
-    if (arg === '--real-data') {
-      mode = 'real-data';
-      continue;
-    }
-    if (arg === '--output') {
-      const value = argv[index + 1];
-      if (!value) throw new Error('--output requires a path');
-      outputPath = path.resolve(process.cwd(), value);
-      index += 1;
-      continue;
-    }
-    throw new Error(`Unknown argument: ${arg}`);
+    index = parseCliArgument(argv, index, options);
   }
 
-  return { mode, outputPath };
+  return options;
+}
+
+function parseCliArgument(argv: string[], index: number, options: EvalCliOptions) {
+  const arg = argv[index];
+  const handler = CLI_ARG_HANDLERS[arg];
+
+  if (handler) return handler(argv, index, options);
+
+  throw new Error(`Unknown argument: ${arg}`);
+}
+
+function handleHelpArgument(_argv: string[], index: number) {
+  printUsage();
+  process.exit(0);
+  return index;
+}
+
+function handleLiveArgument(_argv: string[], index: number, options: EvalCliOptions) {
+  options.mode = 'live';
+  return index;
+}
+
+function handleRealDataArgument(_argv: string[], index: number, options: EvalCliOptions) {
+  options.mode = 'real-data';
+  return index;
+}
+
+function handleOutputArgument(argv: string[], index: number, options: EvalCliOptions) {
+  options.outputPath = resolveOutputPath(argv[index + 1]);
+  return index + 1;
+}
+
+function resolveOutputPath(value: string | undefined) {
+  if (!value) throw new Error('--output requires a path');
+  return path.resolve(process.cwd(), value);
 }
 
 async function main(): Promise<void> {
   const options = parseCliOptions(process.argv.slice(2));
   const report = await runRecommendationEvals({ mode: options.mode });
-  await mkdir(path.dirname(options.outputPath), { recursive: true });
-  await writeFile(options.outputPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  await writeReport(options.outputPath, report);
+  printEvalReport(options, report);
+  setExitCode(report.passed);
+}
 
+async function writeReport(
+  outputPath: string,
+  report: Awaited<ReturnType<typeof runRecommendationEvals>>,
+) {
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+}
+
+function printEvalReport(
+  options: EvalCliOptions,
+  report: Awaited<ReturnType<typeof runRecommendationEvals>>,
+) {
+  printEvalSummary(options, report);
+  for (const result of report.results) {
+    printEvalResult(result);
+  }
+}
+
+function printEvalSummary(
+  options: EvalCliOptions,
+  report: Awaited<ReturnType<typeof runRecommendationEvals>>,
+) {
   console.log(
     `Recommendation evals (${options.mode}): ${report.summary.passed}/${report.summary.fixtureCount} passed. Report: ${options.outputPath}`,
   );
-  for (const result of report.results) {
-    const status = result.passed ? 'PASS' : 'FAIL';
-    console.log(`- ${status} ${result.fixtureId}: ${result.score}/${result.maxScore}`);
-    for (const check of result.checks) {
-      if (!check.passed) {
-        console.log(`  - ${check.label}: ${check.details}`);
-      }
-    }
-  }
+}
 
-  if (!report.passed) {
-    process.exitCode = 1;
-  }
+function printEvalResult(
+  result: Awaited<ReturnType<typeof runRecommendationEvals>>['results'][number],
+) {
+  const status = result.passed ? 'PASS' : 'FAIL';
+  console.log(`- ${status} ${result.fixtureId}: ${result.score}/${result.maxScore}`);
+  result.checks.filter((check) => !check.passed).forEach(printFailedCheck);
+}
+
+function printFailedCheck(
+  check: Awaited<ReturnType<typeof runRecommendationEvals>>['results'][number]['checks'][number],
+) {
+  console.log(`  - ${check.label}: ${check.details}`);
+}
+
+function setExitCode(passed: boolean) {
+  process.exitCode = passed ? 0 : 1;
 }
 
 main().catch((error: unknown) => {

--- a/apps/web/scripts/migrate-db.js
+++ b/apps/web/scripts/migrate-db.js
@@ -32,62 +32,99 @@ async function main() {
   const client = await connectWithRetry(databaseUrl);
 
   try {
-    const files = (await readdir(migrationsDir))
-      .filter((name) => name.endsWith('.sql'))
-      .sort((left, right) => left.localeCompare(right));
-
-    await client.query('BEGIN');
-    try {
-      for (const fileName of files) {
-        const filePath = path.join(migrationsDir, fileName);
-        const sql = await readFile(filePath, 'utf8');
-        console.log(`[db:migrate] Applying ${fileName}`);
-        await client.query(sql);
-      }
-      await client.query('COMMIT');
-    } catch (err) {
-      await client.query('ROLLBACK');
-      throw err;
-    }
-
+    await applyMigrations(client, await readMigrationFileNames());
     console.log('[db:migrate] Migrations complete.');
   } finally {
     await client.end();
   }
 }
 
+async function readMigrationFileNames() {
+  return (await readdir(migrationsDir))
+    .filter((name) => name.endsWith('.sql'))
+    .sort((left, right) => left.localeCompare(right));
+}
+
+async function applyMigrations(client, files) {
+  await client.query('BEGIN');
+  try {
+    await runMigrationFiles(client, files);
+    await client.query('COMMIT');
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  }
+}
+
+async function runMigrationFiles(client, files) {
+  for (const fileName of files) {
+    await applyMigrationFile(client, fileName);
+  }
+}
+
+async function applyMigrationFile(client, fileName) {
+  const filePath = path.join(migrationsDir, fileName);
+  const sql = await readFile(filePath, 'utf8');
+  console.log(`[db:migrate] Applying ${fileName}`);
+  await client.query(sql);
+}
+
 async function connectWithRetry(databaseUrl) {
-  const attempts = Number.isFinite(connectAttempts) && connectAttempts > 0 ? connectAttempts : 20;
-  const delayMs = Number.isFinite(connectDelayMs) && connectDelayMs > 0 ? connectDelayMs : 3000;
+  const attempts = normalizePositiveInteger(connectAttempts, 20);
+  const delayMs = normalizePositiveInteger(connectDelayMs, 3000);
   let lastError;
 
   for (let attempt = 1; attempt <= attempts; attempt++) {
-    const client = new Client({ connectionString: databaseUrl });
-
-    try {
-      await client.connect();
-      if (attempt > 1) {
-        console.log(`[db:migrate] Connected to database on attempt ${attempt}.`);
-      }
-      return client;
-    } catch (error) {
-      await client.end().catch(() => {});
-      lastError = error;
-
-      if (!isTransientConnectionError(error) || attempt === attempts) {
-        throw error;
-      }
-
-      console.warn(
-        `[db:migrate] Database connection failed (${formatConnectionError(error)}). Retrying in ${
-          delayMs / 1000
-        }s (${attempt}/${attempts})...`,
-      );
-      await sleep(delayMs);
+    const result = await tryConnect(databaseUrl, attempt);
+    if (result.client) {
+      return result.client;
     }
+
+    lastError = result.error;
+    await waitBeforeRetry(result.error, { attempt, attempts, delayMs });
   }
 
   throw lastError;
+}
+
+async function tryConnect(databaseUrl, attempt) {
+  const client = new Client({ connectionString: databaseUrl });
+
+  try {
+    await client.connect();
+    logSuccessfulRetry(attempt);
+    return { client };
+  } catch (error) {
+    await client.end().catch(() => {});
+    return { error };
+  }
+}
+
+async function waitBeforeRetry(error, { attempt, attempts, delayMs }) {
+  if (!shouldRetryConnection(error, attempt, attempts)) {
+    throw error;
+  }
+
+  console.warn(
+    `[db:migrate] Database connection failed (${formatConnectionError(error)}). Retrying in ${
+      delayMs / 1000
+    }s (${attempt}/${attempts})...`,
+  );
+  await sleep(delayMs);
+}
+
+function shouldRetryConnection(error, attempt, attempts) {
+  return isTransientConnectionError(error) && attempt < attempts;
+}
+
+function logSuccessfulRetry(attempt) {
+  if (attempt > 1) {
+    console.log(`[db:migrate] Connected to database on attempt ${attempt}.`);
+  }
+}
+
+function normalizePositiveInteger(value, fallback) {
+  return Number.isFinite(value) && value > 0 ? value : fallback;
 }
 
 function isTransientConnectionError(error) {
@@ -95,7 +132,15 @@ function isTransientConnectionError(error) {
 }
 
 function formatConnectionError(error) {
-  return error?.code ?? error?.message ?? 'unknown error';
+  return getErrorCode(error) ?? getErrorMessage(error) ?? 'unknown error';
+}
+
+function getErrorCode(error) {
+  return error?.code;
+}
+
+function getErrorMessage(error) {
+  return error?.message;
 }
 
 function sleep(ms) {
@@ -104,18 +149,25 @@ function sleep(ms) {
 
 async function resolveDatabaseUrl() {
   for (const envFile of envFiles) {
-    try {
-      const content = await readFile(envFile, 'utf8');
-      const match = content.match(/^DATABASE_URL=(.+)$/m);
-      if (match?.[1]) {
-        return match[1].trim();
-      }
-    } catch {
-      // Ignore missing env files and continue to the next fallback.
-    }
+    const databaseUrl = await readDatabaseUrlFromEnvFile(envFile);
+    if (databaseUrl) return databaseUrl;
   }
 
   return null;
+}
+
+async function readDatabaseUrlFromEnvFile(envFile) {
+  try {
+    const content = await readFile(envFile, 'utf8');
+    return extractDatabaseUrl(content);
+  } catch {
+    return null;
+  }
+}
+
+function extractDatabaseUrl(content) {
+  const match = content.match(/^DATABASE_URL=(.+)$/m);
+  return match?.[1]?.trim() ?? null;
 }
 
 main().catch((error) => {

--- a/apps/web/src/app/api/more-tmdb-picks/route.ts
+++ b/apps/web/src/app/api/more-tmdb-picks/route.ts
@@ -25,36 +25,51 @@ async function postHandler(req: NextRequest): Promise<Response> {
   const rateLimitResponse = await applyRateLimit(req);
   if (rateLimitResponse) return rateLimitResponse;
 
-  const locale = parseLocaleFromRequest(req);
-
   try {
-    const body = await readJsonBodyWithLimit(req, RECOMMENDATION_REQUEST_BODY_LIMIT_BYTES);
-    const { quizData, page, excludeIds } = requestBodySchema.parse(body);
+    const tmdbConfigResponse = getTMDBConfigResponse();
+    if (tmdbConfigResponse) return tmdbConfigResponse;
 
-    if (!process.env.TMDB_API_KEY) {
-      return NextResponse.json({ error: 'TMDB not configured' }, { status: 503 });
-    }
-
+    const locale = parseLocaleFromRequest(req);
+    const { quizData, page, excludeIds } = await parseMorePicksRequest(req);
     const movies = await runMorePicksPipeline(quizData, excludeIds, page, locale);
     return NextResponse.json({ movies });
   } catch (error) {
-    const bodyErrorResponse = requestBodyErrorResponse(error);
-    if (bodyErrorResponse) return bodyErrorResponse;
-
-    if (error instanceof z.ZodError) {
-      return NextResponse.json(
-        { error: 'Invalid request', details: error.issues },
-        { status: 400 },
-      );
-    }
-    const isTimeout =
-      (error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError')) ||
-      isOpenAITimeoutError(error);
-    if (isTimeout) {
-      return NextResponse.json({ error: 'Upstream request timed out' }, { status: 504 });
-    }
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    return getMorePicksErrorResponse(error);
   }
+}
+
+function getTMDBConfigResponse() {
+  return process.env.TMDB_API_KEY
+    ? null
+    : NextResponse.json({ error: 'TMDB not configured' }, { status: 503 });
+}
+
+async function parseMorePicksRequest(req: NextRequest) {
+  const body = await readJsonBodyWithLimit(req, RECOMMENDATION_REQUEST_BODY_LIMIT_BYTES);
+  return requestBodySchema.parse(body);
+}
+
+function getMorePicksErrorResponse(error: unknown) {
+  const bodyErrorResponse = requestBodyErrorResponse(error);
+  if (bodyErrorResponse) return bodyErrorResponse;
+
+  if (error instanceof z.ZodError) {
+    return NextResponse.json({ details: error.issues, error: 'Invalid request' }, { status: 400 });
+  }
+
+  if (isMorePicksTimeoutError(error)) {
+    return NextResponse.json({ error: 'Upstream request timed out' }, { status: 504 });
+  }
+
+  return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+}
+
+function isMorePicksTimeoutError(error: unknown) {
+  return isAbortOrTimeoutError(error) || isOpenAITimeoutError(error);
+}
+
+function isAbortOrTimeoutError(error: unknown) {
+  return error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError');
 }
 
 export const POST = withAuth(postHandler);

--- a/apps/web/src/app/api/movie-recommendation/route.ts
+++ b/apps/web/src/app/api/movie-recommendation/route.ts
@@ -18,6 +18,8 @@ import {
 import { setActiveTraceAttributes, withTraceSpan } from '@/lib/tracing';
 import { withAuth } from '@/lib/withAuth';
 
+import type { RecommendationSourceStrategy } from '@/features/recommendation/types';
+
 // ---------------------------------------------------------------------------
 // POST handler
 // ---------------------------------------------------------------------------
@@ -25,127 +27,162 @@ async function postHandler(req: NextRequest): Promise<Response> {
   const startTime = Date.now();
 
   try {
-    const rateLimitResponse = await applyRateLimit(req);
-    if (rateLimitResponse) {
-      recordRecommendationCompletion({
-        mode: 'legacy_sync',
-        status: 'failure',
-        durationMs: Date.now() - startTime,
-      });
-      return rateLimitResponse;
-    }
+    const rateLimitResponse = await getRateLimitResponse(req, startTime);
+    if (rateLimitResponse) return rateLimitResponse;
 
-    const body = await readJsonBodyWithLimit(req, RECOMMENDATION_REQUEST_BODY_LIMIT_BYTES);
+    const context = await getLegacyRecommendationContext(req);
+    logRecommendationRequest(context);
 
-    // Validate request body
-    const validatedBody = requestBodySchema.parse(body);
-
-    // Read locale from Accept-Language header, default to English
-    const locale = parseLocaleFromRequest(req);
-
-    // Normalize to array format for consistent processing
-    const allPeopleData = normalizePeopleData(validatedBody);
-    const experienceMode = 'normal-match';
-    const sourceStrategy = resolveRecommendationSourceStrategy({
-      experienceMode,
-      people: allPeopleData,
-    }).id;
-
-    logger.info(
-      { experienceMode, personCount: allPeopleData.length, locale, sourceStrategy },
-      'Processing recommendation request',
-    );
-
-    const inputBlock = await getRecommendationInputBlock(allPeopleData);
+    const inputBlock = await getRecommendationInputBlock(context.allPeopleData);
     if (inputBlock) {
-      recordRecommendationCompletion({
-        mode: 'legacy_sync',
-        status: 'failure',
-        durationMs: Date.now() - startTime,
-      });
+      recordLegacyRecommendationFailure(startTime);
       return NextResponse.json(inputBlock, { status: 422 });
     }
 
-    // Run the full AI pipeline (Steps 0.5–7)
-    const response = await withTraceSpan(
-      'recommendation.process.legacy_sync',
-      {
-        attributes: {
-          'http.route': '/api/movie-recommendation',
-          'recommendation.experience_mode': experienceMode,
-          'recommendation.mode': 'legacy_sync',
-          'recommendation.people.count': allPeopleData.length,
-          'recommendation.source_strategy': sourceStrategy,
-          locale,
-        },
-      },
-      async () =>
-        runRecommendationPipeline(allPeopleData, locale, {
-          onStageChange: (stage) => {
-            setActiveTraceAttributes({ 'recommendation.stage': stage });
-          },
-          experienceMode,
-          sourceStrategy,
-        }),
-    );
+    const response = await runLegacyRecommendation(context);
 
     const duration = Date.now() - startTime;
-    logger.info(
-      { durationMs: duration, movieCount: response.similarMovies?.length ?? 0 },
-      'Recommendation request completed',
-    );
-    recordRecommendationCompletion({
-      mode: 'legacy_sync',
-      status: 'success',
-      durationMs: duration,
-    });
+    logLegacyRecommendationSuccess(duration, response.similarMovies?.length ?? 0);
+    recordLegacyRecommendationSuccess(duration);
 
     return NextResponse.json(apiResponseSchema.parse(response));
   } catch (error) {
-    recordRecommendationCompletion({
-      mode: 'legacy_sync',
-      status: 'failure',
-      durationMs: Date.now() - startTime,
-    });
-
-    const bodyErrorResponse = requestBodyErrorResponse(error);
-    if (bodyErrorResponse) return bodyErrorResponse;
-
-    // Handle validation errors first — these are client errors (400), not server errors
-    if (error instanceof z.ZodError) {
-      logger.warn({ err: error, issues: error.issues }, 'Invalid request body');
-      return NextResponse.json(
-        {
-          error: 'Invalid request data',
-          details: error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', '),
-        },
-        { status: 400 },
-      );
-    }
-
-    logger.error({ err: error }, 'Error in movie recommendation API');
-
-    if (isOpenAITimeoutError(error)) {
-      return NextResponse.json({ error: 'OpenAI request timed out' }, { status: 504 });
-    }
-
-    // Handle other known errors
-    if (error instanceof Error) {
-      // Return more specific error messages based on error content
-      if (error.message.includes('embedding')) {
-        return NextResponse.json({ error: 'Failed to process preferences' }, { status: 500 });
-      }
-      if (error.message.includes('similar movies')) {
-        return NextResponse.json({ error: 'Failed to find matching movies' }, { status: 500 });
-      }
-      if (error.message.includes('OpenAI')) {
-        return NextResponse.json({ error: 'Failed to generate recommendation' }, { status: 500 });
-      }
-    }
-
-    // Generic error response
-    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+    recordLegacyRecommendationFailure(startTime);
+    return getLegacyRecommendationErrorResponse(error);
   }
+}
+
+type LegacyRecommendationContext = {
+  allPeopleData: ReturnType<typeof normalizePeopleData>;
+  experienceMode: 'normal-match';
+  locale: ReturnType<typeof parseLocaleFromRequest>;
+  sourceStrategy: RecommendationSourceStrategy;
+};
+
+async function getRateLimitResponse(req: NextRequest, startTime: number) {
+  const rateLimitResponse = await applyRateLimit(req);
+  if (rateLimitResponse) {
+    recordLegacyRecommendationFailure(startTime);
+  }
+
+  return rateLimitResponse;
+}
+
+async function getLegacyRecommendationContext(
+  req: NextRequest,
+): Promise<LegacyRecommendationContext> {
+  const body = await readJsonBodyWithLimit(req, RECOMMENDATION_REQUEST_BODY_LIMIT_BYTES);
+  const validatedBody = requestBodySchema.parse(body);
+  const locale = parseLocaleFromRequest(req);
+  const allPeopleData = normalizePeopleData(validatedBody);
+  const experienceMode = 'normal-match';
+  const sourceStrategy = resolveRecommendationSourceStrategy({
+    experienceMode,
+    people: allPeopleData,
+  }).id;
+
+  return { allPeopleData, experienceMode, locale, sourceStrategy };
+}
+
+function logRecommendationRequest(context: LegacyRecommendationContext) {
+  logger.info(
+    {
+      experienceMode: context.experienceMode,
+      locale: context.locale,
+      personCount: context.allPeopleData.length,
+      sourceStrategy: context.sourceStrategy,
+    },
+    'Processing recommendation request',
+  );
+}
+
+async function runLegacyRecommendation(context: LegacyRecommendationContext) {
+  return withTraceSpan(
+    'recommendation.process.legacy_sync',
+    {
+      attributes: {
+        'http.route': '/api/movie-recommendation',
+        'recommendation.experience_mode': context.experienceMode,
+        'recommendation.mode': 'legacy_sync',
+        'recommendation.people.count': context.allPeopleData.length,
+        'recommendation.source_strategy': context.sourceStrategy,
+        locale: context.locale,
+      },
+    },
+    async () =>
+      runRecommendationPipeline(context.allPeopleData, context.locale, {
+        onStageChange: (stage) => {
+          setActiveTraceAttributes({ 'recommendation.stage': stage });
+        },
+        experienceMode: context.experienceMode,
+        sourceStrategy: context.sourceStrategy,
+      }),
+  );
+}
+
+function logLegacyRecommendationSuccess(duration: number, movieCount: number) {
+  logger.info({ durationMs: duration, movieCount }, 'Recommendation request completed');
+}
+
+function recordLegacyRecommendationSuccess(durationMs: number) {
+  recordRecommendationCompletion({ durationMs, mode: 'legacy_sync', status: 'success' });
+}
+
+function recordLegacyRecommendationFailure(startTime: number) {
+  recordRecommendationCompletion({
+    durationMs: Date.now() - startTime,
+    mode: 'legacy_sync',
+    status: 'failure',
+  });
+}
+
+function getLegacyRecommendationErrorResponse(error: unknown) {
+  const bodyErrorResponse = requestBodyErrorResponse(error);
+  if (bodyErrorResponse) return bodyErrorResponse;
+
+  if (error instanceof z.ZodError) {
+    return getValidationErrorResponse(error);
+  }
+
+  logger.error({ err: error }, 'Error in movie recommendation API');
+  return getKnownRecommendationErrorResponse(error);
+}
+
+function getValidationErrorResponse(error: z.ZodError) {
+  logger.warn({ err: error, issues: error.issues }, 'Invalid request body');
+  return NextResponse.json(
+    {
+      details: error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`).join(', '),
+      error: 'Invalid request data',
+    },
+    { status: 400 },
+  );
+}
+
+function getKnownRecommendationErrorResponse(error: unknown) {
+  if (isOpenAITimeoutError(error)) {
+    return NextResponse.json({ error: 'OpenAI request timed out' }, { status: 504 });
+  }
+
+  if (error instanceof Error) {
+    return getKnownErrorMessageResponse(error);
+  }
+
+  return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+}
+
+function getKnownErrorMessageResponse(error: Error) {
+  if (error.message.includes('embedding')) {
+    return NextResponse.json({ error: 'Failed to process preferences' }, { status: 500 });
+  }
+  if (error.message.includes('similar movies')) {
+    return NextResponse.json({ error: 'Failed to find matching movies' }, { status: 500 });
+  }
+  if (error.message.includes('OpenAI')) {
+    return NextResponse.json({ error: 'Failed to generate recommendation' }, { status: 500 });
+  }
+
+  return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
 }
 
 export const POST = withAuth(postHandler);

--- a/apps/web/src/app/api/recommendations/[id]/route.ts
+++ b/apps/web/src/app/api/recommendations/[id]/route.ts
@@ -12,23 +12,32 @@ async function getHandler(
   clientId: string,
   { id }: { id: string },
 ): Promise<Response> {
-  if (!id || typeof id !== 'string') {
-    return NextResponse.json({ error: 'Missing recommendation id' }, { status: 400 });
-  }
+  const validationResponse = getRecommendationIdValidationResponse(id);
+  if (validationResponse) return validationResponse;
 
   try {
-    const viewerUserId = clientId.startsWith('user:') ? clientId.slice('user:'.length) : undefined;
-    const result = await getRecommendationRecord(id, viewerUserId);
-
-    if (!result) {
-      return NextResponse.json({ error: 'Recommendation not found' }, { status: 404 });
-    }
-
-    return NextResponse.json(result);
+    return getRecommendationResponse(id, clientId);
   } catch (err) {
     logger.error({ err, id }, 'Failed to fetch recommendation');
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
+}
+
+function getRecommendationIdValidationResponse(id: string) {
+  return id ? null : NextResponse.json({ error: 'Missing recommendation id' }, { status: 400 });
+}
+
+async function getRecommendationResponse(id: string, clientId: string) {
+  const result = await getRecommendationRecord(id, getViewerUserId(clientId));
+  return result ? NextResponse.json(result) : getRecommendationNotFoundResponse();
+}
+
+function getViewerUserId(clientId: string) {
+  return clientId.startsWith('user:') ? clientId.slice('user:'.length) : undefined;
+}
+
+function getRecommendationNotFoundResponse() {
+  return NextResponse.json({ error: 'Recommendation not found' }, { status: 404 });
 }
 
 // Next.js dynamic route params are passed as the second argument to the route handler

--- a/apps/web/src/app/api/recommendations/route.ts
+++ b/apps/web/src/app/api/recommendations/route.ts
@@ -22,6 +22,13 @@ import {
 import { withTraceSpan } from '@/lib/tracing';
 import { withAuth } from '@/lib/withAuth';
 
+import type {
+  RecommendationExperienceMode,
+  RecommendationSourceStrategy,
+} from '@/features/recommendation/types';
+
+type CreateValidationIssue = { path: Array<string | number>; message: string };
+
 // ---------------------------------------------------------------------------
 // POST /api/recommendations — create a new recommendation job
 // ---------------------------------------------------------------------------
@@ -29,77 +36,153 @@ async function postHandler(req: NextRequest, clientId: string): Promise<Response
   const rateLimitResponse = await applyRateLimit(req);
   if (rateLimitResponse) return rateLimitResponse;
 
-  let body: unknown;
   try {
-    body = await readJsonBodyWithLimit(req, RECOMMENDATION_REQUEST_BODY_LIMIT_BYTES);
-  } catch (error) {
-    const bodyErrorResponse = requestBodyErrorResponse(error);
-    if (bodyErrorResponse) return bodyErrorResponse;
-    throw error;
-  }
+    const parsed = await parseCreateRecommendationBody(req);
+    const context = getCreateRecommendationContext(req, parsed.data);
+    logCreateRecommendationRequest(context);
 
-  // Validate request body
+    const inputBlockResponse = await getInputBlockResponse(context);
+    if (inputBlockResponse) return inputBlockResponse;
+
+    const created = await createRecommendationJob(context, clientId);
+    return NextResponse.json({ id: created.slug }, { status: 201 });
+  } catch (error) {
+    return getCreateRecommendationErrorResponse(error);
+  }
+}
+
+async function parseCreateRecommendationBody(req: NextRequest) {
+  const body = await readJsonBodyWithLimit(req, RECOMMENDATION_REQUEST_BODY_LIMIT_BYTES);
   const parsed = recommendationCreateRequestSchema.safeParse(body);
   if (!parsed.success) {
-    return NextResponse.json(
-      {
-        error: 'Invalid request data',
-        details: parsed.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join(', '),
-      },
-      { status: 400 },
-    );
+    throw parsed.error;
   }
 
-  const createInput = normalizeRecommendationCreateRequest(parsed.data);
+  return parsed;
+}
+
+function getCreateRecommendationContext(
+  req: NextRequest,
+  data: typeof recommendationCreateRequestSchema._output,
+) {
+  const createInput = normalizeRecommendationCreateRequest(data);
   const validatedBody = createInput.quizData;
   const locale = parseLocaleFromRequest(req);
   const allPeopleData = normalizePeopleData(validatedBody);
   const isDeterministic = usesDeterministicE2ERecommendations();
-  const experienceMode = isDeterministic
-    ? 'curated-showcase'
-    : (createInput.experienceMode ?? 'normal-match');
-  const sourceStrategy = isDeterministic
-    ? 'curated-showcase'
-    : resolveRecommendationSourceStrategy({ experienceMode, people: allPeopleData }).id;
 
+  return {
+    allPeopleData,
+    experienceMode: getCreateExperienceMode(isDeterministic, createInput.experienceMode),
+    isDeterministic,
+    locale,
+    sourceStrategy: getCreateSourceStrategy(
+      isDeterministic,
+      createInput.experienceMode,
+      allPeopleData,
+    ),
+    validatedBody,
+  };
+}
+
+type CreateRecommendationContext = ReturnType<typeof getCreateRecommendationContext>;
+
+function getCreateExperienceMode(
+  isDeterministic: boolean,
+  experienceMode: RecommendationExperienceMode | undefined,
+): RecommendationExperienceMode {
+  return isDeterministic ? 'curated-showcase' : (experienceMode ?? 'normal-match');
+}
+
+function getCreateSourceStrategy(
+  isDeterministic: boolean,
+  experienceMode: RecommendationExperienceMode | undefined,
+  allPeopleData: ReturnType<typeof normalizePeopleData>,
+): RecommendationSourceStrategy {
+  const resolvedExperienceMode = getCreateExperienceMode(isDeterministic, experienceMode);
+  return isDeterministic
+    ? 'curated-showcase'
+    : resolveRecommendationSourceStrategy({
+        experienceMode: resolvedExperienceMode,
+        people: allPeopleData,
+      }).id;
+}
+
+function logCreateRecommendationRequest(context: CreateRecommendationContext) {
   logger.info(
-    { experienceMode, personCount: allPeopleData.length, locale, sourceStrategy },
+    {
+      experienceMode: context.experienceMode,
+      locale: context.locale,
+      personCount: context.allPeopleData.length,
+      sourceStrategy: context.sourceStrategy,
+    },
     'Creating recommendation via /api/recommendations',
   );
+}
 
-  if (!isDeterministic) {
-    const inputBlock = await getRecommendationInputBlock(allPeopleData);
-    if (inputBlock) {
-      return NextResponse.json(inputBlock, { status: 422 });
-    }
+async function getInputBlockResponse(context: CreateRecommendationContext) {
+  if (context.isDeterministic) {
+    return null;
   }
 
+  const inputBlock = await getRecommendationInputBlock(context.allPeopleData);
+  return inputBlock ? NextResponse.json(inputBlock, { status: 422 }) : null;
+}
+
+async function createRecommendationJob(context: CreateRecommendationContext, clientId: string) {
   try {
-    const userId = clientId.startsWith('user:') ? clientId.slice('user:'.length) : undefined;
-    const created = await withTraceSpan(
+    return await withTraceSpan(
       'api.recommendations.create',
       {
         attributes: {
           'http.route': '/api/recommendations',
           'recommendation.mode': 'async',
-          'recommendation.experience_mode': experienceMode,
-          'recommendation.people.count': allPeopleData.length,
-          'recommendation.source_strategy': sourceStrategy,
-          locale,
+          'recommendation.experience_mode': context.experienceMode,
+          'recommendation.people.count': context.allPeopleData.length,
+          'recommendation.source_strategy': context.sourceStrategy,
+          locale: context.locale,
         },
       },
       async () =>
-        createAndStartRecommendation(validatedBody, allPeopleData, locale, {
-          experienceMode,
-          sourceStrategy,
-          userId,
+        createAndStartRecommendation(context.validatedBody, context.allPeopleData, context.locale, {
+          experienceMode: context.experienceMode,
+          sourceStrategy: context.sourceStrategy,
+          userId: getClientUserId(clientId),
         }),
     );
-    return NextResponse.json({ id: created.slug }, { status: 201 });
   } catch (err) {
     logger.error({ err }, 'Failed to create recommendation row');
-    return NextResponse.json({ error: 'Failed to create recommendation' }, { status: 500 });
+    throw new Error('Failed to create recommendation');
   }
+}
+
+function getClientUserId(clientId: string) {
+  return clientId.startsWith('user:') ? clientId.slice('user:'.length) : undefined;
+}
+
+function getCreateRecommendationErrorResponse(error: unknown) {
+  const bodyErrorResponse = requestBodyErrorResponse(error);
+  if (bodyErrorResponse) return bodyErrorResponse;
+
+  if (isCreateValidationError(error)) {
+    return getCreateValidationErrorResponse(error);
+  }
+
+  return NextResponse.json({ error: 'Failed to create recommendation' }, { status: 500 });
+}
+
+function isCreateValidationError(error: unknown): error is { issues: CreateValidationIssue[] } {
+  return error instanceof Error && error.name === 'ZodError' && 'issues' in error;
+}
+
+function getCreateValidationErrorResponse(error: { issues: CreateValidationIssue[] }) {
+  return NextResponse.json(
+    {
+      details: error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`).join(', '),
+      error: 'Invalid request data',
+    },
+    { status: 400 },
+  );
 }
 
 export const POST = withAuth(postHandler);

--- a/apps/web/src/app/components/FeaturesSection.tsx
+++ b/apps/web/src/app/components/FeaturesSection.tsx
@@ -6,6 +6,8 @@ import { motion } from 'motion/react';
 import { useLanguage } from '@/i18n';
 import { palette } from '@/styles/designTokens';
 
+import type { ElementType } from 'react';
+
 // Asymmetric 12-column grid: breaks identical card geometry while keeping group mode prominent
 const COL_SPANS = [
   'md:col-span-7', // AI-Powered: wider — the "why"
@@ -17,7 +19,7 @@ const COL_SPANS = [
 export function FeaturesSection() {
   const { t } = useLanguage();
 
-  const features = [
+  const features: FeatureCardData[] = [
     {
       icon: Sparkles,
       title: t.features.aiPowered.title,
@@ -74,55 +76,115 @@ export function FeaturesSection() {
       </motion.div>
 
       <div className="grid grid-cols-1 md:grid-cols-12 gap-5">
-        {features.map((f, i) => (
-          <motion.div
-            key={f.title}
-            initial={{ opacity: 0, y: 30 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            viewport={{ once: true }}
-            transition={{ duration: 0.5, delay: i * 0.1 }}
-            className={`col-span-1 ${COL_SPANS[i]} rounded-2xl flex flex-col gap-4`}
-            style={{
-              padding: f.featured ? '2rem' : '1.5rem',
-              background: f.featured ? `${f.color}0d` : 'var(--pc-surface)',
-              border: `1px solid ${f.featured ? `${f.color}30` : 'var(--pc-bd1)'}`,
-              transition: 'background 0.3s, border-color 0.3s',
-            }}
-          >
-            <div
-              className="rounded-xl flex items-center justify-center"
-              style={{
-                width: f.featured ? '3rem' : '2.5rem',
-                height: f.featured ? '3rem' : '2.5rem',
-                background: `${f.color}18`,
-                color: f.color,
-              }}
-            >
-              <f.icon size={f.featured ? 24 : 20} />
-            </div>
-            <div>
-              <h3
-                className="mb-1"
-                style={{
-                  color: 'var(--pc-t1)',
-                  fontSize: f.featured ? '1.05rem' : '0.95rem',
-                  fontWeight: 600,
-                }}
-              >
-                {f.title}
-              </h3>
-              <p style={{ color: 'var(--pc-t3)', fontSize: '0.85rem', lineHeight: 1.6 }}>
-                {f.desc}
-              </p>
-            </div>
-            {f.featured && (
-              <p className="mt-auto text-xs font-semibold" style={{ color: f.color }}>
-                {t.features.groupMode.worksFor}
-              </p>
-            )}
-          </motion.div>
+        {features.map((feature, index) => (
+          <FeatureCard
+            key={feature.title}
+            columnClass={COL_SPANS[index]}
+            feature={feature}
+            index={index}
+            worksFor={t.features.groupMode.worksFor}
+          />
         ))}
       </div>
     </section>
   );
+}
+
+type FeatureCardData = {
+  color: string;
+  desc: string;
+  featured: boolean;
+  icon: ElementType;
+  title: string;
+};
+
+function FeatureCard({
+  columnClass,
+  feature,
+  index,
+  worksFor,
+}: {
+  columnClass: string;
+  feature: FeatureCardData;
+  index: number;
+  worksFor: string;
+}) {
+  const Icon = feature.icon;
+  const styles = getFeatureCardStyles(feature);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 30 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.5, delay: index * 0.1 }}
+      className={`col-span-1 ${columnClass} rounded-2xl flex flex-col gap-4`}
+      style={styles.card}
+    >
+      <div className="rounded-xl flex items-center justify-center" style={styles.icon}>
+        <Icon size={feature.featured ? 24 : 20} />
+      </div>
+      <div>
+        <h3 className="mb-1" style={styles.title}>
+          {feature.title}
+        </h3>
+        <p style={{ color: 'var(--pc-t3)', fontSize: '0.85rem', lineHeight: 1.6 }}>
+          {feature.desc}
+        </p>
+      </div>
+      {feature.featured && (
+        <p className="mt-auto text-xs font-semibold" style={{ color: feature.color }}>
+          {worksFor}
+        </p>
+      )}
+    </motion.div>
+  );
+}
+
+function getFeatureCardStyles(feature: FeatureCardData) {
+  return {
+    card: getFeatureCardContainerStyle(feature),
+    icon: getFeatureIconStyle(feature),
+    title: getFeatureTitleStyle(feature),
+  };
+}
+
+function getFeatureCardContainerStyle(feature: FeatureCardData) {
+  return {
+    background: getFeatureCardBackground(feature),
+    border: `1px solid ${getFeatureCardBorderColor(feature)}`,
+    padding: getFeaturedValue(feature, '2rem', '1.5rem'),
+    transition: 'background 0.3s, border-color 0.3s',
+  };
+}
+
+function getFeatureIconStyle(feature: FeatureCardData) {
+  const size = getFeaturedValue(feature, '3rem', '2.5rem');
+
+  return {
+    background: `${feature.color}18`,
+    color: feature.color,
+    height: size,
+    width: size,
+  };
+}
+
+function getFeatureTitleStyle(feature: FeatureCardData) {
+  return {
+    color: 'var(--pc-t1)',
+    fontSize: getFeaturedValue(feature, '1.05rem', '0.95rem'),
+    fontWeight: 600,
+  };
+}
+
+function getFeatureCardBackground(feature: FeatureCardData) {
+  return getFeaturedValue(feature, `${feature.color}0d`, 'var(--pc-surface)');
+}
+
+function getFeatureCardBorderColor(feature: FeatureCardData) {
+  return getFeaturedValue(feature, `${feature.color}30`, 'var(--pc-bd1)');
+}
+
+function getFeaturedValue<T>(feature: FeatureCardData, featuredValue: T, defaultValue: T) {
+  return feature.featured ? featuredValue : defaultValue;
 }

--- a/apps/web/src/app/design-system/components/_components/SelectorDemos.tsx
+++ b/apps/web/src/app/design-system/components/_components/SelectorDemos.tsx
@@ -11,26 +11,22 @@ export function GenreChip({
   selected: boolean;
   onToggle: () => void;
 }) {
+  const styles = getGenreChipStyles({ color, selected });
+
   return (
     <button
       type="button"
       onClick={onToggle}
       className="flex items-center gap-3 p-3.5 rounded-xl text-left transition-all duration-200"
-      style={{
-        background: selected ? `${color}18` : 'var(--pc-surface)',
-        border: selected ? `1.5px solid ${color}50` : '1px solid var(--pc-bd1)',
-      }}
+      style={styles.button}
     >
       <div
         className="w-8 h-8 rounded-lg flex items-center justify-center shrink-0"
-        style={{
-          background: selected ? `${color}25` : 'var(--pc-ghost)',
-          color: selected ? color : 'var(--pc-t3)',
-        }}
+        style={styles.icon}
       >
         <Icon size={16} />
       </div>
-      <span className="text-sm font-semibold" style={{ color: selected ? color : 'var(--pc-t1)' }}>
+      <span className="text-sm font-semibold" style={styles.label}>
         {label}
       </span>
     </button>
@@ -54,28 +50,20 @@ export function ToneCard({
   selected: boolean;
   onSelect: () => void;
 }) {
+  const styles = getToneCardStyles({ color, grad, selected });
+
   return (
     <button
       type="button"
       onClick={onSelect}
       className="flex flex-col items-start gap-3 p-4 rounded-2xl text-left transition-all duration-200"
-      style={{
-        background: selected ? grad : 'var(--pc-surface)',
-        border: selected ? `1.5px solid ${color}50` : '1px solid var(--pc-bd1)',
-        boxShadow: selected ? `0 0 20px ${color}14` : 'none',
-      }}
+      style={styles.button}
     >
-      <div
-        className="w-9 h-9 rounded-xl flex items-center justify-center"
-        style={{
-          background: selected ? `${color}20` : 'var(--pc-ghost)',
-          color: selected ? color : 'var(--pc-t3)',
-        }}
-      >
+      <div className="w-9 h-9 rounded-xl flex items-center justify-center" style={styles.icon}>
         <Icon size={16} />
       </div>
       <div>
-        <div className="text-sm font-semibold" style={{ color: selected ? color : 'var(--pc-t1)' }}>
+        <div className="text-sm font-semibold" style={styles.label}>
           {label}
         </div>
         <div className="text-xs mt-0.5" style={{ color: 'var(--pc-t3)' }}>
@@ -101,20 +89,18 @@ export function EraOption({
   selected: boolean;
   onSelect: () => void;
 }) {
+  const styles = getEraOptionStyles({ color, selected });
+
   return (
     <button
       type="button"
       onClick={onSelect}
       className="flex items-center gap-4 p-4 rounded-2xl text-left transition-all duration-200 w-full"
-      style={{
-        background: selected ? `${color}18` : 'var(--pc-surface)',
-        border: selected ? `1.5px solid ${color}60` : '1px solid var(--pc-bd2)',
-        boxShadow: selected ? `0 0 20px ${color}18` : 'none',
-      }}
+      style={styles.button}
     >
       <div className="text-2xl">{emoji}</div>
       <div>
-        <div className="font-semibold text-sm" style={{ color: selected ? color : 'var(--pc-t1)' }}>
+        <div className="font-semibold text-sm" style={styles.label}>
           {title}
         </div>
         <div className="text-xs" style={{ color: 'var(--pc-t3)' }}>
@@ -123,4 +109,81 @@ export function EraOption({
       </div>
     </button>
   );
+}
+
+function getGenreChipStyles({ color, selected }: { color: string; selected: boolean }) {
+  return {
+    button: getSelectableButtonStyle({ borderAlpha: '50', color, selected }),
+    icon: getSelectableIconStyle({ backgroundAlpha: '25', color, selected }),
+    label: getSelectableLabelStyle({ color, selected }),
+  };
+}
+
+function getToneCardStyles({
+  color,
+  grad,
+  selected,
+}: {
+  color: string;
+  grad: string;
+  selected: boolean;
+}) {
+  return {
+    button: {
+      ...getSelectableButtonStyle({ borderAlpha: '50', color, selected, selectedBackground: grad }),
+      boxShadow: selected ? `0 0 20px ${color}14` : 'none',
+    },
+    icon: getSelectableIconStyle({ backgroundAlpha: '20', color, selected }),
+    label: getSelectableLabelStyle({ color, selected }),
+  };
+}
+
+function getEraOptionStyles({ color, selected }: { color: string; selected: boolean }) {
+  return {
+    button: {
+      ...getSelectableButtonStyle({ borderAlpha: '60', color, selected }),
+      boxShadow: selected ? `0 0 20px ${color}18` : 'none',
+    },
+    label: getSelectableLabelStyle({ color, selected }),
+  };
+}
+
+function getSelectableButtonStyle({
+  borderAlpha,
+  color,
+  selected,
+  selectedBackground,
+}: {
+  borderAlpha: '50' | '60';
+  color: string;
+  selected: boolean;
+  selectedBackground?: string;
+}) {
+  return {
+    background: selected ? (selectedBackground ?? `${color}18`) : 'var(--pc-surface)',
+    border: selected ? `1.5px solid ${color}${borderAlpha}` : getInactiveBorder(borderAlpha),
+  };
+}
+
+function getSelectableIconStyle({
+  backgroundAlpha,
+  color,
+  selected,
+}: {
+  backgroundAlpha: '20' | '25';
+  color: string;
+  selected: boolean;
+}) {
+  return {
+    background: selected ? `${color}${backgroundAlpha}` : 'var(--pc-ghost)',
+    color: selected ? color : 'var(--pc-t3)',
+  };
+}
+
+function getSelectableLabelStyle({ color, selected }: { color: string; selected: boolean }) {
+  return { color: selected ? color : 'var(--pc-t1)' };
+}
+
+function getInactiveBorder(borderAlpha: '50' | '60') {
+  return borderAlpha === '60' ? '1px solid var(--pc-bd2)' : '1px solid var(--pc-bd1)';
 }

--- a/apps/web/src/app/design-system/components/page.tsx
+++ b/apps/web/src/app/design-system/components/page.tsx
@@ -34,80 +34,18 @@ import {
 } from './_components';
 import { MOCK_MOVIES, MOCK_TABLE_MOVIES } from './_data';
 
+import type { Translations } from '@/i18n/locales/en';
+
 export default function StyleGuideComponentsPage() {
   const { t } = useLanguage();
-
-  const GENRES_L = [
-    { id: 'action', label: t.genres.action, icon: Zap, color: palette.amber },
-    { id: 'comedy', label: t.genres.comedy, icon: Smile, color: palette.gold },
-    { id: 'drama', label: t.genres.drama, icon: Play, color: palette.purple },
-    { id: 'scifi', label: t.genres.scifi, icon: Sparkles, color: palette.teal },
-  ];
-
-  const TONES_L = [
-    {
-      id: 'light',
-      label: t.tones.light.label,
-      desc: t.tones.light.desc,
-      icon: Sparkles,
-      color: palette.gold,
-      grad: `linear-gradient(135deg, ${palette.gold}18, ${palette.amber}18)`,
-    },
-    {
-      id: 'balanced',
-      label: t.tones.balanced.label,
-      desc: t.tones.balanced.desc,
-      icon: Play,
-      color: palette.teal,
-      grad: `linear-gradient(135deg, ${palette.teal}18, ${palette.blue}18)`,
-    },
-    {
-      id: 'serious',
-      label: t.tones.serious.label,
-      desc: t.tones.serious.desc,
-      icon: Play,
-      color: palette.purple,
-      grad: `linear-gradient(135deg, ${palette.purple}18, ${palette.purpleLight}18)`,
-    },
-    {
-      id: 'dark',
-      label: t.tones.dark.label,
-      desc: t.tones.dark.desc,
-      icon: Clapperboard,
-      color: palette.gray,
-      grad: `linear-gradient(135deg, ${palette.gray}18, ${palette.red}18)`,
-    },
-  ];
-
-  const ERAS_L = [
-    {
-      id: 'new',
-      emoji: '✨',
-      title: t.quiz.era.new.title,
-      desc: t.quiz.era.new.desc,
-      color: palette.teal,
-    },
-    {
-      id: 'classic',
-      emoji: '🎞️',
-      title: t.quiz.era.classic.title,
-      desc: t.quiz.era.classic.desc,
-      color: palette.gold,
-    },
-    {
-      id: 'both',
-      emoji: '🎬',
-      title: t.quiz.era.both.title,
-      desc: t.quiz.era.both.desc,
-      color: palette.purple,
-    },
-  ];
+  const genres = getGenreOptions(t);
+  const tones = getToneOptions(t);
+  const eras = getEraOptions(t);
   // Selectable demo state
   const [selectedGenres, setSelectedGenres] = useState<string[]>(['comedy']);
   const [selectedTone, setSelectedTone] = useState<string>('light');
   const [selectedEra, setSelectedEra] = useState<string>('both');
   const [activeCard, setActiveCard] = useState<number>(0);
-  const [skeletonLoading, setSkeletonLoading] = useState<boolean>(true);
 
   return (
     <div
@@ -304,55 +242,7 @@ export default function StyleGuideComponentsPage() {
         </Section>
 
         {/* ── Skeleton States ──────────────────────────────────────────── */}
-        <Section title={t.styleGuide.sections.skeletonLoading} id="skeleton-loading">
-          <div className="space-y-6">
-            {/* Toggle */}
-            <div className="flex items-center gap-3">
-              <span
-                className="text-xs font-semibold uppercase tracking-widest"
-                style={{ color: 'var(--pc-t3)' }}
-              >
-                {t.styleGuide.comp.stateLabel}
-              </span>
-              <button
-                type="button"
-                onClick={() => setSkeletonLoading((v) => !v)}
-                className="px-3 py-1.5 rounded-lg text-xs font-semibold transition-all duration-200"
-                style={{
-                  background: skeletonLoading ? 'var(--pc-gold-subtle)' : 'var(--pc-surface)',
-                  border: `1px solid ${skeletonLoading ? 'var(--pc-gold-bd)' : 'var(--pc-bd2)'}`,
-                  color: skeletonLoading ? 'var(--pc-gold-text)' : 'var(--pc-t2)',
-                }}
-              >
-                {skeletonLoading ? t.styleGuide.comp.loading : t.styleGuide.comp.loaded}
-              </button>
-            </div>
-
-            {/* MoviesTable */}
-            <div>
-              <p className="text-xs mb-3" style={{ color: 'var(--pc-t3)' }}>
-                {t.styleGuide.comp.skeletonMoviesNote}
-              </p>
-              {skeletonLoading ? (
-                <MoviesTableSkeleton />
-              ) : (
-                <MoviesTable movies={MOCK_TABLE_MOVIES} />
-              )}
-            </div>
-
-            {/* Card skeleton */}
-            <div style={{ borderTop: '1px solid var(--pc-bd1)', paddingTop: '1.5rem' }}>
-              <p className="text-xs mb-3" style={{ color: 'var(--pc-t3)' }}>
-                {t.styleGuide.comp.skeletonCardNote}
-              </p>
-              <div className="flex gap-4 flex-wrap">
-                {MOCK_MOVIES.map((movie) => (
-                  <SkeletonCard key={movie.id} loading={skeletonLoading} movie={movie} />
-                ))}
-              </div>
-            </div>
-          </div>
-        </Section>
+        <SkeletonStatesSection t={t} />
 
         {/* ── AI Content Block ─────────────────────────────────────────── */}
         <Section title={t.styleGuide.sections.aiContentBlock} id="ai-content-block">
@@ -418,7 +308,7 @@ export default function StyleGuideComponentsPage() {
               {t.styleGuide.comp.genreSelectorNote}
             </p>
             <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-              {GENRES_L.map((g) => (
+              {genres.map((g) => (
                 <GenreChip
                   key={g.id}
                   icon={g.icon}
@@ -444,7 +334,7 @@ export default function StyleGuideComponentsPage() {
               {t.styleGuide.comp.toneSelectorNote}
             </p>
             <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-              {TONES_L.map((tone) => (
+              {tones.map((tone) => (
                 <ToneCard
                   key={tone.id}
                   icon={tone.icon}
@@ -468,7 +358,7 @@ export default function StyleGuideComponentsPage() {
               {t.styleGuide.comp.eraSelectorNote}
             </p>
             <div className="flex flex-col gap-3 max-w-sm">
-              {ERAS_L.map((era) => (
+              {eras.map((era) => (
                 <EraOption
                   key={era.id}
                   emoji={era.emoji}
@@ -657,4 +547,161 @@ export default function StyleGuideComponentsPage() {
       </div>
     </div>
   );
+}
+
+function getGenreOptions(t: Translations) {
+  return [
+    { id: 'action', label: t.genres.action, icon: Zap, color: palette.amber },
+    { id: 'comedy', label: t.genres.comedy, icon: Smile, color: palette.gold },
+    { id: 'drama', label: t.genres.drama, icon: Play, color: palette.purple },
+    { id: 'scifi', label: t.genres.scifi, icon: Sparkles, color: palette.teal },
+  ];
+}
+
+function SkeletonStatesSection({ t }: { t: Translations }) {
+  const [skeletonLoading, setSkeletonLoading] = useState<boolean>(true);
+
+  return (
+    <Section title={t.styleGuide.sections.skeletonLoading} id="skeleton-loading">
+      <div className="space-y-6">
+        <SkeletonStateToggle
+          loading={skeletonLoading}
+          t={t}
+          onToggle={() => setSkeletonLoading((value) => !value)}
+        />
+        <MoviesTableLoadingDemo loading={skeletonLoading} t={t} />
+        <SkeletonCardDemo loading={skeletonLoading} t={t} />
+      </div>
+    </Section>
+  );
+}
+
+function SkeletonStateToggle({
+  loading,
+  onToggle,
+  t,
+}: {
+  loading: boolean;
+  onToggle: () => void;
+  t: Translations;
+}) {
+  return (
+    <div className="flex items-center gap-3">
+      <span
+        className="text-xs font-semibold uppercase tracking-widest"
+        style={{ color: 'var(--pc-t3)' }}
+      >
+        {t.styleGuide.comp.stateLabel}
+      </span>
+      <button
+        type="button"
+        onClick={onToggle}
+        className="px-3 py-1.5 rounded-lg text-xs font-semibold transition-all duration-200"
+        style={getSkeletonToggleStyle(loading)}
+      >
+        {getSkeletonStateLabel(t, loading)}
+      </button>
+    </div>
+  );
+}
+
+function MoviesTableLoadingDemo({ loading, t }: { loading: boolean; t: Translations }) {
+  return (
+    <div>
+      <p className="text-xs mb-3" style={{ color: 'var(--pc-t3)' }}>
+        {t.styleGuide.comp.skeletonMoviesNote}
+      </p>
+      {loading ? <MoviesTableSkeleton /> : <MoviesTable movies={MOCK_TABLE_MOVIES} />}
+    </div>
+  );
+}
+
+function SkeletonCardDemo({ loading, t }: { loading: boolean; t: Translations }) {
+  return (
+    <div style={{ borderTop: '1px solid var(--pc-bd1)', paddingTop: '1.5rem' }}>
+      <p className="text-xs mb-3" style={{ color: 'var(--pc-t3)' }}>
+        {t.styleGuide.comp.skeletonCardNote}
+      </p>
+      <div className="flex gap-4 flex-wrap">
+        {MOCK_MOVIES.map((movie) => (
+          <SkeletonCard key={movie.id} loading={loading} movie={movie} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function getSkeletonToggleStyle(loading: boolean) {
+  return {
+    background: loading ? 'var(--pc-gold-subtle)' : 'var(--pc-surface)',
+    border: `1px solid ${loading ? 'var(--pc-gold-bd)' : 'var(--pc-bd2)'}`,
+    color: loading ? 'var(--pc-gold-text)' : 'var(--pc-t2)',
+  };
+}
+
+function getSkeletonStateLabel(t: Translations, loading: boolean) {
+  return loading ? t.styleGuide.comp.loading : t.styleGuide.comp.loaded;
+}
+
+function getToneOptions(t: Translations) {
+  return [
+    {
+      id: 'light',
+      label: t.tones.light.label,
+      desc: t.tones.light.desc,
+      icon: Sparkles,
+      color: palette.gold,
+      grad: `linear-gradient(135deg, ${palette.gold}18, ${palette.amber}18)`,
+    },
+    {
+      id: 'balanced',
+      label: t.tones.balanced.label,
+      desc: t.tones.balanced.desc,
+      icon: Play,
+      color: palette.teal,
+      grad: `linear-gradient(135deg, ${palette.teal}18, ${palette.blue}18)`,
+    },
+    {
+      id: 'serious',
+      label: t.tones.serious.label,
+      desc: t.tones.serious.desc,
+      icon: Play,
+      color: palette.purple,
+      grad: `linear-gradient(135deg, ${palette.purple}18, ${palette.purpleLight}18)`,
+    },
+    {
+      id: 'dark',
+      label: t.tones.dark.label,
+      desc: t.tones.dark.desc,
+      icon: Clapperboard,
+      color: palette.gray,
+      grad: `linear-gradient(135deg, ${palette.gray}18, ${palette.red}18)`,
+    },
+  ];
+}
+
+function getEraOptions(t: Translations) {
+  return [
+    {
+      id: 'new',
+      emoji: '✨',
+      title: t.quiz.era.new.title,
+      desc: t.quiz.era.new.desc,
+      color: palette.teal,
+    },
+    {
+      id: 'classic',
+      emoji: '🎞️',
+      title: t.quiz.era.classic.title,
+      desc: t.quiz.era.classic.desc,
+      color: palette.gold,
+    },
+    {
+      id: 'both',
+      emoji: '🎬',
+      title: t.quiz.era.both.title,
+      desc: t.quiz.era.both.desc,
+      color: palette.purple,
+    },
+  ];
 }

--- a/apps/web/src/app/quiz/components/FastAudience.tsx
+++ b/apps/web/src/app/quiz/components/FastAudience.tsx
@@ -8,6 +8,8 @@ import { palette } from '@/styles/designTokens';
 
 import { AudienceChoiceButton } from './AudienceChoiceButton';
 
+import type { ElementType } from 'react';
+
 interface FastAudienceProps {
   flow: 'fast' | 'normal';
   onBack: () => void;
@@ -25,9 +27,7 @@ export function FastAudience({
 }: FastAudienceProps) {
   const { t } = useLanguage();
   const copy = flow === 'fast' ? t.quiz.fastAudience : t.quiz.normalAudience;
-  const iconBackground = flow === 'fast' ? 'rgba(245,197,24,0.15)' : `${palette.teal}26`;
-  const iconColor = flow === 'fast' ? 'var(--pc-gold-text)' : palette.teal;
-  const HeaderIcon = flow === 'fast' ? Zap : SlidersHorizontal;
+  const presentation = getFastAudiencePresentation(flow);
 
   return (
     <div className="flex min-h-[80vh] flex-1 flex-col items-center justify-center px-5 py-12">
@@ -51,30 +51,7 @@ export function FastAudience({
           {t.quiz.fastAudience.back}
         </button>
 
-        <div className="mb-8 text-center">
-          <div
-            className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl"
-            style={{
-              background: iconBackground,
-              color: iconColor,
-            }}
-          >
-            <HeaderIcon size={26} />
-          </div>
-          <h2
-            style={{
-              fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
-              fontWeight: '600',
-              textTransform: 'uppercase',
-              fontSize: '2rem',
-              letterSpacing: '0.05em',
-              color: 'var(--pc-t1)',
-            }}
-          >
-            {copy.title}
-          </h2>
-          <p style={{ color: 'var(--pc-t3)', fontSize: '0.9rem', marginTop: 6 }}>{copy.subtitle}</p>
-        </div>
+        <FastAudienceHeader copy={copy} presentation={presentation} />
 
         <div className="flex flex-col gap-4">
           <AudienceChoiceButton
@@ -110,4 +87,62 @@ export function FastAudience({
       </motion.div>
     </div>
   );
+}
+
+type FastAudienceCopy = ReturnType<typeof useLanguage>['t']['quiz']['fastAudience'];
+type FastAudiencePresentation = {
+  icon: ElementType;
+  iconBackground: string;
+  iconColor: string;
+};
+
+function FastAudienceHeader({
+  copy,
+  presentation,
+}: {
+  copy: FastAudienceCopy;
+  presentation: FastAudiencePresentation;
+}) {
+  const HeaderIcon = presentation.icon;
+
+  return (
+    <div className="mb-8 text-center">
+      <div
+        className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl"
+        style={{
+          background: presentation.iconBackground,
+          color: presentation.iconColor,
+        }}
+      >
+        <HeaderIcon size={26} />
+      </div>
+      <h2
+        style={{
+          color: 'var(--pc-t1)',
+          fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
+          fontSize: '2rem',
+          fontWeight: '600',
+          letterSpacing: '0.05em',
+          textTransform: 'uppercase',
+        }}
+      >
+        {copy.title}
+      </h2>
+      <p style={{ color: 'var(--pc-t3)', fontSize: '0.9rem', marginTop: 6 }}>{copy.subtitle}</p>
+    </div>
+  );
+}
+
+function getFastAudiencePresentation(flow: FastAudienceProps['flow']): FastAudiencePresentation {
+  return flow === 'fast'
+    ? {
+        icon: Zap,
+        iconBackground: 'rgba(245,197,24,0.15)',
+        iconColor: 'var(--pc-gold-text)',
+      }
+    : {
+        icon: SlidersHorizontal,
+        iconBackground: `${palette.teal}26`,
+        iconColor: palette.teal,
+      };
 }

--- a/apps/web/src/app/quiz/components/steps/EraStep.tsx
+++ b/apps/web/src/app/quiz/components/steps/EraStep.tsx
@@ -5,6 +5,8 @@ import { Clock } from 'lucide-react';
 import { useLanguage } from '@/i18n';
 import { palette } from '@/styles/designTokens';
 
+import { SelectionMark, StepHeader } from './StepPrimitives';
+
 import type { Era, PersonAnswers } from '../../types';
 
 interface EraStepProps {
@@ -12,10 +14,18 @@ interface EraStepProps {
   onUpdate: (updates: Partial<PersonAnswers>) => void;
 }
 
+type EraOptionData = {
+  color: string;
+  desc: string;
+  emoji: string;
+  id: Era;
+  title: string;
+};
+
 export function EraStep({ person, onUpdate }: EraStepProps) {
   const { t } = useLanguage();
 
-  const ERA_OPTIONS = [
+  const eraOptions: EraOptionData[] = [
     {
       id: 'new' as Era,
       emoji: '✨',
@@ -41,85 +51,73 @@ export function EraStep({ person, onUpdate }: EraStepProps) {
 
   return (
     <div className="flex flex-col gap-6 pt-2">
-      <div className="flex items-center gap-3">
-        <div
-          className="w-10 h-10 rounded-xl flex items-center justify-center"
-          style={{
-            background: 'rgba(255,159,28,0.15)',
-            color: 'var(--pc-amber)',
-          }}
-        >
-          <Clock size={20} />
-        </div>
-        <h2
-          style={{
-            fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
-            fontWeight: '600',
-            textTransform: 'uppercase',
-            fontSize: '1.8rem',
-            letterSpacing: '0.04em',
-            color: 'var(--pc-t1)',
-            lineHeight: 1.1,
-          }}
-        >
-          {t.quiz.era.title}
-        </h2>
-      </div>
+      <StepHeader
+        accentBackground="rgba(255,159,28,0.15)"
+        accentColor="var(--pc-amber)"
+        icon={<Clock size={20} />}
+        title={t.quiz.era.title}
+      />
 
       <div className="grid grid-cols-1 gap-4">
-        {ERA_OPTIONS.map((opt) => {
-          const selected = person.era === opt.id;
-          return (
-            <button
-              key={opt.id}
-              onClick={() => onUpdate({ era: opt.id })}
-              className="flex items-center gap-4 p-4 rounded-2xl text-left transition-all duration-200 active:scale-[0.98]"
-              style={{
-                background: selected ? `${opt.color}18` : 'var(--pc-surface)',
-                border: selected ? `1.5px solid ${opt.color}60` : '1px solid var(--pc-bd2)',
-                boxShadow: selected ? `0 0 20px ${opt.color}18` : 'none',
-              }}
-            >
-              <div className="text-2xl">{opt.emoji}</div>
-              <div className="flex-1">
-                <div
-                  style={{
-                    color: selected ? opt.color : 'var(--pc-t1)',
-                    fontWeight: 600,
-                    fontSize: '0.95rem',
-                  }}
-                >
-                  {opt.title}
-                </div>
-                <div
-                  style={{
-                    color: 'var(--pc-t3)',
-                    fontSize: '0.82rem',
-                  }}
-                >
-                  {opt.desc}
-                </div>
-              </div>
-              {selected && (
-                <div
-                  className="w-5 h-5 rounded-full flex items-center justify-center shrink-0"
-                  style={{ background: opt.color }}
-                >
-                  <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
-                    <path
-                      d="M2 5l2.5 2.5L8 3"
-                      stroke="var(--pc-cta-text)"
-                      strokeWidth="1.5"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                </div>
-              )}
-            </button>
-          );
-        })}
+        {eraOptions.map((option) => (
+          <EraOptionButton
+            key={option.id}
+            option={option}
+            selected={person.era === option.id}
+            onSelect={() => onUpdate({ era: option.id })}
+          />
+        ))}
       </div>
     </div>
   );
+}
+
+function EraOptionButton({
+  onSelect,
+  option,
+  selected,
+}: {
+  onSelect: () => void;
+  option: EraOptionData;
+  selected: boolean;
+}) {
+  const styles = getEraOptionStyles(option, selected);
+
+  return (
+    <button
+      onClick={onSelect}
+      className="flex items-center gap-4 p-4 rounded-2xl text-left transition-all duration-200 active:scale-[0.98]"
+      style={styles.button}
+    >
+      <div className="text-2xl">{option.emoji}</div>
+      <div className="flex-1">
+        <div style={styles.title}>{option.title}</div>
+        <div style={{ color: 'var(--pc-t3)', fontSize: '0.82rem' }}>{option.desc}</div>
+      </div>
+      {selected && <SelectionMark color={option.color} />}
+    </button>
+  );
+}
+
+function getEraOptionStyles(option: EraOptionData, selected: boolean) {
+  return {
+    button: {
+      background: getSelectedValue(selected, `${option.color}18`, 'var(--pc-surface)'),
+      border: getSelectedValue(
+        selected,
+        `1.5px solid ${option.color}60`,
+        '1px solid var(--pc-bd2)',
+      ),
+      boxShadow: getSelectedValue(selected, `0 0 20px ${option.color}18`, 'none'),
+    },
+    title: {
+      color: getSelectedValue(selected, option.color, 'var(--pc-t1)'),
+      fontSize: '0.95rem',
+      fontWeight: 600,
+    },
+  };
+}
+
+function getSelectedValue<T>(selected: boolean, selectedValue: T, defaultValue: T) {
+  return selected ? selectedValue : defaultValue;
 }

--- a/apps/web/src/clients/pgClient.ts
+++ b/apps/web/src/clients/pgClient.ts
@@ -102,6 +102,8 @@ interface QueryState {
   rangeTo: number | null;
 }
 
+type WhereClause = QueryState['wheres'][number];
+
 function defaultState(table: string): QueryState {
   assertSafeIdentifier(table, 'table name');
   return {
@@ -129,7 +131,6 @@ function buildSelectSQL(state: QueryState): {
   countValues?: unknown[];
 } {
   const values: unknown[] = [];
-  let idx = 1;
 
   // Column list
   const cols = state.headOnly ? '1' : state.columns;
@@ -140,69 +141,80 @@ function buildSelectSQL(state: QueryState): {
   const selectCols = needsWindowCount ? `${cols}, COUNT(*) OVER() AS _total_count` : cols;
 
   let sql = `SELECT ${selectCols} FROM "${state.table}"`;
-
-  // WHERE clauses
-  if (state.wheres.length > 0) {
-    const clauses = state.wheres.map((w) => {
-      if (w.op === 'IN') {
-        // Use = ANY($n) with a single array parameter for efficient IN queries.
-        const arr = w.value as unknown[];
-        values.push(arr);
-        return `"${w.column}" = ANY($${idx++})`;
-      }
-      const placeholder = `$${idx++}`;
-      values.push(w.value);
-      if (w.op === 'ILIKE') {
-        return `"${w.column}" ILIKE ${placeholder} ESCAPE '\\'`;
-      }
-      return `"${w.column}" ${w.op} ${placeholder}`;
-    });
-    sql += ` WHERE ${clauses.join(' AND ')}`;
-  }
+  sql += buildWhereSQL(state.wheres, values);
 
   // ORDER BY
   if (state.orderBy) {
     sql += ` ORDER BY "${state.orderBy.column}" ${state.orderBy.ascending ? 'ASC' : 'DESC'}`;
   }
 
-  // LIMIT / OFFSET via range
-  if (state.rangeFrom !== null && state.rangeTo !== null) {
-    const limit = safeNonNegativeInt(state.rangeTo - state.rangeFrom + 1);
-    const offset = safeNonNegativeInt(state.rangeFrom);
-    sql += ` LIMIT ${limit} OFFSET ${offset}`;
-  } else if (state.limitVal !== null) {
-    sql += ` LIMIT ${safeNonNegativeInt(state.limitVal)}`;
-  }
+  sql += buildLimitSQL(state);
 
   // Build a separate COUNT(*) query used as fallback when the window-function
   // path returns zero rows (OFFSET past end of result set), or for head-only queries.
-  let countText: string | undefined;
-  let countValues: unknown[] | undefined;
-  if (state.countMode === 'exact') {
-    let countSQL = `SELECT COUNT(*) as count FROM "${state.table}"`;
-    const cValues: unknown[] = [];
-    let cIdx = 1;
-    if (state.wheres.length > 0) {
-      const clauses = state.wheres.map((w) => {
-        if (w.op === 'IN') {
-          const arr = w.value as unknown[];
-          cValues.push(arr);
-          return `"${w.column}" = ANY($${cIdx++})`;
-        }
-        const placeholder = `$${cIdx++}`;
-        cValues.push(w.value);
-        if (w.op === 'ILIKE') {
-          return `"${w.column}" ILIKE ${placeholder} ESCAPE '\\'`;
-        }
-        return `"${w.column}" ${w.op} ${placeholder}`;
-      });
-      countSQL += ` WHERE ${clauses.join(' AND ')}`;
-    }
-    countText = countSQL;
-    countValues = cValues;
+  const countQuery = buildCountQuery(state);
+
+  return {
+    countText: countQuery?.text,
+    countValues: countQuery?.values,
+    text: sql,
+    useWindowCount: needsWindowCount,
+    values,
+  };
+}
+
+function buildWhereSQL(wheres: WhereClause[], values: unknown[]) {
+  const clauses = buildWhereClauses(wheres, values);
+  return clauses.length > 0 ? ` WHERE ${clauses.join(' AND ')}` : '';
+}
+
+function buildWhereClauses(wheres: WhereClause[], values: unknown[]) {
+  const index = { value: 1 };
+  return wheres.map((where) => buildWhereClause(where, values, index));
+}
+
+function buildWhereClause(where: WhereClause, values: unknown[], index: { value: number }) {
+  if (where.op === 'IN') {
+    values.push(where.value as unknown[]);
+    return `"${where.column}" = ANY($${index.value++})`;
   }
 
-  return { text: sql, values, useWindowCount: needsWindowCount, countText, countValues };
+  const placeholder = `$${index.value++}`;
+  values.push(where.value);
+  return where.op === 'ILIKE'
+    ? `"${where.column}" ILIKE ${placeholder} ESCAPE '\\'`
+    : `"${where.column}" ${where.op} ${placeholder}`;
+}
+
+function buildLimitSQL(state: QueryState) {
+  const rangeSQL = buildRangeSQL(state);
+  return rangeSQL ?? buildLimitOnlySQL(state);
+}
+
+function buildRangeSQL(state: QueryState) {
+  if (state.rangeFrom === null || state.rangeTo === null) {
+    return null;
+  }
+
+  const limit = safeNonNegativeInt(state.rangeTo - state.rangeFrom + 1);
+  const offset = safeNonNegativeInt(state.rangeFrom);
+  return ` LIMIT ${limit} OFFSET ${offset}`;
+}
+
+function buildLimitOnlySQL(state: QueryState) {
+  return state.limitVal === null ? '' : ` LIMIT ${safeNonNegativeInt(state.limitVal)}`;
+}
+
+function buildCountQuery(state: QueryState) {
+  if (state.countMode !== 'exact') {
+    return null;
+  }
+
+  const values: unknown[] = [];
+  return {
+    text: `SELECT COUNT(*) as count FROM "${state.table}"${buildWhereSQL(state.wheres, values)}`,
+    values,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -214,40 +226,13 @@ async function executeSelect<T>(pool: PgPool, state: QueryState): Promise<QueryR
     const { text, values, useWindowCount, countText, countValues } = buildSelectSQL(state);
 
     if (state.headOnly) {
-      // For head-only queries, we only need the count
-      if (countText) {
-        const countResult = await pool.query(countText, countValues);
-        return {
-          data: null,
-          error: null,
-          count: parseInt(countResult.rows[0]?.count ?? '0', 10),
-        };
-      }
-      return { data: null, error: null };
+      return executeHeadOnlySelect(pool, countText, countValues);
     }
 
     const result = await pool.query(text, values);
 
     if (useWindowCount) {
-      // Extract the injected _total_count window column and strip it from rows.
-      type RowWithCount = T & { _total_count?: string | number };
-      const rows = result.rows as RowWithCount[];
-
-      if (rows.length > 0) {
-        const count = parseInt(String(rows[0]._total_count ?? '0'), 10);
-        const data = rows.map(({ _total_count: _, ...rest }) => rest as T);
-        return { data, error: null, count };
-      }
-
-      // The OFFSET is past the end of the result set — the window function cannot
-      // return a count. Fall back to a separate COUNT(*) query.
-      // Any error thrown here is caught by the outer try/catch and returned as
-      // a QueryResult error, consistent with the rest of this function.
-      const fallbackCount =
-        countText != null
-          ? parseInt((await pool.query(countText, countValues)).rows[0]?.count ?? '0', 10)
-          : 0;
-      return { data: [], error: null, count: fallbackCount };
+      return executeWindowCountSelect<T>(pool, result.rows, countText, countValues);
     }
 
     return {
@@ -260,6 +245,42 @@ async function executeSelect<T>(pool: PgPool, state: QueryState): Promise<QueryR
       error: { message: err instanceof Error ? err.message : String(err) },
     };
   }
+}
+
+async function executeHeadOnlySelect<T>(
+  pool: PgPool,
+  countText: string | undefined,
+  countValues: unknown[] | undefined,
+): Promise<QueryResult<T>> {
+  if (!countText) {
+    return { data: null, error: null };
+  }
+
+  return { count: await queryCount(pool, countText, countValues), data: null, error: null };
+}
+
+async function executeWindowCountSelect<T>(
+  pool: PgPool,
+  rows: unknown[],
+  countText: string | undefined,
+  countValues: unknown[] | undefined,
+): Promise<QueryResult<T>> {
+  type RowWithCount = T & { _total_count?: string | number };
+  const rowsWithCount = rows as RowWithCount[];
+
+  if (rowsWithCount.length > 0) {
+    const count = parseInt(String(rowsWithCount[0]._total_count ?? '0'), 10);
+    const data = rowsWithCount.map(({ _total_count: _, ...rest }) => rest as T);
+    return { count, data, error: null };
+  }
+
+  const fallbackCount = countText ? await queryCount(pool, countText, countValues) : 0;
+  return { count: fallbackCount, data: [], error: null };
+}
+
+async function queryCount(pool: PgPool, countText: string, countValues: unknown[] | undefined) {
+  const countResult = await pool.query(countText, countValues);
+  return parseInt(countResult.rows[0]?.count ?? '0', 10);
 }
 
 // ---------------------------------------------------------------------------
@@ -396,47 +417,9 @@ function createInsert<T>(pool: PgPool, table: string, rows: T | T[]): QueryInser
     }
 
     try {
-      // Get column names from the first row and validate
-      const columns = Object.keys(rowArray[0] as Record<string, unknown>);
-      columns.forEach((c) => assertSafeIdentifier(c, 'column name'));
-      const colList = columns.map((c) => `"${c}"`).join(', ');
-
-      const valuePlaceholders: string[] = [];
-      const values: unknown[] = [];
-      let idx = 1;
-
-      for (const row of rowArray) {
-        const record = row as Record<string, unknown>;
-        const placeholders: string[] = [];
-        for (const col of columns) {
-          let val = record[col];
-          // Convert embedding arrays to pgvector string format
-          if (col === 'embedding' && Array.isArray(val)) {
-            val = `[${(val as number[]).join(',')}]`;
-          }
-          placeholders.push(`$${idx++}`);
-          values.push(val);
-        }
-        valuePlaceholders.push(`(${placeholders.join(', ')})`);
-      }
-
-      let sql = `INSERT INTO "${table}" (${colList}) VALUES ${valuePlaceholders.join(', ')}`;
-      if (returning) {
-        // Validate RETURNING column names and quote identifiers consistently.
-        const returningClause =
-          returning === '*'
-            ? '*'
-            : returning
-                .split(',')
-                .map((c) => c.trim())
-                .map((c) => {
-                  assertSafeIdentifier(c, 'column name');
-                  return `"${c}"`;
-                })
-                .join(', ');
-        sql += ` RETURNING ${returningClause}`;
-      }
-
+      const columns = getInsertColumns(rowArray);
+      const { values, valuePlaceholders } = buildInsertValues(rowArray, columns);
+      const sql = buildInsertSQL(table, columns, valuePlaceholders, returning);
       const result = await pool.query(sql, values);
       return { data: (result.rows as T[]) ?? [], error: null };
     } catch (err) {
@@ -466,6 +449,68 @@ function createInsert<T>(pool: PgPool, table: string, rows: T | T[]): QueryInser
       } as PromiseLike<QueryResult<T>>;
     },
   };
+}
+
+function getInsertColumns<T>(rowArray: T[]) {
+  const columns = Object.keys(rowArray[0] as Record<string, unknown>);
+  columns.forEach((column) => assertSafeIdentifier(column, 'column name'));
+  return columns;
+}
+
+function buildInsertValues<T>(rowArray: T[], columns: string[]) {
+  const values: unknown[] = [];
+  const index = { value: 1 };
+  const valuePlaceholders = rowArray.map((row) =>
+    buildInsertRowValues(row, columns, values, index),
+  );
+
+  return { values, valuePlaceholders };
+}
+
+function buildInsertRowValues<T>(
+  row: T,
+  columns: string[],
+  values: unknown[],
+  index: { value: number },
+) {
+  const record = row as Record<string, unknown>;
+  const placeholders = columns.map((column) => {
+    values.push(normalizeInsertValue(column, record[column]));
+    return `$${index.value++}`;
+  });
+
+  return `(${placeholders.join(', ')})`;
+}
+
+function normalizeInsertValue(column: string, value: unknown) {
+  return column === 'embedding' && Array.isArray(value)
+    ? `[${(value as number[]).join(',')}]`
+    : value;
+}
+
+function buildInsertSQL(
+  table: string,
+  columns: string[],
+  valuePlaceholders: string[],
+  returning: string | null,
+) {
+  const colList = columns.map((column) => `"${column}"`).join(', ');
+  const returningClause = buildReturningClause(returning);
+  return `INSERT INTO "${table}" (${colList}) VALUES ${valuePlaceholders.join(', ')}${returningClause}`;
+}
+
+function buildReturningClause(returning: string | null) {
+  return returning ? ` RETURNING ${formatReturningColumns(returning)}` : '';
+}
+
+function formatReturningColumns(returning: string) {
+  return returning === '*' ? '*' : returning.split(',').map(formatReturningColumn).join(', ');
+}
+
+function formatReturningColumn(column: string) {
+  const trimmed = column.trim();
+  assertSafeIdentifier(trimmed, 'column name');
+  return `"${trimmed}"`;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/components/AgeRatingChip/AgeRatingChip.tsx
+++ b/apps/web/src/components/AgeRatingChip/AgeRatingChip.tsx
@@ -15,76 +15,71 @@ interface AgeRatingChipProps {
 /**
  * Maps age ratings to semantic color token classes
  */
-function getRatingColorClasses(rating: AgeRating): {
+type RatingColorClasses = {
   background: string;
   text: string;
   border: string;
-} {
-  const normalizedRating = rating.toUpperCase().trim();
+};
 
-  switch (normalizedRating) {
-    // Safe content - Green (G rating)
-    case 'G':
-      return {
-        background: 'bg-[var(--rating-safe-bg)]',
-        text: 'text-[var(--rating-safe-text)]',
-        border: 'border-[var(--rating-safe-border)]',
-      };
+const RATING_COLOR_BY_GROUP: Record<string, RatingColorClasses> = {
+  caution: {
+    background: 'bg-[var(--rating-caution-bg)]',
+    border: 'border-[var(--rating-caution-border)]',
+    text: 'text-[var(--rating-caution-text)]',
+  },
+  mature: {
+    background: 'bg-[var(--rating-mature-bg)]',
+    border: 'border-[var(--rating-mature-border)]',
+    text: 'text-[var(--rating-mature-text)]',
+  },
+  safe: {
+    background: 'bg-[var(--rating-safe-bg)]',
+    border: 'border-[var(--rating-safe-border)]',
+    text: 'text-[var(--rating-safe-text)]',
+  },
+  teen: {
+    background: 'bg-[var(--rating-teen-bg)]',
+    border: 'border-[var(--rating-teen-border)]',
+    text: 'text-[var(--rating-teen-text)]',
+  },
+  unknown: {
+    background: 'bg-[var(--rating-unknown-bg)]',
+    border: 'border-[var(--rating-unknown-border)]',
+    text: 'text-[var(--rating-unknown-text)]',
+  },
+};
 
-    // Caution content - Blue (PG, 12+ ratings)
-    case 'PG':
-    case '12+':
-      return {
-        background: 'bg-[var(--rating-caution-bg)]',
-        text: 'text-[var(--rating-caution-text)]',
-        border: 'border-[var(--rating-caution-border)]',
-      };
+const RATING_GROUP_BY_VALUE: Record<string, keyof typeof RATING_COLOR_BY_GROUP> = {
+  '12+': 'caution',
+  '15': 'mature',
+  '16+': 'mature',
+  '18+': 'mature',
+  G: 'safe',
+  'NOT RATED': 'unknown',
+  NR: 'unknown',
+  PG: 'caution',
+  'PG-13': 'teen',
+  R: 'mature',
+};
 
-    // Teen content - Orange (PG-13 rating)
-    case 'PG-13':
-      return {
-        background: 'bg-[var(--rating-teen-bg)]',
-        text: 'text-[var(--rating-teen-text)]',
-        border: 'border-[var(--rating-teen-border)]',
-      };
+function getRatingColorClasses(rating: AgeRating): RatingColorClasses {
+  const group = RATING_GROUP_BY_VALUE[rating.toUpperCase().trim()] ?? 'unknown';
 
-    // Mature content - Red (R, 15, 16+, 18+ ratings)
-    case 'R':
-    case '15':
-    case '16+':
-    case '18+':
-      return {
-        background: 'bg-[var(--rating-mature-bg)]',
-        text: 'text-[var(--rating-mature-text)]',
-        border: 'border-[var(--rating-mature-border)]',
-      };
-
-    // Unknown/Unrated - Gray (NR, NOT RATED)
-    case 'NR':
-    case 'NOT RATED':
-    default:
-      return {
-        background: 'bg-[var(--rating-unknown-bg)]',
-        text: 'text-[var(--rating-unknown-text)]',
-        border: 'border-[var(--rating-unknown-border)]',
-      };
-  }
+  return RATING_COLOR_BY_GROUP[group];
 }
 
 /**
  * Gets size-specific classes for the chip
  */
 function getSizeClasses(size: 'sm' | 'md' | 'lg'): string {
-  switch (size) {
-    case 'sm':
-      return 'px-4 py-0.5 text-xs';
-    case 'lg':
-      return 'px-4 py-2 text-base';
-    case 'md':
-    default:
-      return 'px-4 py-1 text-sm';
-  }
+  return SIZE_CLASSES[size];
 }
+
+const SIZE_CLASSES = {
+  lg: 'px-4 py-2 text-base',
+  md: 'px-4 py-1 text-sm',
+  sm: 'px-4 py-0.5 text-xs',
+};
 
 /**
  * AgeRatingChip - A reusable component for displaying movie age ratings

--- a/apps/web/src/components/AuthProvider/AuthProvider.tsx
+++ b/apps/web/src/components/AuthProvider/AuthProvider.tsx
@@ -59,15 +59,16 @@ async function fetchSession(): Promise<AuthState> {
       return { status: 'anonymous', userId: null };
     }
 
-    const data = (await response.json()) as SessionResponse;
-    if (data.authenticated && data.userId) {
-      return { status: 'authenticated', userId: data.userId };
-    }
-
-    return { status: 'anonymous', userId: null };
+    return toAuthState((await response.json()) as SessionResponse);
   } catch {
     return { status: 'anonymous', userId: null };
   }
+}
+
+function toAuthState(data: SessionResponse): AuthState {
+  return data.authenticated && data.userId
+    ? { status: 'authenticated', userId: data.userId }
+    : { status: 'anonymous', userId: null };
 }
 
 const AuthContext = createContext<AuthContextValue>({

--- a/apps/web/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/apps/web/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -23,30 +23,52 @@ export function Breadcrumbs({ items, className }: BreadcrumbsProps) {
   return (
     <nav aria-label="Breadcrumb" className={className}>
       <ol className="flex flex-wrap items-center" style={labelStyle}>
-        {items.map((item, index) => {
-          const isCurrent = index === items.length - 1;
-          return (
-            <li key={index} className="flex items-center">
-              {index > 0 && (
-                <span aria-hidden="true" className="mx-1">
-                  {'/'}
-                </span>
-              )}
-              {item.href && !isCurrent ? (
-                <Link
-                  href={item.href}
-                  className="hover:opacity-70 transition-opacity duration-150"
-                  style={{ color: 'inherit' }}
-                >
-                  {item.label}
-                </Link>
-              ) : (
-                <span aria-current={isCurrent ? 'page' : undefined}>{item.label}</span>
-              )}
-            </li>
-          );
-        })}
+        {items.map((item, index) => (
+          <BreadcrumbListItem
+            key={index}
+            item={item}
+            isCurrent={index === items.length - 1}
+            showSeparator={index > 0}
+          />
+        ))}
       </ol>
     </nav>
   );
+}
+
+function BreadcrumbListItem({
+  item,
+  isCurrent,
+  showSeparator,
+}: {
+  item: BreadcrumbItem;
+  isCurrent: boolean;
+  showSeparator: boolean;
+}) {
+  return (
+    <li className="flex items-center">
+      {showSeparator && (
+        <span aria-hidden="true" className="mx-1">
+          {'/'}
+        </span>
+      )}
+      <BreadcrumbLabel item={item} isCurrent={isCurrent} />
+    </li>
+  );
+}
+
+function BreadcrumbLabel({ item, isCurrent }: { item: BreadcrumbItem; isCurrent: boolean }) {
+  if (item.href && !isCurrent) {
+    return (
+      <Link
+        href={item.href}
+        className="hover:opacity-70 transition-opacity duration-150"
+        style={{ color: 'inherit' }}
+      >
+        {item.label}
+      </Link>
+    );
+  }
+
+  return <span aria-current={isCurrent ? 'page' : undefined}>{item.label}</span>;
 }

--- a/apps/web/src/components/LanguageSwitcher/LanguageSwitcher.tsx
+++ b/apps/web/src/components/LanguageSwitcher/LanguageSwitcher.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import { ChevronDown } from 'lucide-react';
-import { type KeyboardEvent, useEffect, useRef, useState } from 'react';
+import { type KeyboardEvent, type RefObject, useEffect, useRef, useState } from 'react';
 
 import { type Locale, useLanguage } from '@/i18n';
 
-const LOCALES: { code: Locale; label: string; native: string }[] = [
+type LocaleOption = { code: Locale; label: string; native: string };
+
+const LOCALES: LocaleOption[] = [
   { code: 'en', label: 'EN', native: 'English' },
   { code: 'ru', label: 'RU', native: 'Русский' },
   { code: 'fi', label: 'FI', native: 'Suomi' },
@@ -15,18 +17,8 @@ export function LanguageSwitcher() {
   const { locale, setLocale, t } = useLanguage();
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
-
   const current = LOCALES.find((l) => l.code === locale) ?? LOCALES[0];
-
-  useEffect(() => {
-    function handleClickOutside(e: MouseEvent) {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    }
-    if (open) document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [open]);
+  useOutsideClose(ref, open, () => setOpen(false));
 
   function handleKeyDown(e: KeyboardEvent<HTMLDivElement>) {
     if (e.key === 'Escape') setOpen(false);
@@ -34,72 +26,157 @@ export function LanguageSwitcher() {
 
   return (
     <div ref={ref} className="relative" onKeyDown={handleKeyDown}>
-      <button
-        onClick={() => setOpen((o) => !o)}
-        aria-haspopup="menu"
-        aria-expanded={open}
-        aria-label={t.nav.switchLanguage}
-        className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-semibold transition-colors duration-150"
-        style={{
-          background: open ? 'var(--pc-gold-subtle)' : 'transparent',
-          color: open ? 'var(--pc-gold-text)' : 'var(--pc-t3)',
-          border: open ? '1px solid var(--pc-gold-bd-subtle)' : '1px solid var(--pc-bd1)',
-        }}
-      >
-        {current.label}
-        <ChevronDown
-          size={12}
-          style={{
-            transform: open ? 'rotate(180deg)' : 'rotate(0deg)',
-            transition: 'transform 0.15s ease',
-          }}
-        />
-      </button>
+      <LanguageToggleButton
+        current={current}
+        label={t.nav.switchLanguage}
+        open={open}
+        onToggle={() => setOpen((value) => !value)}
+      />
 
       {open && (
-        <div
-          role="menu"
-          aria-label={t.nav.switchLanguage}
-          className="absolute right-0 mt-1.5 min-w-[120px] rounded-xl overflow-hidden z-50"
-          style={{
-            background: 'var(--pc-surface)',
-            border: '1px solid var(--pc-bd2)',
-            boxShadow: '0 8px 24px rgba(0,0,0,0.18)',
+        <LanguageMenu
+          activeLocale={locale}
+          label={t.nav.switchLanguage}
+          onSelect={(code) => {
+            setLocale(code);
+            setOpen(false);
           }}
-        >
-          {LOCALES.map(({ code, label, native }) => {
-            const isActive = code === locale;
-            return (
-              <button
-                key={code}
-                role="menuitemradio"
-                aria-checked={isActive}
-                onClick={() => {
-                  setLocale(code);
-                  setOpen(false);
-                }}
-                className="w-full flex items-center gap-2.5 px-3 py-2 text-left text-xs transition-colors duration-100"
-                style={{
-                  background: isActive ? 'var(--pc-gold-subtle)' : 'transparent',
-                  color: isActive ? 'var(--pc-gold-text)' : 'var(--pc-t2)',
-                  fontWeight: isActive ? 600 : 400,
-                }}
-              >
-                <span
-                  className="w-6 text-center font-semibold"
-                  style={{
-                    color: isActive ? 'var(--pc-gold-text)' : 'var(--pc-t4)',
-                    fontSize: '0.7rem',
-                  }}
-                >
-                  {label}
-                </span>
-                <span>{native}</span>
-              </button>
-            );
-          })}
-        </div>
+        />
       )}
     </div>
   );
+}
+
+function useOutsideClose(
+  ref: RefObject<HTMLDivElement | null>,
+  open: boolean,
+  onClose: () => void,
+) {
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose();
+      }
+    }
+    if (open) document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [onClose, open, ref]);
+}
+
+function LanguageToggleButton({
+  current,
+  label,
+  onToggle,
+  open,
+}: {
+  current: LocaleOption;
+  label: string;
+  onToggle: () => void;
+  open: boolean;
+}) {
+  return (
+    <button
+      onClick={onToggle}
+      aria-haspopup="menu"
+      aria-expanded={open}
+      aria-label={label}
+      className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-semibold transition-colors duration-150"
+      style={getToggleButtonStyle(open)}
+    >
+      {current.label}
+      <ChevronDown size={12} style={getChevronStyle(open)} />
+    </button>
+  );
+}
+
+function LanguageMenu({
+  activeLocale,
+  label,
+  onSelect,
+}: {
+  activeLocale: Locale;
+  label: string;
+  onSelect: (code: Locale) => void;
+}) {
+  return (
+    <div
+      role="menu"
+      aria-label={label}
+      className="absolute right-0 mt-1.5 min-w-[120px] rounded-xl overflow-hidden z-50"
+      style={{
+        background: 'var(--pc-surface)',
+        border: '1px solid var(--pc-bd2)',
+        boxShadow: '0 8px 24px rgba(0,0,0,0.18)',
+      }}
+    >
+      {LOCALES.map((option) => (
+        <LanguageMenuItem
+          key={option.code}
+          active={option.code === activeLocale}
+          option={option}
+          onSelect={onSelect}
+        />
+      ))}
+    </div>
+  );
+}
+
+function LanguageMenuItem({
+  active,
+  option,
+  onSelect,
+}: {
+  active: boolean;
+  option: LocaleOption;
+  onSelect: (code: Locale) => void;
+}) {
+  const styles = getLanguageMenuItemStyles(active);
+
+  return (
+    <button
+      role="menuitemradio"
+      aria-checked={active}
+      onClick={() => onSelect(option.code)}
+      className="w-full flex items-center gap-2.5 px-3 py-2 text-left text-xs transition-colors duration-100"
+      style={styles.button}
+    >
+      <span className="w-6 text-center font-semibold" style={styles.label}>
+        {option.label}
+      </span>
+      <span>{option.native}</span>
+    </button>
+  );
+}
+
+function getChevronStyle(open: boolean) {
+  return {
+    transform: open ? 'rotate(180deg)' : 'rotate(0deg)',
+    transition: 'transform 0.15s ease',
+  };
+}
+
+function getToggleButtonStyle(open: boolean) {
+  return {
+    background: getActiveValue(open, 'var(--pc-gold-subtle)', 'transparent'),
+    border: getActiveValue(open, '1px solid var(--pc-gold-bd-subtle)', '1px solid var(--pc-bd1)'),
+    color: getActiveValue(open, 'var(--pc-gold-text)', 'var(--pc-t3)'),
+  };
+}
+
+function getLanguageMenuItemStyles(active: boolean) {
+  return {
+    button: {
+      background: getActiveValue(active, 'var(--pc-gold-subtle)', 'transparent'),
+      color: getActiveValue(active, 'var(--pc-gold-text)', 'var(--pc-t2)'),
+      fontWeight: getActiveValue(active, 600, 400),
+    },
+    label: {
+      color: getActiveValue(active, 'var(--pc-gold-text)', 'var(--pc-t4)'),
+      fontSize: '0.7rem',
+    },
+  };
+}
+
+function getActiveValue<T>(active: boolean, activeValue: T, inactiveValue: T) {
+  return active ? activeValue : inactiveValue;
 }

--- a/apps/web/src/components/MoviesTable/MoviesTable.tsx
+++ b/apps/web/src/components/MoviesTable/MoviesTable.tsx
@@ -97,9 +97,8 @@ function MoviesTableEmptyState({
   onClearFilters,
 }: MoviesTableEmptyStateProps) {
   const { t } = useLanguage();
-  const title = hasActiveFilters ? t.moviesPage.emptyFilteredTitle : t.moviesPage.emptyCatalogTitle;
-  const body = hasActiveFilters ? t.moviesPage.emptyFilteredBody : t.moviesPage.emptyCatalogBody;
-  const canClearFilters = hasActiveFilters && onClearFilters;
+  const copy = getEmptyStateCopy(t, hasActiveFilters);
+  const canClearFilters = Boolean(hasActiveFilters && onClearFilters);
 
   return (
     <div
@@ -118,26 +117,14 @@ function MoviesTableEmptyState({
         <SearchX size={22} strokeWidth={1.8} />
       </div>
       <h2 className="text-base font-semibold" style={{ color: 'var(--pc-t1)' }}>
-        {title}
+        {copy.title}
       </h2>
       <p className="mt-2 max-w-sm text-sm leading-6" style={{ color: 'var(--pc-t3)' }}>
-        {body}
+        {copy.body}
       </p>
-      {canClearFilters ? (
-        <button
-          type="button"
-          onClick={onClearFilters}
-          className="mt-5 inline-flex h-10 items-center justify-center gap-2 rounded-lg px-4 text-sm font-semibold transition-colors duration-200"
-          style={{
-            background: 'var(--pc-surface-hover)',
-            border: '1px solid var(--pc-bd2)',
-            color: 'var(--pc-t2)',
-          }}
-        >
-          <X size={16} aria-hidden="true" />
-          {t.moviesPage.clearFilters}
-        </button>
-      ) : null}
+      {canClearFilters && (
+        <ClearFiltersButton label={t.moviesPage.clearFilters} onClearFilters={onClearFilters} />
+      )}
     </div>
   );
 }
@@ -147,7 +134,6 @@ export function MoviesTable({
   hasActiveFilters = false,
   onClearFilters,
 }: MoviesTableProps) {
-  const { t } = useLanguage();
   const isMobile = useIsMobile();
 
   // Show the skeleton while the breakpoint is being measured to avoid a brief
@@ -157,57 +143,129 @@ export function MoviesTable({
 
   if (isMobile) {
     return (
+      <MobileMoviesTable
+        movies={movies}
+        hasActiveFilters={hasActiveFilters}
+        onClearFilters={onClearFilters}
+      />
+    );
+  }
+
+  return (
+    <DesktopMoviesTable
+      movies={movies}
+      hasActiveFilters={hasActiveFilters}
+      onClearFilters={onClearFilters}
+    />
+  );
+}
+
+type MoviesPageCopy = ReturnType<typeof useLanguage>['t'];
+
+function getEmptyStateCopy(t: MoviesPageCopy, hasActiveFilters: boolean) {
+  return hasActiveFilters
+    ? { body: t.moviesPage.emptyFilteredBody, title: t.moviesPage.emptyFilteredTitle }
+    : { body: t.moviesPage.emptyCatalogBody, title: t.moviesPage.emptyCatalogTitle };
+}
+
+function ClearFiltersButton({
+  label,
+  onClearFilters,
+}: {
+  label: string;
+  onClearFilters?: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClearFilters}
+      className="mt-5 inline-flex h-10 items-center justify-center gap-2 rounded-lg px-4 text-sm font-semibold transition-colors duration-200"
+      style={{
+        background: 'var(--pc-surface-hover)',
+        border: '1px solid var(--pc-bd2)',
+        color: 'var(--pc-t2)',
+      }}
+    >
+      <X size={16} aria-hidden="true" />
+      {label}
+    </button>
+  );
+}
+
+function MobileMoviesTable({ movies, hasActiveFilters, onClearFilters }: MoviesTableProps) {
+  if (movies.length === 0) {
+    return (
       <div className="flex flex-col gap-3">
-        {movies.length === 0 ? (
-          <div
-            className="rounded-2xl"
-            style={{
-              background: 'var(--pc-surface)',
-              border: '1px solid var(--pc-bd2)',
-            }}
-          >
-            <MoviesTableEmptyState
-              compact
-              hasActiveFilters={hasActiveFilters}
-              onClearFilters={onClearFilters}
-            />
-          </div>
-        ) : (
-          movies.map((movie) => (
-            <div
-              key={movie.id}
-              className="rounded-2xl p-4"
-              style={{
-                background: 'var(--pc-surface)',
-                border: '1px solid var(--pc-bd2)',
-              }}
-            >
-              <div className="flex items-start justify-between gap-3 mb-2">
-                <div className="flex-1 min-w-0">
-                  <div className="text-sm font-semibold" style={{ color: 'var(--pc-t1)' }}>
-                    {movie.name}
-                  </div>
-                  <div className="text-xs mt-0.5" style={{ color: 'var(--pc-t4)' }}>
-                    {movie.year}
-                  </div>
-                </div>
-                <AgeRatingChip rating={movie.age_rating as z.infer<typeof ageRatings>} size="sm" />
-              </div>
-              <div className="flex items-center gap-4 mt-2">
-                <span className="text-xs" style={{ color: 'var(--pc-t3)' }}>
-                  {formatDuration(movie.duration)}
-                </span>
-                <span className="text-xs font-semibold" style={{ color: 'var(--pc-gold-text)' }}>
-                  ★ {movie.score_rating.toFixed(1)}
-                  <span style={{ color: 'var(--pc-t4)', fontWeight: 400 }}>/10</span>
-                </span>
-              </div>
-            </div>
-          ))
-        )}
+        <MobileEmptyState hasActiveFilters={hasActiveFilters} onClearFilters={onClearFilters} />
       </div>
     );
   }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {movies.map((movie) => (
+        <MobileMovieCard key={movie.id} movie={movie} />
+      ))}
+    </div>
+  );
+}
+
+function MobileEmptyState({
+  hasActiveFilters,
+  onClearFilters,
+}: Pick<MoviesTableProps, 'hasActiveFilters' | 'onClearFilters'>) {
+  return (
+    <div
+      className="rounded-2xl"
+      style={{
+        background: 'var(--pc-surface)',
+        border: '1px solid var(--pc-bd2)',
+      }}
+    >
+      <MoviesTableEmptyState
+        compact
+        hasActiveFilters={hasActiveFilters}
+        onClearFilters={onClearFilters}
+      />
+    </div>
+  );
+}
+
+function MobileMovieCard({ movie }: { movie: Movie }) {
+  return (
+    <div
+      className="rounded-2xl p-4"
+      style={{
+        background: 'var(--pc-surface)',
+        border: '1px solid var(--pc-bd2)',
+      }}
+    >
+      <div className="flex items-start justify-between gap-3 mb-2">
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-semibold" style={{ color: 'var(--pc-t1)' }}>
+            {movie.name}
+          </div>
+          <div className="text-xs mt-0.5" style={{ color: 'var(--pc-t4)' }}>
+            {movie.year}
+          </div>
+        </div>
+        <AgeRatingChip rating={movie.age_rating as z.infer<typeof ageRatings>} size="sm" />
+      </div>
+      <div className="flex items-center gap-4 mt-2">
+        <span className="text-xs" style={{ color: 'var(--pc-t3)' }}>
+          {formatDuration(movie.duration)}
+        </span>
+        <span className="text-xs font-semibold" style={{ color: 'var(--pc-gold-text)' }}>
+          ★ {movie.score_rating.toFixed(1)}
+          <span style={{ color: 'var(--pc-t4)', fontWeight: 400 }}>/10</span>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function DesktopMoviesTable({ movies, hasActiveFilters, onClearFilters }: MoviesTableProps) {
+  const { t } = useLanguage();
 
   return (
     <div
@@ -248,14 +306,7 @@ export function MoviesTable({
         </thead>
         <tbody>
           {movies.length === 0 ? (
-            <tr>
-              <td colSpan={4} className="px-0 py-0">
-                <MoviesTableEmptyState
-                  hasActiveFilters={hasActiveFilters}
-                  onClearFilters={onClearFilters}
-                />
-              </td>
-            </tr>
+            <DesktopEmptyRow hasActiveFilters={hasActiveFilters} onClearFilters={onClearFilters} />
           ) : (
             movies.map((movie, i) => (
               <tr
@@ -296,5 +347,21 @@ export function MoviesTable({
         </tbody>
       </table>
     </div>
+  );
+}
+
+function DesktopEmptyRow({
+  hasActiveFilters,
+  onClearFilters,
+}: Pick<MoviesTableProps, 'hasActiveFilters' | 'onClearFilters'>) {
+  return (
+    <tr>
+      <td colSpan={4} className="px-0 py-0">
+        <MoviesTableEmptyState
+          hasActiveFilters={hasActiveFilters}
+          onClearFilters={onClearFilters}
+        />
+      </td>
+    </tr>
   );
 }

--- a/apps/web/src/features/recommendation/candidateFilters.ts
+++ b/apps/web/src/features/recommendation/candidateFilters.ts
@@ -28,6 +28,15 @@ export type FeedbackCandidateSignals = {
 const FEEDBACK_DOWNRANK_AMOUNT = 0.08;
 const LIKED_MEMORY_BOOST_AMOUNT = 0.04;
 
+const EXCLUDED_FEEDBACK_KINDS = new Set<FeedbackMoviePreference['kind']>([
+  'already_watched',
+  'not_interested',
+  'recently_recommended',
+  'too_obscure',
+  'too_obvious',
+  'watched',
+]);
+
 export function getMentionedMovieTitleKeys(allPeopleData: PersonFormData[]): Set<string> {
   return new Set(
     allPeopleData
@@ -61,54 +70,79 @@ export function excludeMentionedTMDBMovies(
 export function getFeedbackCandidateSignals(
   preferences: FeedbackMoviePreference[],
 ): FeedbackCandidateSignals {
-  const excludedMovieKeys = new Set<string>();
-  const excludedTitleKeys = new Set<string>();
-  const downrankMovieKeys = new Set<string>();
-  const downrankTitleKeys = new Set<string>();
-  const boostMovieKeys = new Set<string>();
-  const boostTitleKeys = new Set<string>();
+  const signals = createEmptyFeedbackCandidateSignals();
 
   for (const preference of preferences) {
-    const movieKey =
+    addPreferenceToSignals(signals, preference);
+  }
+
+  return signals;
+}
+
+function createEmptyFeedbackCandidateSignals(): FeedbackCandidateSignals {
+  return {
+    boostMovieKeys: new Set<string>(),
+    boostTitleKeys: new Set<string>(),
+    downrankMovieKeys: new Set<string>(),
+    downrankTitleKeys: new Set<string>(),
+    excludedMovieKeys: new Set<string>(),
+    excludedTitleKeys: new Set<string>(),
+  };
+}
+
+function addPreferenceToSignals(
+  signals: FeedbackCandidateSignals,
+  preference: FeedbackMoviePreference,
+) {
+  const keys = getPreferenceKeys(preference);
+  const targets = getSignalTargets(signals, preference.kind);
+
+  if (!targets) {
+    return;
+  }
+
+  addFeedbackKeys(targets.movieKeys, targets.titleKeys, keys);
+}
+
+function getPreferenceKeys(preference: FeedbackMoviePreference) {
+  return {
+    movieKey:
       preference.movieKey ??
       getMovieIdentityKey({
         tmdbId: preference.tmdbId,
         title: preference.movieName,
         year: preference.movieYear,
-      });
-    const titleKey = getMovieTitleKey(preference.movieName);
+      }),
+    titleKey: getMovieTitleKey(preference.movieName),
+  };
+}
 
-    if (
-      preference.kind === 'already_watched' ||
-      preference.kind === 'watched' ||
-      preference.kind === 'recently_recommended' ||
-      preference.kind === 'not_interested' ||
-      preference.kind === 'too_obvious' ||
-      preference.kind === 'too_obscure'
-    ) {
-      if (movieKey) excludedMovieKeys.add(movieKey);
-      if (titleKey) excludedTitleKeys.add(titleKey);
-    }
-
-    if (preference.kind === 'wrong_mood') {
-      if (movieKey) downrankMovieKeys.add(movieKey);
-      if (titleKey) downrankTitleKeys.add(titleKey);
-    }
-
-    if (preference.kind === 'liked') {
-      if (movieKey) boostMovieKeys.add(movieKey);
-      if (titleKey) boostTitleKeys.add(titleKey);
-    }
+function getSignalTargets(
+  signals: FeedbackCandidateSignals,
+  kind: FeedbackMoviePreference['kind'],
+) {
+  if (EXCLUDED_FEEDBACK_KINDS.has(kind)) {
+    return { movieKeys: signals.excludedMovieKeys, titleKeys: signals.excludedTitleKeys };
   }
 
-  return {
-    excludedMovieKeys,
-    excludedTitleKeys,
-    downrankMovieKeys,
-    downrankTitleKeys,
-    boostMovieKeys,
-    boostTitleKeys,
-  };
+  if (kind === 'wrong_mood') {
+    return { movieKeys: signals.downrankMovieKeys, titleKeys: signals.downrankTitleKeys };
+  }
+
+  if (kind === 'liked') {
+    return { movieKeys: signals.boostMovieKeys, titleKeys: signals.boostTitleKeys };
+  }
+
+  return null;
+}
+
+function addFeedbackKeys(
+  movieKeys: Set<string>,
+  titleKeys: Set<string>,
+  keys: { movieKey: string | null; titleKey: string | null },
+) {
+  if (keys.movieKey) movieKeys.add(keys.movieKey);
+  if (keys.titleKey) titleKeys.add(keys.titleKey);
 }
 
 function getLocalMovieIdentityKey(movie: EnhancedMovieMatch): string | null {

--- a/apps/web/src/features/recommendation/recommendation.ts
+++ b/apps/web/src/features/recommendation/recommendation.ts
@@ -122,22 +122,53 @@ async function findNearestMatch(embedding: number[]): Promise<EnhancedMovieMatch
   }
 
   return (data as LocalMatchRow[])
-    .map((movie) => ({
-      ...movie,
-      similarity: adjustLocalSimilarityForMetadata(movie),
-      source: getLocalCandidateSource(movie.tmdb_match_source),
-      tmdbId: movie.tmdb_id ?? movie.tmdbId ?? null,
-      tmdbMatchSource: movie.tmdb_match_source ?? movie.tmdbMatchSource ?? null,
-      originalLanguage: movie.original_language ?? movie.originalLanguage ?? null,
-      voteCount: movie.vote_count ?? movie.voteCount ?? null,
-      popularity: movie.popularity ?? movie.popularity ?? null,
-      metadataQualityScore: movie.metadata_quality_score ?? movie.metadataQualityScore ?? 0,
-      metadataQualityFlags:
-        normalizeMetadataQualityFlags(movie.metadata_quality_flags) ??
-        movie.metadataQualityFlags ??
-        [],
-    }))
+    .map(toEnhancedLocalMatch)
     .sort((a, b) => b.similarity - a.similarity);
+}
+
+function toEnhancedLocalMatch(movie: LocalMatchRow): EnhancedMovieMatch {
+  return {
+    ...movie,
+    metadataQualityFlags: getLocalMetadataQualityFlags(movie),
+    metadataQualityScore: getLocalMetadataQualityScore(movie),
+    originalLanguage: getLocalOriginalLanguage(movie),
+    popularity: getLocalPopularity(movie),
+    similarity: adjustLocalSimilarityForMetadata(movie),
+    source: getLocalCandidateSource(movie.tmdb_match_source),
+    tmdbId: getLocalTMDBId(movie),
+    tmdbMatchSource: getLocalTMDBMatchSource(movie),
+    voteCount: getLocalVoteCount(movie),
+  };
+}
+
+function getLocalMetadataQualityFlags(movie: LocalMatchRow) {
+  return (
+    normalizeMetadataQualityFlags(movie.metadata_quality_flags) ?? movie.metadataQualityFlags ?? []
+  );
+}
+
+function getLocalMetadataQualityScore(movie: LocalMatchRow) {
+  return movie.metadata_quality_score ?? movie.metadataQualityScore ?? 0;
+}
+
+function getLocalOriginalLanguage(movie: LocalMatchRow) {
+  return movie.original_language ?? movie.originalLanguage ?? null;
+}
+
+function getLocalPopularity(movie: LocalMatchRow) {
+  return movie.popularity ?? movie.popularity ?? null;
+}
+
+function getLocalTMDBId(movie: LocalMatchRow) {
+  return movie.tmdb_id ?? movie.tmdbId ?? null;
+}
+
+function getLocalTMDBMatchSource(movie: LocalMatchRow) {
+  return movie.tmdb_match_source ?? movie.tmdbMatchSource ?? null;
+}
+
+function getLocalVoteCount(movie: LocalMatchRow) {
+  return movie.vote_count ?? movie.voteCount ?? null;
 }
 
 /** Find similar movies in the local vector store. Returns an empty array if none found or DB unavailable. */

--- a/apps/web/src/hooks/usePosterPosters.ts
+++ b/apps/web/src/hooks/usePosterPosters.ts
@@ -32,13 +32,22 @@ interface CacheEntry {
 function readCache(): string[] | null {
   try {
     const raw = localStorage.getItem(CACHE_KEY);
-    if (!raw) return null;
-    const entry = JSON.parse(raw) as CacheEntry;
-    if (Date.now() - entry.ts > CACHE_TTL_MS) return null;
-    return entry.posters.length > 0 ? entry.posters : null;
+    return raw ? getValidCachePosters(JSON.parse(raw) as CacheEntry) : null;
   } catch {
     return null;
   }
+}
+
+function getValidCachePosters(entry: CacheEntry) {
+  if (isCacheExpired(entry)) {
+    return null;
+  }
+
+  return entry.posters.length > 0 ? entry.posters : null;
+}
+
+function isCacheExpired(entry: CacheEntry) {
+  return Date.now() - entry.ts > CACHE_TTL_MS;
 }
 
 function writeCache(posters: string[]): void {
@@ -67,12 +76,15 @@ async function fetchPosterURLs(): Promise<string[]> {
  * This runs client-side only because the component is loaded with `ssr: false`.
  */
 function resolveInitialPosters(initialPosters?: string[]): string[] {
-  if (initialPosters && initialPosters.length > 0) return initialPosters;
-  if (typeof window !== 'undefined') {
-    const cached = readCache();
-    if (cached) return cached;
-  }
-  return FALLBACK_POSTERS;
+  return getProvidedPosters(initialPosters) ?? getCachedPosters() ?? FALLBACK_POSTERS;
+}
+
+function getProvidedPosters(initialPosters?: string[]) {
+  return initialPosters && initialPosters.length > 0 ? initialPosters : null;
+}
+
+function getCachedPosters() {
+  return typeof window === 'undefined' ? null : readCache();
 }
 
 /**

--- a/apps/web/src/hooks/useRecommendation.ts
+++ b/apps/web/src/hooks/useRecommendation.ts
@@ -6,6 +6,7 @@ import { useRef, useState } from 'react';
 import { getCsrfToken } from '@/lib/csrfClient';
 
 import type { RecommendationWithMovies } from '@/lib/db/recommendations';
+import type { MutableRefObject } from 'react';
 
 /** Stop polling for more-picks after 2 minutes — prevents an infinite spinner when workers are down. */
 const MORE_PICKS_POLL_TIMEOUT_MS = 2 * 60 * 1000;
@@ -49,31 +50,65 @@ export function useRecommendation(id: string) {
       return res.json() as Promise<RecommendationWithMovies>;
     },
     refetchInterval: (query) => {
-      if (query.state.error) return false;
-
-      const status = query.state.data?.status;
-      const morePicksStatus = query.state.data?.morePicksStatus;
-      if (status === 'failed') return false;
-      if (status !== 'completed') return 2000;
-      // Keep polling while the more-picks job is in flight, but stop after timeout
-      if (morePicksStatus === 'pending' || morePicksStatus === 'processing') {
-        if (morePicksPendingSince.current === null) {
-          morePicksPendingSince.current = Date.now();
-        }
-        if (Date.now() - morePicksPendingSince.current > MORE_PICKS_POLL_TIMEOUT_MS) {
-          setMorePicksTimedOut(true);
-          return false;
-        }
-        return 2000;
-      }
-      // Job resolved (completed / failed / null) — reset timeout tracking
-      morePicksPendingSince.current = null;
-      setMorePicksTimedOut(false);
-      return false;
+      return getRecommendationRefetchInterval({
+        data: query.state.data,
+        error: query.state.error,
+        morePicksPendingSince,
+        setMorePicksTimedOut,
+      });
     },
     staleTime: Infinity,
     retry: shouldRetryRecommendationFetch,
   });
 
   return { ...query, morePicksTimedOut };
+}
+
+function getRecommendationRefetchInterval({
+  data,
+  error,
+  morePicksPendingSince,
+  setMorePicksTimedOut,
+}: {
+  data: RecommendationWithMovies | undefined;
+  error: Error | null;
+  morePicksPendingSince: MutableRefObject<number | null>;
+  setMorePicksTimedOut: (timedOut: boolean) => void;
+}) {
+  if (error || data?.status === 'failed') return false;
+  if (data?.status !== 'completed') return 2000;
+
+  return getMorePicksRefetchInterval(
+    data.morePicksStatus,
+    morePicksPendingSince,
+    setMorePicksTimedOut,
+  );
+}
+
+function getMorePicksRefetchInterval(
+  morePicksStatus: RecommendationWithMovies['morePicksStatus'],
+  morePicksPendingSince: MutableRefObject<number | null>,
+  setMorePicksTimedOut: (timedOut: boolean) => void,
+) {
+  if (morePicksStatus === 'pending' || morePicksStatus === 'processing') {
+    return getPendingMorePicksRefetchInterval(morePicksPendingSince, setMorePicksTimedOut);
+  }
+
+  morePicksPendingSince.current = null;
+  setMorePicksTimedOut(false);
+  return false;
+}
+
+function getPendingMorePicksRefetchInterval(
+  morePicksPendingSince: MutableRefObject<number | null>,
+  setMorePicksTimedOut: (timedOut: boolean) => void,
+) {
+  morePicksPendingSince.current ??= Date.now();
+
+  if (Date.now() - morePicksPendingSince.current > MORE_PICKS_POLL_TIMEOUT_MS) {
+    setMorePicksTimedOut(true);
+    return false;
+  }
+
+  return 2000;
 }

--- a/apps/web/src/i18n/index.tsx
+++ b/apps/web/src/i18n/index.tsx
@@ -41,13 +41,24 @@ function getLocaleSnapshot(): Locale {
 }
 
 function detectLocale(): Locale {
-  const saved = localStorage.getItem(LOCALE_STORAGE_KEY);
-  if (saved && (LOCALES as string[]).includes(saved)) return saved as Locale;
+  return getSavedLocale() ?? getBrowserLocale() ?? 'en';
+}
+
+function getSavedLocale(): Locale | null {
+  return normalizeLocale(localStorage.getItem(LOCALE_STORAGE_KEY));
+}
+
+function getBrowserLocale(): Locale | null {
   const browserLangs = navigator.languages ?? [navigator.language];
-  const detected = browserLangs
-    .map((l) => l.split('-')[0].toLowerCase())
-    .find((l) => (LOCALES as string[]).includes(l));
-  return (detected as Locale) ?? 'en';
+  return browserLangs.map(getBaseLanguage).map(normalizeLocale).find(Boolean) ?? null;
+}
+
+function getBaseLanguage(language: string) {
+  return language.split('-')[0].toLowerCase();
+}
+
+function normalizeLocale(value: string | null): Locale | null {
+  return value && (LOCALES as string[]).includes(value) ? (value as Locale) : null;
 }
 
 function notifyLocaleChange(): void {

--- a/apps/web/src/integrations/tmdb/MovieService.ts
+++ b/apps/web/src/integrations/tmdb/MovieService.ts
@@ -8,6 +8,103 @@ export const IMAGE_BASE_URL = 'https://image.tmdb.org/t/p';
 
 type Fetcher = typeof globalThis.fetch;
 
+function getSearchParams(
+  cleanedTitle: string,
+  year: number | undefined,
+  withYear: boolean,
+): Record<string, string> {
+  return {
+    include_adult: 'false',
+    language: 'en-US',
+    query: cleanedTitle,
+    ...(withYear && year ? { year: String(year) } : {}),
+  };
+}
+
+function selectBestMovieMatch(
+  results: TMDB_MovieEntry[],
+  cleanedTitle: string,
+  year: number | undefined,
+  withYear: boolean,
+): TMDB_MovieEntry | undefined {
+  if (results.length === 0) return undefined;
+
+  const pool = getCandidatePool(results, cleanedTitle, withYear);
+  if (pool.length === 0) return undefined;
+
+  return getYearMatchedMovie(pool, year) ?? pool[0];
+}
+
+function getCandidatePool(
+  results: TMDB_MovieEntry[],
+  cleanedTitle: string,
+  withYear: boolean,
+): TMDB_MovieEntry[] {
+  const normalizedQuery = normalizeMovieTitle(cleanedTitle);
+  const candidateMatches =
+    getExactTitleMatches(results, cleanedTitle) ||
+    getNormalizedTitleMatches(results, normalizedQuery);
+
+  return candidateMatches ?? getFallbackCandidatePool(results, normalizedQuery, withYear);
+}
+
+function getExactTitleMatches(results: TMDB_MovieEntry[], cleanedTitle: string) {
+  const matches = results.filter(
+    (movie) => movie.title.toLowerCase() === cleanedTitle.toLowerCase(),
+  );
+
+  return matches.length > 0 ? matches : null;
+}
+
+function getNormalizedTitleMatches(results: TMDB_MovieEntry[], normalizedQuery: string) {
+  const matches = results.filter((movie) => normalizeMovieTitle(movie.title) === normalizedQuery);
+
+  return matches.length > 0 ? matches : null;
+}
+
+function getFallbackCandidatePool(
+  results: TMDB_MovieEntry[],
+  normalizedQuery: string,
+  withYear: boolean,
+) {
+  const prefixMatches = results.filter((movie) => isPrefixTitleMatch(movie.title, normalizedQuery));
+
+  if (prefixMatches.length > 0) {
+    return prefixMatches;
+  }
+
+  return withYear ? [] : [results[0]];
+}
+
+function isPrefixTitleMatch(title: string, normalizedQuery: string) {
+  const normalizedTitle = normalizeMovieTitle(title);
+
+  return normalizedTitle.startsWith(normalizedQuery) || normalizedQuery.startsWith(normalizedTitle);
+}
+
+function getYearMatchedMovie(pool: TMDB_MovieEntry[], year: number | undefined) {
+  if (!year) {
+    return undefined;
+  }
+
+  return pool.find((movie) => isReleaseYearMatch(movie, year));
+}
+
+function isReleaseYearMatch(movie: TMDB_MovieEntry, year: number) {
+  const releaseYear = parseTMDBReleaseYear(movie.release_date);
+  return Math.abs(releaseYear - year) <= 1;
+}
+
+// Normalized comparison handles variations like "Brother 2" vs
+// "Brother 2: The Elder's Blood".
+function normalizeMovieTitle(title: string) {
+  return title
+    .toLowerCase()
+    .replace(/[^\w\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
 export class MovieService {
   constructor(
     private fetcher: Fetcher = globalThis.fetch,
@@ -50,85 +147,8 @@ export class MovieService {
     // Strip optional year suffix like " (1997)" that OpenAI sometimes appends to titles.
     const cleanedTitle = movieTitle.replace(/\s*\(\d{4}\)\s*$/, '').trim();
 
-    // Normalized comparison: lowercase + collapse whitespace + strip punctuation.
-    // Handles minor variations like "Brother 2" vs "Brother 2: The Elder's Blood".
-    const normalize = (s: string) =>
-      s
-        .toLowerCase()
-        .replace(/[^\w\s]/g, ' ')
-        .replace(/\s+/g, ' ')
-        .trim();
-    const normalizedQuery = normalize(cleanedTitle);
-
-    const searchOnce = async (withYear: boolean): Promise<TMDB_MovieEntry | undefined> => {
-      try {
-        const params: Record<string, string> = {
-          query: cleanedTitle,
-          language: 'en-US',
-          include_adult: 'false',
-        };
-        if (withYear && year) {
-          params['year'] = String(year);
-        }
-        const response = await this.tmdbGet('/search/movie', params);
-        if (!response.ok) {
-          logger.warn(
-            { status: response.status, movieTitle: cleanedTitle, withYear },
-            'TMDB search request failed',
-          );
-          return undefined;
-        }
-
-        const data = (await response.json()) as { results?: TMDB_MovieEntry[] };
-        const results: TMDB_MovieEntry[] = data.results ?? [];
-        if (results.length === 0) return undefined;
-
-        // 1. Exact title match (case-insensitive)
-        const exactMatches = results.filter(
-          (m) => m.title.toLowerCase() === cleanedTitle.toLowerCase(),
-        );
-
-        // 2. Normalized match — strips punctuation/extra spaces
-        const normalizedMatches =
-          exactMatches.length > 0
-            ? exactMatches
-            : results.filter((m) => normalize(m.title) === normalizedQuery);
-
-        // 3. Prefix/contains match — e.g. "Brother 2" matches "Brother 2: The Elder's Blood"
-        const candidateMatches =
-          normalizedMatches.length > 0
-            ? normalizedMatches
-            : results.filter(
-                (m) =>
-                  normalize(m.title).startsWith(normalizedQuery) ||
-                  normalizedQuery.startsWith(normalize(m.title)),
-              );
-
-        // 4. Last resort: trust TMDB ranking (first result), only without year constraint
-        const pool = candidateMatches.length > 0 ? candidateMatches : !withYear ? [results[0]] : [];
-        if (pool.length === 0) return undefined;
-
-        // Prefer the entry whose release year matches when a year is provided.
-        if (year) {
-          const yearMatch = pool.find((m) => {
-            const releaseYear = parseTMDBReleaseYear(m.release_date);
-            return Math.abs(releaseYear - year) <= 1; // ±1 year tolerance for release-date shifts
-          });
-          if (yearMatch) return yearMatch;
-        }
-
-        return pool[0];
-      } catch (error) {
-        logger.warn(
-          { err: error, movieTitle: cleanedTitle, withYear },
-          'TMDB search request failed',
-        );
-        return undefined;
-      }
-    };
-
     // Cascade: search with year first (better disambiguation), fall back without year.
-    const withYear = year ? await searchOnce(true) : undefined;
+    const withYear = year ? await this.searchMovie(cleanedTitle, year, true) : undefined;
     if (withYear) return withYear;
 
     if (year) {
@@ -137,11 +157,46 @@ export class MovieService {
         'Year-scoped TMDB search found nothing, retrying without year',
       );
     }
-    const withoutYear = await searchOnce(false);
+    const withoutYear = await this.searchMovie(cleanedTitle, year, false);
     if (!withoutYear) {
       logger.warn({ movieTitle, cleanedTitle }, 'No TMDB movie found with title after cascade');
     }
     return withoutYear;
+  }
+
+  private async searchMovie(
+    cleanedTitle: string,
+    year: number | undefined,
+    withYear: boolean,
+  ): Promise<TMDB_MovieEntry | undefined> {
+    try {
+      const results = await this.fetchSearchResults(cleanedTitle, year, withYear);
+      return selectBestMovieMatch(results, cleanedTitle, year, withYear);
+    } catch (error) {
+      logger.warn({ err: error, movieTitle: cleanedTitle, withYear }, 'TMDB search request failed');
+      return undefined;
+    }
+  }
+
+  private async fetchSearchResults(
+    cleanedTitle: string,
+    year: number | undefined,
+    withYear: boolean,
+  ): Promise<TMDB_MovieEntry[]> {
+    const response = await this.tmdbGet(
+      '/search/movie',
+      getSearchParams(cleanedTitle, year, withYear),
+    );
+    if (!response.ok) {
+      logger.warn(
+        { status: response.status, movieTitle: cleanedTitle, withYear },
+        'TMDB search request failed',
+      );
+      return [];
+    }
+
+    const data = (await response.json()) as { results?: TMDB_MovieEntry[] };
+    return data.results ?? [];
   }
 
   async getLocalizedMovieInfo(

--- a/apps/web/src/lib/auth/session.ts
+++ b/apps/web/src/lib/auth/session.ts
@@ -43,33 +43,41 @@ function verifySessionToken(token: string): SessionPayload | null {
     return null;
   }
 
-  const expectedSignature = signValue(encodedPayload, secret);
-  const signatureBuffer = Buffer.from(signature);
-  const expectedSignatureBuffer = Buffer.from(expectedSignature);
-  if (
-    signatureBuffer.length !== expectedSignatureBuffer.length ||
-    !timingSafeEqual(signatureBuffer, expectedSignatureBuffer)
-  ) {
+  if (!isValidSignature(encodedPayload, signature, secret)) {
     return null;
   }
 
   try {
-    const parsed = JSON.parse(Buffer.from(encodedPayload, 'base64url').toString('utf8')) as
-      | SessionPayload
-      | undefined;
-
-    if (!parsed?.sub || typeof parsed.exp !== 'number') {
-      return null;
-    }
-
-    if (parsed.exp <= Math.floor(Date.now() / 1000)) {
-      return null;
-    }
-
-    return parsed;
+    return parseValidSessionPayload(encodedPayload);
   } catch {
     return null;
   }
+}
+
+function isValidSignature(encodedPayload: string, signature: string, secret: string): boolean {
+  const signatureBuffer = Buffer.from(signature);
+  const expectedSignatureBuffer = Buffer.from(signValue(encodedPayload, secret));
+
+  return (
+    signatureBuffer.length === expectedSignatureBuffer.length &&
+    timingSafeEqual(signatureBuffer, expectedSignatureBuffer)
+  );
+}
+
+function parseValidSessionPayload(encodedPayload: string): SessionPayload | null {
+  const parsed = JSON.parse(Buffer.from(encodedPayload, 'base64url').toString('utf8')) as
+    | SessionPayload
+    | undefined;
+
+  return isValidSessionPayload(parsed) ? parsed : null;
+}
+
+function isValidSessionPayload(payload: SessionPayload | undefined): payload is SessionPayload {
+  return Boolean(payload?.sub && typeof payload.exp === 'number' && !isExpired(payload.exp));
+}
+
+function isExpired(exp: number): boolean {
+  return exp <= Math.floor(Date.now() / 1000);
 }
 
 export function getSessionFromRequest(req: Pick<NextRequest, 'cookies'>): SessionPayload | null {

--- a/apps/web/src/lib/openaiTimeout.ts
+++ b/apps/web/src/lib/openaiTimeout.ts
@@ -18,52 +18,57 @@ export function openAIRequestOptions(timeoutMs: number): OpenAI.RequestOptions {
 
 export function isOpenAITimeoutError(error: unknown): boolean {
   const seen = new Set<unknown>();
+  const queue: unknown[] = [error];
 
-  function visit(value: unknown): boolean {
-    if (!value || seen.has(value)) return false;
+  while (queue.length > 0) {
+    const value = queue.shift();
+    if (!value || seen.has(value)) {
+      continue;
+    }
     seen.add(value);
 
-    if (value instanceof Error) {
-      if (
-        value.name === 'AbortError' ||
-        value.name === 'TimeoutError' ||
-        value.name === 'APIConnectionTimeoutError'
-      ) {
-        return true;
-      }
-
-      const message = value.message.toLowerCase();
-      if (
-        message.includes('timed out') ||
-        message.includes('timeout') ||
-        message.includes('aborted')
-      ) {
-        return true;
-      }
-
-      return visit(value.cause);
+    if (isTimeoutLikeValue(value)) {
+      return true;
     }
 
-    if (typeof value === 'object') {
-      const maybeError = value as { name?: unknown; message?: unknown; cause?: unknown };
-      if (
-        maybeError.name === 'AbortError' ||
-        maybeError.name === 'TimeoutError' ||
-        maybeError.name === 'APIConnectionTimeoutError'
-      ) {
-        return true;
-      }
-      if (
-        typeof maybeError.message === 'string' &&
-        /timed out|timeout|aborted/i.test(maybeError.message)
-      ) {
-        return true;
-      }
-      return visit(maybeError.cause);
+    const cause = getErrorCause(value);
+    if (cause) {
+      queue.push(cause);
     }
+  }
 
+  return false;
+}
+
+function isTimeoutLikeValue(value: unknown): boolean {
+  if (value instanceof Error) {
+    return isTimeoutName(value.name) || isTimeoutMessage(value.message);
+  }
+
+  if (typeof value !== 'object') {
     return false;
   }
 
-  return visit(error);
+  const maybeError = value as { name?: unknown; message?: unknown };
+  return isTimeoutName(maybeError.name) || isTimeoutMessage(maybeError.message);
+}
+
+function isTimeoutName(name: unknown): boolean {
+  return name === 'AbortError' || name === 'TimeoutError' || name === 'APIConnectionTimeoutError';
+}
+
+function isTimeoutMessage(message: unknown): boolean {
+  return typeof message === 'string' && /timed out|timeout|aborted/i.test(message);
+}
+
+function getErrorCause(value: unknown): unknown {
+  if (value instanceof Error) {
+    return value.cause;
+  }
+
+  if (typeof value === 'object') {
+    return (value as { cause?: unknown }).cause;
+  }
+
+  return undefined;
 }

--- a/apps/web/src/lib/tracingSetup.ts
+++ b/apps/web/src/lib/tracingSetup.ts
@@ -21,61 +21,102 @@ const globalTracingState = globalThis as typeof globalThis & {
   __popChoiceTracing?: PopChoiceTracingState;
 };
 
+const DIAG_LOG_LEVEL_BY_NAME: Record<string, DiagLogLevel> = {
+  debug: DiagLogLevel.DEBUG,
+  error: DiagLogLevel.ERROR,
+  info: DiagLogLevel.INFO,
+  none: DiagLogLevel.NONE,
+  verbose: DiagLogLevel.VERBOSE,
+  warn: DiagLogLevel.WARN,
+};
+
 export function initTracing(service: RuntimeService): void {
   if (!isTracingEnabled()) return;
 
   const state = (globalTracingState.__popChoiceTracing ??= { started: false });
   if (state.started) return;
 
-  const endpoint = resolveTraceEndpoint();
-  const sampleRate = parseSampleRate();
-
-  if (process.env.OTEL_DIAG_LOG_LEVEL) {
-    diag.setLogger(new DiagConsoleLogger(), parseDiagLogLevel(process.env.OTEL_DIAG_LOG_LEVEL));
-  }
-
-  const sdk = new NodeSDK({
-    resource: resourceFromAttributes({
-      'service.name': process.env.OTEL_SERVICE_NAME ?? `popchoice-${service}`,
-      'service.namespace': 'popchoice',
-      'service.version': process.env.APP_VERSION ?? 'development',
-      'service.instance.id': process.env.HOSTNAME,
-      'deployment.environment': process.env.NODE_ENV ?? 'development',
-    }),
-    sampler: new ParentBasedSampler({
-      root: new TraceIdRatioBasedSampler(sampleRate),
-    }),
-    traceExporter: new OTLPTraceExporter({ url: endpoint }),
-    instrumentations: [
-      new HttpInstrumentation({
-        ignoreIncomingRequestHook: (req) => {
-          const url = req.url ?? '';
-          return url.startsWith('/api/metrics') || url.startsWith('/_next/');
-        },
-        redactedQueryParams: ['token', 'api_key', 'key', 'signature', 'sig'],
-      }),
-      new UndiciInstrumentation({
-        requireParentforSpans: true,
-      }),
-      new PgInstrumentation({
-        enhancedDatabaseReporting: false,
-        requireParentSpan: true,
-      }),
-      new IORedisInstrumentation({
-        requireParentSpan: true,
-      }),
-    ],
-  });
+  const config = getTracingConfig(service);
+  configureDiagLogger();
+  const sdk = createTracingSdk(config);
 
   sdk.start();
   state.sdk = sdk;
   state.started = true;
 
-  logger.info({ endpoint, sampleRate, service }, 'OpenTelemetry tracing initialized');
+  logger.info(config, 'OpenTelemetry tracing initialized');
 
   process.once('beforeExit', () => {
     void shutdownTracing();
   });
+}
+
+function getTracingConfig(service: RuntimeService) {
+  return {
+    endpoint: resolveTraceEndpoint(),
+    sampleRate: parseSampleRate(),
+    service,
+  };
+}
+
+function configureDiagLogger() {
+  const logLevel = process.env.OTEL_DIAG_LOG_LEVEL;
+  if (!logLevel) return;
+
+  diag.setLogger(new DiagConsoleLogger(), parseDiagLogLevel(logLevel));
+}
+
+function createTracingSdk({
+  endpoint,
+  sampleRate,
+  service,
+}: {
+  endpoint: string;
+  sampleRate: number;
+  service: RuntimeService;
+}) {
+  return new NodeSDK({
+    instrumentations: createInstrumentations(),
+    resource: resourceFromAttributes(getResourceAttributes(service)),
+    sampler: new ParentBasedSampler({
+      root: new TraceIdRatioBasedSampler(sampleRate),
+    }),
+    traceExporter: new OTLPTraceExporter({ url: endpoint }),
+  });
+}
+
+function getResourceAttributes(service: RuntimeService) {
+  return {
+    'deployment.environment': process.env.NODE_ENV ?? 'development',
+    'service.instance.id': process.env.HOSTNAME,
+    'service.name': process.env.OTEL_SERVICE_NAME ?? `popchoice-${service}`,
+    'service.namespace': 'popchoice',
+    'service.version': process.env.APP_VERSION ?? 'development',
+  };
+}
+
+function createInstrumentations() {
+  return [
+    new HttpInstrumentation({
+      ignoreIncomingRequestHook: shouldIgnoreIncomingRequest,
+      redactedQueryParams: ['token', 'api_key', 'key', 'signature', 'sig'],
+    }),
+    new UndiciInstrumentation({
+      requireParentforSpans: true,
+    }),
+    new PgInstrumentation({
+      enhancedDatabaseReporting: false,
+      requireParentSpan: true,
+    }),
+    new IORedisInstrumentation({
+      requireParentSpan: true,
+    }),
+  ];
+}
+
+function shouldIgnoreIncomingRequest(req: { url?: string | undefined }) {
+  const url = req.url ?? '';
+  return url.startsWith('/api/metrics') || url.startsWith('/_next/');
 }
 
 export async function shutdownTracing(): Promise<void> {
@@ -109,30 +150,27 @@ function resolveTraceEndpoint(): string {
 }
 
 function parseSampleRate(): number {
-  const raw =
+  const raw = getSampleRateRawValue();
+  const parsed = Number.parseFloat(raw);
+  return Number.isFinite(parsed) ? clampSampleRate(parsed) : getDefaultSampleRate();
+}
+
+function getSampleRateRawValue(): string {
+  return (
     process.env.TRACING_SAMPLE_RATE ??
     process.env.OTEL_TRACES_SAMPLER_ARG ??
-    (process.env.NODE_ENV === 'production' ? '0.05' : '1');
-  const parsed = Number.parseFloat(raw);
-  if (!Number.isFinite(parsed)) return process.env.NODE_ENV === 'production' ? 0.05 : 1;
-  return Math.max(0, Math.min(parsed, 1));
+    String(getDefaultSampleRate())
+  );
+}
+
+function getDefaultSampleRate() {
+  return process.env.NODE_ENV === 'production' ? 0.05 : 1;
+}
+
+function clampSampleRate(value: number) {
+  return Math.max(0, Math.min(value, 1));
 }
 
 function parseDiagLogLevel(raw: string): DiagLogLevel {
-  switch (raw.toLowerCase()) {
-    case 'debug':
-      return DiagLogLevel.DEBUG;
-    case 'info':
-      return DiagLogLevel.INFO;
-    case 'warn':
-      return DiagLogLevel.WARN;
-    case 'error':
-      return DiagLogLevel.ERROR;
-    case 'verbose':
-      return DiagLogLevel.VERBOSE;
-    case 'none':
-      return DiagLogLevel.NONE;
-    default:
-      return DiagLogLevel.ERROR;
-  }
+  return DIAG_LOG_LEVEL_BY_NAME[raw.toLowerCase()] ?? DiagLogLevel.ERROR;
 }

--- a/apps/web/src/lib/workers/metricsServer.ts
+++ b/apps/web/src/lib/workers/metricsServer.ts
@@ -18,16 +18,13 @@ import {
   metricsContentType,
 } from '@/lib/metrics';
 
-import type { Server } from 'node:http';
+import type { IncomingMessage, Server, ServerResponse } from 'node:http';
 
 const DEFAULT_WORKER_METRICS_PORT = 9464;
 
 function parsePort(value: string | undefined): number {
-  if (!value) return DEFAULT_WORKER_METRICS_PORT;
-  const parsed = Number.parseInt(value, 10);
-  return Number.isFinite(parsed) && parsed > 0 && parsed < 65536
-    ? parsed
-    : DEFAULT_WORKER_METRICS_PORT;
+  const parsed = value ? Number.parseInt(value, 10) : NaN;
+  return isValidPort(parsed) ? parsed : DEFAULT_WORKER_METRICS_PORT;
 }
 
 // Imported dynamically by startWorkers.ts.
@@ -37,36 +34,7 @@ export function startWorkerMetricsServer(): Server | null {
 
   const port = parsePort(process.env.WORKER_METRICS_PORT);
   const server = createServer((req, res) => {
-    void (async () => {
-      if (req.url !== '/metrics') {
-        res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
-        res.end('Not found.\n');
-        return;
-      }
-
-      const authorization = Array.isArray(req.headers.authorization)
-        ? req.headers.authorization[0]
-        : req.headers.authorization;
-
-      if (!isMetricsRequestAuthorized(authorization ?? null)) {
-        res.writeHead(401, { 'Content-Type': 'text/plain; charset=utf-8' });
-        res.end('Unauthorized.\n');
-        return;
-      }
-
-      const body = await collectMetrics([
-        { name: MOVIE_SEED_QUEUE_NAME, queue: seedQueue },
-        { name: RECOMMENDATION_QUEUE_NAME, queue: recommendationQueue },
-        { name: MORE_PICKS_QUEUE_NAME, queue: morePicksQueue },
-        { name: CATALOG_MAINTENANCE_QUEUE_NAME, queue: catalogMaintenanceQueue },
-      ]);
-
-      res.writeHead(200, {
-        'Cache-Control': 'no-store',
-        'Content-Type': metricsContentType(),
-      });
-      res.end(body);
-    })().catch((err) => {
+    void handleMetricsRequest(req, res).catch((err) => {
       logger.error({ err }, 'Worker metrics scrape failed');
       res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
       res.end('Metrics scrape failed.\n');
@@ -82,4 +50,51 @@ export function startWorkerMetricsServer(): Server | null {
   });
 
   return server;
+}
+
+function isValidPort(port: number) {
+  return Number.isFinite(port) && port > 0 && port < 65536;
+}
+
+async function handleMetricsRequest(req: IncomingMessage, res: ServerResponse) {
+  const earlyResponse = writeEarlyMetricsResponse(req, res);
+  if (earlyResponse) return;
+
+  const body = await collectMetrics([
+    { name: MOVIE_SEED_QUEUE_NAME, queue: seedQueue },
+    { name: RECOMMENDATION_QUEUE_NAME, queue: recommendationQueue },
+    { name: MORE_PICKS_QUEUE_NAME, queue: morePicksQueue },
+    { name: CATALOG_MAINTENANCE_QUEUE_NAME, queue: catalogMaintenanceQueue },
+  ]);
+
+  res.writeHead(200, {
+    'Cache-Control': 'no-store',
+    'Content-Type': metricsContentType(),
+  });
+  res.end(body);
+}
+
+function writeEarlyMetricsResponse(req: IncomingMessage, res: ServerResponse) {
+  if (req.url !== '/metrics') {
+    writeTextResponse(res, 404, 'Not found.\n');
+    return true;
+  }
+
+  if (!isMetricsRequestAuthorized(getAuthorizationHeader(req))) {
+    writeTextResponse(res, 401, 'Unauthorized.\n');
+    return true;
+  }
+
+  return false;
+}
+
+function getAuthorizationHeader(req: IncomingMessage) {
+  return Array.isArray(req.headers.authorization)
+    ? req.headers.authorization[0]
+    : (req.headers.authorization ?? null);
+}
+
+function writeTextResponse(res: ServerResponse, status: number, body: string) {
+  res.writeHead(status, { 'Content-Type': 'text/plain; charset=utf-8' });
+  res.end(body);
 }

--- a/apps/web/src/lib/workers/movieSeedWorker.ts
+++ b/apps/web/src/lib/workers/movieSeedWorker.ts
@@ -1,4 +1,4 @@
-import { Worker } from 'bullmq';
+import { type Job, Worker } from 'bullmq';
 
 import { deserializeTMDBEmbeddings, seedMovies } from '@/features/recommendation/tmdb';
 import {
@@ -23,65 +23,13 @@ export function createMovieSeedWorker(): Worker<MovieSeedJobData> | null {
     return null;
   }
 
-  const worker = new Worker<MovieSeedJobData>(
-    MOVIE_SEED_QUEUE_NAME,
-    async (job) => {
-      const { tmdbMovies, localKeys, tmdbEmbeddings } = job.data;
-      await withTraceSpan(
-        'movie_seed.worker.process',
-        {
-          carrier: job.data.trace,
-          attributes: {
-            'messaging.system': 'bullmq',
-            'messaging.destination.name': MOVIE_SEED_QUEUE_NAME,
-            'messaging.operation.name': 'process',
-            'job.id': String(job.id ?? 'unknown'),
-            'job.name': job.name,
-            'movie.count': tmdbMovies.length,
-          },
-        },
-        async () => {
-          const embeddingsMap = deserializeTMDBEmbeddings(tmdbEmbeddings);
-          await seedMovies(tmdbMovies, new Set(localKeys), embeddingsMap);
-        },
-      );
-    },
-    { connection },
-  );
-
-  worker.on('completed', (job) => {
-    recordQueueJobEvent({
-      queue: MOVIE_SEED_QUEUE_NAME,
-      job: job.name,
-      event: 'completed',
-      final: true,
-    });
-    logger.info(
-      { jobId: job.id, queuedMovies: job.data.tmdbMovies.length },
-      'Movie seeding job completed',
-    );
+  const worker = new Worker<MovieSeedJobData>(MOVIE_SEED_QUEUE_NAME, processMovieSeedJob, {
+    connection,
   });
 
-  worker.on('failed', (job, err) => {
-    const attemptsMade = job?.attemptsMade ?? 0;
-    recordQueueJobEvent({
-      queue: MOVIE_SEED_QUEUE_NAME,
-      job: job?.name ?? 'unknown',
-      event: 'failed',
-      final: attemptsMade >= MAX_MOVIE_SEED_ATTEMPTS,
-    });
-    logger.error(
-      {
-        err,
-        jobId: job?.id,
-        queuedMovies: job?.data?.tmdbMovies?.length ?? 0,
-        attemptsMade,
-        maxAttempts: MAX_MOVIE_SEED_ATTEMPTS,
-        willRetry: attemptsMade < MAX_MOVIE_SEED_ATTEMPTS,
-      },
-      'Movie seeding job failed',
-    );
-  });
+  worker.on('completed', recordMovieSeedCompleted);
+
+  worker.on('failed', recordMovieSeedFailed);
 
   worker.on('error', (err) => {
     logger.error({ err }, 'Movie seeding worker encountered an unrecoverable error');
@@ -94,4 +42,84 @@ export function createMovieSeedWorker(): Worker<MovieSeedJobData> | null {
   });
 
   return worker;
+}
+
+async function processMovieSeedJob(job: Job<MovieSeedJobData>) {
+  const { tmdbMovies, localKeys, tmdbEmbeddings } = job.data;
+  await withTraceSpan(
+    'movie_seed.worker.process',
+    {
+      carrier: job.data.trace,
+      attributes: getMovieSeedTraceAttributes(job, tmdbMovies.length),
+    },
+    async () => {
+      const embeddingsMap = deserializeTMDBEmbeddings(tmdbEmbeddings);
+      await seedMovies(tmdbMovies, new Set(localKeys), embeddingsMap);
+    },
+  );
+}
+
+function getMovieSeedTraceAttributes(job: Job<MovieSeedJobData>, movieCount: number) {
+  return {
+    'messaging.system': 'bullmq',
+    'messaging.destination.name': MOVIE_SEED_QUEUE_NAME,
+    'messaging.operation.name': 'process',
+    'job.id': String(job.id ?? 'unknown'),
+    'job.name': job.name,
+    'movie.count': movieCount,
+  };
+}
+
+function recordMovieSeedCompleted(job: { id?: string; name: string; data: MovieSeedJobData }) {
+  recordQueueJobEvent({
+    event: 'completed',
+    final: true,
+    job: job.name,
+    queue: MOVIE_SEED_QUEUE_NAME,
+  });
+  logger.info(
+    { jobId: job.id, queuedMovies: job.data.tmdbMovies.length },
+    'Movie seeding job completed',
+  );
+}
+
+function recordMovieSeedFailed(
+  job: { attemptsMade: number; data?: MovieSeedJobData; id?: string; name: string } | undefined,
+  err: Error,
+) {
+  const attemptsMade = getMovieSeedAttemptsMade(job);
+  recordQueueJobEvent({
+    event: 'failed',
+    final: isFinalMovieSeedAttempt(attemptsMade),
+    job: getMovieSeedJobName(job),
+    queue: MOVIE_SEED_QUEUE_NAME,
+  });
+  logger.error(getMovieSeedFailureLogData(job, err, attemptsMade), 'Movie seeding job failed');
+}
+
+function getMovieSeedAttemptsMade(job: { attemptsMade: number } | undefined) {
+  return job?.attemptsMade ?? 0;
+}
+
+function isFinalMovieSeedAttempt(attemptsMade: number) {
+  return attemptsMade >= MAX_MOVIE_SEED_ATTEMPTS;
+}
+
+function getMovieSeedJobName(job: { name: string } | undefined) {
+  return job?.name ?? 'unknown';
+}
+
+function getMovieSeedFailureLogData(
+  job: { data?: MovieSeedJobData; id?: string } | undefined,
+  err: Error,
+  attemptsMade: number,
+) {
+  return {
+    attemptsMade,
+    err,
+    jobId: job?.id,
+    maxAttempts: MAX_MOVIE_SEED_ATTEMPTS,
+    queuedMovies: job?.data?.tmdbMovies?.length ?? 0,
+    willRetry: attemptsMade < MAX_MOVIE_SEED_ATTEMPTS,
+  };
 }

--- a/apps/web/src/lib/workers/recommendationWorker.ts
+++ b/apps/web/src/lib/workers/recommendationWorker.ts
@@ -1,4 +1,4 @@
-import { Worker } from 'bullmq';
+import { type Job, Worker } from 'bullmq';
 
 import {
   completeRecommendationRecord,
@@ -21,6 +21,8 @@ import type { RecommendationJobData } from '@/lib/jobQueue';
 
 const MAX_RECOMMENDATION_ATTEMPTS = RECOMMENDATION_JOB_OPTIONS.attempts;
 
+type RecommendationPeopleData = Extract<RecommendationJobData['quizData'], unknown[]>;
+
 // Imported dynamically by startWorkers.ts.
 // fallow-ignore-next-line unused-export
 export function createRecommendationWorker(): Worker<RecommendationJobData> | null {
@@ -32,123 +34,13 @@ export function createRecommendationWorker(): Worker<RecommendationJobData> | nu
 
   const worker = new Worker<RecommendationJobData>(
     RECOMMENDATION_QUEUE_NAME,
-    async (job) => {
-      const { recommendationId, quizData, locale, userId } = job.data;
-      const allPeopleData = Array.isArray(quizData) ? quizData : [quizData];
-      const experienceMode = job.data.experienceMode ?? 'normal-match';
-      const sourceStrategy =
-        job.data.sourceStrategy ??
-        resolveRecommendationSourceStrategy({
-          experienceMode,
-          people: allPeopleData,
-        }).id;
-
-      await withTraceSpan(
-        'recommendation.worker.process',
-        {
-          carrier: job.data.trace,
-          attributes: {
-            'messaging.system': 'bullmq',
-            'messaging.destination.name': RECOMMENDATION_QUEUE_NAME,
-            'messaging.operation.name': 'process',
-            'job.id': String(job.id ?? 'unknown'),
-            'job.name': job.name,
-            'recommendation.experience_mode': experienceMode,
-            'recommendation.id': recommendationId,
-            'recommendation.mode': 'async_worker',
-            'recommendation.source_strategy': sourceStrategy,
-          },
-        },
-        async () => {
-          const startTime = Date.now();
-
-          logger.info({ recommendationId, jobId: job.id }, 'Recommendation job started');
-
-          // Mark as processing
-          await markRecommendationProcessing(recommendationId);
-
-          try {
-            // Run the full AI pipeline
-            const result = await runRecommendationPipeline(allPeopleData, locale, {
-              onStageChange: async (stage) => {
-                setActiveTraceAttributes({ 'recommendation.stage': stage });
-                await markRecommendationStage(recommendationId, stage);
-              },
-              experienceMode,
-              sourceStrategy,
-              userId,
-            });
-
-            const movieCount = await completeRecommendationRecord(recommendationId, result);
-
-            logger.info(
-              { recommendationId, jobId: job.id, movieCount },
-              'Recommendation job completed',
-            );
-            recordRecommendationCompletion({
-              mode: 'async_worker',
-              status: 'success',
-              durationMs: Date.now() - startTime,
-            });
-          } catch (err) {
-            recordRecommendationCompletion({
-              mode: 'async_worker',
-              status: 'failure',
-              durationMs: Date.now() - startTime,
-            });
-            const message = err instanceof Error ? err.message : String(err);
-            logger.error({ err, recommendationId, jobId: job.id }, 'Recommendation job failed');
-
-            // Mark as failed — will be overwritten on retry, becomes permanent on last attempt
-            await failRecommendationRecord(recommendationId, message).catch((dbErr) => {
-              logger.error(
-                { err: dbErr, recommendationId },
-                'Failed to update recommendation status',
-              );
-            });
-
-            // Rethrow so BullMQ handles retries
-            throw err;
-          }
-        },
-      );
-    },
+    processRecommendationJob,
     { connection },
   );
 
-  worker.on('completed', (job) => {
-    recordQueueJobEvent({
-      queue: RECOMMENDATION_QUEUE_NAME,
-      job: job.name,
-      event: 'completed',
-      final: true,
-    });
-    logger.info(
-      { jobId: job.id, recommendationId: job.data.recommendationId },
-      'Recommendation job completed successfully',
-    );
-  });
+  worker.on('completed', recordRecommendationJobCompleted);
 
-  worker.on('failed', (job, err) => {
-    const attemptsMade = job?.attemptsMade ?? 0;
-    recordQueueJobEvent({
-      queue: RECOMMENDATION_QUEUE_NAME,
-      job: job?.name ?? 'unknown',
-      event: 'failed',
-      final: attemptsMade >= MAX_RECOMMENDATION_ATTEMPTS,
-    });
-    logger.error(
-      {
-        err,
-        jobId: job?.id,
-        recommendationId: job?.data?.recommendationId,
-        attemptsMade,
-        maxAttempts: MAX_RECOMMENDATION_ATTEMPTS,
-        willRetry: attemptsMade < MAX_RECOMMENDATION_ATTEMPTS,
-      },
-      'Recommendation job failed',
-    );
-  });
+  worker.on('failed', recordRecommendationJobFailed);
 
   worker.on('error', (err) => {
     logger.error({ err }, 'Recommendation worker encountered an unrecoverable error');
@@ -161,4 +53,192 @@ export function createRecommendationWorker(): Worker<RecommendationJobData> | nu
   });
 
   return worker;
+}
+
+async function processRecommendationJob(job: Job<RecommendationJobData>) {
+  const context = getRecommendationJobContext(job);
+
+  await withTraceSpan(
+    'recommendation.worker.process',
+    {
+      carrier: job.data.trace,
+      attributes: getRecommendationTraceAttributes(job, context),
+    },
+    () => runRecommendationJob(job, context),
+  );
+}
+
+function getRecommendationJobContext(job: Job<RecommendationJobData>) {
+  const { recommendationId, quizData, locale, userId } = job.data;
+  const allPeopleData: RecommendationPeopleData = Array.isArray(quizData) ? quizData : [quizData];
+  const experienceMode = job.data.experienceMode ?? 'normal-match';
+  const sourceStrategy = getRecommendationSourceStrategy(job, allPeopleData, experienceMode);
+
+  return { allPeopleData, experienceMode, locale, recommendationId, sourceStrategy, userId };
+}
+
+function getRecommendationSourceStrategy(
+  job: Job<RecommendationJobData>,
+  allPeopleData: RecommendationPeopleData,
+  experienceMode: NonNullable<RecommendationJobData['experienceMode']>,
+) {
+  return (
+    job.data.sourceStrategy ??
+    resolveRecommendationSourceStrategy({
+      experienceMode,
+      people: allPeopleData,
+    }).id
+  );
+}
+
+function getRecommendationTraceAttributes(
+  job: Job<RecommendationJobData>,
+  context: ReturnType<typeof getRecommendationJobContext>,
+) {
+  return {
+    'messaging.system': 'bullmq',
+    'messaging.destination.name': RECOMMENDATION_QUEUE_NAME,
+    'messaging.operation.name': 'process',
+    'job.id': String(job.id ?? 'unknown'),
+    'job.name': job.name,
+    'recommendation.experience_mode': context.experienceMode,
+    'recommendation.id': context.recommendationId,
+    'recommendation.mode': 'async_worker',
+    'recommendation.source_strategy': context.sourceStrategy,
+  };
+}
+
+async function runRecommendationJob(
+  job: Job<RecommendationJobData>,
+  context: ReturnType<typeof getRecommendationJobContext>,
+) {
+  const startTime = Date.now();
+  logger.info(
+    { recommendationId: context.recommendationId, jobId: job.id },
+    'Recommendation job started',
+  );
+  await markRecommendationProcessing(context.recommendationId);
+
+  try {
+    await completeRecommendationJob(job, context, startTime);
+  } catch (err) {
+    await failRecommendationJob(job, context.recommendationId, err, startTime);
+    throw err;
+  }
+}
+
+async function completeRecommendationJob(
+  job: Job<RecommendationJobData>,
+  context: ReturnType<typeof getRecommendationJobContext>,
+  startTime: number,
+) {
+  const result = await runRecommendationPipeline(context.allPeopleData, context.locale, {
+    onStageChange: async (stage) => {
+      setActiveTraceAttributes({ 'recommendation.stage': stage });
+      await markRecommendationStage(context.recommendationId, stage);
+    },
+    experienceMode: context.experienceMode,
+    sourceStrategy: context.sourceStrategy,
+    userId: context.userId,
+  });
+
+  const movieCount = await completeRecommendationRecord(context.recommendationId, result);
+
+  logger.info(
+    { recommendationId: context.recommendationId, jobId: job.id, movieCount },
+    'Recommendation job completed',
+  );
+  recordRecommendationCompletionEvent('success', startTime);
+}
+
+async function failRecommendationJob(
+  job: Job<RecommendationJobData>,
+  recommendationId: string,
+  err: unknown,
+  startTime: number,
+) {
+  recordRecommendationCompletionEvent('failure', startTime);
+  logger.error({ err, recommendationId, jobId: job.id }, 'Recommendation job failed');
+  await markRecommendationFailed(recommendationId, err);
+}
+
+async function markRecommendationFailed(recommendationId: string, err: unknown) {
+  await failRecommendationRecord(recommendationId, getErrorMessage(err)).catch((dbErr) => {
+    logger.error({ err: dbErr, recommendationId }, 'Failed to update recommendation status');
+  });
+}
+
+function getErrorMessage(err: unknown) {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function recordRecommendationCompletionEvent(status: 'failure' | 'success', startTime: number) {
+  recordRecommendationCompletion({
+    mode: 'async_worker',
+    status,
+    durationMs: Date.now() - startTime,
+  });
+}
+
+function recordRecommendationJobCompleted(job: {
+  data: RecommendationJobData;
+  id?: string;
+  name: string;
+}) {
+  recordQueueJobEvent({
+    event: 'completed',
+    final: true,
+    job: job.name,
+    queue: RECOMMENDATION_QUEUE_NAME,
+  });
+  logger.info(
+    { jobId: job.id, recommendationId: job.data.recommendationId },
+    'Recommendation job completed successfully',
+  );
+}
+
+function recordRecommendationJobFailed(
+  job:
+    | { attemptsMade: number; data?: RecommendationJobData; id?: string; name: string }
+    | undefined,
+  err: Error,
+) {
+  const attemptsMade = getRecommendationAttemptsMade(job);
+  recordQueueJobEvent({
+    event: 'failed',
+    final: isFinalRecommendationAttempt(attemptsMade),
+    job: getRecommendationJobName(job),
+    queue: RECOMMENDATION_QUEUE_NAME,
+  });
+  logger.error(
+    getRecommendationFailureLogData(job, err, attemptsMade),
+    'Recommendation job failed',
+  );
+}
+
+function getRecommendationAttemptsMade(job: { attemptsMade: number } | undefined) {
+  return job?.attemptsMade ?? 0;
+}
+
+function isFinalRecommendationAttempt(attemptsMade: number) {
+  return attemptsMade >= MAX_RECOMMENDATION_ATTEMPTS;
+}
+
+function getRecommendationJobName(job: { name: string } | undefined) {
+  return job?.name ?? 'unknown';
+}
+
+function getRecommendationFailureLogData(
+  job: { data?: RecommendationJobData; id?: string } | undefined,
+  err: Error,
+  attemptsMade: number,
+) {
+  return {
+    attemptsMade,
+    err,
+    jobId: job?.id,
+    maxAttempts: MAX_RECOMMENDATION_ATTEMPTS,
+    recommendationId: job?.data?.recommendationId,
+    willRetry: attemptsMade < MAX_RECOMMENDATION_ATTEMPTS,
+  };
 }

--- a/apps/web/src/lib/workers/startWorkers.ts
+++ b/apps/web/src/lib/workers/startWorkers.ts
@@ -1,9 +1,20 @@
 import logger from '@/lib/logger';
 import { initTracing, shutdownTracing } from '@/lib/tracingSetup';
 
+import type { Server } from 'node:http';
+
 initTracing('workers');
 
 async function main() {
+  const modules = await loadWorkerModules();
+  const runtime = createWorkerRuntime(modules);
+
+  validateCoreWorkers(runtime);
+  logMissingWorkers(runtime);
+  registerShutdownHandlers(runtime, modules.closeBullMQQueues);
+}
+
+async function loadWorkerModules() {
   const [
     { closeBullMQQueues },
     { createCatalogMaintenanceWorker },
@@ -22,72 +33,131 @@ async function main() {
     import('./recommendationEvalWorker'),
   ]);
 
-  const catalogMaintenanceWorker = createCatalogMaintenanceWorker();
-  const movieSeedWorker = createMovieSeedWorker();
-  const recommendationWorker = createRecommendationWorker();
-  const morePicksWorker = createMorePicksWorker();
-  const recommendationEvalWorker = createRecommendationEvalWorker();
-  const metricsServer = startWorkerMetricsServer();
+  return {
+    closeBullMQQueues,
+    createCatalogMaintenanceWorker,
+    createMorePicksWorker,
+    createMovieSeedWorker,
+    createRecommendationEvalWorker,
+    createRecommendationWorker,
+    startWorkerMetricsServer,
+  };
+}
 
-  if (!catalogMaintenanceWorker && !movieSeedWorker && !recommendationWorker) {
-    // Both core workers failed — REDIS_URL is likely unset or Redis is unreachable.
-    // Exiting is intentional: running with zero workers provides no value.
-    logger.error('No core workers could be started. Exiting.');
-    process.exit(1);
+type WorkerModules = Awaited<ReturnType<typeof loadWorkerModules>>;
+type ClosableWorker = {
+  close: () => Promise<unknown> | unknown;
+};
+type WorkerRuntime = {
+  catalogMaintenanceWorker: ClosableWorker | null;
+  metricsServer: Server | null;
+  morePicksWorker: ClosableWorker | null;
+  movieSeedWorker: ClosableWorker | null;
+  recommendationEvalWorker: ClosableWorker | null;
+  recommendationWorker: ClosableWorker | null;
+};
+
+function createWorkerRuntime(modules: WorkerModules): WorkerRuntime {
+  return {
+    catalogMaintenanceWorker: modules.createCatalogMaintenanceWorker(),
+    metricsServer: modules.startWorkerMetricsServer(),
+    morePicksWorker: modules.createMorePicksWorker(),
+    movieSeedWorker: modules.createMovieSeedWorker(),
+    recommendationEvalWorker: modules.createRecommendationEvalWorker(),
+    recommendationWorker: modules.createRecommendationWorker(),
+  };
+}
+
+function validateCoreWorkers(runtime: WorkerRuntime) {
+  const coreWorkers = [
+    runtime.catalogMaintenanceWorker,
+    runtime.movieSeedWorker,
+    runtime.recommendationWorker,
+  ];
+
+  if (coreWorkers.some(Boolean)) {
+    return;
   }
 
-  if (!catalogMaintenanceWorker) {
-    logger.warn('Catalog maintenance worker could not be created — continuing without it.');
-  }
+  logger.error('No core workers could be started. Exiting.');
+  process.exit(1);
+}
 
-  if (!movieSeedWorker) {
-    logger.warn('Movie seeding worker could not be created — continuing without it.');
-  }
+function logMissingWorkers(runtime: WorkerRuntime) {
+  const workerLogs: Array<[ClosableWorker | null, string]> = [
+    [
+      runtime.catalogMaintenanceWorker,
+      'Catalog maintenance worker could not be created — continuing without it.',
+    ],
+    [runtime.movieSeedWorker, 'Movie seeding worker could not be created — continuing without it.'],
+    [
+      runtime.recommendationWorker,
+      'Recommendation worker could not be created — continuing without it.',
+    ],
+    [runtime.morePicksWorker, 'More-picks worker could not be created — continuing without it.'],
+    [
+      runtime.recommendationEvalWorker,
+      'Recommendation eval worker could not be created — continuing without it.',
+    ],
+  ];
 
-  if (!recommendationWorker) {
-    logger.warn('Recommendation worker could not be created — continuing without it.');
+  for (const [worker, message] of workerLogs) {
+    if (!worker) logger.warn(message);
   }
+}
 
-  if (!morePicksWorker) {
-    logger.warn('More-picks worker could not be created — continuing without it.');
-  }
-
-  if (!recommendationEvalWorker) {
-    logger.warn('Recommendation eval worker could not be created — continuing without it.');
-  }
-
+function registerShutdownHandlers(
+  runtime: WorkerRuntime,
+  closeBullMQQueues: WorkerModules['closeBullMQQueues'],
+) {
   const shutdown = async (signal: NodeJS.Signals) => {
-    logger.info({ signal }, 'Shutting down workers');
-    try {
-      await Promise.all([
-        catalogMaintenanceWorker?.close(),
-        movieSeedWorker?.close(),
-        recommendationWorker?.close(),
-        morePicksWorker?.close(),
-        recommendationEvalWorker?.close(),
-        new Promise<void>((resolve, reject) => {
-          if (!metricsServer) {
-            resolve();
-            return;
-          }
-          metricsServer.close((error) => {
-            if (error) reject(error);
-            else resolve();
-          });
-        }),
-      ]);
-      await closeBullMQQueues();
-      await shutdownTracing();
-      logger.info('Workers closed gracefully');
-      process.exit(0);
-    } catch (error) {
-      logger.error({ err: error }, 'Error while shutting down workers');
-      process.exit(1);
-    }
+    await shutdownWorkers(signal, runtime, closeBullMQQueues);
   };
 
   process.on('SIGTERM', () => void shutdown('SIGTERM'));
   process.on('SIGINT', () => void shutdown('SIGINT'));
+}
+
+async function shutdownWorkers(
+  signal: NodeJS.Signals,
+  runtime: WorkerRuntime,
+  closeBullMQQueues: WorkerModules['closeBullMQQueues'],
+) {
+  logger.info({ signal }, 'Shutting down workers');
+  try {
+    await Promise.all([...getWorkerCloseTasks(runtime), closeMetricsServer(runtime.metricsServer)]);
+    await closeBullMQQueues();
+    await shutdownTracing();
+    logger.info('Workers closed gracefully');
+    process.exit(0);
+  } catch (error) {
+    logger.error({ err: error }, 'Error while shutting down workers');
+    process.exit(1);
+  }
+}
+
+function getWorkerCloseTasks(runtime: WorkerRuntime) {
+  return [
+    runtime.catalogMaintenanceWorker?.close(),
+    runtime.movieSeedWorker?.close(),
+    runtime.recommendationWorker?.close(),
+    runtime.morePicksWorker?.close(),
+    runtime.recommendationEvalWorker?.close(),
+  ];
+}
+
+function closeMetricsServer(metricsServer: Server | null) {
+  return new Promise<void>((resolve, reject) => {
+    if (!metricsServer) {
+      resolve();
+      return;
+    }
+
+    metricsServer.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
 }
 
 void main().catch((error) => {

--- a/docs/QUALITY.md
+++ b/docs/QUALITY.md
@@ -98,3 +98,8 @@ The root config intentionally ignores `**/e2e/**` for dead-code reachability and
 `collections/server` as a generated Fumadocs import. Keep those ignores narrow:
 e2e behavior is covered by Playwright jobs, and docs type-check runs
 `fumadocs-mdx` before `tsc`.
+
+The health config also ignores `apps/web/public/mockServiceWorker.js` because it
+is the generated MSW browser worker checked into `public/`. Regenerate it through
+MSW tooling when the package requires an update; do not hand-refactor it to
+silence complexity metrics.

--- a/scripts/check-backoffice-module-size.mjs
+++ b/scripts/check-backoffice-module-size.mjs
@@ -8,26 +8,49 @@ const defaultMaxLines = 350;
 const allowedLargeFiles = new Map();
 
 function sourceFiles(dir) {
-  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
-    const entryPath = join(dir, entry.name);
-    if (entry.isDirectory()) {
-      if (entry.name === '.next' || entry.name === 'node_modules') return [];
-      return sourceFiles(entryPath);
-    }
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) =>
+    sourceFilesForEntry(dir, entry),
+  );
+}
 
-    if (!entry.name.endsWith('.ts') && !entry.name.endsWith('.tsx')) return [];
-    if (entry.name.endsWith('.test.ts') || entry.name.endsWith('.test.tsx')) return [];
-    return [entryPath];
-  });
+function sourceFilesForEntry(dir, entry) {
+  const entryPath = join(dir, entry.name);
+  if (entry.isDirectory()) {
+    return sourceFilesForDirectory(entry.name, entryPath);
+  }
+
+  return isCheckedSourceFile(entry.name) ? [entryPath] : [];
+}
+
+function sourceFilesForDirectory(name, entryPath) {
+  return isIgnoredDirectory(name) ? [] : sourceFiles(entryPath);
+}
+
+function isIgnoredDirectory(name) {
+  return name === '.next' || name === 'node_modules';
+}
+
+function isCheckedSourceFile(name) {
+  return isSourceFile(name) && !isTestFile(name);
+}
+
+function isSourceFile(name) {
+  return name.endsWith('.ts') || name.endsWith('.tsx');
+}
+
+function isTestFile(name) {
+  return name.endsWith('.test.ts') || name.endsWith('.test.tsx');
+}
+
+function getModuleSize(filePath) {
+  const relativePath = relative(repoRoot, filePath);
+  const maxLines = allowedLargeFiles.get(relativePath) ?? defaultMaxLines;
+  const lines = readFileSync(filePath, 'utf8').split('\n').length;
+  return { lines, maxLines, relativePath };
 }
 
 const oversizedFiles = sourceFiles(sourceRoot)
-  .map((filePath) => {
-    const relativePath = relative(repoRoot, filePath);
-    const maxLines = allowedLargeFiles.get(relativePath) ?? defaultMaxLines;
-    const lines = readFileSync(filePath, 'utf8').split('\n').length;
-    return { lines, maxLines, relativePath };
-  })
+  .map(getModuleSize)
   .filter(({ lines, maxLines }) => lines > maxLines)
   .sort((a, b) => b.lines - a.lines);
 


### PR DESCRIPTION
## Summary
- split the remaining Fallow complexity hotspots across recommendation APIs, workers, scripts, UI components, and shared helpers
- document the narrow generated MSW worker health ignore
- bring Fallow health complexity findings to zero for the repo

Closes part of #717.

## Verification
- npm run format:check
- npm run lint:check --workspace=apps/web
- npm run type-check --workspace=apps/web
- npm run type-check
- npm run test --workspace=apps/web
- npm run eval:recommendations --workspace=apps/web
- npm run build
- npx fallow health --format json --quiet => functions_above_threshold: 0
- pre-push: lint, server tests, production build, Storybook tests