### PR TITLE
Document 0.2.0 Better Taste Control plan

### DIFF
--- a/docs/PRODUCT-BEHAVIOR.md
+++ b/docs/PRODUCT-BEHAVIOR.md
@@ -171,6 +171,25 @@ reactions, account memory, and result feedback. Future quiz work should make
 favorite/reference movies less mandatory, capture more explicit avoid signals,
 and use more concrete "tonight" language.
 
+The `v0.2.0` Better Taste Control milestone is tracked by
+[#826](https://github.com/shchilkin/PopChoice/issues/826). Planned scope:
+
+- [#827](https://github.com/shchilkin/PopChoice/issues/827): explicit avoids
+  and constraints in Fast Pick and Normal Match.
+- [#828](https://github.com/shchilkin/PopChoice/issues/828): optional,
+  lower-friction reference movie UX.
+- [#829](https://github.com/shchilkin/PopChoice/issues/829): discovery
+  appetite for safe, balanced, and surprising picks.
+- [#830](https://github.com/shchilkin/PopChoice/issues/830): result feedback
+  loop v1.
+- [#831](https://github.com/shchilkin/PopChoice/issues/831): deterministic eval
+  coverage for taste-control signals.
+- [#832](https://github.com/shchilkin/PopChoice/issues/832): product docs and
+  release notes.
+
+Until those issues are implemented and verified, this section is planned
+behavior, not the current product contract.
+
 Group rooms are a larger milestone under
 [#359](https://github.com/shchilkin/PopChoice/issues/359), split into:
 

--- a/docs/RECOMMENDATION-ROADMAP.md
+++ b/docs/RECOMMENDATION-ROADMAP.md
@@ -52,6 +52,36 @@ This creates a usable first recommendation, but the data is coarse. It asks user
 - Normal Match is producing promising qualitative results for specific intent prompts. A Russian dystopian/post-apocalyptic survival prompt returned a strong `Blade Runner`-style selection and explanation.
 - Duo and Group need more manual product QA after the entry-flow ordering is fixed, especially to verify whether compromise results feel meaningfully different from solo recommendations.
 
+## 0.2.0 Better Taste Control Release Plan
+
+The next product release is tracked by
+[#826](https://github.com/shchilkin/PopChoice/issues/826). The release should
+make PopChoice more controllable without turning the quiz into a technical
+filter form. Users should be able to say what they want, what they want to
+avoid, and how safe or surprising the pick should feel.
+
+The planned PR sequence is:
+
+1. [#827](https://github.com/shchilkin/PopChoice/issues/827): add explicit
+   avoids and constraints to Fast Pick and Normal Match.
+2. [#828](https://github.com/shchilkin/PopChoice/issues/828): make reference
+   movie input optional and lower-friction.
+3. [#829](https://github.com/shchilkin/PopChoice/issues/829): add discovery
+   appetite control for safe, balanced, and surprising recommendations.
+4. [#830](https://github.com/shchilkin/PopChoice/issues/830): improve the
+   result feedback loop so feedback can guide follow-up recommendations.
+5. [#831](https://github.com/shchilkin/PopChoice/issues/831): expand
+   deterministic recommendation eval coverage for the new taste-control
+   signals.
+6. [#832](https://github.com/shchilkin/PopChoice/issues/832): keep product docs
+   and release notes aligned as behavior lands.
+
+Out of scope for `v0.2.0`:
+
+- Taste Swipe MVP.
+- Multi-device group rooms.
+- A full canonical `TasteSignal[]` backend rewrite.
+
 ## Target Model: Taste Signals
 
 Both quiz answers and swipe interactions should eventually map into a shared signal model.

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -1,0 +1,45 @@
+---
+title: 'PopChoice v0.2.0'
+---
+
+# PopChoice v0.2.0
+
+Draft release notes for the Better Taste Control milestone.
+
+Status: planned. Tracked by
+[#826](https://github.com/shchilkin/PopChoice/issues/826).
+
+## Release Goal
+
+Make PopChoice feel more controllable by letting users describe what they want,
+what they want to avoid, and how safe or surprising the recommendation should
+be.
+
+## Planned Highlights
+
+- Explicit avoids and constraints in Fast Pick and Normal Match.
+- Optional, lower-friction reference movie UX.
+- Discovery appetite control for safe, balanced, and surprising picks.
+- Result feedback loop v1, including stronger follow-up actions from completed
+  results.
+- Deterministic recommendation eval cases for the new taste-control signals.
+- Product docs that keep current behavior separate from planned behavior until
+  implementation lands.
+
+## Out Of Scope
+
+- Taste Swipe MVP.
+- Multi-device group rooms.
+- A full canonical `TasteSignal[]` recommendation backend rewrite.
+
+## Verification Before Promotion
+
+- Run the standard checks required by the implementation PRs.
+- Run `npm run eval:recommendations` for prompt, ranking, candidate filtering,
+  feedback-signal, or eval-fixture changes.
+- Run product e2e coverage for changed quiz, recommendation, result feedback,
+  and movie-memory flows.
+- Verify the deployed `development` environment before promoting to
+  `production`.
+- Confirm `/api/build` reports `version: 0.2.0`, the expected channel, and the
+  expected source branch or commit after release promotion.


### PR DESCRIPTION
## Summary
- link the v0.2.0 Better Taste Control milestone and child issues from the recommendation roadmap
- add planned product-behavior scope for the 0.2.0 taste-control work
- add draft v0.2.0 release notes with promotion verification notes

## Verification
- /Users/shchilkin/dev/PopChoice/node_modules/.bin/prettier --check docs/RECOMMENDATION-ROADMAP.md docs/PRODUCT-BEHAVIOR.md docs/releases/v0.2.0.md
- git diff --check

Tracks #826. Supports #832.