### PR TITLE
refactor: consolidate low-risk duplicate helpers

### DIFF
--- a/apps/web/src/lib/auth/password.ts
+++ b/apps/web/src/lib/auth/password.ts
@@ -20,13 +20,8 @@ import { randomBytes, scrypt, timingSafeEqual } from 'node:crypto';
 const SCRYPT_OPTIONS = { N: 32_768, r: 8, p: 1, maxmem: 64 * 1024 * 1024 } as const;
 const KEY_LENGTH = 32;
 
-/**
- * Hashes a plaintext password with a fresh random salt.
- * Returns a `salt:hash` string safe to store in the database.
- */
-export async function hashPassword(plaintext: string): Promise<string> {
-  const salt = randomBytes(16).toString('hex');
-  const hash = await new Promise<string>((resolve, reject) => {
+function derivePasswordHash(plaintext: string, salt: string): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
     scrypt(plaintext, salt, KEY_LENGTH, SCRYPT_OPTIONS, (err, derivedKey) => {
       if (err) {
         reject(err);
@@ -35,6 +30,15 @@ export async function hashPassword(plaintext: string): Promise<string> {
       resolve(derivedKey.toString('hex'));
     });
   });
+}
+
+/**
+ * Hashes a plaintext password with a fresh random salt.
+ * Returns a `salt:hash` string safe to store in the database.
+ */
+export async function hashPassword(plaintext: string): Promise<string> {
+  const salt = randomBytes(16).toString('hex');
+  const hash = await derivePasswordHash(plaintext, salt);
   return `${salt}:${hash}`;
 }
 
@@ -47,15 +51,7 @@ export async function verifyPassword(plaintext: string, stored: string): Promise
   if (separatorIndex === -1) return false;
   const salt = stored.slice(0, separatorIndex);
   const storedHash = stored.slice(separatorIndex + 1);
-  const candidateHash = await new Promise<string>((resolve, reject) => {
-    scrypt(plaintext, salt, KEY_LENGTH, SCRYPT_OPTIONS, (err, derivedKey) => {
-      if (err) {
-        reject(err);
-        return;
-      }
-      resolve(derivedKey.toString('hex'));
-    });
-  });
+  const candidateHash = await derivePasswordHash(plaintext, salt);
   const storedBuf = Buffer.from(storedHash, 'hex');
   const candidateBuf = Buffer.from(candidateHash, 'hex');
   if (storedBuf.length !== candidateBuf.length) return false;

--- a/packages/shared/src/catalogDuplicateMerge.ts
+++ b/packages/shared/src/catalogDuplicateMerge.ts
@@ -249,14 +249,18 @@ function parseJsonArray<T>(value: string | T[] | null | undefined): T[] {
   return Array.isArray(parsed) ? (parsed as T[]) : [];
 }
 
-function classifyIdentity(
-  movies: CatalogDuplicateMergeMovieSnapshot[],
-): CatalogDuplicateMergeIdentityKind {
-  const tmdbIds = new Set(
+function getFiniteTmdbIds(movies: CatalogDuplicateMergeMovieSnapshot[]): Set<number> {
+  return new Set(
     movies
       .map((movie) => movie.tmdb_id)
       .filter((tmdbId): tmdbId is number => tmdbId !== null && Number.isFinite(tmdbId)),
   );
+}
+
+function classifyIdentity(
+  movies: CatalogDuplicateMergeMovieSnapshot[],
+): CatalogDuplicateMergeIdentityKind {
+  const tmdbIds = getFiniteTmdbIds(movies);
   if (tmdbIds.size === 1 && movies.every((movie) => movie.tmdb_id !== null)) {
     return 'confirmed_tmdb_duplicate';
   }
@@ -275,11 +279,7 @@ function buildWarnings(
   userMemoryConflictCount: number,
 ): string[] {
   const warnings: string[] = [];
-  const tmdbIds = new Set(
-    movies
-      .map((movie) => movie.tmdb_id)
-      .filter((tmdbId): tmdbId is number => tmdbId !== null && Number.isFinite(tmdbId)),
-  );
+  const tmdbIds = getFiniteTmdbIds(movies);
 
   if (identityKind === 'candidate_normalized_title_year') {
     warnings.push('Normalized title/year groups are candidate duplicates, not proof of identity.');


### PR DESCRIPTION
## Summary
- consolidate password scrypt derivation into a private helper
- reuse a local TMDB id Set helper in catalog duplicate merge classification/warnings

## Fallow
- dupes: 11 -> 9
- health: 87.5 A -> 87.5 A
- coupling penalty unchanged at 2.5

## Verification
- npm run test --workspace=packages/shared -- catalogDuplicateMerge.test.ts
- npm run build --workspace=packages/shared
- npm run type-check --workspace=apps/web
- npm run lint:check
- npx fallow dupes --format json --quiet
- npx fallow health --score --format json --quiet
- pre-push: lint, server tests, production build