### PR TITLE
refactor: share backoffice data table chrome

### DIFF
--- a/apps/backoffice/src/components/catalog-repair-audit/index.tsx
+++ b/apps/backoffice/src/components/catalog-repair-audit/index.tsx
@@ -1,7 +1,7 @@
 import type { CatalogRepairActionAudit } from '@pop-choice/shared';
 
 import { formatBackofficeDateTime } from '../../lib/backoffice';
-import { JsonDetails } from '../shared';
+import { DataTable, JsonDetails } from '../shared';
 
 export function humanizeBackofficeIdentifier(value: string): string {
   return value.replace(/_/g, ' ').replace(/\b\w/g, (letter) => letter.toUpperCase());
@@ -132,42 +132,31 @@ export function RepairAuditRows({ audit }: { audit: CatalogRepairActionAudit[] }
   }
 
   return (
-    <div className="table-scroll">
-      <table className="repair-audit-table">
-        <thead>
-          <tr>
-            <th>When</th>
-            <th>Actor</th>
-            <th>Issue</th>
-            <th>Target</th>
-            <th>Action</th>
-            <th>Result</th>
-          </tr>
-        </thead>
-        <tbody>
-          {audit.map((entry) => (
-            <tr key={entry.id}>
-              <td>
-                <time dateTime={entry.createdAt} title={formatBackofficeDateTime(entry.createdAt)}>
-                  {formatCompactBackofficeDateTime(entry.createdAt)}
-                </time>
-              </td>
-              <td>{entry.actor}</td>
-              <td>
-                <span className="repair-issue-label">
-                  {humanizeBackofficeIdentifier(entry.issueKey)}
-                </span>
-                <span className="repair-issue-key">{entry.issueKey}</span>
-              </td>
-              <td>{formatRepairTarget(entry)}</td>
-              <td>{humanizeBackofficeIdentifier(entry.action)}</td>
-              <td>
-                <RepairResultSummary entry={entry} />
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+    <DataTable
+      className="repair-audit-table"
+      columns={['When', 'Actor', 'Issue', 'Target', 'Action', 'Result']}
+    >
+      {audit.map((entry) => (
+        <tr key={entry.id}>
+          <td>
+            <time dateTime={entry.createdAt} title={formatBackofficeDateTime(entry.createdAt)}>
+              {formatCompactBackofficeDateTime(entry.createdAt)}
+            </time>
+          </td>
+          <td>{entry.actor}</td>
+          <td>
+            <span className="repair-issue-label">
+              {humanizeBackofficeIdentifier(entry.issueKey)}
+            </span>
+            <span className="repair-issue-key">{entry.issueKey}</span>
+          </td>
+          <td>{formatRepairTarget(entry)}</td>
+          <td>{humanizeBackofficeIdentifier(entry.action)}</td>
+          <td>
+            <RepairResultSummary entry={entry} />
+          </td>
+        </tr>
+      ))}
+    </DataTable>
   );
 }

--- a/apps/backoffice/src/components/movie-detail/metadataPanels.tsx
+++ b/apps/backoffice/src/components/movie-detail/metadataPanels.tsx
@@ -2,9 +2,9 @@ import type { CatalogMovieDetail, CatalogMovieDetailTMDBReview } from '@pop-choi
 
 import { formatBackofficeDateTime } from '../../lib/backoffice';
 import {
+  DataTable,
   EmptyState,
   PanelHeader,
-  TableScroll,
   formatDuration,
   formatTMDBMetadataValue,
 } from '../shared';
@@ -21,38 +21,24 @@ export function RelatedReviewsPanel({ reviews }: { reviews: CatalogMovieDetailTM
       {reviews.length === 0 ? (
         <EmptyState>No TMDB review rows are attached to this movie.</EmptyState>
       ) : (
-        <TableScroll>
-          <table>
-            <thead>
-              <tr>
-                <th>Review</th>
-                <th>Reason</th>
-                <th>Status</th>
-                <th>Candidates</th>
-                <th>Updated</th>
-                <th>Audit</th>
-              </tr>
-            </thead>
-            <tbody>
-              {reviews.map((review) => (
-                <tr key={review.id}>
-                  <td>
-                    <a href={`/tmdb-reviews/${encodeURIComponent(review.id)}`}>#{review.id}</a>
-                  </td>
-                  <td>
-                    <ReasonBadge reason={review.reason} />
-                  </td>
-                  <td>
-                    <StatusBadge status={review.status} />
-                  </td>
-                  <td>{review.candidates.length}</td>
-                  <td>{formatBackofficeDateTime(review.updatedAt)}</td>
-                  <td>{review.audit.length}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </TableScroll>
+        <DataTable columns={['Review', 'Reason', 'Status', 'Candidates', 'Updated', 'Audit']}>
+          {reviews.map((review) => (
+            <tr key={review.id}>
+              <td>
+                <a href={`/tmdb-reviews/${encodeURIComponent(review.id)}`}>#{review.id}</a>
+              </td>
+              <td>
+                <ReasonBadge reason={review.reason} />
+              </td>
+              <td>
+                <StatusBadge status={review.status} />
+              </td>
+              <td>{review.candidates.length}</td>
+              <td>{formatBackofficeDateTime(review.updatedAt)}</td>
+              <td>{review.audit.length}</td>
+            </tr>
+          ))}
+        </DataTable>
       )}
     </section>
   );

--- a/apps/backoffice/src/components/recommendation-evals/detail.tsx
+++ b/apps/backoffice/src/components/recommendation-evals/detail.tsx
@@ -6,7 +6,7 @@ import type {
 
 import { formatBackofficeDateTime } from '../../lib/backoffice';
 import { BackofficeLayout } from '../backoffice-layout';
-import { CatalogStat } from '../shared';
+import { CatalogStat, DataTable } from '../shared';
 import { JsonBlock, recommendationEvalStatusLabel, RecommendationEvalStatusBadge } from './shared';
 
 function EvalRunSummary({ run }: { run: RecommendationEvalRun }) {
@@ -149,23 +149,12 @@ export function RecommendationEvalDetailPage({ detail }: { detail: Recommendatio
           <h2>Fixture results</h2>
           <span className="count">{results.length}</span>
         </div>
-        <div className="table-scroll">
-          <table className="recommendation-eval-table">
-            <thead>
-              <tr>
-                <th>Fixture</th>
-                <th>Name</th>
-                <th>Status</th>
-                <th>Score</th>
-                <th>Checks</th>
-                <th>Error</th>
-              </tr>
-            </thead>
-            <tbody>
-              <EvalResultRows results={results} />
-            </tbody>
-          </table>
-        </div>
+        <DataTable
+          className="recommendation-eval-table"
+          columns={['Fixture', 'Name', 'Status', 'Score', 'Checks', 'Error']}
+        >
+          <EvalResultRows results={results} />
+        </DataTable>
       </section>
       <section className="panel">
         <div className="panel-header">

--- a/apps/backoffice/src/components/recommendation-evals/list.tsx
+++ b/apps/backoffice/src/components/recommendation-evals/list.tsx
@@ -2,7 +2,7 @@ import type { RecommendationEvalRun, RecommendationEvalRunPage } from '@pop-choi
 
 import { formatBackofficeDateTime } from '../../lib/backoffice';
 import { BackofficeLayout } from '../backoffice-layout';
-import { SimplePaginationControls } from '../shared';
+import { DataTable, SimplePaginationControls } from '../shared';
 import { buildRecommendationEvalPageHref, RecommendationEvalStatusBadge } from './shared';
 
 function RecommendationEvalRows({ runs }: { runs: RecommendationEvalRun[] }) {
@@ -149,26 +149,22 @@ export function RecommendationEvalListPage({
           totalCount={runPage.totalCount}
           hrefForPage={(page) => buildRecommendationEvalPageHref({ page, pageSize: runPage.limit })}
         />
-        <div className="table-scroll">
-          <table className="recommendation-eval-table">
-            <thead>
-              <tr>
-                <th>Run</th>
-                <th>Status</th>
-                <th>Mode</th>
-                <th>Source</th>
-                <th>Actor</th>
-                <th>Passed</th>
-                <th>Failed</th>
-                <th>Created</th>
-                <th />
-              </tr>
-            </thead>
-            <tbody>
-              <RecommendationEvalRows runs={runPage.runs} />
-            </tbody>
-          </table>
-        </div>
+        <DataTable
+          className="recommendation-eval-table"
+          columns={[
+            'Run',
+            'Status',
+            'Mode',
+            'Source',
+            'Actor',
+            'Passed',
+            'Failed',
+            'Created',
+            'Actions',
+          ]}
+        >
+          <RecommendationEvalRows runs={runPage.runs} />
+        </DataTable>
         <SimplePaginationControls
           ariaLabel="Recommendation eval run pagination bottom"
           emptyLabel="No recommendation eval runs"

--- a/apps/backoffice/src/components/repair-batches/detail.tsx
+++ b/apps/backoffice/src/components/repair-batches/detail.tsx
@@ -8,7 +8,7 @@ import { formatBackofficeDateTime } from '../../lib/backoffice';
 import { BackofficeLayout } from '../backoffice-layout';
 import { RepairStatusBadge } from '../catalog-repair-status';
 import { CatalogMaintenanceRealtimeRefresh } from '../catalogMaintenanceRealtimeRefresh';
-import { PanelHeader, SimplePaginationControls, TableScroll } from '../shared';
+import { DataTable, PanelHeader, SimplePaginationControls } from '../shared';
 import {
   RepairBatchContextPanel,
   RepairBatchItemRows,
@@ -132,28 +132,24 @@ export function RepairBatchDetailPage({
           totalCount={items.totalCount}
           hrefForPage={hrefForItemPage}
         />
-        <TableScroll>
-          <table className="repair-batch-table">
-            <thead>
-              <tr>
-                <th>Item</th>
-                <th>Issue</th>
-                <th>Movie</th>
-                <th>Status</th>
-                <th>Job</th>
-                <th>Reason</th>
-                <th>Language</th>
-                <th>Error</th>
-                <th>Pressure</th>
-                <th>Updated</th>
-                <th>Action</th>
-              </tr>
-            </thead>
-            <tbody>
-              <RepairBatchItemRows items={items.items} />
-            </tbody>
-          </table>
-        </TableScroll>
+        <DataTable
+          className="repair-batch-table"
+          columns={[
+            'Item',
+            'Issue',
+            'Movie',
+            'Status',
+            'Job',
+            'Reason',
+            'Language',
+            'Error',
+            'Pressure',
+            'Updated',
+            'Action',
+          ]}
+        >
+          <RepairBatchItemRows items={items.items} />
+        </DataTable>
         <SimplePaginationControls
           ariaLabel="Catalog repair batch item pagination bottom"
           emptyLabel="No repair batch items"

--- a/apps/backoffice/src/components/repair-batches/list.tsx
+++ b/apps/backoffice/src/components/repair-batches/list.tsx
@@ -9,7 +9,7 @@ import { formatBackofficeDateTime } from '../../lib/backoffice';
 import { BackofficeLayout } from '../backoffice-layout';
 import { RepairStatusBadge } from '../catalog-repair-status';
 import { CatalogMaintenanceRealtimeRefresh } from '../catalogMaintenanceRealtimeRefresh';
-import { PanelHeader, SimplePaginationControls, TableEmptyRow, TableScroll } from '../shared';
+import { DataTable, PanelHeader, SimplePaginationControls, TableEmptyRow } from '../shared';
 import { FilterLink } from './filterLink';
 import { buildRepairBatchListHref } from './helpers';
 
@@ -136,26 +136,22 @@ export function RepairBatchListPage({
           totalCount={batchPage.totalCount}
           hrefForPage={hrefForPage}
         />
-        <TableScroll>
-          <table className="repair-batch-table">
-            <thead>
-              <tr>
-                <th>ID</th>
-                <th>Status</th>
-                <th>Issue</th>
-                <th>Actor</th>
-                <th>Limit</th>
-                <th>Candidates</th>
-                <th>Outcomes</th>
-                <th>Created</th>
-                <th />
-              </tr>
-            </thead>
-            <tbody>
-              <RepairBatchRows batches={batchPage.batches} />
-            </tbody>
-          </table>
-        </TableScroll>
+        <DataTable
+          className="repair-batch-table"
+          columns={[
+            'ID',
+            'Status',
+            'Issue',
+            'Actor',
+            'Limit',
+            'Candidates',
+            'Outcomes',
+            'Created',
+            'Actions',
+          ]}
+        >
+          <RepairBatchRows batches={batchPage.batches} />
+        </DataTable>
         <SimplePaginationControls
           ariaLabel="Catalog repair batch pagination bottom"
           emptyLabel="No repair batches"

--- a/apps/backoffice/src/components/shared/index.test.tsx
+++ b/apps/backoffice/src/components/shared/index.test.tsx
@@ -1,7 +1,7 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 
-import { EmptyState, JsonDetails, PanelHeader, TableEmptyRow, TableScroll } from '.';
+import { DataTable, EmptyState, JsonDetails, PanelHeader, TableEmptyRow, TableScroll } from '.';
 
 describe('shared backoffice components', () => {
   it('renders panel headers with optional hints, counts, and actions', () => {
@@ -50,6 +50,26 @@ describe('shared backoffice components', () => {
     expect(empty).toBe('<p class="empty compact">No rows</p>');
     expect(table).toContain('class="table-scroll"');
     expect(table).toContain('<td colSpan="4" class="empty">No records</td>');
+  });
+
+  it('renders shared data tables with headers and scroll chrome', () => {
+    const html = renderToStaticMarkup(
+      <DataTable className="result-table" columns={['Name', 'Status', 'Actions']}>
+        <tr>
+          <td>Fixture A</td>
+          <td>passed</td>
+          <td>
+            <a href="/fixtures/a">Open</a>
+          </td>
+        </tr>
+      </DataTable>,
+    );
+
+    expect(html).toContain('class="table-scroll"');
+    expect(html).toContain('<table class="result-table">');
+    expect(html).toContain('<th>Name</th>');
+    expect(html).toContain('<th>Actions</th>');
+    expect(html).toContain('<td>Fixture A</td>');
   });
 
   it('renders JSON details with a fallback for unserializable values', () => {

--- a/apps/backoffice/src/components/shared/index.tsx
+++ b/apps/backoffice/src/components/shared/index.tsx
@@ -49,6 +49,33 @@ export function TableScroll({ children, className }: { children: ReactNode; clas
   return <div className={joinClassNames('table-scroll', className)}>{children}</div>;
 }
 
+export function DataTable({
+  children,
+  className,
+  columns,
+  scrollClassName,
+}: {
+  children: ReactNode;
+  className?: string;
+  columns: ReactNode[];
+  scrollClassName?: string;
+}) {
+  return (
+    <TableScroll className={scrollClassName}>
+      <table className={className}>
+        <thead>
+          <tr>
+            {columns.map((column, index) => (
+              <th key={index}>{column}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>{children}</tbody>
+      </table>
+    </TableScroll>
+  );
+}
+
 export function TableEmptyRow({ children, colSpan }: { children: ReactNode; colSpan: number }) {
   return (
     <tr>

--- a/apps/backoffice/src/components/tmdb-reviews/auditRows.tsx
+++ b/apps/backoffice/src/components/tmdb-reviews/auditRows.tsx
@@ -1,44 +1,33 @@
 import type { TMDBMatchReviewActionAudit } from '@pop-choice/shared';
 
 import { formatBackofficeDateTime } from '../../lib/backoffice';
+import { DataTable } from '../shared';
 import { StatusBadge } from './reviewPresentation';
 
 export function AuditRows({ audit }: { audit: TMDBMatchReviewActionAudit[] }) {
   if (audit.length === 0) return <p className="empty">No decisions have been recorded yet.</p>;
 
   return (
-    <table>
-      <thead>
-        <tr>
-          <th>When</th>
-          <th>Actor</th>
-          <th>Action</th>
-          <th>Status</th>
-          <th>Candidate</th>
-          <th>Note</th>
+    <DataTable columns={['When', 'Actor', 'Action', 'Status', 'Candidate', 'Note']}>
+      {audit.map((entry) => (
+        <tr key={entry.id}>
+          <td>{formatBackofficeDateTime(entry.createdAt)}</td>
+          <td>{entry.actor}</td>
+          <td>{entry.action.replaceAll('_', ' ')}</td>
+          <td>
+            {entry.previousStatus ? (
+              <StatusBadge status={entry.previousStatus} />
+            ) : (
+              <span className="data-pill neutral">-</span>
+            )}{' '}
+            <StatusBadge status={entry.newStatus} />
+          </td>
+          <td>
+            {entry.candidate?.id ?? '-'} {entry.candidate ? entry.candidate.title : ''}
+          </td>
+          <td>{entry.note ?? '-'}</td>
         </tr>
-      </thead>
-      <tbody>
-        {audit.map((entry) => (
-          <tr key={entry.id}>
-            <td>{formatBackofficeDateTime(entry.createdAt)}</td>
-            <td>{entry.actor}</td>
-            <td>{entry.action.replaceAll('_', ' ')}</td>
-            <td>
-              {entry.previousStatus ? (
-                <StatusBadge status={entry.previousStatus} />
-              ) : (
-                <span className="data-pill neutral">-</span>
-              )}{' '}
-              <StatusBadge status={entry.newStatus} />
-            </td>
-            <td>
-              {entry.candidate?.id ?? '-'} {entry.candidate ? entry.candidate.title : ''}
-            </td>
-            <td>{entry.note ?? '-'}</td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
+      ))}
+    </DataTable>
   );
 }


### PR DESCRIPTION
## Summary
- add a shared backoffice DataTable wrapper for scroll chrome, headers, and table body
- reuse it across repair batches, recommendation evals, catalog repair audit, movie metadata reviews, and TMDB review audit rows
- remove table skeleton duplication while preserving existing empty states and table classes

## Fallow
- dupes: 21 -> 14 clone groups
- health: 87.9 A unchanged
- dead-code: 0 unchanged
- local fallow audit still hits the known temp-worktree blocker: could not create a temporary worktree for base ref

## Verification
- npm run type-check --workspace=apps/backoffice
- npm run test --workspace=apps/backoffice (46 files, 188 tests)
- npm run quality:structure --workspace=apps/backoffice
- npm run build:backoffice
- npx fallow dupes --format json --quiet
- npx fallow health --score --format json --quiet
- npx fallow dead-code --format json --quiet
- pre-commit type-check
- pre-push lint, server tests (80 files, 1146 tests), production build