### PR TITLE
Polish backoffice repair UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,9 @@ storybook-static
 # Claude
 .claude/
 
+# local agent artifacts
+.impeccable/
+
 # Turborepo
 .turbo
 **/.turbo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,10 @@ Before opening or marking ready any PR that changes user-facing or operator-faci
 issues before publishing the PR. If a finding is intentionally deferred, document why in the PR
 description and add or link a follow-up issue.
 
+Do not commit raw `.impeccable/critique/*` snapshots. They are local agent working notes and are
+ignored by git. Promote durable decisions into `DESIGN.md`, `docs/UI-DEVELOPMENT.md`,
+`docs/ROADMAP-ARCHITECTURE.md`, or the PR description instead.
+
 ## Gotchas
 
 - Next.js uses `apps/web/src/proxy.ts` for the CSRF cookie path. Older docs or comments may still say middleware.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -117,6 +117,7 @@ The backoffice is a working console, not a brand showcase. Prefer a minimal, cle
 - Show actionable work first. Healthy or resolved state belongs in compact secondary summaries below the work queue, not as full-size panels mixed into the action list.
 - Avoid decorative glow, ambient shine, or showcase effects in operational views. Reserve accent color for active navigation, warnings, repair actions, and status.
 - Prefer one-line labels and copy when they remain readable. Let layout breathe with vertical spacing instead of forced line breaks.
+- Treat design critiques as inputs, not source artifacts. Keep raw agent snapshots local; document lasting backoffice decisions here or in `docs/UI-DEVELOPMENT.md`.
 
 ## 2. Colors: The Marquee Palette
 

--- a/apps/backoffice/src/app/globals.css
+++ b/apps/backoffice/src/app/globals.css
@@ -805,62 +805,6 @@ input:disabled {
   font-weight: 900;
   text-align: center;
 }
-.healthy-checks {
-  display: grid;
-  gap: 10px;
-  margin-bottom: 14px;
-  padding: 12px 14px;
-  border: 1px solid color-mix(in srgb, var(--good), var(--border) 74%);
-  border-radius: 8px;
-  background: rgba(21, 24, 29, 0.62);
-}
-.healthy-checks-heading {
-  display: flex;
-  justify-content: space-between;
-  gap: 12px;
-  align-items: center;
-}
-.healthy-checks-heading .page-kicker {
-  margin-bottom: 3px;
-  color: var(--good);
-}
-.healthy-checks-heading h2 {
-  font-size: 15px;
-}
-.healthy-checks-list {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 6px 18px;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-.healthy-checks-list li {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  min-width: 0;
-  gap: 8px;
-  align-items: center;
-  padding: 2px 0;
-  color: var(--muted);
-  font-size: 12px;
-  font-weight: 750;
-}
-.healthy-checks-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 999px;
-  background: var(--good);
-}
-.healthy-checks-list span:nth-child(2) {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.healthy-checks-list span:last-child {
-  color: var(--good);
-  white-space: nowrap;
-}
 .queue-tabs {
   display: flex;
   gap: 8px;
@@ -1259,65 +1203,6 @@ input:disabled {
   display: grid;
   gap: 6px;
   margin: 0;
-}
-.movie-repair-panel {
-  display: grid;
-  gap: 14px;
-}
-.movie-repair-form {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: end;
-  gap: 12px;
-  margin: 0;
-}
-.movie-repair-form label {
-  display: grid;
-  gap: 6px;
-  min-width: min(320px, 100%);
-  color: var(--muted);
-  font-size: 12px;
-  font-weight: 800;
-}
-.movie-repair-form select {
-  min-height: 42px;
-  padding: 0 12px;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--surface);
-  color: var(--text);
-  font: inherit;
-  font-weight: 800;
-}
-.manual-metadata-panel {
-  gap: 12px;
-}
-.manual-metadata-form {
-  display: grid;
-  grid-template-columns: repeat(5, minmax(150px, 1fr)) auto;
-  gap: 10px;
-  align-items: end;
-  margin: 0;
-}
-.manual-metadata-form label {
-  display: grid;
-  gap: 5px;
-  min-width: 0;
-  color: var(--muted);
-  font-size: 12px;
-  font-weight: 800;
-}
-.manual-metadata-form label span {
-  overflow: hidden;
-  color: var(--muted-2);
-  font-size: 11px;
-  font-weight: 700;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.manual-metadata-form input {
-  width: 100%;
-  min-width: 0;
 }
 .bulk-repair-actions {
   display: grid;
@@ -1749,107 +1634,15 @@ input:disabled {
   gap: 14px;
   margin-bottom: 14px;
 }
-.movie-cockpit {
-  display: grid;
-  grid-template-columns: minmax(420px, 1.05fr) minmax(360px, 0.95fr);
-  gap: 14px;
-  align-items: start;
-  margin-bottom: 14px;
+.detail-grid .panel.needs-work {
+  border-color: var(--border);
 }
-.movie-cockpit .panel {
-  margin-bottom: 0;
-}
-.movie-cockpit-actions {
-  display: grid;
-  gap: 14px;
-}
-.movie-cockpit .manual-metadata-form {
-  grid-template-columns: repeat(2, minmax(150px, 1fr));
-}
-.movie-cockpit .manual-metadata-form button {
-  justify-self: start;
-}
-.movie-identity {
-  display: grid;
-  grid-template-columns: 150px minmax(0, 1fr);
-  gap: 18px;
-  padding: 14px;
-}
-.movie-poster,
-.movie-poster-placeholder {
-  width: 150px;
-  aspect-ratio: 2 / 3;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: #101318;
-}
-.movie-poster {
-  display: block;
-  object-fit: cover;
-}
-.movie-poster-placeholder {
-  display: grid;
-  place-items: center;
-  color: var(--muted);
-  font-size: 12px;
-  font-weight: 850;
-  text-transform: uppercase;
-}
-.movie-identity-copy {
-  display: grid;
-  align-content: start;
-  gap: 10px;
-  min-width: 0;
-}
-.movie-identity-copy h2 {
-  font-size: clamp(24px, 3vw, 34px);
-  line-height: 1.08;
-}
-.movie-identity-copy p {
-  margin: 0;
-  max-width: 860px;
-  color: var(--muted);
-}
-.movie-title-line,
-.movie-subtitle,
-.identity-metrics,
 .flag-list,
 .tag-list {
   display: flex;
   gap: 8px;
   align-items: center;
   flex-wrap: wrap;
-}
-.movie-title-line {
-  justify-content: space-between;
-}
-.movie-subtitle {
-  color: var(--muted);
-  font-size: 13px;
-  font-weight: 800;
-}
-.movie-subtitle span:not(:last-child)::after {
-  content: '·';
-  margin-left: 8px;
-  color: var(--subtle);
-}
-.identity-metrics {
-  margin: 2px 0 0;
-  align-items: stretch;
-}
-.identity-metrics div {
-  min-width: 150px;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 8px 10px;
-  background: rgba(17, 20, 25, 0.72);
-}
-.identity-metrics dt {
-  font-size: 11px;
-}
-.identity-metrics dd {
-  font-size: 13px;
-  font-weight: 800;
 }
 .flag-list,
 .tag-list {
@@ -2113,8 +1906,7 @@ input:disabled {
     flex-direction: column;
   }
   .queue-status-main,
-  .manual-repair-form,
-  .manual-metadata-form {
+  .manual-repair-form {
     align-items: stretch;
     flex-direction: column;
     display: flex;
@@ -2151,17 +1943,11 @@ input:disabled {
     grid-template-columns: 1fr;
     justify-content: stretch;
   }
-  .detail-grid,
-  .movie-cockpit {
+  .detail-grid {
     grid-template-columns: 1fr;
   }
-  .movie-identity,
   .duplicate-context {
     grid-template-columns: 1fr;
-  }
-  .movie-poster,
-  .movie-poster-placeholder {
-    width: min(180px, 100%);
   }
   .decision-actions {
     grid-template-columns: 1fr;
@@ -2191,8 +1977,7 @@ input:disabled {
   .actions,
   .decision-actions,
   .bulk-repair-actions,
-  .bulk-repair-form,
-  .manual-metadata-form {
+  .bulk-repair-form {
     align-items: stretch;
     flex-direction: column;
   }

--- a/apps/backoffice/src/components/catalog-health/index.test.tsx
+++ b/apps/backoffice/src/components/catalog-health/index.test.tsx
@@ -90,7 +90,7 @@ describe('catalog health page action sections', () => {
     expect(html).not.toContain('No affected movies.');
     expect(html).not.toContain('Missing vote_count');
     expect(html).toContain('No affected rows');
-    expect(html).toContain('aria-label="Missing runtime: 0 affected"');
+    expect(html).toContain('aria-label="Missing runtime: clear"');
     expect(html).toContain('Missing runtime');
     expect(html.match(/class="panel issue-panel/g)?.length).toBe(2);
     expect(html.indexOf('Missing tmdb_id')).toBeLessThan(html.indexOf('Missing poster_url'));

--- a/apps/backoffice/src/components/catalog-health/index.tsx
+++ b/apps/backoffice/src/components/catalog-health/index.tsx
@@ -134,20 +134,33 @@ function HealthyCatalogChecks({ checks }: { checks: CatalogHealthReport['issues'
   if (checks.length === 0) return null;
 
   return (
-    <section className="healthy-checks" aria-labelledby="healthy-catalog-checks-title">
-      <div className="healthy-checks-heading">
-        <div>
-          <p className="page-kicker">Resolved checks</p>
-          <h2 id="healthy-catalog-checks-title">No affected rows</h2>
+    <section
+      className="mb-3 grid gap-3 rounded-lg border border-[color-mix(in_srgb,var(--good),var(--border)_74%)] bg-[rgba(21,24,29,0.52)] p-4"
+      aria-labelledby="healthy-catalog-checks-title"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="grid gap-1">
+          <p className="m-0 text-xs font-black uppercase tracking-[0.08em] text-[var(--good)]">
+            Resolved checks
+          </p>
+          <h2
+            id="healthy-catalog-checks-title"
+            className="text-base font-medium text-[var(--text)]"
+          >
+            No affected rows
+          </h2>
         </div>
         <Badge variant="success">{checks.length} clear</Badge>
       </div>
-      <ul className="healthy-checks-list">
+      <ul className="m-0 grid list-none gap-0 p-0">
         {checks.map((issue) => (
-          <li aria-label={`${issue.label}: 0 affected`} key={issue.key}>
-            <span aria-hidden="true" className="healthy-checks-dot" />
-            <span>{issue.label}</span>
-            <span>0 affected</span>
+          <li
+            aria-label={`${issue.label}: clear`}
+            className="flex min-h-9 items-center gap-3 border-t border-[rgba(139,151,170,0.16)] py-2 text-sm font-bold text-[var(--muted)] first:border-t-0"
+            key={issue.key}
+          >
+            <span aria-hidden="true" className="h-2 w-2 rounded-full bg-[var(--good)]" />
+            <span className="min-w-0 flex-1 truncate">{issue.label}</span>
           </li>
         ))}
       </ul>

--- a/apps/backoffice/src/components/movie-detail/healthPanels.tsx
+++ b/apps/backoffice/src/components/movie-detail/healthPanels.tsx
@@ -1,43 +1,54 @@
 import type { CatalogMovieDetail } from '@pop-choice/shared';
+import { Badge, cn } from '@pop-choice/ui';
 
 import { CountPill } from '../shared';
 import { duplicatePeerCount, splitHealthFlags } from './helpers';
 
 export function HealthFlagsPanel({ detail }: { detail: CatalogMovieDetail }) {
   const { activeFlags, resolvedFlags } = splitHealthFlags(detail.healthFlags);
+  const needsWork = activeFlags.length > 0;
 
   return (
-    <article className={`panel ${activeFlags.length > 0 ? 'needs-work' : 'healthy'}`}>
-      <div className="panel-header">
-        <div>
-          <h2>Health flags</h2>
-          <div className="issue-hint">
-            Same predicates as Catalog Health, scoped to this movie row.
-          </div>
+    <article
+      className={cn(
+        'grid gap-4 border-t pt-5',
+        needsWork
+          ? 'border-[var(--warn)]'
+          : 'border-[color-mix(in_srgb,var(--good),var(--border)_70%)]',
+      )}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="grid gap-1">
+          <h2 className="text-base font-medium text-[var(--text)]">Health flags</h2>
+          <p className="m-0 text-sm font-bold text-[var(--muted)]">
+            Catalog Health checks scoped to this movie row.
+          </p>
         </div>
-        <CountPill
-          count={activeFlags.length}
-          state={activeFlags.length > 0 ? 'warning' : 'healthy'}
-        />
+        <Badge
+          className="min-w-12 text-center text-base"
+          variant={needsWork ? 'warning' : 'success'}
+        >
+          {activeFlags.length}
+        </Badge>
       </div>
-      <div className="flag-list">
+      <div className="flex flex-wrap items-start gap-2">
         {activeFlags.length === 0 ? (
-          <span className="pill healthy">No active flags</span>
+          <Badge variant="success">No active flags</Badge>
         ) : (
           activeFlags.map((flag) => (
-            <span key={flag.key} className="pill warning">
+            <Badge key={flag.key} variant="warning">
               {flag.label}
-            </span>
+            </Badge>
           ))
         )}
       </div>
-      <details className="compact-details">
-        <summary>Resolved checks ({resolvedFlags.length})</summary>
-        <div className="flag-list">
+      <details className="text-sm font-bold text-[var(--muted)]">
+        <summary className="cursor-pointer">Resolved checks ({resolvedFlags.length})</summary>
+        <div className="mt-3 flex flex-wrap items-start gap-2">
           {resolvedFlags.map((flag) => (
-            <span key={flag.key} className="pill">
+            <Badge key={flag.key} variant="muted">
               {flag.label}
-            </span>
+            </Badge>
           ))}
         </div>
       </details>

--- a/apps/backoffice/src/components/movie-detail/identityPanel.test.tsx
+++ b/apps/backoffice/src/components/movie-detail/identityPanel.test.tsx
@@ -6,7 +6,9 @@ import { MovieIdentityPanel } from './identityPanel';
 
 describe('MovieIdentityPanel', () => {
   it('renders active issue, poster fallback, localized title, and TMDB metadata', () => {
-    const html = renderToStaticMarkup(<MovieIdentityPanel detail={catalogMovieDetail()} />);
+    const html = renderToStaticMarkup(
+      <MovieIdentityPanel detail={catalogMovieDetail()} manualStatus={null} />,
+    );
 
     expect(html).toContain('Movie #42');
     expect(html).toContain('1 active issue(s)');
@@ -16,6 +18,9 @@ describe('MovieIdentityPanel', () => {
     expect(html).toContain('href="https://www.themoviedb.org/movie/949"');
     expect(html).toContain('92%');
     expect(html).toContain('manual_review');
+    expect(html).toContain('Manual correction');
+    expect(html).toContain('Edit fields');
+    expect(html).not.toContain('name="poster_url"');
   });
 
   it('renders the healthy state and local fallbacks when metadata is missing', () => {
@@ -33,7 +38,7 @@ describe('MovieIdentityPanel', () => {
       },
     });
 
-    const html = renderToStaticMarkup(<MovieIdentityPanel detail={detail} />);
+    const html = renderToStaticMarkup(<MovieIdentityPanel detail={detail} manualStatus={null} />);
 
     expect(html).toContain('Healthy');
     expect(html).toContain('src="https://image.test/poster.jpg"');

--- a/apps/backoffice/src/components/movie-detail/identityPanel.tsx
+++ b/apps/backoffice/src/components/movie-detail/identityPanel.tsx
@@ -3,19 +3,30 @@ import { Badge } from '@pop-choice/ui';
 
 import { formatBackofficeDateTime } from '../../lib/backoffice';
 import { formatDuration, formatPercent, moviePosterSrc } from '../shared';
+import { ManualMovieMetadataPanel } from './manualFieldsPanel';
 
 function MoviePoster({ posterUrl, title }: { posterUrl: string | null; title: string }) {
   const src = moviePosterSrc(posterUrl);
 
   if (!src) {
     return (
-      <div className="movie-poster-placeholder" aria-label="No poster stored">
+      <div
+        className="grid aspect-[2/3] min-h-[320px] w-full place-items-center rounded-lg border border-[var(--border)] bg-[#101318] text-sm font-black uppercase tracking-normal text-[var(--muted)] sm:min-h-[420px] lg:min-h-0"
+        aria-label="No poster stored"
+      >
         No poster
       </div>
     );
   }
 
-  return <img className="movie-poster" src={src} alt={`${title} poster`} loading="lazy" />;
+  return (
+    <img
+      className="block aspect-[2/3] w-full rounded-lg border border-[var(--border)] bg-[#101318] object-cover"
+      src={src}
+      alt={`${title} poster`}
+      loading="lazy"
+    />
+  );
 }
 
 function TMDBMovieLink({ tmdbId }: { tmdbId: number | null }) {
@@ -28,52 +39,65 @@ function TMDBMovieLink({ tmdbId }: { tmdbId: number | null }) {
   );
 }
 
-export function MovieIdentityPanel({ detail }: { detail: CatalogMovieDetail }) {
+export function MovieIdentityPanel({
+  detail,
+  manualStatus,
+}: {
+  detail: CatalogMovieDetail;
+  manualStatus: string | null;
+}) {
   const { movie } = detail;
   const activeFlags = detail.healthFlags.filter((flag) => flag.isActive);
+  const metricClassName =
+    'min-w-[170px] flex-1 border-t border-[rgba(139,151,170,0.22)] pt-3 text-sm font-extrabold text-[var(--text)]';
 
   return (
-    <section className="movie-identity panel">
-      <MoviePoster posterUrl={movie.posterUrl} title={movie.name} />
-      <div className="movie-identity-copy">
-        <div className="movie-title-line">
-          <span className="small-note">Movie #{movie.id}</span>
+    <section className="flex flex-col gap-8 border-b border-[var(--border)] pb-8 lg:flex-row lg:items-start">
+      <div className="w-full max-w-[300px] shrink-0">
+        <MoviePoster posterUrl={movie.posterUrl} title={movie.name} />
+      </div>
+      <div className="grid min-w-0 flex-1 content-start gap-5">
+        <div className="flex flex-wrap items-center gap-3">
+          <span className="text-sm font-bold text-[var(--subtle)]">Movie #{movie.id}</span>
           <Badge variant={activeFlags.length > 0 ? 'warning' : 'success'}>
             {activeFlags.length > 0 ? `${activeFlags.length} active issue(s)` : 'Healthy'}
           </Badge>
         </div>
-        <h2>{movie.name}</h2>
-        <div className="movie-subtitle">
+        <h2 className="sr-only">{movie.name}</h2>
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-base font-extrabold text-[var(--muted)]">
           {movie.localizedName ? <span>{movie.localizedName}</span> : null}
           <span>{movie.year}</span>
           <span>{formatDuration(movie.duration)}</span>
           <span>{movie.ageRating || '-'}</span>
         </div>
-        <p>{movie.description || 'No local description stored.'}</p>
-        <dl className="identity-metrics">
-          <div>
-            <dt>TMDB</dt>
+        <p className="m-0 max-w-3xl text-base leading-7 text-[var(--muted)]">
+          {movie.description || 'No local description stored.'}
+        </p>
+        <dl className="mt-2 flex flex-wrap gap-x-6 gap-y-4">
+          <div className={metricClassName}>
+            <dt className="mb-1 text-xs font-extrabold text-[var(--muted)]">TMDB</dt>
             <dd>
               <TMDBMovieLink tmdbId={movie.tmdbId} />
             </dd>
           </div>
-          <div>
-            <dt>Match confidence</dt>
+          <div className={metricClassName}>
+            <dt className="mb-1 text-xs font-extrabold text-[var(--muted)]">Match confidence</dt>
             <dd>{formatPercent(movie.tmdbMatchConfidence)}</dd>
           </div>
-          <div>
-            <dt>Match source</dt>
+          <div className={metricClassName}>
+            <dt className="mb-1 text-xs font-extrabold text-[var(--muted)]">Match source</dt>
             <dd>{movie.tmdbMatchSource ?? '-'}</dd>
           </div>
-          <div>
-            <dt>Matched at</dt>
+          <div className={metricClassName}>
+            <dt className="mb-1 text-xs font-extrabold text-[var(--muted)]">Matched at</dt>
             <dd>{formatBackofficeDateTime(movie.tmdbMatchedAt)}</dd>
           </div>
-          <div>
-            <dt>Metadata refreshed</dt>
+          <div className={metricClassName}>
+            <dt className="mb-1 text-xs font-extrabold text-[var(--muted)]">Metadata refreshed</dt>
             <dd>{formatBackofficeDateTime(movie.tmdbMetadataRefreshedAt)}</dd>
           </div>
         </dl>
+        <ManualMovieMetadataPanel detail={detail} manualStatus={manualStatus} />
       </div>
     </section>
   );

--- a/apps/backoffice/src/components/movie-detail/index.tsx
+++ b/apps/backoffice/src/components/movie-detail/index.tsx
@@ -9,7 +9,6 @@ import {
   DuplicatePeersPanel,
   HealthFlagsPanel,
   LocalFactsPanel,
-  ManualMovieMetadataPanel,
   MetadataOverviewPanel,
   MovieIdentityPanel,
   MovieRepairPanel,
@@ -48,7 +47,7 @@ export function CatalogMovieDetailPage({
       }
       actions={
         <>
-          <ButtonLink href="/catalog-health">Back to health</ButtonLink>
+          <ButtonLink href="/catalog-health">Catalog health</ButtonLink>
           {movie.tmdbId === null ? null : (
             <ButtonLink
               href={`https://www.themoviedb.org/movie/${movie.tmdbId}`}
@@ -56,22 +55,21 @@ export function CatalogMovieDetailPage({
               target="_blank"
               variant="quiet"
             >
-              TMDB
+              Open in TMDB
             </ButtonLink>
           )}
         </>
       }
     >
-      <section className="movie-cockpit" aria-label="Movie repair cockpit">
-        <MovieIdentityPanel detail={detail} />
-        <div className="movie-cockpit-actions">
-          <MovieRepairPanel detail={detail} repairStatus={repairStatus} />
-          <ManualMovieMetadataPanel detail={detail} manualStatus={manualStatus} />
-        </div>
+      <section className="grid gap-5" aria-label="Movie workspace">
+        <MovieIdentityPanel detail={detail} manualStatus={manualStatus} />
+        <MovieRepairPanel detail={detail} repairStatus={repairStatus} />
+      </section>
+      <section className="my-8 grid gap-6 xl:grid-cols-[minmax(0,1.1fr)_minmax(320px,0.9fr)] xl:items-start">
+        <HealthFlagsPanel detail={detail} />
+        <LocalFactsPanel detail={detail} />
       </section>
       <section className="detail-grid">
-        <LocalFactsPanel detail={detail} />
-        <HealthFlagsPanel detail={detail} />
         <MetadataOverviewPanel detail={detail} />
         <DuplicatePeersPanel detail={detail} />
       </section>

--- a/apps/backoffice/src/components/movie-detail/manualFieldsPanel.stories.tsx
+++ b/apps/backoffice/src/components/movie-detail/manualFieldsPanel.stories.tsx
@@ -6,7 +6,7 @@ import { ManualMovieMetadataPanel } from './manualFieldsPanel';
 import '../../app/globals.css';
 
 const meta: Meta<typeof ManualMovieMetadataPanel> = {
-  title: 'Backoffice/Movie Detail/Manual Metadata Panel',
+  title: 'Backoffice/Movie Detail/Edit Metadata Fields',
   component: ManualMovieMetadataPanel,
   parameters: {
     layout: 'padded',

--- a/apps/backoffice/src/components/movie-detail/manualFieldsPanel.test.tsx
+++ b/apps/backoffice/src/components/movie-detail/manualFieldsPanel.test.tsx
@@ -5,17 +5,18 @@ import { catalogMovieDetail } from '../../test/backofficeFixtures';
 import { ManualMovieMetadataPanel } from './manualFieldsPanel';
 
 describe('ManualMovieMetadataPanel', () => {
-  it('renders a blank manual override form with current values as operator context', () => {
+  it('renders a compact dialog trigger for manual metadata correction', () => {
     const html = renderToStaticMarkup(
       <ManualMovieMetadataPanel detail={catalogMovieDetail()} manualStatus="updated" />,
     );
 
-    expect(html).toContain('Manual metadata override');
+    expect(html).toContain('Manual correction');
+    expect(html).toContain('Edit fields');
     expect(html).toContain('Manual metadata fields were applied.');
-    expect(html).toContain('href="https://www.themoviedb.org/search?query=Heat%201995"');
-    expect(html).toContain('Current: 949');
-    expect(html).toContain('name="tmdb_id"');
-    expect(html).not.toContain('name="tmdb_id" placeholder="e.g. 475557" value=');
-    expect(html).toContain('Apply manual fields');
+    expect(html).toContain('aria-haspopup="dialog"');
+    expect(html).not.toContain('name="tmdb_id"');
+    expect(html).not.toContain('name="note"');
+    expect(html).not.toContain('placeholder="e.g. 475557"');
+    expect(html).not.toContain('placeholder="PG-13"');
   });
 });

--- a/apps/backoffice/src/components/movie-detail/manualFieldsPanel.tsx
+++ b/apps/backoffice/src/components/movie-detail/manualFieldsPanel.tsx
@@ -1,5 +1,18 @@
+'use client';
+
 import type { CatalogMovieDetail } from '@pop-choice/shared';
-import { Button, ButtonLink } from '@pop-choice/ui';
+import {
+  Button,
+  ButtonLink,
+  buttonVariants,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@pop-choice/ui';
 
 function manualStatusMessage(status: string | null): string | null {
   if (status === 'updated') return 'Manual metadata fields were applied.';
@@ -30,64 +43,143 @@ export function ManualMovieMetadataPanel({
   const searchQuery = encodeURIComponent(`${movie.name} ${movie.year}`);
 
   return (
-    <section className="panel manual-metadata-panel">
-      <div className="panel-header">
-        <div>
-          <h2>Manual metadata override</h2>
-          <div className="issue-hint">
-            Add only fields you have verified. Blank inputs leave the current movie row unchanged.
+    <section className="border-t border-[rgba(139,151,170,0.22)] pt-4">
+      <Dialog defaultOpen={manualStatus !== null}>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="grid min-w-0 gap-1">
+            <h3 className="text-base font-medium leading-tight text-[var(--text)]">
+              Manual correction
+            </h3>
+            <p className="m-0 text-sm font-bold leading-5 text-[var(--muted)]">
+              Edit verified metadata only when the automated repair path needs help.
+            </p>
           </div>
+          <DialogTrigger className={buttonVariants({ size: 'sm', variant: 'ghost' })} type="button">
+            Edit fields
+          </DialogTrigger>
         </div>
-        <ButtonLink
-          href={`https://www.themoviedb.org/search?query=${searchQuery}`}
-          rel="noreferrer"
-          target="_blank"
-          variant="quiet"
-        >
-          Search TMDB
-        </ButtonLink>
-      </div>
-      {flash ? <p className={`repair-message ${manualStatusTone(manualStatus)}`}>{flash}</p> : null}
-      <form
-        action={`/movies/${encodeURIComponent(movie.id)}/actions`}
-        className="manual-metadata-form"
-        method="post"
-      >
-        <input type="hidden" name="return_to" value={`/movies/${encodeURIComponent(movie.id)}`} />
-        <input
-          type="hidden"
-          name="note"
-          value={`Manual metadata override for ${movie.name} (${movie.year})`}
-        />
-        <label>
-          TMDB id
-          <span>Current: {currentValue(movie.tmdbId)}</span>
-          <input inputMode="numeric" name="tmdb_id" placeholder="e.g. 475557" />
-        </label>
-        <label>
-          Localized name
-          <span>Current: {currentValue(movie.localizedName)}</span>
-          <input name="localized_name" placeholder="Localized display title" />
-        </label>
-        <label>
-          Poster URL
-          <span>Current: {currentValue(movie.posterUrl)}</span>
-          <input name="poster_url" placeholder="https://image.tmdb.org/t/p/w500/..." />
-        </label>
-        <label>
-          Runtime
-          <span>Current: {currentValue(movie.duration)}</span>
-          <input inputMode="numeric" name="runtime" placeholder="Minutes" />
-        </label>
-        <label>
-          Age rating
-          <span>Current: {currentValue(movie.ageRating)}</span>
-          <input name="age_rating" placeholder="PG-13" />
-        </label>
-        <Button type="submit" variant="primary">
-          Apply manual fields
-        </Button>
-      </form>
+        {flash ? (
+          <p className={`repair-message ${manualStatusTone(manualStatus)} mt-3`}>{flash}</p>
+        ) : null}
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit verified metadata</DialogTitle>
+            <DialogDescription>
+              Save only fields you have checked against a trusted source. Blank fields are ignored.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-[var(--border)] bg-[var(--surface-2)] p-3">
+            <p className="m-0 max-w-2xl text-sm font-bold leading-5 text-[var(--muted)]">
+              These values save directly to the movie row and are recorded in the repair audit.
+            </p>
+            <ButtonLink
+              href={`https://www.themoviedb.org/search?query=${searchQuery}`}
+              rel="noreferrer"
+              target="_blank"
+              variant="quiet"
+            >
+              Search TMDB
+            </ButtonLink>
+          </div>
+          {flash ? (
+            <p className={`repair-message ${manualStatusTone(manualStatus)}`}>{flash}</p>
+          ) : null}
+          <form
+            action={`/movies/${encodeURIComponent(movie.id)}/actions`}
+            className="grid gap-4"
+            method="post"
+          >
+            <input
+              type="hidden"
+              name="return_to"
+              value={`/movies/${encodeURIComponent(movie.id)}`}
+            />
+            <div className="flex flex-wrap gap-3">
+              <label className="grid min-w-56 flex-1 gap-1 text-xs font-extrabold text-[var(--muted)]">
+                TMDB id
+                <span className="truncate text-[11px] font-bold text-[var(--muted-2)]">
+                  Current: {currentValue(movie.tmdbId)}
+                </span>
+                <input
+                  className="w-full min-w-0"
+                  defaultValue={movie.tmdbId ?? ''}
+                  inputMode="numeric"
+                  name="tmdb_id"
+                  placeholder="TMDB id"
+                />
+              </label>
+              <label className="grid min-w-56 flex-1 gap-1 text-xs font-extrabold text-[var(--muted)]">
+                Localized name
+                <span className="truncate text-[11px] font-bold text-[var(--muted-2)]">
+                  Current: {currentValue(movie.localizedName)}
+                </span>
+                <input
+                  className="w-full min-w-0"
+                  defaultValue={movie.localizedName ?? ''}
+                  name="localized_name"
+                  placeholder="Localized title"
+                />
+              </label>
+              <label className="grid min-w-56 flex-1 gap-1 text-xs font-extrabold text-[var(--muted)]">
+                Poster URL
+                <span className="truncate text-[11px] font-bold text-[var(--muted-2)]">
+                  Current: {currentValue(movie.posterUrl)}
+                </span>
+                <input
+                  className="w-full min-w-0"
+                  defaultValue={movie.posterUrl ?? ''}
+                  name="poster_url"
+                  placeholder="Poster URL or TMDB image path"
+                />
+              </label>
+              <label className="grid min-w-56 flex-1 gap-1 text-xs font-extrabold text-[var(--muted)]">
+                Runtime
+                <span className="truncate text-[11px] font-bold text-[var(--muted-2)]">
+                  Current: {currentValue(movie.duration)}
+                </span>
+                <input
+                  className="w-full min-w-0"
+                  defaultValue={movie.duration ?? ''}
+                  inputMode="numeric"
+                  name="runtime"
+                  placeholder="Minutes"
+                />
+              </label>
+              <label className="grid min-w-56 flex-1 gap-1 text-xs font-extrabold text-[var(--muted)]">
+                Age rating
+                <span className="truncate text-[11px] font-bold text-[var(--muted-2)]">
+                  Current: {currentValue(movie.ageRating)}
+                </span>
+                <input
+                  className="w-full min-w-0"
+                  defaultValue={movie.ageRating ?? ''}
+                  name="age_rating"
+                  placeholder="Age rating"
+                />
+              </label>
+            </div>
+            <label className="grid gap-1 text-xs font-extrabold text-[var(--muted)]">
+              Operator note
+              <span className="truncate text-[11px] font-bold text-[var(--muted-2)]">
+                Stored in the repair audit
+              </span>
+              <input
+                className="w-full min-w-0"
+                name="note"
+                placeholder={`Verified source for ${movie.name} (${movie.year})`}
+              />
+            </label>
+            <DialogFooter className="justify-start">
+              <Button type="submit" variant="primary">
+                Save fields
+              </Button>
+              <span className="text-xs font-bold text-[var(--muted-2)]">
+                Blank fields are left unchanged.
+              </span>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
     </section>
   );
 }

--- a/apps/backoffice/src/components/movie-detail/metadataPanels.tsx
+++ b/apps/backoffice/src/components/movie-detail/metadataPanels.tsx
@@ -46,40 +46,42 @@ export function RelatedReviewsPanel({ reviews }: { reviews: CatalogMovieDetailTM
 
 export function LocalFactsPanel({ detail }: { detail: CatalogMovieDetail }) {
   const { movie } = detail;
+  const factClassName =
+    'grid grid-cols-[120px_minmax(0,1fr)] gap-4 border-b border-[rgba(139,151,170,0.16)] py-2 last:border-b-0';
 
   return (
-    <article className="panel">
-      <PanelHeader title="Local facts" />
-      <dl className="facts">
-        <div>
+    <article className="grid gap-3 border-t border-[var(--border)] pt-5">
+      <h2 className="text-base font-medium text-[var(--text)]">Local facts</h2>
+      <dl className="grid gap-0">
+        <div className={factClassName}>
           <dt>Local id</dt>
           <dd>{movie.id}</dd>
         </div>
-        <div>
+        <div className={factClassName}>
           <dt>Name</dt>
           <dd>{movie.name}</dd>
         </div>
-        <div>
+        <div className={factClassName}>
           <dt>Localized</dt>
           <dd>{movie.localizedName ?? '-'}</dd>
         </div>
-        <div>
+        <div className={factClassName}>
           <dt>Year</dt>
           <dd>{movie.year}</dd>
         </div>
-        <div>
+        <div className={factClassName}>
           <dt>Runtime</dt>
           <dd>{formatDuration(movie.duration)}</dd>
         </div>
-        <div>
+        <div className={factClassName}>
           <dt>Age rating</dt>
           <dd>{movie.ageRating || '-'}</dd>
         </div>
-        <div>
+        <div className={factClassName}>
           <dt>Score</dt>
           <dd>{movie.scoreRating}</dd>
         </div>
-        <div>
+        <div className={factClassName}>
           <dt>Poster</dt>
           <dd>{movie.posterUrl ?? '-'}</dd>
         </div>

--- a/apps/backoffice/src/components/movie-detail/repairPanel.test.tsx
+++ b/apps/backoffice/src/components/movie-detail/repairPanel.test.tsx
@@ -7,16 +7,32 @@ import { MovieRepairPanel } from './repairPanel';
 describe('MovieRepairPanel', () => {
   it('renders the focused repair form for repairable active flags', () => {
     const html = renderToStaticMarkup(
-      <MovieRepairPanel detail={catalogMovieDetail()} repairStatus="queued" />,
+      <MovieRepairPanel detail={catalogMovieDetail()} repairStatus={null} />,
     );
 
+    expect(html).toContain('Repair action');
     expect(html).toContain('1 repairable');
-    expect(html).toContain('repair-message accepted');
     expect(html).toContain('name="action" value="enqueue_backfill"');
     expect(html).toContain('name="movie_id" value="42"');
     expect(html).toContain('name="issue_key"');
     expect(html).toContain('Missing poster');
-    expect(html).toContain('Queue focused repair');
+    expect(html).toContain('Queue repair');
+    expect(html).not.toContain('No action');
+  });
+
+  it('renders queued state without asking for another immediate repair', () => {
+    const detail = catalogMovieDetail({
+      healthFlags: [catalogMovieDetailHealthFlag({ isActive: false })],
+    });
+
+    const html = renderToStaticMarkup(<MovieRepairPanel detail={detail} repairStatus="queued" />);
+
+    expect(html).toContain('Repair queued');
+    expect(html).toContain('Queued');
+    expect(html).toContain('repair-message accepted');
+    expect(html).toContain('Open queue');
+    expect(html).not.toContain('Queue repair');
+    expect(html).not.toContain('No action');
   });
 
   it('renders manual-review copy for active non-repairable flags', () => {
@@ -26,10 +42,10 @@ describe('MovieRepairPanel', () => {
 
     const html = renderToStaticMarkup(<MovieRepairPanel detail={detail} repairStatus="failed" />);
 
-    expect(html).toContain('No action');
+    expect(html).toContain('Manual review needed');
     expect(html).toContain('repair-message warn');
-    expect(html).toContain('manual review or duplicate-merge tooling');
-    expect(html).not.toContain('Queue focused repair');
+    expect(html).toContain('operator review or duplicate-merge tooling');
+    expect(html).not.toContain('Queue repair');
   });
 
   it('renders the no-active-flags copy for healthy movies', () => {
@@ -39,7 +55,8 @@ describe('MovieRepairPanel', () => {
 
     const html = renderToStaticMarkup(<MovieRepairPanel detail={detail} repairStatus={null} />);
 
-    expect(html).toContain('No action');
+    expect(html).toContain('No repair needed');
+    expect(html).toContain('Healthy');
     expect(html).toContain('No active catalog-health flags need repair for this movie.');
     expect(html).not.toContain('repair-message');
   });

--- a/apps/backoffice/src/components/movie-detail/repairPanel.tsx
+++ b/apps/backoffice/src/components/movie-detail/repairPanel.tsx
@@ -1,7 +1,19 @@
 import type { CatalogMovieDetail } from '@pop-choice/shared';
-import { Badge, Button } from '@pop-choice/ui';
+import { Badge, Button, ButtonLink } from '@pop-choice/ui';
 
-import { repairableHealthFlags, repairFlashMessage, repairFlashTone } from './helpers';
+import {
+  normalizeRepairFlashStatus,
+  repairableHealthFlags,
+  repairFlashMessage,
+  repairFlashTone,
+} from './helpers';
+
+function isQueuedRepairStatus(status: string | null): boolean {
+  const normalized = normalizeRepairFlashStatus(status);
+  return (
+    normalized === 'queued' || normalized === 'deduped' || normalized === 'orchestration_queued'
+  );
+}
 
 export function MovieRepairPanel({
   detail,
@@ -14,55 +26,103 @@ export function MovieRepairPanel({
   const activeFlags = detail.healthFlags.filter((flag) => flag.isActive);
   const flash = repairFlashMessage(repairStatus);
   const flashTone = repairFlashTone(repairStatus);
+  const repairQueued = isQueuedRepairStatus(repairStatus);
+  const hasRepairableFlags = repairableFlags.length > 0;
+  const title = repairQueued
+    ? 'Repair queued'
+    : hasRepairableFlags
+      ? 'Repair action'
+      : activeFlags.length > 0
+        ? 'Manual review needed'
+        : 'No repair needed';
+  const badgeVariant = repairQueued
+    ? 'accent'
+    : hasRepairableFlags
+      ? 'accent'
+      : activeFlags.length > 0
+        ? 'warning'
+        : 'success';
+  const badgeLabel = repairQueued
+    ? 'Queued'
+    : hasRepairableFlags
+      ? `${repairableFlags.length} repairable`
+      : activeFlags.length > 0
+        ? `${activeFlags.length} active`
+        : 'Healthy';
 
   return (
-    <section className="panel movie-repair-panel">
-      <div className="panel-header">
-        <div>
-          <h2>Focused repair</h2>
-          <div className="issue-hint">
-            Queue one catalog-maintenance job for this movie through the existing paced worker path.
+    <section className="grid gap-4 border-y border-[var(--border)] py-5">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="grid gap-1">
+          <h2 className="text-base font-medium text-[var(--text)]">{title}</h2>
+          <div className="text-sm font-bold text-[var(--muted)]">
+            Use one paced catalog-maintenance job per movie.
           </div>
         </div>
-        <Badge variant={repairableFlags.length > 0 ? 'accent' : 'muted'}>
-          {repairableFlags.length > 0 ? `${repairableFlags.length} repairable` : 'No action'}
-        </Badge>
+        <Badge variant={badgeVariant}>{badgeLabel}</Badge>
       </div>
       {flash ? <p className={`repair-message ${flashTone}`}>{flash}</p> : null}
-      {repairableFlags.length > 0 ? (
-        <form className="movie-repair-form" action="/catalog-health/actions" method="post">
-          <input type="hidden" name="action" value="enqueue_backfill" />
-          <input type="hidden" name="movie_id" value={detail.movie.id} />
-          <input
-            type="hidden"
-            name="return_to"
-            value={`/movies/${encodeURIComponent(detail.movie.id)}`}
-          />
-          <input
-            type="hidden"
-            name="note"
-            value={`Queued from movie detail for ${detail.movie.name}`}
-          />
-          <label>
-            Repair reason
-            <select name="issue_key" defaultValue={repairableFlags[0]?.key}>
-              {repairableFlags.map((flag) => (
-                <option key={flag.key} value={flag.key}>
-                  {flag.label}
-                </option>
-              ))}
-            </select>
-          </label>
-          <Button type="submit" variant="primary">
-            Queue focused repair
-          </Button>
-        </form>
+      {repairQueued ? (
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <p className="m-0 max-w-3xl text-sm font-bold leading-6 text-[var(--muted)]">
+            The worker will refresh this row through the catalog maintenance queue. Verify the
+            result there before applying manual fields.
+          </p>
+          <ButtonLink href="/queue" variant="quiet">
+            Open queue
+          </ButtonLink>
+        </div>
+      ) : hasRepairableFlags ? (
+        <div className="grid gap-3 xl:grid-cols-[minmax(0,640px)_minmax(260px,1fr)] xl:items-end">
+          <form
+            className="flex flex-wrap items-end gap-3"
+            action="/catalog-health/actions"
+            method="post"
+          >
+            <input type="hidden" name="action" value="enqueue_backfill" />
+            <input type="hidden" name="movie_id" value={detail.movie.id} />
+            <input
+              type="hidden"
+              name="return_to"
+              value={`/movies/${encodeURIComponent(detail.movie.id)}`}
+            />
+            <input
+              type="hidden"
+              name="note"
+              value={`Queued from movie detail for ${detail.movie.name}`}
+            />
+            <label className="min-w-[min(360px,100%)] text-xs font-extrabold text-[var(--muted)]">
+              Issue to repair
+              <select
+                className="min-h-11 rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 font-extrabold text-[var(--text)]"
+                name="issue_key"
+                defaultValue={repairableFlags[0]?.key}
+              >
+                {repairableFlags.map((flag) => (
+                  <option key={flag.key} value={flag.key}>
+                    {flag.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <Button className="min-h-11 px-4" type="submit" variant="primary">
+              Queue repair
+            </Button>
+          </form>
+          <p className="m-0 max-w-2xl text-sm font-bold leading-6 text-[var(--muted)] xl:pb-2">
+            Start with the selected issue, then let the worker update TMDB-backed metadata before
+            making manual corrections.
+          </p>
+        </div>
       ) : activeFlags.length > 0 ? (
-        <p className="empty">
-          Active issues for this movie need manual review or duplicate-merge tooling.
+        <p className="m-0 max-w-3xl text-sm font-bold leading-6 text-[var(--muted)]">
+          Active issues for this movie need operator review or duplicate-merge tooling before
+          another repair job can help.
         </p>
       ) : (
-        <p className="empty">No active catalog-health flags need repair for this movie.</p>
+        <p className="m-0 max-w-3xl text-sm font-bold leading-6 text-[var(--muted)]">
+          No active catalog-health flags need repair for this movie.
+        </p>
       )}
     </section>
   );

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -38,6 +38,9 @@ For docs ownership, navigation, and issue hygiene, use **[Documentation Governan
   guard used to keep operator UI/routes split into reviewable files
 - `$impeccable critique <target>` - Run before publishing UI PRs, then address
   actionable findings or document deferred follow-ups in the PR.
+  Raw `.impeccable/critique/*` snapshots are local working notes and should not be
+  committed. Move durable UI decisions into `DESIGN.md`, `docs/UI-DEVELOPMENT.md`,
+  roadmap docs, issues, or the PR description.
 
 ### Development
 

--- a/docs/UI-DEVELOPMENT.md
+++ b/docs/UI-DEVELOPMENT.md
@@ -108,3 +108,15 @@ Do not put domain components such as `CatalogHealthOverview`, `RepairBatchItemsT
   action-column width.
 - Add stories or browser tests for long labels, unavailable data, open confirmations, and narrow
   viewports before merging UI workflow changes.
+
+## Critique Artifacts
+
+Run `$impeccable critique <target>` for meaningful UI changes, but keep generated critique
+snapshots local. The `.impeccable/` directory is ignored because timestamped tool output makes PRs
+noisy and ages faster than the implementation. Carry forward only the decisions that should outlive
+the run:
+
+- Update `DESIGN.md` for visual principles, tone, hierarchy, and component rules.
+- Update this guide for reusable UI workflow or primitive guidance.
+- Update `docs/ROADMAP-ARCHITECTURE.md` or GitHub issues for deferred work.
+- Summarize critique score, fixed items, and accepted follow-ups in the PR description when useful.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4083,25 +4083,25 @@
       }
     },
     "node_modules/@radix-ui/react-dialog": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
-      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.16.tgz",
+      "integrity": "sha512-l9ok83YBclEZhbjgzt76Hw733e6cvRKPNgO6GJ/IETlufXG9p+fRu2wlvpImQvR6xdJ8h7J8J2DBvsPEiEsKMw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-focus-guards": "1.1.3",
-        "@radix-ui/react-focus-scope": "1.1.7",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-slot": "1.2.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.12",
+        "@radix-ui/react-focus-guards": "1.1.4",
+        "@radix-ui/react-focus-scope": "1.1.9",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-portal": "1.1.11",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-slot": "1.2.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
         "aria-hidden": "^1.2.4",
-        "react-remove-scroll": "^2.6.3"
+        "react-remove-scroll": "^2.7.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4118,14 +4118,272 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/primitive": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz",
+      "integrity": "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-context": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.4.tgz",
+      "integrity": "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.12.tgz",
+      "integrity": "sha512-MhoruH6xEzsbvOmo4TNgMfmtvRGyDZw4MDSdf4ybMHfezjqwzv6hyd4lsMzBp8K9Sn6sGzCF62x1I7BYUECXOg==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-escape-keydown": "1.1.2"
       },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz",
+      "integrity": "sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.9.tgz",
+      "integrity": "sha512-9Se8t+Zry+1rEOL7Y6l/4ANYU/TOtAtf8O2fKdwLltcaMcm6kOqYGbzO4tMFQ0bvzO920pRAoHpFZ4W85S3keQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-id": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+      "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.11.tgz",
+      "integrity": "sha512-UEytdjgEh2tJGgD/gZK4FUx6t1rNIlM3U0DENhSrG7I75FGm1DnaDuVUWF1pWAWUwGmn1sCJ1VGHn8LhN1aTOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.6.tgz",
+      "integrity": "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.5.tgz",
+      "integrity": "sha512-zifXeB8Y88qCYx8PLZ5oQb32KwZub+s925mMoZsBBq9KUQqWKkREubTfs6ASjRPPBe7Jt9O8OHH89+95VG+grA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+      "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
+      "integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.2.tgz",
+      "integrity": "sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -4511,13 +4769,28 @@
       }
     },
     "node_modules/@radix-ui/react-slot": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
-      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.5.tgz",
+      "integrity": "sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
+        "@radix-ui/react-compose-refs": "1.1.3"
       },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -19691,8 +19964,11 @@
     "packages/ui": {
       "name": "@pop-choice/ui",
       "version": "0.1.0-beta.0",
+      "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.16"
+      },
       "devDependencies": {
-        "@types/react": "19.2.16",
+        "@types/react": "^19.2.17",
         "typescript": "6.0.3"
       },
       "engines": {
@@ -19702,16 +19978,6 @@
       "peerDependencies": {
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
-      }
-    },
-    "packages/ui/node_modules/@types/react": {
-      "version": "19.2.16",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.16.tgz",
-      "integrity": "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "^3.2.2"
       }
     },
     "services/db-migrate": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -20,6 +20,10 @@
       "types": "./src/breadcrumb.tsx",
       "default": "./src/breadcrumb.tsx"
     },
+    "./dialog": {
+      "types": "./src/dialog.tsx",
+      "default": "./src/dialog.tsx"
+    },
     "./tabs": {
       "types": "./src/tabs.tsx",
       "default": "./src/tabs.tsx"
@@ -38,8 +42,11 @@
     "dev": "tsc --noEmit --watch",
     "type-check": "tsc --noEmit"
   },
+  "dependencies": {
+    "@radix-ui/react-dialog": "^1.1.16"
+  },
   "devDependencies": {
-    "@types/react": "19.2.16",
+    "@types/react": "^19.2.17",
     "typescript": "6.0.3"
   },
   "peerDependencies": {

--- a/packages/ui/src/dialog.tsx
+++ b/packages/ui/src/dialog.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import type { ComponentPropsWithoutRef, ComponentRef, HTMLAttributes } from 'react';
+import { forwardRef } from 'react';
+
+import { cn } from './utils';
+
+export const Dialog = DialogPrimitive.Root;
+export const DialogTrigger = DialogPrimitive.Trigger;
+export const DialogClose = DialogPrimitive.Close;
+export const DialogPortal = DialogPrimitive.Portal;
+
+export const DialogOverlay = forwardRef<
+  ComponentRef<typeof DialogPrimitive.Overlay>,
+  ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(function DialogOverlay({ className, ...props }, ref) {
+  return (
+    <DialogPrimitive.Overlay
+      ref={ref}
+      className={cn(
+        'fixed inset-0 z-50 bg-black/70 backdrop-blur-sm data-[state=closed]:animate-none',
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+
+export const DialogContent = forwardRef<
+  ComponentRef<typeof DialogPrimitive.Content>,
+  ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(function DialogContent({ children, className, ...props }, ref) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        ref={ref}
+        className={cn(
+          'fixed left-1/2 top-1/2 z-50 grid max-h-[min(84vh,760px)] w-[min(920px,calc(100vw-32px))] -translate-x-1/2 -translate-y-1/2 gap-4 overflow-y-auto rounded-lg border border-[var(--border-strong)] bg-[var(--surface)] p-5 text-[var(--text)] shadow-[0_18px_60px_rgba(0,0,0,0.48)] focus:outline-none',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className="absolute right-3 top-3 inline-flex h-8 w-8 items-center justify-center rounded-[7px] border border-transparent text-lg font-black leading-none text-[var(--muted)] transition-colors hover:border-[var(--border)] hover:bg-[var(--surface-2)] hover:text-[var(--text)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--focus)]">
+          <span aria-hidden="true">×</span>
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+});
+
+export function DialogHeader({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('grid gap-1 pr-10', className)} {...props} />;
+}
+
+export function DialogFooter({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:items-center', className)}
+      {...props}
+    />
+  );
+}
+
+export const DialogTitle = forwardRef<
+  ComponentRef<typeof DialogPrimitive.Title>,
+  ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(function DialogTitle({ className, ...props }, ref) {
+  return (
+    <DialogPrimitive.Title
+      ref={ref}
+      className={cn('text-lg font-semibold leading-tight text-[var(--text)]', className)}
+      {...props}
+    />
+  );
+});
+
+export const DialogDescription = forwardRef<
+  ComponentRef<typeof DialogPrimitive.Description>,
+  ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(function DialogDescription({ className, ...props }, ref) {
+  return (
+    <DialogPrimitive.Description
+      ref={ref}
+      className={cn('text-sm font-bold leading-5 text-[var(--muted)]', className)}
+      {...props}
+    />
+  );
+});

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,6 +1,7 @@
 export * from './badge';
 export * from './breadcrumb';
 export * from './button';
+export * from './dialog';
 export * from './table';
 export * from './tabs';
 export * from './utils';


### PR DESCRIPTION
## Summary
- Move backoffice manual metadata correction into a shared dialog-based edit flow.
- Add a shared UI Dialog primitive and reduce custom backoffice CSS in favor of Tailwind-first composition.
- Polish catalog-health/movie-detail repair surfaces and document critique-history/UI-development conventions.

## Verification
- npm run test --workspace=apps/backoffice
- npm run quality:structure --workspace=apps/backoffice
- npm run type-check --workspace=packages/ui
- npm run type-check --workspace=apps/backoffice
- npm run build:backoffice
- Browser smoke on /movies/1 manual edit dialog
- Pre-commit type-check: packages/shared, packages/ui, apps/web, apps/backoffice
- Pre-push lint:check, test:server, production build