### PR TITLE
refactor: share recommendation API route helpers

### DIFF
--- a/apps/web/src/app/api/movie-recommendation/route.ts
+++ b/apps/web/src/app/api/movie-recommendation/route.ts
@@ -14,6 +14,7 @@ import {
   RECOMMENDATION_REQUEST_BODY_LIMIT_BYTES,
   readJsonBodyWithLimit,
   requestBodyErrorResponse,
+  requestValidationErrorResponse,
 } from '@/lib/requestBody';
 import { setActiveTraceAttributes, withTraceSpan } from '@/lib/tracing';
 import { withAuth } from '@/lib/withAuth';
@@ -150,13 +151,7 @@ function getLegacyRecommendationErrorResponse(error: unknown) {
 
 function getValidationErrorResponse(error: z.ZodError) {
   logger.warn({ err: error, issues: error.issues }, 'Invalid request body');
-  return NextResponse.json(
-    {
-      details: error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`).join(', '),
-      error: 'Invalid request data',
-    },
-    { status: 400 },
-  );
+  return requestValidationErrorResponse(error.issues);
 }
 
 function getKnownRecommendationErrorResponse(error: unknown) {

--- a/apps/web/src/app/api/recommendations/[id]/feedback/route.ts
+++ b/apps/web/src/app/api/recommendations/[id]/feedback/route.ts
@@ -7,7 +7,12 @@ import {
 } from '@/lib/db/recommendations';
 import logger from '@/lib/logger';
 import { applyRateLimit } from '@/lib/rateLimit';
-import { withAuth } from '@/lib/withAuth';
+
+import {
+  authenticatedRecommendationSlugPost,
+  recommendationIdValidationResponse,
+  userIdFromRecommendationClient,
+} from '../routeHelpers';
 
 const feedbackSchema = z
   .object({
@@ -30,9 +35,8 @@ async function postHandler(
   const rateLimitResponse = await applyRateLimit(req);
   if (rateLimitResponse) return rateLimitResponse;
 
-  if (!slug || typeof slug !== 'string') {
-    return NextResponse.json({ error: 'Missing recommendation id' }, { status: 400 });
-  }
+  const validationResponse = recommendationIdValidationResponse(slug);
+  if (validationResponse) return validationResponse;
 
   const parsed = feedbackSchema.safeParse(await req.json().catch(() => null));
   if (!parsed.success) {
@@ -40,11 +44,10 @@ async function postHandler(
   }
 
   try {
-    const userId = clientId.startsWith('user:') ? clientId.slice('user:'.length) : undefined;
     const created = await createRecommendationFeedback({
       slug,
       kind: parsed.data.kind as RecommendationFeedbackKind,
-      userId,
+      userId: userIdFromRecommendationClient(clientId),
     });
 
     if (!created) {
@@ -65,6 +68,5 @@ export async function POST(
   req: NextRequest,
   context: { params: Promise<{ id: string }> },
 ): Promise<Response> {
-  const { id: slug } = await context.params;
-  return withAuth((r, clientId) => postHandler(r, clientId, { slug }))(req);
+  return authenticatedRecommendationSlugPost(req, context, postHandler);
 }

--- a/apps/web/src/app/api/recommendations/[id]/more-picks/route.ts
+++ b/apps/web/src/app/api/recommendations/[id]/more-picks/route.ts
@@ -4,7 +4,11 @@ import { startMorePicksRequest } from '@/features/recommendation/morePicksJobs';
 import { claimMorePicksRequest } from '@/features/recommendation/morePicksPersistence';
 import { parseLocaleFromRequest } from '@/lib/locale';
 import { applyRateLimit } from '@/lib/rateLimit';
-import { withAuth } from '@/lib/withAuth';
+
+import {
+  authenticatedRecommendationSlugPost,
+  recommendationIdValidationResponse,
+} from '../routeHelpers';
 
 // ---------------------------------------------------------------------------
 // POST /api/recommendations/[id]/more-picks
@@ -23,9 +27,8 @@ async function postHandler(
   const rateLimitResponse = await applyRateLimit(req);
   if (rateLimitResponse) return rateLimitResponse;
 
-  if (!slug || typeof slug !== 'string') {
-    return NextResponse.json({ error: 'Missing recommendation id' }, { status: 400 });
-  }
+  const validationResponse = recommendationIdValidationResponse(slug);
+  if (validationResponse) return validationResponse;
 
   // Atomically claim the slot — fails gracefully if already claimed
   const claimed = await claimMorePicksRequest(slug);
@@ -46,6 +49,5 @@ export async function POST(
   req: NextRequest,
   context: { params: Promise<{ id: string }> },
 ): Promise<Response> {
-  const { id: slug } = await context.params;
-  return withAuth((r, clientId) => postHandler(r, clientId, { slug }))(req);
+  return authenticatedRecommendationSlugPost(req, context, postHandler);
 }

--- a/apps/web/src/app/api/recommendations/[id]/route.ts
+++ b/apps/web/src/app/api/recommendations/[id]/route.ts
@@ -4,6 +4,8 @@ import { getRecommendationRecord } from '@/features/recommendation/persistence';
 import logger from '@/lib/logger';
 import { withAuth } from '@/lib/withAuth';
 
+import { recommendationIdValidationResponse, userIdFromRecommendationClient } from './routeHelpers';
+
 // ---------------------------------------------------------------------------
 // GET /api/recommendations/[id]
 // ---------------------------------------------------------------------------
@@ -12,7 +14,7 @@ async function getHandler(
   clientId: string,
   { id }: { id: string },
 ): Promise<Response> {
-  const validationResponse = getRecommendationIdValidationResponse(id);
+  const validationResponse = recommendationIdValidationResponse(id);
   if (validationResponse) return validationResponse;
 
   try {
@@ -23,17 +25,9 @@ async function getHandler(
   }
 }
 
-function getRecommendationIdValidationResponse(id: string) {
-  return id ? null : NextResponse.json({ error: 'Missing recommendation id' }, { status: 400 });
-}
-
 async function getRecommendationResponse(id: string, clientId: string) {
-  const result = await getRecommendationRecord(id, getViewerUserId(clientId));
+  const result = await getRecommendationRecord(id, userIdFromRecommendationClient(clientId));
   return result ? NextResponse.json(result) : getRecommendationNotFoundResponse();
-}
-
-function getViewerUserId(clientId: string) {
-  return clientId.startsWith('user:') ? clientId.slice('user:'.length) : undefined;
 }
 
 function getRecommendationNotFoundResponse() {

--- a/apps/web/src/app/api/recommendations/[id]/routeHelpers.test.ts
+++ b/apps/web/src/app/api/recommendations/[id]/routeHelpers.test.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/withAuth', () => ({
+  withAuth:
+    (handler: (req: NextRequest, clientId: string) => Promise<Response> | Response) =>
+    (req: NextRequest) =>
+      handler(req, 'user:77'),
+}));
+
+import {
+  authenticatedRecommendationSlugPost,
+  recommendationIdValidationResponse,
+  userIdFromRecommendationClient,
+} from './routeHelpers';
+
+describe('recommendation id route helpers', () => {
+  it('returns a missing id response only for empty recommendation ids', async () => {
+    expect(recommendationIdValidationResponse('rec-123')).toBeNull();
+
+    const response = recommendationIdValidationResponse('');
+
+    expect(response).not.toBeNull();
+    if (!response) throw new Error('Expected a missing recommendation id response');
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: 'Missing recommendation id' });
+  });
+
+  it('extracts signed-in user ids from recommendation auth client ids', () => {
+    expect(userIdFromRecommendationClient('user:42')).toBe('42');
+    expect(userIdFromRecommendationClient('browser-csrf')).toBeUndefined();
+  });
+
+  it('passes dynamic recommendation slugs through the authenticated route wrapper', async () => {
+    const request = new NextRequest('http://localhost/api/recommendations/rec-123/feedback', {
+      method: 'POST',
+    });
+
+    const response = await authenticatedRecommendationSlugPost(
+      request,
+      { params: Promise.resolve({ id: 'rec-123' }) },
+      (_req, clientId, { slug }) => NextResponse.json({ clientId, slug }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ clientId: 'user:77', slug: 'rec-123' });
+  });
+});

--- a/apps/web/src/app/api/recommendations/[id]/routeHelpers.ts
+++ b/apps/web/src/app/api/recommendations/[id]/routeHelpers.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { withAuth } from '@/lib/withAuth';
+
+type RecommendationSlugHandler = (
+  req: NextRequest,
+  clientId: string,
+  params: { slug: string },
+) => Promise<Response> | Response;
+
+export function recommendationIdValidationResponse(id: string) {
+  return id ? null : NextResponse.json({ error: 'Missing recommendation id' }, { status: 400 });
+}
+
+export function userIdFromRecommendationClient(clientId: string) {
+  return clientId.startsWith('user:') ? clientId.slice('user:'.length) : undefined;
+}
+
+export async function authenticatedRecommendationSlugPost(
+  req: NextRequest,
+  context: { params: Promise<{ id: string }> },
+  handler: RecommendationSlugHandler,
+): Promise<Response> {
+  const { id: slug } = await context.params;
+  return withAuth((r, clientId) => handler(r, clientId, { slug }))(req);
+}

--- a/apps/web/src/app/api/recommendations/route.ts
+++ b/apps/web/src/app/api/recommendations/route.ts
@@ -18,6 +18,8 @@ import {
   RECOMMENDATION_REQUEST_BODY_LIMIT_BYTES,
   readJsonBodyWithLimit,
   requestBodyErrorResponse,
+  requestValidationErrorResponse,
+  type ValidationIssue,
 } from '@/lib/requestBody';
 import { withTraceSpan } from '@/lib/tracing';
 import { withAuth } from '@/lib/withAuth';
@@ -26,8 +28,6 @@ import type {
   RecommendationExperienceMode,
   RecommendationSourceStrategy,
 } from '@/features/recommendation/types';
-
-type CreateValidationIssue = { path: Array<string | number>; message: string };
 
 // ---------------------------------------------------------------------------
 // POST /api/recommendations — create a new recommendation job
@@ -171,18 +171,12 @@ function getCreateRecommendationErrorResponse(error: unknown) {
   return NextResponse.json({ error: 'Failed to create recommendation' }, { status: 500 });
 }
 
-function isCreateValidationError(error: unknown): error is { issues: CreateValidationIssue[] } {
+function isCreateValidationError(error: unknown): error is { issues: ValidationIssue[] } {
   return error instanceof Error && error.name === 'ZodError' && 'issues' in error;
 }
 
-function getCreateValidationErrorResponse(error: { issues: CreateValidationIssue[] }) {
-  return NextResponse.json(
-    {
-      details: error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`).join(', '),
-      error: 'Invalid request data',
-    },
-    { status: 400 },
-  );
+function getCreateValidationErrorResponse(error: { issues: ValidationIssue[] }) {
+  return requestValidationErrorResponse(error.issues);
 }
 
 export const POST = withAuth(postHandler);

--- a/apps/web/src/lib/requestBody.test.ts
+++ b/apps/web/src/lib/requestBody.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { requestValidationErrorResponse } from './requestBody';
+
+describe('request body helpers', () => {
+  it('formats validation issues for invalid request data responses', async () => {
+    const response = requestValidationErrorResponse([
+      { path: ['people', 0, 'tonePreference'], message: 'Required' },
+    ]);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      details: 'people.0.tonePreference: Required',
+      error: 'Invalid request data',
+    });
+  });
+});

--- a/apps/web/src/lib/requestBody.ts
+++ b/apps/web/src/lib/requestBody.ts
@@ -3,6 +3,11 @@ import { NextResponse, type NextRequest } from 'next/server';
 export const RECOMMENDATION_REQUEST_BODY_LIMIT_BYTES = 16 * 1024;
 export const POSTER_REQUEST_BODY_LIMIT_BYTES = 32 * 1024;
 
+export type ValidationIssue = {
+  message: string;
+  path: PropertyKey[];
+};
+
 class RequestBodyTooLargeError extends Error {
   constructor(readonly limitBytes: number) {
     super(`Request body exceeds ${limitBytes} bytes`);
@@ -58,4 +63,16 @@ export function requestBodyErrorResponse(error: unknown): NextResponse | null {
     return NextResponse.json({ error: error.message }, { status: 400 });
   }
   return null;
+}
+
+export function requestValidationErrorResponse(issues: ValidationIssue[]): NextResponse {
+  return NextResponse.json(
+    {
+      details: issues
+        .map((issue) => `${issue.path.map(String).join('.')}: ${issue.message}`)
+        .join(', '),
+      error: 'Invalid request data',
+    },
+    { status: 400 },
+  );
 }


### PR DESCRIPTION
## Summary
- share invalid request-data response formatting through request body helpers
- add local recommendation id route helpers for slug validation, authenticated slug POST wrapping, and user id extraction
- reuse the helpers across recommendation detail, feedback, more-picks, sync create, and async create routes

## Fallow
- dupes: 14 -> 11 clone groups
- health: 87.5 A (from 87.9 A; coupling penalty 2.1 -> 2.5, still within the 85-90 target band)
- dead-code: 0 unchanged
- complexity findings: 0 unchanged
- local fallow audit still hits the known temp-worktree blocker: could not create a temporary worktree for base ref

## Verification
- npm run test --workspace=apps/web targeted recommendation route helper tests (5 files, 14 tests)
- npm run type-check --workspace=apps/web
- npx fallow dupes --format json --quiet
- npx fallow health --score --format json --quiet
- npx fallow dead-code --format json --quiet
- pre-commit type-check
- pre-push lint, server tests (82 files, 1150 tests), production build
