### PR TITLE
Improve Grafana Telegram alert formatting

### DIFF
--- a/docs/OBSERVABILITY-ALERTS.md
+++ b/docs/OBSERVABILITY-ALERTS.md
@@ -53,8 +53,9 @@ groups notifications by folder, alert name, and severity. After enabling it, use
 Grafana's contact point **Test** action before relying on alert delivery.
 
 Telegram messages use the `popchoice.telegram.message` template instead of
-Grafana's default message. The message is intentionally short for mobile triage
-and includes:
+Grafana's default message. The contact point sends Telegram HTML with compact
+emoji markers so mobile triage can scan state, severity, and links quickly. The
+message includes:
 
 - `FIRING` or `RESOLVED`, severity, and alert name.
 - The summary and action annotation when the alert provides them.

--- a/docs/OBSERVABILITY-METRICS.md
+++ b/docs/OBSERVABILITY-METRICS.md
@@ -99,9 +99,9 @@ GRAFANA_TELEGRAM_CHAT_ID=<telegram-chat-id>
 If either value is missing, Grafana starts without provisioning the Telegram
 contact point so the observability stack can still run safely.
 
-Telegram alert notifications use a PopChoice-specific plain-text template. Set
-`GF_SERVER_ROOT_URL` to the public Grafana URL if silence, dashboard, and
-Grafana links should be useful outside the Docker network.
+Telegram alert notifications use a PopChoice-specific HTML template with compact
+emoji markers. Set `GF_SERVER_ROOT_URL` to the public Grafana URL if silence,
+dashboard, and Grafana links should be useful outside the Docker network.
 
 The template is intentionally compact for mobile triage: firing or resolved
 state, severity, alert name, summary, action, affected targets, and links. Raw

--- a/observability/images/grafana/entrypoint.sh
+++ b/observability/images/grafana/entrypoint.sh
@@ -12,47 +12,50 @@ templates:
     name: popchoice.telegram.message
     template: |
       {{ define "popchoice.alert.target" -}}
-      {{- with index .Labels "service" }}{{ . }}{{ else }}{{ with index .Labels "job" }}{{ . }}{{ else }}target{{ end }}{{ end -}}
-      {{- with index .Labels "instance" }} ({{ . }}){{ end -}}
+      <code>{{- with index .Labels "service" }}{{ . | html }}{{ else }}{{ with index .Labels "job" }}{{ . | html }}{{ else }}target{{ end }}{{ end -}}
+      {{- with index .Labels "instance" }} ({{ . | html }}){{ end -}}</code>
       {{- end }}
-      {{ define "popchoice.telegram.message" }}
-      {{ if eq .Status "firing" }}FIRING{{ else }}RESOLVED{{ end }} {{ with index .CommonLabels "severity" }}{{ . }}{{ end }}: {{ with index .CommonLabels "alertname" }}{{ . }}{{ else }}Grafana alert{{ end }}
-      {{ with index .CommonAnnotations "summary" }}
-      {{ . }}
-      {{ end }}
-      {{ with index .CommonAnnotations "action" }}
-      Action: {{ . }}
-      {{ end }}
+      {{ define "popchoice.alert.links" -}}
+      {{- with .SilenceURL }}  🔕 <a href="{{ . | html }}">Silence</a>{{ "\n" }}{{- end }}
+      {{- with .DashboardURL }}  📊 <a href="{{ . | html }}">Dashboard</a>{{ "\n" }}{{- end }}
+      {{- with index .Annotations "runbook_url" }}  📘 Runbook: <code>{{ . | html }}</code>{{ "\n" }}{{- end }}
+      {{- end }}
+      {{ define "popchoice.telegram.message" -}}
+      {{ if eq .Status "firing" }}🔥 <b>FIRING</b>{{ else }}✅ <b>RESOLVED</b>{{ end }}{{ with index .CommonLabels "severity" }} <code>{{ . | html }}</code>{{ end }}
+      <b>{{ with index .CommonLabels "alertname" }}{{ . | html }}{{ else }}Grafana alert{{ end }}</b>
+      {{- with index .CommonAnnotations "summary" }}
+      {{ . | html }}
+      {{- end }}
+      {{- with index .CommonAnnotations "action" }}
 
-      {{ if .Alerts.Firing }}
-      Firing: {{ len .Alerts.Firing }}
-      {{ range .Alerts.Firing }}
-      - {{ template "popchoice.alert.target" . }}
-        {{ with index .Annotations "description" }}
-        {{ . }}
-        {{ end }}
-        {{ with .SilenceURL }}
-        Silence: {{ . }}
-        {{ end }}
-        {{ with index .Annotations "runbook_url" }}
-        Runbook: {{ . }}
-        {{ end }}
-      {{ end }}
-      {{ end }}
+      🛠 <b>Action:</b> {{ . | html }}
+      {{- end }}
+      {{- with index .CommonLabels "owner" }}
+      👤 <b>Owner:</b> <code>{{ . | html }}</code>
+      {{- end }}
+      {{- if .Alerts.Firing }}
 
-      {{ if .Alerts.Resolved }}
-      Resolved: {{ len .Alerts.Resolved }}
-      {{ range .Alerts.Resolved }}
-      - {{ template "popchoice.alert.target" . }}
-        {{ with .DashboardURL }}
-        Dashboard: {{ . }}
-        {{ end }}
-      {{ end }}
-      {{ end }}
+      🚨 <b>Firing:</b> {{ len .Alerts.Firing }}
+      {{- range .Alerts.Firing }}
+      • {{ template "popchoice.alert.target" . }}
+      {{- with index .Annotations "description" }}
+        ↳ {{ . | html }}
+      {{- end }}
+      {{ template "popchoice.alert.links" . }}
+      {{- end }}
+      {{- end }}
+      {{- if .Alerts.Resolved }}
 
-      {{ with .ExternalURL }}
-      Grafana: {{ . }}
-      {{ end }}
+      ✅ <b>Resolved:</b> {{ len .Alerts.Resolved }}
+      {{- range .Alerts.Resolved }}
+      • {{ template "popchoice.alert.target" . }}
+      {{ template "popchoice.alert.links" . }}
+      {{- end }}
+      {{- end }}
+      {{- with .ExternalURL -}}
+
+      🔎 <a href="{{ . | html }}">Open Grafana</a>
+      {{- end }}
       {{- end }}
 YAML
 
@@ -68,6 +71,7 @@ contactPoints:
           chatid: "${GRAFANA_TELEGRAM_CHAT_ID}"
           bottoken: "${GRAFANA_TELEGRAM_BOT_TOKEN}"
           uploadImage: false
+          parse_mode: HTML
           message: |
             {{ template "popchoice.telegram.message" . }}
 


### PR DESCRIPTION
## Summary
- Switch Grafana Telegram alert notifications to Telegram HTML parse mode.
- Add emoji markers, bold status/title text, code-formatted labels, and clickable Grafana/Silence/Dashboard links.
- Escape dynamic alert fields for Telegram HTML and update observability docs to describe the new format.

## Validation
- `sh -n observability/images/grafana/entrypoint.sh`
- `git diff --check origin/development..HEAD`
- Generated the Telegram provisioning YAML and parsed it with Ruby YAML.
- Rendered representative `RESOLVED` and `FIRING` Telegram template payloads with Go templates.

## Notes
- Branch was rebased onto current `origin/development` before push.