### PR TITLE
Stabilize backoffice repair flows

### DIFF
--- a/apps/backoffice/e2e/catalog-health.spec.ts
+++ b/apps/backoffice/e2e/catalog-health.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from 'playwright/test';
+
+import { backofficeBaseUrl, operatorHeaders } from './helpers';
+
+test('renders deterministic catalog health data without desktop overflow', async ({ page }) => {
+  await page.setExtraHTTPHeaders(operatorHeaders());
+  await page.goto('/');
+
+  await expect(page.getByRole('heading', { name: 'Catalog Health' })).toBeVisible();
+  await expect(page.getByRole('navigation', { name: 'Backoffice sections' })).toBeVisible();
+  await expect(page.locator('#issue-missing_poster_url')).toContainText('Missing poster_url');
+  await expect(page.locator('#issue-missing_poster_url')).toContainText(
+    'PopChoice E2E Space Opera',
+  );
+  await expect(page.locator('#issue-missing_tmdb_id')).toContainText('Healthy');
+  await expect(page.locator('#issue-missing_tmdb_id')).not.toContainText(
+    'PopChoice E2E Space Opera',
+  );
+
+  const layout = await page.evaluate(() => ({
+    clientWidth: document.documentElement.clientWidth,
+    scrollWidth: document.documentElement.scrollWidth,
+  }));
+
+  expect(layout.scrollWidth).toBeLessThanOrEqual(layout.clientWidth + 2);
+});
+
+test('queues a focused catalog repair through the enhanced form path', async ({ page }) => {
+  await page.setExtraHTTPHeaders(operatorHeaders());
+  await page.goto('/?issue=missing_poster_url');
+
+  const row = page.locator('[data-repair-row][data-issue-key="missing_poster_url"]').first();
+  await expect(row).toContainText('PopChoice E2E Space Opera');
+
+  const responsePromise = page.waitForResponse(
+    (response) =>
+      response.url().endsWith('/catalog-health/actions') && response.request().method() === 'POST',
+  );
+  await row.getByRole('button', { name: 'Queue backfill' }).click();
+
+  const response = await responsePromise;
+  expect(response.ok()).toBe(true);
+  await expect(row.locator('[data-repair-message]')).toContainText('Accepted for worker', {
+    timeout: 3_000,
+  });
+});
+
+test('does not redirect action responses to a bind-address host', async ({ request }) => {
+  const baseURL = backofficeBaseUrl();
+  const bindOrigin = `http://0.0.0.0:${new URL(baseURL).port}`;
+  const response = await request.post('/catalog-health/actions', {
+    form: {
+      action: 'enqueue_backfill',
+      issue_key: 'missing_poster_url',
+      movie_id: '1',
+    },
+    headers: {
+      ...operatorHeaders(),
+      accept: 'text/html',
+      host: new URL(bindOrigin).host,
+      origin: bindOrigin,
+    },
+    maxRedirects: 0,
+  });
+
+  expect(response.status()).toBe(303);
+  expect(response.headers().location).toBeTruthy();
+  expect(response.headers().location).not.toContain('0.0.0.0');
+});

--- a/apps/backoffice/e2e/helpers.ts
+++ b/apps/backoffice/e2e/helpers.ts
@@ -1,0 +1,13 @@
+export function backofficeBaseUrl(): string {
+  return process.env.E2E_BACKOFFICE_BASE_URL ?? 'http://127.0.0.1:3104';
+}
+
+export function operatorHeaders(): Record<string, string> {
+  const username = process.env.E2E_BACKOFFICE_OPERATOR_USERNAME ?? 'e2e-operator';
+  const password = process.env.E2E_BACKOFFICE_OPERATOR_PASSWORD ?? 'e2e-password';
+  const token = Buffer.from(`${username}:${password}`).toString('base64');
+
+  return {
+    authorization: `Basic ${token}`,
+  };
+}

--- a/apps/backoffice/package.json
+++ b/apps/backoffice/package.json
@@ -9,6 +9,7 @@
     "quality:structure": "node ../../scripts/check-backoffice-module-size.mjs",
     "start": "next start",
     "test": "vitest run",
+    "test:e2e": "playwright test --config playwright.e2e.config.ts",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/backoffice/playwright.e2e.config.ts
+++ b/apps/backoffice/playwright.e2e.config.ts
@@ -1,12 +1,17 @@
-import { defineConfig, devices } from 'playwright/test';
 import { fileURLToPath } from 'node:url';
 
-const e2ePort = Number.parseInt(process.env.E2E_BACKOFFICE_PORT ?? '3101', 10);
+import { defineConfig, devices } from 'playwright/test';
+
+const e2ePort = Number.parseInt(process.env.E2E_BACKOFFICE_PORT ?? '3104', 10);
 const baseURL = process.env.E2E_BACKOFFICE_BASE_URL ?? `http://127.0.0.1:${e2ePort}`;
 const databaseUrl =
   process.env.E2E_DATABASE_URL ?? 'postgresql://popchoice_e2e@127.0.0.1:55432/popchoice_e2e';
 const redisUrl = process.env.E2E_REDIS_URL ?? 'redis://127.0.0.1:56379';
-const operatorCredentials = Buffer.from('e2e-operator:e2e-operator-secret').toString('base64');
+const operatorUsername = process.env.E2E_BACKOFFICE_OPERATOR_USERNAME ?? 'e2e-operator';
+const operatorPassword = process.env.E2E_BACKOFFICE_OPERATOR_PASSWORD ?? 'e2e-password';
+const operatorCredentials = Buffer.from(`${operatorUsername}:${operatorPassword}`).toString(
+  'base64',
+);
 const repoRoot = fileURLToPath(new URL('../../', import.meta.url));
 
 export default defineConfig({
@@ -26,28 +31,31 @@ export default defineConfig({
       Authorization: `Basic ${operatorCredentials}`,
     },
     httpCredentials: {
-      password: 'e2e-operator-secret',
-      username: 'e2e-operator',
+      password: operatorPassword,
+      username: operatorUsername,
     },
-    trace: 'on-first-retry',
     screenshot: 'only-on-failure',
+    trace: 'on-first-retry',
+    viewport: { height: 1000, width: 1440 },
   },
   webServer: {
     command: `npm run build --workspace=packages/shared && PORT=${e2ePort} npm run dev --workspace=apps/backoffice -- --hostname 127.0.0.1`,
     cwd: repoRoot,
-    url: `${baseURL}/healthz`,
-    reuseExistingServer: false,
-    timeout: 120_000,
     env: {
       BULL_BOARD_URL: '',
+      CATALOG_HEALTH_SAMPLE_LIMIT: '5',
       DATABASE_URL: databaseUrl,
-      OPERATOR_AUTH_PASSWORD: 'e2e-operator-secret',
+      OPERATOR_AUTH_PASSWORD: operatorPassword,
       OPERATOR_AUTH_REQUIRED: '1',
-      OPERATOR_AUTH_USERNAME: 'e2e-operator',
+      OPERATOR_AUTH_USERNAME: operatorUsername,
       REDIS_URL: redisUrl,
       RESEND_API_KEY: '',
       TMDB_API_KEY: '',
+      TMDB_LANGUAGE: 'en-US',
     },
+    reuseExistingServer: false,
+    timeout: 120_000,
+    url: baseURL,
   },
   projects: [
     {

--- a/apps/backoffice/src/app/catalog-health/actions/route.test.ts
+++ b/apps/backoffice/src/app/catalog-health/actions/route.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../../../test/backofficeActionRoute';
 
 const mocks = vi.hoisted(() => ({
+  backofficeRedirectUrl: vi.fn(),
   backofficeActionErrorResponse: vi.fn(),
   backofficeActionFailureResponse: vi.fn(),
   buildCatalogRepairActionBody: vi.fn(),
@@ -34,6 +35,7 @@ vi.mock('../../../lib/backoffice', () => ({
 }));
 
 vi.mock('../../../lib/sameOriginRequest', () => ({
+  backofficeRedirectUrl: mocks.backofficeRedirectUrl,
   isSameOriginRequest: mocks.isSameOriginRequest,
 }));
 
@@ -95,6 +97,9 @@ describe('catalog health repair action route', () => {
       return 'unavailable';
     });
     mocks.getBackofficeErrorStatus.mockReturnValue(500);
+    mocks.backofficeRedirectUrl.mockImplementation(
+      (request: Request, path: string) => new URL(path, request.url),
+    );
     mocks.isSameOriginRequest.mockReturnValue(true);
     mocks.parseBackofficeReturnPath.mockImplementation((value: FormDataEntryValue | null) =>
       typeof value === 'string' ? value : '/',

--- a/apps/backoffice/src/app/catalog-health/actions/route.ts
+++ b/apps/backoffice/src/app/catalog-health/actions/route.ts
@@ -11,7 +11,7 @@ import {
   performCatalogRepairAction,
   wantsBackofficeJsonResponse,
 } from '../../../lib/backoffice';
-import { isSameOriginRequest } from '../../../lib/sameOriginRequest';
+import { backofficeRedirectUrl, isSameOriginRequest } from '../../../lib/sameOriginRequest';
 
 export const dynamic = 'force-dynamic';
 
@@ -24,7 +24,7 @@ function buildRepairRedirectUrl({
   returnPath: string;
   repairStatus: string;
 }) {
-  const url = new URL(returnPath, request.url);
+  const url = backofficeRedirectUrl(request, returnPath, { trustRequestEvidence: true });
   url.searchParams.set('repair', repairStatus);
   return url;
 }
@@ -38,7 +38,7 @@ export async function POST(request: NextRequest) {
         return backofficeActionFailureResponse('Forbidden.', 403);
       }
 
-      return NextResponse.redirect(new URL('/?repair=forbidden', request.url), 303);
+      return NextResponse.redirect(backofficeRedirectUrl(request, '/?repair=forbidden'), 303);
     }
 
     const formData = await request.formData();

--- a/apps/backoffice/src/app/tmdb-reviews/[id]/actions/route.test.ts
+++ b/apps/backoffice/src/app/tmdb-reviews/[id]/actions/route.test.ts
@@ -8,6 +8,7 @@ import {
 
 const mocks = vi.hoisted(() => ({
   applyTMDBReviewFormAction: vi.fn(),
+  backofficeRedirectUrl: vi.fn(),
   backofficeActionErrorResponse: vi.fn(),
   backofficeActionFailureResponse: vi.fn(),
   getBackofficeErrorStatus: vi.fn(),
@@ -26,6 +27,7 @@ vi.mock('../../../../lib/backoffice', () => ({
 }));
 
 vi.mock('../../../../lib/sameOriginRequest', () => ({
+  backofficeRedirectUrl: mocks.backofficeRedirectUrl,
   isSameOriginRequest: mocks.isSameOriginRequest,
 }));
 
@@ -58,6 +60,9 @@ describe('TMDB review action route', () => {
       review: { id: 'review-1' },
     });
     mocks.getBackofficeErrorStatus.mockReturnValue(500);
+    mocks.backofficeRedirectUrl.mockImplementation(
+      (request: Request, path: string) => new URL(path, request.url),
+    );
     mocks.isSameOriginRequest.mockReturnValue(true);
     mocks.wantsBackofficeJsonResponse.mockImplementation((request: Request) => {
       const accept = request.headers.get('accept') ?? '';

--- a/apps/backoffice/src/app/tmdb-reviews/[id]/actions/route.ts
+++ b/apps/backoffice/src/app/tmdb-reviews/[id]/actions/route.ts
@@ -8,7 +8,7 @@ import {
   logBackofficeError,
   wantsBackofficeJsonResponse,
 } from '../../../../lib/backoffice';
-import { isSameOriginRequest } from '../../../../lib/sameOriginRequest';
+import { backofficeRedirectUrl, isSameOriginRequest } from '../../../../lib/sameOriginRequest';
 
 export const dynamic = 'force-dynamic';
 
@@ -47,7 +47,10 @@ export async function POST(request: NextRequest, context: ReviewActionContext) {
       });
     }
 
-    return NextResponse.redirect(new URL(result.redirectTo, request.url), 303);
+    return NextResponse.redirect(
+      backofficeRedirectUrl(request, result.redirectTo, { trustRequestEvidence: true }),
+      303,
+    );
   } catch (error) {
     logBackofficeError('Failed to apply TMDB match review action', error);
     const status = getBackofficeErrorStatus(error);

--- a/apps/backoffice/src/catalogMaintenanceQueue.test.ts
+++ b/apps/backoffice/src/catalogMaintenanceQueue.test.ts
@@ -1,4 +1,24 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockGetJobCounts, MockQueue, MockRedis } = vi.hoisted(() => {
+  const mockGetJobCounts = vi.fn();
+
+  function MockQueue(this: { getJobCounts: ReturnType<typeof vi.fn> }) {
+    this.getJobCounts = mockGetJobCounts;
+  }
+
+  function MockRedis(this: { on: ReturnType<typeof vi.fn> }) {
+    this.on = vi.fn();
+  }
+
+  return { mockGetJobCounts, MockQueue, MockRedis };
+});
+
+vi.mock('bullmq', () => ({ Queue: MockQueue }));
+vi.mock('ioredis', () => ({ Redis: MockRedis }));
+vi.mock('@pop-choice/shared', () => ({
+  logger: { error: vi.fn() },
+}));
 
 import {
   enqueueCatalogBackfillMovieFromBackoffice,
@@ -11,6 +31,10 @@ import {
 } from './catalogMaintenanceQueue';
 
 describe('catalog maintenance queue helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('sanitizes BullMQ job ids so operator-supplied ids cannot contain colons', () => {
     expect(getCatalogBackfillMovieJobId('tmdb:331')).toBe('backfill-tmdb-331');
     expect(getCatalogRepairBatchJobId('batch:12')).toBe('repair-batch-batch-12');
@@ -109,5 +133,26 @@ describe('catalog maintenance queue helpers', () => {
       { label: 'Page size', value: '25' },
       { label: 'Language', value: 'en-US' },
     ]);
+  });
+
+  it('reports an unavailable queue snapshot when Redis count reads fail', async () => {
+    mockGetJobCounts.mockRejectedValueOnce(new Error('redis unavailable'));
+
+    await expect(
+      getCatalogMaintenanceQueueSnapshot('redis://localhost:6379'),
+    ).resolves.toMatchObject({
+      available: false,
+      counts: {
+        active: 0,
+        completed: 0,
+        delayed: 0,
+        failed: 0,
+        prioritized: 0,
+        waiting: 0,
+        waitingChildren: 0,
+      },
+      openJobs: 0,
+      queueName: 'catalog-maintenance',
+    });
   });
 });

--- a/apps/backoffice/src/catalogMaintenanceQueue.ts
+++ b/apps/backoffice/src/catalogMaintenanceQueue.ts
@@ -1,5 +1,4 @@
-import { Queue } from 'bullmq';
-import type { Job } from 'bullmq';
+import { Queue, type Job } from 'bullmq';
 import { Redis } from 'ioredis';
 
 import { logger } from '@pop-choice/shared';
@@ -20,8 +19,14 @@ import {
   summarizeCatalogMaintenanceJobPayload,
   type CatalogBackfillReason,
   type CatalogMaintenanceJobData,
-  type CatalogMaintenanceQueueCounts,
+  type CatalogMaintenanceQueueJobPage,
+  type CatalogMaintenanceQueueJobSummary,
   type CatalogMaintenanceQueueJobState,
+  type CatalogMaintenanceQueueSnapshot,
+  type EnqueueCatalogBackfillMovieInput,
+  type EnqueueCatalogBackfillMovieResult,
+  type EnqueueCatalogRepairBatchInput,
+  type EnqueueCatalogRepairBatchResult,
 } from './catalogMaintenanceQueueHelpers';
 
 export const CATALOG_MAINTENANCE_QUEUE_NAME = 'catalog-maintenance';
@@ -32,80 +37,44 @@ export {
   isCatalogMaintenanceQueueJobState,
   summarizeCatalogMaintenanceJobPayload,
 };
-export type { CatalogBackfillReason, CatalogMaintenanceQueueJobState };
+export type {
+  CatalogBackfillReason,
+  CatalogMaintenanceQueueJobPage,
+  CatalogMaintenanceQueueJobState,
+  CatalogMaintenanceQueueJobSummary,
+  CatalogMaintenanceQueueSnapshot,
+  EnqueueCatalogBackfillMovieInput,
+  EnqueueCatalogBackfillMovieResult,
+  EnqueueCatalogRepairBatchInput,
+  EnqueueCatalogRepairBatchResult,
+};
 
-export interface EnqueueCatalogBackfillMovieInput {
-  movieId: string | number;
-  reason: CatalogBackfillReason;
-  language?: string;
-  repairBatchId?: string | number;
-  repairBatchItemId?: string | number;
-}
-
-export interface EnqueueCatalogRepairBatchInput {
-  batchId: string | number;
-  issueKey: string;
-  limit: number;
-  pageSize: number;
-  language?: string;
-  staleAfterDays: number;
-}
-
-export interface EnqueueCatalogBackfillMovieResult {
-  queueName: string;
-  jobName: string;
+function enqueueResult({
+  jobId,
+  jobName,
+  language,
+  status,
+}: {
   jobId: string;
+  jobName: string;
   language: string;
   status: 'queued' | 'deduped';
-}
-
-export interface EnqueueCatalogRepairBatchResult {
-  queueName: string;
-  jobName: string;
-  jobId: string;
-  language: string;
-  status: 'queued' | 'deduped';
-}
-
-export interface CatalogMaintenanceQueueSnapshot {
-  queueName: string;
-  available: boolean;
-  counts: CatalogMaintenanceQueueCounts;
-  openJobs: number;
-  updatedAt: string;
-}
-
-export interface CatalogMaintenanceQueueJobSummary {
-  id: string;
-  name: string;
-  state: CatalogMaintenanceQueueJobState;
-  attemptsMade: number;
-  attemptsConfigured: number | null;
-  createdAt: string | null;
-  processedAt: string | null;
-  finishedAt: string | null;
-  failedReason: string | null;
-  payload: Array<{ label: string; value: string }>;
-  repairBatchId: string | null;
-  repairBatchItemId: string | null;
-  movieId: string | null;
-}
-
-export interface CatalogMaintenanceQueueJobPage {
-  queueName: string;
-  available: boolean;
-  state: CatalogMaintenanceQueueJobState;
-  jobs: CatalogMaintenanceQueueJobSummary[];
-  counts: CatalogMaintenanceQueueSnapshot['counts'];
-  openJobs: number;
-  totalCount: number;
-  limit: number;
-  offset: number;
-  updatedAt: string;
+}): EnqueueCatalogBackfillMovieResult {
+  return { queueName: CATALOG_MAINTENANCE_QUEUE_NAME, jobName, jobId, language, status };
 }
 
 let redisConnection: Redis | null = null;
 let catalogMaintenanceQueue: Queue<CatalogMaintenanceJobData> | null = null;
+
+function unavailableSnapshot(): CatalogMaintenanceQueueSnapshot {
+  return {
+    queueName: CATALOG_MAINTENANCE_QUEUE_NAME,
+    available: false,
+    counts: EMPTY_CATALOG_MAINTENANCE_QUEUE_COUNTS,
+    openJobs: 0,
+    updatedAt: new Date().toISOString(),
+  };
+}
 
 function getCatalogMaintenanceQueue(
   redisUrl: string | undefined,
@@ -154,24 +123,24 @@ export async function getCatalogMaintenanceQueueSnapshot(
   const queue = getCatalogMaintenanceQueue(redisUrl);
 
   if (!queue) {
-    return {
-      queueName: CATALOG_MAINTENANCE_QUEUE_NAME,
-      available: false,
-      counts: EMPTY_CATALOG_MAINTENANCE_QUEUE_COUNTS,
-      openJobs: 0,
-      updatedAt: new Date().toISOString(),
-    };
+    return unavailableSnapshot();
   }
 
-  const counts = await queue.getJobCounts(
-    'active',
-    'completed',
-    'delayed',
-    'failed',
-    'prioritized',
-    'waiting',
-    'waiting-children',
-  );
+  let counts: Record<string, number>;
+  try {
+    counts = await queue.getJobCounts(
+      'active',
+      'completed',
+      'delayed',
+      'failed',
+      'prioritized',
+      'waiting',
+      'waiting-children',
+    );
+  } catch (error) {
+    logger.error('Backoffice failed to read BullMQ catalog-maintenance counts', { err: error });
+    return unavailableSnapshot();
+  }
   const normalizedCounts: CatalogMaintenanceQueueSnapshot['counts'] = {
     active: counts.active ?? 0,
     completed: counts.completed ?? 0,
@@ -255,13 +224,12 @@ export async function enqueueCatalogBackfillMovieFromBackoffice(
   if (existingJob) {
     const state = await existingJob.getState();
     if (ACTIVE_DEDUPE_STATES.has(state)) {
-      return {
-        queueName: CATALOG_MAINTENANCE_QUEUE_NAME,
+      return enqueueResult({
         jobName: CATALOG_BACKFILL_MOVIE_JOB_NAME,
         jobId: String(existingJob.id ?? jobId),
         language,
         status: 'deduped',
-      };
+      });
     }
 
     await existingJob.remove();
@@ -283,13 +251,12 @@ export async function enqueueCatalogBackfillMovieFromBackoffice(
     },
   );
 
-  return {
-    queueName: CATALOG_MAINTENANCE_QUEUE_NAME,
+  return enqueueResult({
     jobName: CATALOG_BACKFILL_MOVIE_JOB_NAME,
     jobId: String(job.id ?? jobId),
     language,
     status: 'queued',
-  };
+  });
 }
 
 export async function enqueueCatalogRepairBatchFromBackoffice(
@@ -306,13 +273,12 @@ export async function enqueueCatalogRepairBatchFromBackoffice(
   if (existingJob) {
     const state = await existingJob.getState();
     if (ACTIVE_DEDUPE_STATES.has(state)) {
-      return {
-        queueName: CATALOG_MAINTENANCE_QUEUE_NAME,
+      return enqueueResult({
         jobName: CATALOG_ENQUEUE_REPAIR_BATCH_JOB_NAME,
         jobId: String(existingJob.id ?? jobId),
         language,
         status: 'deduped',
-      };
+      });
     }
 
     await existingJob.remove();
@@ -335,11 +301,10 @@ export async function enqueueCatalogRepairBatchFromBackoffice(
     },
   );
 
-  return {
-    queueName: CATALOG_MAINTENANCE_QUEUE_NAME,
+  return enqueueResult({
     jobName: CATALOG_ENQUEUE_REPAIR_BATCH_JOB_NAME,
     jobId: String(job.id ?? jobId),
     language,
     status: 'queued',
-  };
+  });
 }

--- a/apps/backoffice/src/catalogMaintenanceQueueHelpers.ts
+++ b/apps/backoffice/src/catalogMaintenanceQueueHelpers.ts
@@ -62,6 +62,76 @@ export interface CatalogMaintenanceJobData {
   [key: string]: unknown;
 }
 
+export interface EnqueueCatalogBackfillMovieInput {
+  movieId: string | number;
+  reason: CatalogBackfillReason;
+  language?: string;
+  repairBatchId?: string | number;
+  repairBatchItemId?: string | number;
+}
+
+export interface EnqueueCatalogRepairBatchInput {
+  batchId: string | number;
+  issueKey: string;
+  limit: number;
+  pageSize: number;
+  language?: string;
+  staleAfterDays: number;
+}
+
+export interface EnqueueCatalogBackfillMovieResult {
+  queueName: string;
+  jobName: string;
+  jobId: string;
+  language: string;
+  status: 'queued' | 'deduped';
+}
+
+export interface EnqueueCatalogRepairBatchResult {
+  queueName: string;
+  jobName: string;
+  jobId: string;
+  language: string;
+  status: 'queued' | 'deduped';
+}
+
+export interface CatalogMaintenanceQueueSnapshot {
+  queueName: string;
+  available: boolean;
+  counts: CatalogMaintenanceQueueCounts;
+  openJobs: number;
+  updatedAt: string;
+}
+
+export interface CatalogMaintenanceQueueJobSummary {
+  id: string;
+  name: string;
+  state: CatalogMaintenanceQueueJobState;
+  attemptsMade: number;
+  attemptsConfigured: number | null;
+  createdAt: string | null;
+  processedAt: string | null;
+  finishedAt: string | null;
+  failedReason: string | null;
+  payload: Array<{ label: string; value: string }>;
+  repairBatchId: string | null;
+  repairBatchItemId: string | null;
+  movieId: string | null;
+}
+
+export interface CatalogMaintenanceQueueJobPage {
+  queueName: string;
+  available: boolean;
+  state: CatalogMaintenanceQueueJobState;
+  jobs: CatalogMaintenanceQueueJobSummary[];
+  counts: CatalogMaintenanceQueueCounts;
+  openJobs: number;
+  totalCount: number;
+  limit: number;
+  offset: number;
+  updatedAt: string;
+}
+
 type PayloadEntry = { label: string; value: string };
 
 export function normalizeLanguage(language?: string): string {

--- a/apps/backoffice/src/components/catalogHealthLiveRefresh.tsx
+++ b/apps/backoffice/src/components/catalogHealthLiveRefresh.tsx
@@ -42,6 +42,7 @@ export function CatalogHealthLiveRefresh({
   const router = useRouter();
   const searchParams = useSearchParams();
   const [isPending, startTransition] = useTransition();
+  const [hasMounted, setHasMounted] = useState(false);
   const [connectionState, setConnectionState] = useState<LiveConnectionState>('connecting');
   const [data, setData] = useState(initialData);
   const [isFallbackFetching, setIsFallbackFetching] = useState(false);
@@ -60,6 +61,10 @@ export function CatalogHealthLiveRefresh({
   const lastSearch = useRef(search);
   const refreshRequestId = useRef(0);
   const refreshSeconds = Math.max(fallbackIntervalSeconds, 30);
+
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
 
   useEffect(() => {
     if (lastSearch.current === search) return;
@@ -202,7 +207,7 @@ export function CatalogHealthLiveRefresh({
     <div className={`live-refresh ${connectionState}`} aria-live="polite">
       <span className={status.dotClassName} aria-hidden="true" />
       <span>{status.statusCopy}</span>
-      <span className="live-refresh-meta">{status.metaCopy}</span>
+      <span className="live-refresh-meta">{hasMounted ? status.metaCopy : 'Waiting'}</span>
       <LiveRefreshError text={status.errorText} />
     </div>
   );

--- a/apps/backoffice/src/lib/backofficeRepairAction.test.ts
+++ b/apps/backoffice/src/lib/backofficeRepairAction.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockCreateCatalogRepairBatch,
+  mockCreateCatalogRepairBatchItem,
+  mockEnsureCatalogRepairActionSchema,
+  mockEnsureRecommendationEvalRunSchema,
+  mockEnsureTMDBMatchReviewActionSchema,
+  mockEnqueueCatalogBackfillMovieFromBackoffice,
+  mockGetCatalogRepairMovieSnapshot,
+  mockInitDatabase,
+  mockReadBackofficeRuntimeConfig,
+  mockRecordCatalogRepairAction,
+  mockRefreshCatalogRepairBatchCounts,
+  mockUpdateCatalogRepairBatchItemEnqueueResult,
+} = vi.hoisted(() => ({
+  mockCreateCatalogRepairBatch: vi.fn(),
+  mockCreateCatalogRepairBatchItem: vi.fn(),
+  mockEnsureCatalogRepairActionSchema: vi.fn(),
+  mockEnsureRecommendationEvalRunSchema: vi.fn(),
+  mockEnsureTMDBMatchReviewActionSchema: vi.fn(),
+  mockEnqueueCatalogBackfillMovieFromBackoffice: vi.fn(),
+  mockGetCatalogRepairMovieSnapshot: vi.fn(),
+  mockInitDatabase: vi.fn(),
+  mockReadBackofficeRuntimeConfig: vi.fn(),
+  mockRecordCatalogRepairAction: vi.fn(),
+  mockRefreshCatalogRepairBatchCounts: vi.fn(),
+  mockUpdateCatalogRepairBatchItemEnqueueResult: vi.fn(),
+}));
+
+vi.mock('@pop-choice/shared', () => ({
+  applyTMDBMatchReviewAction: vi.fn(),
+  createCatalogRepairBatch: mockCreateCatalogRepairBatch,
+  createCatalogRepairBatchItem: mockCreateCatalogRepairBatchItem,
+  ensureCatalogRepairActionSchema: mockEnsureCatalogRepairActionSchema,
+  ensureRecommendationEvalRunSchema: mockEnsureRecommendationEvalRunSchema,
+  ensureTMDBMatchReviewActionSchema: mockEnsureTMDBMatchReviewActionSchema,
+  getCatalogRepairMovieSnapshot: mockGetCatalogRepairMovieSnapshot,
+  initDatabase: mockInitDatabase,
+  isTMDBMatchReviewReason: vi.fn(),
+  isTMDBMatchReviewSort: vi.fn(),
+  isTMDBMatchReviewStatus: vi.fn(),
+  listCatalogHealthIssueMoviePage: vi.fn(),
+  logger: { error: vi.fn(), info: vi.fn() },
+  readBackofficeRuntimeConfig: mockReadBackofficeRuntimeConfig,
+  recordCatalogRepairAction: mockRecordCatalogRepairAction,
+  refreshCatalogRepairBatchCounts: mockRefreshCatalogRepairBatchCounts,
+  updateCatalogRepairBatchItemEnqueueResult: mockUpdateCatalogRepairBatchItemEnqueueResult,
+}));
+
+vi.mock('../catalogMaintenanceQueue', () => ({
+  enqueueCatalogBackfillMovieFromBackoffice: mockEnqueueCatalogBackfillMovieFromBackoffice,
+}));
+
+import { performCatalogRepairAction } from './backoffice';
+
+function operatorHeaders(): Headers {
+  return new Headers({
+    authorization: `Basic ${Buffer.from('operator:secret').toString('base64')}`,
+  });
+}
+
+describe('performCatalogRepairAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockReadBackofficeRuntimeConfig.mockReturnValue({
+      catalogHealthSampleLimit: 5,
+      catalogHealthStaleDays: 180,
+      databaseUrl: 'postgres://localhost/popchoice',
+      operatorAuth: null,
+      operatorAuthRateLimitMax: 30,
+      operatorAuthRateLimitWindowSeconds: 900,
+      port: 3004,
+      redisUrl: 'redis://localhost:6379',
+      tmdbLanguage: 'en-US',
+    });
+    mockEnsureCatalogRepairActionSchema.mockResolvedValue(undefined);
+    mockEnsureRecommendationEvalRunSchema.mockResolvedValue(undefined);
+    mockEnsureTMDBMatchReviewActionSchema.mockResolvedValue(undefined);
+    mockGetCatalogRepairMovieSnapshot.mockResolvedValue({
+      age_rating: 'PG-13',
+      duration: 112,
+      id: '334',
+      localized_name: null,
+      name: 'Memento',
+      poster_url: null,
+      tmdb_id: 77,
+      tmdb_match_confidence: 1,
+      tmdb_match_source: 'fixture',
+      tmdb_matched_at: null,
+      tmdb_metadata_refreshed_at: null,
+      year: 2000,
+    });
+    mockCreateCatalogRepairBatch.mockResolvedValue({ id: '7' });
+    mockCreateCatalogRepairBatchItem.mockResolvedValue({ id: '11' });
+    mockEnqueueCatalogBackfillMovieFromBackoffice.mockResolvedValue({
+      jobId: 'backfill-334',
+      jobName: 'backfill-movie',
+      language: 'en-US',
+      queueName: 'catalog-maintenance',
+      status: 'queued',
+    });
+    mockUpdateCatalogRepairBatchItemEnqueueResult.mockResolvedValue({ id: '11' });
+    mockRefreshCatalogRepairBatchCounts.mockResolvedValue({ id: '7' });
+    mockRecordCatalogRepairAction.mockResolvedValue({ id: '21' });
+  });
+
+  it('creates durable batch and item tracking for focused repair jobs', async () => {
+    const formData = new FormData();
+    formData.set('action', 'enqueue_backfill');
+    formData.set('issue_key', 'missing_poster_url');
+    formData.set('movie_id', '334');
+
+    const result = await performCatalogRepairAction(formData, operatorHeaders());
+
+    expect(result).toMatchObject({
+      issueKey: 'missing_poster_url',
+      mode: 'single',
+      movieId: '334',
+      status: 'queued',
+    });
+    expect(mockCreateCatalogRepairBatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'enqueue_backfill',
+        actor: 'operator',
+        attemptedCount: 1,
+        issueKey: 'missing_poster_url',
+        requestedLimit: 1,
+        targetId: '334',
+        targetType: 'movie',
+        totalCandidates: 1,
+      }),
+    );
+    expect(mockCreateCatalogRepairBatchItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        batchId: '7',
+        issueKey: 'missing_poster_url',
+        movieId: '334',
+        reason: 'missing_metadata',
+      }),
+    );
+    expect(mockEnqueueCatalogBackfillMovieFromBackoffice).toHaveBeenCalledWith(
+      expect.objectContaining({
+        movieId: '334',
+        reason: 'missing_metadata',
+        repairBatchId: '7',
+        repairBatchItemId: '11',
+      }),
+      'redis://localhost:6379',
+    );
+    expect(mockUpdateCatalogRepairBatchItemEnqueueResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        itemId: '11',
+        jobId: 'backfill-334',
+        status: 'queued',
+      }),
+    );
+    expect(mockRecordCatalogRepairAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repairBatchId: '7',
+        repairBatchItemId: '11',
+        targetId: '334',
+      }),
+    );
+  });
+});

--- a/apps/backoffice/src/lib/catalogSingleRepairAction.ts
+++ b/apps/backoffice/src/lib/catalogSingleRepairAction.ts
@@ -1,7 +1,11 @@
 import {
+  createCatalogRepairBatch,
+  createCatalogRepairBatchItem,
   getCatalogRepairMovieSnapshot,
   recordCatalogRepairAction,
+  refreshCatalogRepairBatchCounts,
   type BackofficeRuntimeConfig,
+  updateCatalogRepairBatchItemEnqueueResult,
 } from '@pop-choice/shared';
 
 import { enqueueCatalogBackfillMovieFromBackoffice } from '../catalogMaintenanceQueue';
@@ -30,24 +34,61 @@ export async function performSingleCatalogRepairAction({
     throw backofficeActionError('Movie not found.', 404);
   }
 
+  const actor = parseOperatorActor(headers);
+  const note = typeof formData.get('note') === 'string' ? String(formData.get('note')) : undefined;
+  const reason = getBackfillReasonForIssue(issueKey);
+  const batch = await createCatalogRepairBatch({
+    action: 'enqueue_backfill',
+    actor,
+    issueKey,
+    targetType: 'movie',
+    targetId: movieId,
+    requestedLimit: 1,
+    totalCandidates: 1,
+    attemptedCount: 1,
+    note,
+    previousState: { ...snapshot },
+  });
+  const batchItem = await createCatalogRepairBatchItem({
+    batchId: batch.id,
+    issueKey,
+    language: config.tmdbLanguage,
+    movieId,
+    movieSnapshot: { ...snapshot },
+    reason,
+  });
   const job = await enqueueCatalogBackfillMovieFromBackoffice(
     {
       movieId,
-      reason: getBackfillReasonForIssue(issueKey),
+      reason,
       language: config.tmdbLanguage,
+      repairBatchId: batch.id,
+      repairBatchItemId: batchItem.id,
     },
     config.redisUrl,
   );
 
+  await updateCatalogRepairBatchItemEnqueueResult({
+    itemId: batchItem.id,
+    status: job?.status ?? 'unavailable',
+    queueName: job?.queueName ?? 'catalog-maintenance',
+    jobName: job?.jobName,
+    jobId: job?.jobId,
+    language: job?.language ?? config.tmdbLanguage,
+    result: job ? { ...job } : { status: 'queue_unavailable', queueName: 'catalog-maintenance' },
+  });
+  await refreshCatalogRepairBatchCounts(batch.id);
   await recordCatalogRepairAction({
     action: 'enqueue_backfill',
-    actor: parseOperatorActor(headers),
+    actor,
     issueKey,
     targetType: 'movie',
     targetId: movieId,
-    note: typeof formData.get('note') === 'string' ? String(formData.get('note')) : undefined,
+    note,
     previousState: { ...snapshot },
     result: job ? { ...job } : { status: 'queue_unavailable', queueName: 'catalog-maintenance' },
+    repairBatchId: batch.id,
+    repairBatchItemId: batchItem.id,
   });
 
   return {

--- a/apps/backoffice/src/lib/sameOriginRequest.test.ts
+++ b/apps/backoffice/src/lib/sameOriginRequest.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { isSameOriginRequest } from './sameOriginRequest';
+import { backofficeRedirectUrl, isSameOriginRequest } from './sameOriginRequest';
 
 type SameOriginRequest = Parameters<typeof isSameOriginRequest>[0];
 
@@ -80,5 +80,45 @@ describe('isSameOriginRequest', () => {
         }),
       ),
     ).toBe(false);
+  });
+});
+
+describe('backofficeRedirectUrl', () => {
+  it('prefers forwarded public hosts over bind addresses', () => {
+    expect(
+      backofficeRedirectUrl(
+        request('http://0.0.0.0:3000/catalog-health/actions', {
+          host: '0.0.0.0:3000',
+          'x-forwarded-host': 'backoffice.pop-choice.shchilkin.dev',
+          'x-forwarded-proto': 'https',
+        }),
+        '/?repair=queued',
+      ).toString(),
+    ).toBe('https://backoffice.pop-choice.shchilkin.dev/?repair=queued');
+  });
+
+  it('can use same-origin request evidence after validation', () => {
+    expect(
+      backofficeRedirectUrl(
+        request('http://0.0.0.0:3000/catalog-health/actions', {
+          origin: 'https://backoffice.pop-choice.shchilkin.dev',
+        }),
+        '/?repair=queued',
+        { trustRequestEvidence: true },
+      ).toString(),
+    ).toBe('https://backoffice.pop-choice.shchilkin.dev/?repair=queued');
+  });
+
+  it('does not trust bind-address origin evidence for redirects', () => {
+    expect(
+      backofficeRedirectUrl(
+        request('http://0.0.0.0:3000/catalog-health/actions', {
+          host: '0.0.0.0:3000',
+          origin: 'http://0.0.0.0:3000',
+        }),
+        '/?repair=queued',
+        { trustRequestEvidence: true },
+      ).toString(),
+    ).toBe('http://localhost/?repair=queued');
   });
 });

--- a/apps/backoffice/src/lib/sameOriginRequest.ts
+++ b/apps/backoffice/src/lib/sameOriginRequest.ts
@@ -2,6 +2,87 @@ import type { NextRequest } from 'next/server';
 
 import { expectedSameOrigins, hasMatchingOriginEvidence } from './sameOriginRequestOrigins';
 
+function normalizedOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}
+
+function normalizedSafeOrigin(value: string): string | null {
+  const origin = normalizedOrigin(value);
+  if (!origin) return null;
+
+  const { host } = new URL(origin);
+  return isBindableHost(host) ? null : origin;
+}
+
+function lastHeaderValue(value: string | null): string | null {
+  const last = value
+    ?.split(',')
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .at(-1);
+
+  return last || null;
+}
+
+function firstHeaderValue(value: string | null): string | null {
+  const first = value
+    ?.split(',')
+    .map((part) => part.trim())
+    .filter(Boolean)
+    .at(0);
+
+  return first || null;
+}
+
 export function isSameOriginRequest(request: NextRequest): boolean {
   return hasMatchingOriginEvidence(request.headers, expectedSameOrigins(request));
+}
+
+function requestProtocol(request: NextRequest): string {
+  const forwardedProto = firstHeaderValue(request.headers.get('x-forwarded-proto'));
+  if (forwardedProto) return forwardedProto;
+
+  const origin = normalizedOrigin(request.url);
+  return origin ? new URL(request.url).protocol.replace(/:$/, '') : 'http';
+}
+
+function isBindableHost(host: string): boolean {
+  const hostname = host
+    .split(':')[0]
+    ?.replace(/^\[|\]$/g, '')
+    .toLowerCase();
+  return hostname === '0.0.0.0' || hostname === '::' || hostname === '';
+}
+
+export function backofficeRedirectUrl(
+  request: NextRequest,
+  path: string,
+  { trustRequestEvidence = false }: { trustRequestEvidence?: boolean } = {},
+): URL {
+  const forwardedHost = lastHeaderValue(request.headers.get('x-forwarded-host'));
+  const host = forwardedHost ?? request.headers.get('host');
+  if (host && !isBindableHost(host)) {
+    return new URL(path, `${requestProtocol(request)}://${host}`);
+  }
+
+  if (trustRequestEvidence) {
+    const origin = request.headers.get('origin');
+    const normalizedRequestOrigin = origin ? normalizedSafeOrigin(origin) : null;
+    if (normalizedRequestOrigin) return new URL(path, normalizedRequestOrigin);
+
+    const referer = request.headers.get('referer');
+    const normalizedReferer = referer ? normalizedSafeOrigin(referer) : null;
+    if (normalizedReferer) return new URL(path, normalizedReferer);
+  }
+
+  const requestUrl = new URL(request.url);
+  if (!isBindableHost(requestUrl.host)) {
+    return new URL(path, requestUrl);
+  }
+
+  return new URL(path, 'http://localhost');
 }

--- a/apps/web/src/lib/workers/catalogMaintenanceWorker.test.ts
+++ b/apps/web/src/lib/workers/catalogMaintenanceWorker.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  capturedProcessor,
+  mockCreateBullMQConnection,
+  mockCreateEmbeddings,
+  mockEnsureCatalogMetadataSchema,
+  mockEnsureCatalogRepairActionSchema,
+  mockExtractCatalogMetadata,
+  mockExtractUSCertification,
+  mockFetchMovieDetails,
+  mockGetPool,
+  mockInitDatabase,
+  mockRecordQueueJobEvent,
+  mockUpsertMovieCatalogMetadata,
+  mockWorkerOn,
+  MockWorker,
+} = vi.hoisted(() => {
+  const capturedProcessor: { current: ((job: unknown) => Promise<void>) | null } = {
+    current: null,
+  };
+  const mockWorkerOn = vi.fn();
+
+  function MockWorker(
+    this: { on: ReturnType<typeof vi.fn>; waitUntilReady: ReturnType<typeof vi.fn> },
+    _queue: string,
+    processor: (job: unknown) => Promise<void>,
+  ) {
+    capturedProcessor.current = processor;
+    this.on = mockWorkerOn;
+    this.waitUntilReady = vi.fn().mockResolvedValue(undefined);
+  }
+
+  return {
+    capturedProcessor,
+    mockCreateBullMQConnection: vi.fn(),
+    mockCreateEmbeddings: vi.fn(),
+    mockEnsureCatalogMetadataSchema: vi.fn(),
+    mockEnsureCatalogRepairActionSchema: vi.fn(),
+    mockExtractCatalogMetadata: vi.fn(),
+    mockExtractUSCertification: vi.fn(),
+    mockFetchMovieDetails: vi.fn(),
+    mockGetPool: vi.fn(),
+    mockInitDatabase: vi.fn(),
+    mockRecordQueueJobEvent: vi.fn(),
+    mockUpsertMovieCatalogMetadata: vi.fn(),
+    mockWorkerOn,
+    MockWorker,
+  };
+});
+
+vi.mock('bullmq', () => ({
+  Worker: Object.assign(MockWorker, {
+    RateLimitError: () => new Error('rate limited'),
+  }),
+}));
+
+vi.mock('@pop-choice/shared', () => ({
+  catalogRepairCompletionStatusForResolution: (resolved: boolean) =>
+    resolved ? 'completed_resolved' : 'completed_unresolved',
+  createEmbeddings: mockCreateEmbeddings,
+  ensureCatalogMetadataSchema: mockEnsureCatalogMetadataSchema,
+  ensureCatalogRepairActionSchema: mockEnsureCatalogRepairActionSchema,
+  getPool: mockGetPool,
+  initDatabase: mockInitDatabase,
+  insertMovies: vi.fn(),
+  isCatalogHealthIssueResolvedForMovie: vi.fn().mockResolvedValue(true),
+  refreshCatalogRepairBatchCounts: vi.fn(),
+  updateCatalogRepairBatchItemStatus: vi.fn(),
+  upsertMovieCatalogMetadata: mockUpsertMovieCatalogMetadata,
+}));
+
+vi.mock('@/features/catalogMaintenance/tmdb', () => ({
+  TMDBRateLimitError: class TMDBRateLimitError extends Error {
+    retryAfterMs = 1000;
+  },
+  extractCatalogMetadata: mockExtractCatalogMetadata,
+  extractUSCertification: mockExtractUSCertification,
+  fetchMovieDetails: mockFetchMovieDetails,
+  fetchTMDBSourcePage: vi.fn(),
+  getPosterUrl: (path: string | null | undefined) =>
+    path ? `https://image.tmdb.org/t/p/w500${path}` : null,
+  movieToEmbeddingText: vi.fn().mockReturnValue('embedding text'),
+  parseTMDBYear: vi.fn().mockReturnValue(2024),
+  searchMovieMatch: vi.fn(),
+}));
+
+vi.mock('@/lib/jobQueue', () => ({
+  CATALOG_MAINTENANCE_JOB_NAMES: {
+    backfillMovie: 'backfill-movie',
+    discoverTMDBSourcePage: 'discover-tmdb-source-page',
+    seedTMDBMovie: 'seed-tmdb-movie',
+  },
+  CATALOG_MAINTENANCE_JOB_OPTIONS: {
+    attempts: 4,
+    backoff: { type: 'exponential', delay: 5000 },
+    removeOnComplete: 500,
+    removeOnFail: 200,
+  },
+  CATALOG_MAINTENANCE_QUEUE_NAME: 'catalog-maintenance',
+  createBullMQConnection: mockCreateBullMQConnection,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  default: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+vi.mock('@/lib/metrics', () => ({
+  recordQueueJobEvent: mockRecordQueueJobEvent,
+  recordTMDBProviderError: vi.fn(),
+}));
+vi.mock('@/lib/tracing', () => ({
+  withTraceSpan: (_name: string, _options: unknown, callback: () => Promise<void>) => callback(),
+}));
+
+import { createCatalogMaintenanceWorker } from './catalogMaintenanceWorker';
+
+function backfillJob(reason: 'missing_metadata' | 'missing_tmdb_id' = 'missing_metadata') {
+  return {
+    attemptsMade: 0,
+    data: {
+      language: 'en-US',
+      movieId: '334',
+      reason,
+      version: 1,
+    },
+    id: 'backfill-334',
+    name: 'backfill-movie',
+  };
+}
+
+describe('createCatalogMaintenanceWorker', () => {
+  const query = vi.fn();
+
+  beforeEach(() => {
+    vi.stubEnv('DATABASE_URL', 'postgres://localhost/test');
+    vi.stubEnv('TMDB_API_KEY', 'tmdb-test-key');
+    vi.stubEnv('OPENAI_API_KEY', '');
+    mockCreateBullMQConnection.mockReturnValue({ host: 'localhost' });
+    mockEnsureCatalogMetadataSchema.mockResolvedValue(undefined);
+    mockEnsureCatalogRepairActionSchema.mockResolvedValue(undefined);
+    mockGetPool.mockReturnValue({ query });
+    query.mockReset();
+    query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            description: 'A puzzle thriller.',
+            duration: 113,
+            id: '334',
+            name: 'Memento',
+            score_rating: 8.4,
+            tmdb_id: 77,
+            year: 2000,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+    mockFetchMovieDetails.mockResolvedValue({
+      id: 77,
+      original_language: 'en',
+      original_title: 'Memento',
+      overview: 'A puzzle thriller.',
+      popularity: 20,
+      poster_path: '/poster.jpg',
+      release_date: '2000-10-11',
+      runtime: 113,
+      title: 'Memento',
+      vote_average: 8.4,
+      vote_count: 1000,
+    });
+    mockExtractUSCertification.mockReturnValue('R');
+    mockExtractCatalogMetadata.mockReturnValue({
+      genres: [],
+      keywords: [],
+      people: [],
+      providers: [],
+      qualityFlags: [],
+      qualityScore: 100,
+      snapshot: { id: 77, title: 'Memento' },
+    });
+    mockUpsertMovieCatalogMetadata.mockResolvedValue(undefined);
+    mockCreateEmbeddings.mockResolvedValue([[0.1, 0.2]]);
+    mockWorkerOn.mockReset();
+    capturedProcessor.current = null;
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+  });
+
+  it('does not require OpenAI embeddings for metadata-only backfill jobs', async () => {
+    createCatalogMaintenanceWorker();
+
+    expect(capturedProcessor.current).not.toBeNull();
+    await capturedProcessor.current!(backfillJob('missing_metadata'));
+
+    expect(mockCreateEmbeddings).not.toHaveBeenCalled();
+    expect(query.mock.calls[1][0]).toContain('embedding = COALESCE($7::vector, embedding)');
+    expect(query.mock.calls[1][1][6]).toBeNull();
+    expect(mockUpsertMovieCatalogMetadata).toHaveBeenCalledWith(
+      expect.objectContaining({ movieId: '334' }),
+    );
+  });
+
+  it('still requires OpenAI embeddings for missing TMDB identity backfills', async () => {
+    createCatalogMaintenanceWorker();
+
+    await expect(capturedProcessor.current!(backfillJob('missing_tmdb_id'))).rejects.toThrow(
+      'OPENAI_API_KEY is required for catalog backfill jobs',
+    );
+  });
+});

--- a/apps/web/src/lib/workers/catalogMaintenanceWorker.ts
+++ b/apps/web/src/lib/workers/catalogMaintenanceWorker.ts
@@ -1164,12 +1164,6 @@ function getRequiredTMDBApiKeyForBackfill(): string {
   return apiKey;
 }
 
-function getRequiredOpenAIKeyForBackfill(): string {
-  const openAIKey = process.env.OPENAI_API_KEY;
-  if (!openAIKey) throw new Error('OPENAI_API_KEY is required for catalog backfill jobs');
-  return openAIKey;
-}
-
 async function resolveBackfillMovieMatch(
   apiKey: string,
   movie: BackfillMovieRow,
@@ -1272,10 +1266,18 @@ function getBackfillEmbeddingText(prepared: Extract<PreparedBackfillMovie, { sta
 
 async function createBackfillEmbedding(
   prepared: Extract<PreparedBackfillMovie, { status: 'ready' }>,
-): Promise<number[]> {
-  const [embedding] = await createEmbeddings(getRequiredOpenAIKeyForBackfill(), [
-    getBackfillEmbeddingText(prepared),
-  ]);
+  reason: CatalogBackfillMovieJobData['reason'],
+): Promise<number[] | null> {
+  const openAIKey = process.env.OPENAI_API_KEY;
+  if (!openAIKey) {
+    const requiresEmbeddingRefresh = reason === 'missing_tmdb_id' || !reason;
+    if (requiresEmbeddingRefresh) {
+      throw new Error('OPENAI_API_KEY is required for catalog backfill jobs');
+    }
+    return null;
+  }
+
+  const [embedding] = await createEmbeddings(openAIKey, [getBackfillEmbeddingText(prepared)]);
   if (!embedding) throw new Error(`Embedding missing for movie ${prepared.movie.id}`);
   return embedding;
 }
@@ -1316,7 +1318,7 @@ function getBackfillPopularity(details: TMDBMovieDetails): number | null {
 }
 
 async function updateBackfilledMovie(input: {
-  embedding: number[];
+  embedding: number[] | null;
   metadata: TMDBCatalogMetadata;
   prepared: Extract<PreparedBackfillMovie, { status: 'ready' }>;
 }): Promise<void> {
@@ -1332,7 +1334,7 @@ async function updateBackfilledMovie(input: {
             tmdb_matched_at = now(),
             poster_url = COALESCE($5, poster_url),
             localized_name = COALESCE($6, localized_name),
-            embedding = $7::vector,
+            embedding = COALESCE($7::vector, embedding),
             original_title = $8,
             original_language = $9,
             release_date = $10::date,
@@ -1348,7 +1350,7 @@ async function updateBackfilledMovie(input: {
       match.confidence,
       getBackfillPosterUrl(details),
       getBackfillLocalizedName(details, movie),
-      JSON.stringify(input.embedding),
+      input.embedding ? JSON.stringify(input.embedding) : null,
       getBackfillOriginalTitle(details),
       getBackfillOriginalLanguage(details),
       getBackfillReleaseDate(details),
@@ -1367,7 +1369,7 @@ async function persistBackfillMovie(input: {
   repairItem: CatalogRepairBatchItem | null;
 }): Promise<void> {
   const metadata = extractCatalogMetadata(input.prepared.details);
-  const embedding = await createBackfillEmbedding(input.prepared);
+  const embedding = await createBackfillEmbedding(input.prepared, input.job.data.reason);
 
   await updateBackfilledMovie({ embedding, metadata, prepared: input.prepared });
   await upsertSeedCatalogMetadata(input.prepared.movie.id, metadata);

--- a/packages/shared/src/catalogHealth.test.ts
+++ b/packages/shared/src/catalogHealth.test.ts
@@ -45,7 +45,7 @@ describe('catalog health issue movie pages', () => {
           id: '334',
           name: 'Memento',
           year: 2000,
-          tmdb_id: null,
+          tmdb_id: 77,
           poster_url: null,
           localized_name: null,
           duration: 113,
@@ -68,7 +68,7 @@ describe('catalog health issue movie pages', () => {
       totalCount: 351,
       limit: MAX_CATALOG_HEALTH_ISSUE_PAGE_SIZE,
       offset: MAX_CATALOG_HEALTH_ISSUE_OFFSET,
-      movies: [{ id: '334', name: 'Memento', tmdb_id: null }],
+      movies: [{ id: '334', name: 'Memento', tmdb_id: 77 }],
     });
     expect(poolMock.query).toHaveBeenCalledTimes(2);
     expect(poolMock.query.mock.calls[0][1]).toEqual([]);
@@ -76,6 +76,62 @@ describe('catalog health issue movie pages', () => {
       MAX_CATALOG_HEALTH_ISSUE_PAGE_SIZE,
       MAX_CATALOG_HEALTH_ISSUE_OFFSET,
     ]);
+  });
+
+  it('keeps TMDB-dependent metadata counts behind the missing-tmdb-id hierarchy', async () => {
+    poolMock.query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            total_movies: 1,
+            missing_poster_url: 0,
+            missing_localized_name: 0,
+            missing_tmdb_id: 1,
+            missing_runtime: 0,
+            missing_age_rating: 0,
+            missing_tmdb_matched_at: 0,
+            stale_tmdb_metadata: 0,
+            missing_cast_metadata: 0,
+            missing_director_metadata: 0,
+            missing_genre_metadata: 0,
+            missing_keyword_metadata: 0,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: '334',
+            name: 'Memento',
+            year: 2000,
+            tmdb_id: null,
+            poster_url: null,
+            localized_name: null,
+            duration: 0,
+            age_rating: '',
+            tmdb_matched_at: null,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const report = await getCatalogHealthReport({ sampleLimit: 5, staleAfterDays: 180 });
+
+    expect(report.issues.find((issue) => issue.key === 'missing_tmdb_id')).toMatchObject({
+      count: 1,
+      samples: [{ id: '334', tmdb_id: null }],
+    });
+    expect(report.issues.find((issue) => issue.key === 'missing_poster_url')?.count).toBe(0);
+    const summarySql = String(poolMock.query.mock.calls[0][0]);
+    expect(summarySql).toContain(
+      "tmdb_id IS NOT NULL AND (poster_url IS NULL OR btrim(poster_url) = '')",
+    );
+    expect(summarySql).toContain('tmdb_id IS NOT NULL AND duration <= 0');
+    expect(summarySql).toContain(
+      "tmdb_id IS NOT NULL AND (age_rating IS NULL OR btrim(age_rating) = '')",
+    );
+    expect(summarySql).toContain('tmdb_metadata_refreshed_at IS NULL');
   });
 
   it('keeps stale metadata threshold parameterized separately from pagination', async () => {
@@ -110,8 +166,25 @@ describe('catalog health issue movie pages', () => {
 
     expect(String(poolMock.query.mock.calls[0][0])).toContain('WHERE id = $1');
     expect(String(poolMock.query.mock.calls[0][0])).toContain(
-      "poster_url IS NULL OR btrim(poster_url) = ''",
+      "tmdb_id IS NOT NULL AND (poster_url IS NULL OR btrim(poster_url) = '')",
     );
+    expect(poolMock.query.mock.calls[0][1]).toEqual(['334']);
+  });
+
+  it('considers missing localized_name resolved after a TMDB metadata refresh', async () => {
+    poolMock.query.mockResolvedValueOnce({ rows: [{ issue_exists: false }] });
+
+    await expect(
+      isCatalogHealthIssueResolvedForMovie({
+        issueKey: 'missing_localized_name',
+        movieId: '334',
+        staleAfterDays: 180,
+      }),
+    ).resolves.toBe(true);
+
+    const sql = String(poolMock.query.mock.calls[0][0]);
+    expect(sql).toContain("(localized_name IS NULL OR btrim(localized_name) = '')");
+    expect(sql).toContain('tmdb_metadata_refreshed_at IS NULL');
     expect(poolMock.query.mock.calls[0][1]).toEqual(['334']);
   });
 

--- a/packages/shared/src/catalogHealth.ts
+++ b/packages/shared/src/catalogHealth.ts
@@ -106,13 +106,19 @@ const SUMMARY_METRIC_KEYS: SummaryMetricKey[] = [
   'missing_keyword_metadata',
 ];
 
+const MISSING_LOCALIZED_NAME_WHERE = `
+      tmdb_id IS NOT NULL
+        AND (localized_name IS NULL OR btrim(localized_name) = '')
+        AND tmdb_metadata_refreshed_at IS NULL
+`;
+
 const SUMMARY_SQL = `SELECT
     COUNT(*)::int AS total_movies,
-    COUNT(*) FILTER (WHERE poster_url IS NULL OR btrim(poster_url) = '')::int AS missing_poster_url,
-    COUNT(*) FILTER (WHERE localized_name IS NULL OR btrim(localized_name) = '')::int AS missing_localized_name,
+    COUNT(*) FILTER (WHERE tmdb_id IS NOT NULL AND (poster_url IS NULL OR btrim(poster_url) = ''))::int AS missing_poster_url,
+    COUNT(*) FILTER (WHERE ${MISSING_LOCALIZED_NAME_WHERE})::int AS missing_localized_name,
     COUNT(*) FILTER (WHERE tmdb_id IS NULL)::int AS missing_tmdb_id,
-    COUNT(*) FILTER (WHERE duration <= 0)::int AS missing_runtime,
-    COUNT(*) FILTER (WHERE age_rating IS NULL OR btrim(age_rating) = '')::int AS missing_age_rating,
+    COUNT(*) FILTER (WHERE tmdb_id IS NOT NULL AND duration <= 0)::int AS missing_runtime,
+    COUNT(*) FILTER (WHERE tmdb_id IS NOT NULL AND (age_rating IS NULL OR btrim(age_rating) = ''))::int AS missing_age_rating,
     COUNT(*) FILTER (WHERE tmdb_id IS NOT NULL AND tmdb_matched_at IS NULL)::int AS missing_tmdb_matched_at,
     COUNT(*) FILTER (
       WHERE tmdb_id IS NOT NULL
@@ -179,12 +185,12 @@ export const CATALOG_HEALTH_ISSUE_DEFINITIONS: CatalogHealthIssueDefinition[] = 
   {
     key: 'missing_poster_url',
     label: 'Missing poster_url',
-    where: () => "poster_url IS NULL OR btrim(poster_url) = ''",
+    where: () => "tmdb_id IS NOT NULL AND (poster_url IS NULL OR btrim(poster_url) = '')",
   },
   {
     key: 'missing_localized_name',
     label: 'Missing localized_name',
-    where: () => "localized_name IS NULL OR btrim(localized_name) = ''",
+    where: () => MISSING_LOCALIZED_NAME_WHERE,
   },
   {
     key: 'missing_tmdb_id',
@@ -194,12 +200,12 @@ export const CATALOG_HEALTH_ISSUE_DEFINITIONS: CatalogHealthIssueDefinition[] = 
   {
     key: 'missing_runtime',
     label: 'Missing runtime',
-    where: () => 'duration <= 0',
+    where: () => 'tmdb_id IS NOT NULL AND duration <= 0',
   },
   {
     key: 'missing_age_rating',
     label: 'Missing age_rating',
-    where: () => "age_rating IS NULL OR btrim(age_rating) = ''",
+    where: () => "tmdb_id IS NOT NULL AND (age_rating IS NULL OR btrim(age_rating) = '')",
   },
   {
     key: 'missing_tmdb_matched_at',

--- a/packages/shared/src/catalogRepairActions.test.ts
+++ b/packages/shared/src/catalogRepairActions.test.ts
@@ -222,7 +222,10 @@ describe('catalog repair audit pages', () => {
       null,
       JSON.stringify({ issueKey: 'missing_poster_url' }),
     ]);
-    expect(poolMock.query.mock.calls[2][0]).toContain("WHEN $2 IN ('queued', 'deduped') THEN NULL");
+    expect(poolMock.query.mock.calls[2][0]).toContain(
+      "WHEN $2 IN ('deduped', 'unavailable', 'enqueue_failed') THEN now()",
+    );
+    expect(poolMock.query.mock.calls[2][0]).toContain("WHEN $2 = 'queued' THEN NULL");
     expect(poolMock.query.mock.calls[2][1][7]).toBe(JSON.stringify({ status: 'queued' }));
   });
 
@@ -304,9 +307,56 @@ describe('catalog repair audit pages', () => {
       "status IN ('completed', 'completed_resolved')",
     );
     expect(String(poolMock.query.mock.calls[0][0])).toContain("status = 'completed_unresolved'");
+    expect(String(poolMock.query.mock.calls[0][0])).toContain(
+      'completed_count + deduped_count = attempted_count',
+    );
     expect(String(poolMock.query.mock.calls[0][0])).toContain("'completedUnresolved'");
     expect(String(poolMock.query.mock.calls[0][0])).toContain(
-      'WHEN completed_count = attempted_count THEN',
+      'WHEN completed_count + deduped_count = attempted_count THEN',
+    );
+  });
+
+  it('treats deduped enqueue outcomes as terminal batch progress', async () => {
+    poolMock.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: '11',
+          batch_id: '7',
+          movie_id: '334',
+          issue_key: 'missing_poster_url',
+          status: 'deduped',
+          queue_name: 'catalog-maintenance',
+          job_name: 'backfill-movie',
+          job_id: 'backfill-334',
+          language: 'en-US',
+          reason: 'missing_metadata',
+          error_message: null,
+          movie_snapshot: { id: '334' },
+          result: { status: 'deduped' },
+          created_at: '2026-05-28 09:00:01+00',
+          updated_at: '2026-05-28 09:00:02+00',
+          completed_at: '2026-05-28 09:00:02+00',
+        },
+      ],
+    });
+
+    const item = await updateCatalogRepairBatchItemEnqueueResult({
+      itemId: '11',
+      status: 'deduped',
+      queueName: 'catalog-maintenance',
+      jobName: 'backfill-movie',
+      jobId: 'backfill-334',
+      language: 'en-US',
+      result: { status: 'deduped' },
+    });
+
+    expect(item).toMatchObject({
+      completedAt: '2026-05-28 09:00:02+00',
+      id: '11',
+      status: 'deduped',
+    });
+    expect(String(poolMock.query.mock.calls[0][0])).toContain(
+      "WHEN $2 IN ('deduped', 'unavailable', 'enqueue_failed') THEN now()",
     );
   });
 

--- a/packages/shared/src/catalogRepairActions.ts
+++ b/packages/shared/src/catalogRepairActions.ts
@@ -725,8 +725,8 @@ export async function updateCatalogRepairBatchItemEnqueueResult(
             result = COALESCE($8::jsonb, result),
             updated_at = now(),
             completed_at = CASE
-              WHEN $2 IN ('unavailable', 'enqueue_failed') THEN now()
-              WHEN $2 IN ('queued', 'deduped') THEN NULL
+              WHEN $2 IN ('deduped', 'unavailable', 'enqueue_failed') THEN now()
+              WHEN $2 = 'queued' THEN NULL
               ELSE completed_at
             END
       WHERE id = $1
@@ -833,14 +833,15 @@ export async function refreshCatalogRepairBatchCounts(
          *,
          CASE
            WHEN attempted_count = 0 THEN 'empty'
-           WHEN completed_count = attempted_count THEN 'completed'
+           WHEN completed_count + deduped_count = attempted_count THEN 'completed'
            WHEN failed_count = attempted_count THEN 'failed'
            WHEN unavailable_count = attempted_count THEN 'unavailable'
            WHEN completed_count
              + unresolved_count
              + skipped_count
              + failed_count
-             + unavailable_count = attempted_count
+             + unavailable_count
+             + deduped_count = attempted_count
              THEN 'partial'
            WHEN failed_count + unavailable_count + unresolved_count + skipped_count > 0 THEN 'partial'
            WHEN processing_count > 0 THEN 'processing'


### PR DESCRIPTION
## Summary
- fix safe backoffice redirects so repair actions never send operators to bind hosts like 0.0.0.0
- make focused repair create durable repair batch/item records and keep deduped repair items terminal for batch completion
- enforce catalog-health repair hierarchy: TMDB-dependent metadata issues wait for tmdb_id, and metadata-only backfills can run without OpenAI embeddings
- add backoffice Playwright e2e coverage plus focused unit coverage for queue, repair, health, and worker edge cases

## Checks
- npm run test --workspace=packages/shared -- catalogHealth catalogRepairActions
- npm run build --workspace=packages/shared
- npm run test --workspace=apps/backoffice
- npm run type-check --workspace=apps/backoffice
- npm run test --workspace=apps/web -- catalogMaintenanceWorker
- npm run type-check --workspace=apps/web
- npm run test:e2e:backoffice