### PR TITLE
Align production promotion with main branch

### DIFF
--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -36,11 +36,26 @@ jobs:
           DEPLOY_ENVIRONMENT: ${{ inputs.deploy_environment || 'none' }}
         run: echo "deploy_environment=${DEPLOY_ENVIRONMENT}" >> "$GITHUB_OUTPUT"
 
-      - name: Require development ref for Coolify deploys
-        if: github.event_name == 'workflow_dispatch' && inputs.deploy_environment != 'none' && github.ref_name != 'development'
+      - name: Require matching release ref for Coolify deploys
+        if: github.event_name == 'workflow_dispatch' && inputs.deploy_environment != 'none'
+        env:
+          DEPLOY_ENVIRONMENT: ${{ inputs.deploy_environment }}
+          SELECTED_REF: ${{ github.ref_name }}
         run: |
-          echo "Coolify deployments must be dispatched from the development branch."
-          echo "Selected ref: ${GITHUB_REF_NAME}"
+          case "${DEPLOY_ENVIRONMENT}:${SELECTED_REF}" in
+            development:development)
+              exit 0
+              ;;
+            production:main)
+              exit 0
+              ;;
+          esac
+
+          echo "Coolify deploys must be dispatched from the matching release ref."
+          echo "Development deploys use ref: development"
+          echo "Production deploys use ref: main"
+          echo "Selected deploy environment: ${DEPLOY_ENVIRONMENT}"
+          echo "Selected ref: ${SELECTED_REF}"
           exit 1
 
   build-images:
@@ -249,7 +264,7 @@ jobs:
 
   deploy-production:
     name: Deploy production
-    if: github.event_name == 'workflow_dispatch' && github.ref_name == 'development' && inputs.deploy_environment == 'production'
+    if: github.event_name == 'workflow_dispatch' && github.ref_name == 'main' && inputs.deploy_environment == 'production'
     needs: build-images
     runs-on: ubuntu-latest
     environment: production

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -126,8 +126,9 @@ On pull requests from the same repository, the workflow publishes:
 - `pr-<number>` – moving PR tag for the latest image built for that PR
 
 On pushes to `development`, it also publishes `development`. Manual
-`workflow_dispatch` runs can publish either `development` or `production`,
-depending on the selected deploy environment.
+`workflow_dispatch` runs can publish `development` from the `development` ref or
+promote `production` from the `main` ref, depending on the selected deploy
+environment.
 
 Each image receives OCI labels for the repository, workflow run, checked
 commit, source PR branch, source PR head commit, and image role. Published runs
@@ -155,10 +156,11 @@ staging, not production promotion.
 
 For production, create a separate Coolify resource with its own database,
 Redis, volumes, domains, and secrets. The GitHub workflow supports a gated
-promotion path: manually run `Container Images` on the `development` branch,
-choose `deploy_environment=production`, approve the GitHub Environment if
-required, and let the job publish the moving `production` image tag before
-triggering the production Coolify webhook. The production resource should use
+promotion path: after staging is accepted, merge `development` into `main`,
+manually run `Container Images` on the `main` branch, choose
+`deploy_environment=production`, approve the GitHub Environment if required,
+and let the job publish the moving `production` image tag before triggering the
+production Coolify webhook. The production resource should use
 `IMAGE_TAG=production` and `DEPLOYMENT_ENVIRONMENT=production` for that path.
 
 The immutable `sha-<12-char-github-sha>` tags are still published for audit and
@@ -274,7 +276,8 @@ If the PR is docs-only (`docs/**` and root-level `*.md`), heavy CI jobs are skip
 **`container-images.yml`** triggers on pull requests to `development`, pushes
 to `development`, and manual dispatches. Manual runs expose a
 `deploy_environment` input with `development`, `production`, and `none` choices;
-Coolify deploys are only allowed from the `development` ref. The workflow
+Coolify deploys are only allowed from the matching release ref: `development`
+deploys run from `development`, and `production` deploys run from `main`. The workflow
 intentionally does not use docs-only path filtering: image-build changes often
 span workflow files, Dockerfiles, package manifests, and deployment docs, and
 the workflow itself is the source of truth for the deployable artifact.

--- a/docs/COOLIFY.md
+++ b/docs/COOLIFY.md
@@ -500,7 +500,7 @@ For production release promotion:
    `POPCHOICE_DEPLOY_VERIFY_BASE_URL` secrets.
 3. Configure required reviewers on the GitHub `production` Environment.
 4. After the development resource passes the smoke checklist, manually run the
-   `Container Images` workflow on the `development` branch with
+   `Container Images` workflow on the `main` branch with
    `deploy_environment=production`.
 5. Approve the GitHub Environment deployment. The workflow publishes the
    `production` image tag for every service, triggers the production Coolify


### PR DESCRIPTION
## Summary
- allow development deploys only from the development ref and production deploys only from main
- update CI/CD and Coolify docs to describe the manual release promotion flow

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/container-images.yml"); puts "workflow yaml ok"'
- git diff --check