### PR TITLE
Add taste-control recommendation eval fixtures

### DIFF
--- a/apps/web/src/features/recommendation/evals/fixtures.ts
+++ b/apps/web/src/features/recommendation/evals/fixtures.ts
@@ -41,6 +41,14 @@ const candidateCatalog: RecommendationEvalCandidate[] = [
   { name: 'PopChoice E2E Cozy Mystery', year: 2021 },
   { name: 'PopChoice E2E Ensemble Comedy', year: 2020 },
   { name: 'PopChoice E2E Grounded Thriller', year: 2016 },
+  { name: 'PopChoice E2E Neon Frontier', year: 2025 },
+  { name: 'PopChoice E2E Haunted Starship', year: 2022 },
+  { name: 'PopChoice E2E Left-Field Comedy', year: 2023 },
+  { name: 'PopChoice E2E Familiar Romcom', year: 2019 },
+  { name: 'PopChoice E2E Short Group Mystery', year: 2021 },
+  { name: 'PopChoice E2E Three-Hour Epic', year: 2009 },
+  { name: 'PopChoice E2E Oddball Heist', year: 2024 },
+  { name: 'PopChoice E2E Gore Carnival', year: 2020 },
 ];
 
 const movieDetailsByName: Record<
@@ -88,6 +96,48 @@ const movieDetailsByName: Record<
     score_rating: 7.9,
     tmdbId: 900007,
   },
+  'PopChoice E2E Familiar Romcom': {
+    age_rating: 'PG-13',
+    aiDescription: 'An obvious, familiar date-night romcom with a very safe shape.',
+    duration: 104,
+    score_rating: 7.1,
+    tmdbId: 900011,
+  },
+  'PopChoice E2E Gore Carnival': {
+    age_rating: 'R',
+    aiDescription: 'A gruesome gore spectacle built around shock scenes and splatter.',
+    duration: 111,
+    score_rating: 7.2,
+    tmdbId: 900015,
+  },
+  'PopChoice E2E Haunted Starship': {
+    age_rating: 'R',
+    aiDescription: 'A horror-leaning space thriller with haunted corridors and jump scares.',
+    duration: 116,
+    score_rating: 7.4,
+    tmdbId: 900009,
+  },
+  'PopChoice E2E Left-Field Comedy': {
+    age_rating: 'PG-13',
+    aiDescription: 'A funny, offbeat date-night comedy with playful surprise.',
+    duration: 99,
+    score_rating: 8.0,
+    tmdbId: 900010,
+  },
+  'PopChoice E2E Neon Frontier': {
+    age_rating: 'PG-13',
+    aiDescription: 'A dark sci-fi frontier story with kinetic ideas and clean tension.',
+    duration: 119,
+    score_rating: 8.5,
+    tmdbId: 900008,
+  },
+  'PopChoice E2E Oddball Heist': {
+    age_rating: 'PG-13',
+    aiDescription: 'A surprising heist movie with strange comedy and nimble pacing.',
+    duration: 102,
+    score_rating: 8.2,
+    tmdbId: 900014,
+  },
   'PopChoice E2E Space Opera': {
     age_rating: 'PG-13',
     aiDescription:
@@ -95,6 +145,20 @@ const movieDetailsByName: Record<
     duration: 142,
     score_rating: 8.7,
     tmdbId: 900001,
+  },
+  'PopChoice E2E Short Group Mystery': {
+    age_rating: 'PG',
+    aiDescription: 'A compact group mystery with clean stakes and quick social momentum.',
+    duration: 96,
+    score_rating: 7.9,
+    tmdbId: 900012,
+  },
+  'PopChoice E2E Three-Hour Epic': {
+    age_rating: 'PG-13',
+    aiDescription: 'A long runtime three-hour epic with sweeping battles and heavy pacing.',
+    duration: 188,
+    score_rating: 8.4,
+    tmdbId: 900013,
   },
 };
 
@@ -258,6 +322,36 @@ function getMockSourceDistribution(
   return distribution;
 }
 
+function getCandidates(names: string[]): RecommendationEvalCandidate[] {
+  return names.map((name) => {
+    const candidate = candidateCatalog.find((movie) => movie.name === name);
+    if (!candidate) throw new Error(`Missing deterministic eval candidate "${name}".`);
+    return candidate;
+  });
+}
+
+function getTasteControlResponse({
+  description,
+  sourceStrategy,
+  titles,
+}: {
+  description: string;
+  sourceStrategy: RecommendationEvalSourceStrategy;
+  titles: string[];
+}): ApiResponse {
+  return {
+    dbMovieCount: candidateCatalog.length,
+    description,
+    similarMovies: titles.map((title, index) =>
+      toSimilarMovie(title, index, sourceStrategy, index === 0),
+    ),
+    candidateSourceDistribution: getMockSourceDistribution(sourceStrategy, titles.length),
+    sourceStrategy,
+    title: titles[0] ?? '',
+    usedBroaderSearch: sourceStrategy !== 'curated-showcase',
+  };
+}
+
 function getMinCandidateSources(
   sourceStrategy: RecommendationEvalSourceStrategy,
 ): NonNullable<RecommendationEvalFixture['expectations']['minCandidateSources']> {
@@ -296,8 +390,285 @@ function getMockResponse(
   };
 }
 
-export const recommendationEvalFixtures: RecommendationEvalFixture[] =
-  recommendationEvalScenarioMatrix.map(({ audience, depth, sourceStrategy }) => ({
+export const recommendationEvalTasteControlFixtures: RecommendationEvalFixture[] = [
+  {
+    audience: 'solo',
+    candidates: getCandidates([
+      'PopChoice E2E Neon Frontier',
+      'PopChoice E2E Haunted Starship',
+      'PopChoice E2E Space Opera',
+      'PopChoice E2E Grounded Thriller',
+    ]),
+    depth: 'focused',
+    description: 'Dark sci-fi but no horror, with no required reference movie.',
+    expectations: {
+      allowedMainTitles: ['PopChoice E2E Neon Frontier'],
+      forbiddenTitles: ['PopChoice E2E Haunted Starship'],
+      forbiddenTerms: ['sexual minors', 'self-harm instructions'],
+      minCandidateSources: { 'tmdb-discover': 1, 'tmdb-search': 1 },
+      minDescriptionCharacters: 80,
+      minMetadataCompleteCandidates: 3,
+      minPassingScore: 90,
+      minSimilarMovies: 3,
+      requiredExplanationTerms: ['solo', 'sci-fi', 'avoid', 'horror', 'balanced'],
+      tasteControl: {
+        discoveryAppetite: 'balanced',
+        hardAvoidTerms: ['horror', 'haunted'],
+        optionalReferenceMovie: true,
+      },
+    },
+    id: 'taste-dark-sci-fi-no-horror',
+    locale: 'en' as const,
+    mockResponse: getTasteControlResponse({
+      description:
+        'For the solo viewer, Neon Frontier keeps dark sci-fi momentum, avoids horror, and stays balanced instead of becoming a bleak shock pick.',
+      sourceStrategy: 'tmdb-first',
+      titles: [
+        'PopChoice E2E Neon Frontier',
+        'PopChoice E2E Space Opera',
+        'PopChoice E2E Grounded Thriller',
+      ],
+    }),
+    name: 'taste control / dark sci-fi / no horror',
+    people: [
+      {
+        favoriteMovie: '',
+        favoriteMovieWhy: 'Dark sci-fi mood. Avoid: horror. Discovery appetite: balanced.',
+        moodPreference: ['Sci-Fi', 'Adventurous'],
+        name: 'Riley',
+        newVsClassic: 'Balanced',
+        tonePreference: 'Tense but not scary',
+      },
+    ],
+    sourceStrategy: 'tmdb-first',
+    userMemories: [],
+  },
+  {
+    audience: 'solo',
+    candidates: getCandidates([
+      'PopChoice E2E Left-Field Comedy',
+      'PopChoice E2E Familiar Romcom',
+      'PopChoice E2E Ensemble Comedy',
+      'PopChoice E2E Cozy Mystery',
+    ]),
+    depth: 'focused',
+    description: 'Funny date night that should not collapse to an obvious romcom.',
+    expectations: {
+      allowedMainTitles: ['PopChoice E2E Left-Field Comedy'],
+      forbiddenTitles: ['PopChoice E2E Familiar Romcom'],
+      forbiddenTerms: ['sexual minors', 'self-harm instructions'],
+      minCandidateSources: { 'local-cache': 1, 'tmdb-discover': 1 },
+      minDescriptionCharacters: 80,
+      minMetadataCompleteCandidates: 3,
+      minPassingScore: 90,
+      minSimilarMovies: 3,
+      requiredExplanationTerms: ['solo', 'funny', 'date-night', 'avoid', 'obvious'],
+      tasteControl: {
+        discoveryAppetite: 'surprising',
+        hardAvoidTerms: ['obvious'],
+      },
+    },
+    id: 'taste-funny-date-night-not-obvious',
+    locale: 'en' as const,
+    mockResponse: getTasteControlResponse({
+      description:
+        'For the solo date-night brief, Left-Field Comedy keeps things funny and surprising while avoiding the obvious comfort-romcom lane.',
+      sourceStrategy: 'hybrid-fast',
+      titles: [
+        'PopChoice E2E Left-Field Comedy',
+        'PopChoice E2E Ensemble Comedy',
+        'PopChoice E2E Cozy Mystery',
+      ],
+    }),
+    name: 'taste control / funny date night / not obvious',
+    people: [
+      {
+        favoriteMovie: 'Palm Springs',
+        favoriteMovieWhy:
+          'Funny date-night energy. Avoid: too obvious. Discovery appetite: surprising.',
+        moodPreference: ['Funny', 'Romantic'],
+        name: 'Riley',
+        newVsClassic: 'New',
+        tonePreference: 'Playful',
+      },
+    ],
+    sourceStrategy: 'hybrid-fast',
+    userMemories: [],
+  },
+  {
+    audience: 'group',
+    candidates: getCandidates([
+      'PopChoice E2E Short Group Mystery',
+      'PopChoice E2E Three-Hour Epic',
+      'PopChoice E2E Ensemble Comedy',
+      'PopChoice E2E Family Adventure',
+    ]),
+    depth: 'compromise',
+    description: 'Group pick with a hard no on long runtime.',
+    expectations: {
+      allowedMainTitles: ['PopChoice E2E Short Group Mystery'],
+      forbiddenTitles: ['PopChoice E2E Three-Hour Epic'],
+      forbiddenTerms: ['sexual minors', 'self-harm instructions'],
+      minCandidateSources: { curated: 3 },
+      minDescriptionCharacters: 80,
+      minMetadataCompleteCandidates: 3,
+      minPassingScore: 90,
+      minSimilarMovies: 3,
+      requiredExplanationTerms: ['group', 'both', 'avoid', 'long runtime'],
+      tasteControl: {
+        hardAvoidTerms: ['long runtime', 'three-hour'],
+        maxRuntimeMinutes: 125,
+      },
+    },
+    id: 'taste-group-no-long-runtime',
+    locale: 'en',
+    mockResponse: getTasteControlResponse({
+      description:
+        'For the group, Short Group Mystery gives both sides quick social momentum and avoids long runtime fatigue.',
+      sourceStrategy: 'curated-showcase',
+      titles: [
+        'PopChoice E2E Short Group Mystery',
+        'PopChoice E2E Ensemble Comedy',
+        'PopChoice E2E Family Adventure',
+      ],
+    }),
+    name: 'taste control / group / no long runtime',
+    people: [
+      {
+        favoriteMovie: 'Knives Out',
+        favoriteMovieWhy: 'Group mystery night. Avoid: long runtime.',
+        moodPreference: ['Mystery', 'Funny'],
+        name: 'Alex',
+        newVsClassic: 'Balanced',
+        tonePreference: 'Social',
+      },
+      {
+        favoriteMovie: 'Game Night',
+        favoriteMovieWhy: 'Keep it quick and energetic.',
+        moodPreference: ['Funny', 'Energetic'],
+        name: 'Sam',
+        newVsClassic: 'Balanced',
+        tonePreference: 'Fast',
+      },
+    ],
+    sourceStrategy: 'curated-showcase',
+    userMemories: [],
+  },
+  {
+    audience: 'solo',
+    candidates: getCandidates([
+      'PopChoice E2E Oddball Heist',
+      'PopChoice E2E Gore Carnival',
+      'PopChoice E2E Left-Field Comedy',
+      'PopChoice E2E Cozy Mystery',
+    ]),
+    depth: 'focused',
+    description: 'Surprise me, but no gore.',
+    expectations: {
+      allowedMainTitles: ['PopChoice E2E Oddball Heist'],
+      forbiddenTitles: ['PopChoice E2E Gore Carnival'],
+      forbiddenTerms: ['sexual minors', 'self-harm instructions'],
+      minCandidateSources: { 'tmdb-discover': 1, 'tmdb-search': 1 },
+      minDescriptionCharacters: 80,
+      minMetadataCompleteCandidates: 3,
+      minPassingScore: 90,
+      minSimilarMovies: 3,
+      requiredExplanationTerms: ['solo', 'surprising', 'avoid', 'gore'],
+      tasteControl: {
+        discoveryAppetite: 'surprising',
+        hardAvoidTerms: ['gore', 'gruesome'],
+      },
+    },
+    id: 'taste-surprise-no-gore',
+    locale: 'en',
+    mockResponse: getTasteControlResponse({
+      description:
+        'For the solo viewer, Oddball Heist is surprising and strange while explicitly avoiding gore or gruesome shock value.',
+      sourceStrategy: 'tmdb-first',
+      titles: [
+        'PopChoice E2E Oddball Heist',
+        'PopChoice E2E Left-Field Comedy',
+        'PopChoice E2E Cozy Mystery',
+      ],
+    }),
+    name: 'taste control / surprise me / no gore',
+    people: [
+      {
+        favoriteMovie: '',
+        favoriteMovieWhy: 'Surprise me. Avoid: gore. Discovery appetite: surprising.',
+        moodPreference: ['Funny', 'Adventurous'],
+        name: 'Riley',
+        newVsClassic: 'New',
+        tonePreference: 'Odd but friendly',
+      },
+    ],
+    sourceStrategy: 'tmdb-first',
+    userMemories: [],
+  },
+  {
+    audience: 'solo',
+    candidates: getCandidates([
+      'PopChoice E2E Cozy Mystery',
+      'PopChoice E2E Familiar Romcom',
+      'PopChoice E2E Three-Hour Epic',
+      'PopChoice E2E Gore Carnival',
+      'PopChoice E2E Ensemble Comedy',
+      'PopChoice E2E Family Adventure',
+    ]),
+    depth: 'memory-aware',
+    description: 'Feedback-derived memory should block watched, wrong-mood, and rejected titles.',
+    expectations: {
+      allowedMainTitles: ['PopChoice E2E Cozy Mystery'],
+      forbiddenTitles: [
+        'PopChoice E2E Familiar Romcom',
+        'PopChoice E2E Three-Hour Epic',
+        'PopChoice E2E Gore Carnival',
+      ],
+      forbiddenTerms: ['sexual minors', 'self-harm instructions'],
+      minCandidateSources: { 'local-cache': 1, 'tmdb-discover': 1 },
+      minDescriptionCharacters: 80,
+      minMetadataCompleteCandidates: 3,
+      minPassingScore: 90,
+      minSimilarMovies: 3,
+      requiredExplanationTerms: ['solo', 'avoid', 'watched', 'wrong mood'],
+      tasteControl: {
+        feedbackMemoryKinds: ['watched', 'wrong_mood', 'not_interested'],
+      },
+    },
+    id: 'taste-feedback-memory-repeat-avoidance',
+    locale: 'en',
+    mockResponse: getTasteControlResponse({
+      description:
+        'For the solo viewer, Cozy Mystery respects feedback memory: it avoids watched titles, wrong mood signals, and rejected picks.',
+      sourceStrategy: 'hybrid-fast',
+      titles: [
+        'PopChoice E2E Cozy Mystery',
+        'PopChoice E2E Ensemble Comedy',
+        'PopChoice E2E Family Adventure',
+      ],
+    }),
+    name: 'taste control / feedback memory / repeat avoidance',
+    people: [
+      {
+        favoriteMovie: '',
+        favoriteMovieWhy: 'Need a softer reset after recent misses.',
+        moodPreference: ['Mystery', 'Heartwarming'],
+        name: 'Riley',
+        newVsClassic: 'Balanced',
+        tonePreference: 'Gentle',
+      },
+    ],
+    sourceStrategy: 'hybrid-fast',
+    userMemories: [
+      { kind: 'watched', movieName: 'PopChoice E2E Familiar Romcom', movieYear: 2019 },
+      { kind: 'wrong_mood', movieName: 'PopChoice E2E Three-Hour Epic', movieYear: 2009 },
+      { kind: 'not_interested', movieName: 'PopChoice E2E Gore Carnival', movieYear: 2020 },
+    ],
+  },
+];
+
+export const recommendationEvalFixtures: RecommendationEvalFixture[] = [
+  ...recommendationEvalScenarioMatrix.map(({ audience, depth, sourceStrategy }) => ({
     audience,
     candidates: candidateCatalog,
     depth,
@@ -313,10 +684,12 @@ export const recommendationEvalFixtures: RecommendationEvalFixture[] =
       requiredExplanationTerms: getRequiredExplanationTerms(audience, depth),
     },
     id: `${audience}-${depth}-${sourceStrategy}`,
-    locale: 'en',
+    locale: 'en' as const,
     mockResponse: getMockResponse(audience, depth, sourceStrategy),
     name: `${audience} / ${depth} / ${sourceStrategy}`,
     people: getPeople(audience),
     sourceStrategy,
     userMemories: getMemories(depth),
-  }));
+  })),
+  ...recommendationEvalTasteControlFixtures,
+];

--- a/apps/web/src/features/recommendation/evals/scoring.test.ts
+++ b/apps/web/src/features/recommendation/evals/scoring.test.ts
@@ -6,6 +6,7 @@ import {
   recommendationEvalFixtures,
   recommendationEvalScenarioMatrix,
   recommendationEvalSourceStrategies,
+  recommendationEvalTasteControlFixtures,
 } from './fixtures';
 import { buildRecommendationEvalReport, scoreRecommendationEvalFixture } from './scoring';
 
@@ -15,7 +16,9 @@ describe('recommendation eval scoring', () => {
       scoreRecommendationEvalFixture(fixture, fixture.mockResponse),
     );
 
-    expect(results).toHaveLength(recommendationEvalScenarioMatrix.length);
+    expect(results).toHaveLength(
+      recommendationEvalScenarioMatrix.length + recommendationEvalTasteControlFixtures.length,
+    );
     expect(results.every((result) => result.passed)).toBe(true);
     expect(results.every((result) => result.score === 100)).toBe(true);
   });
@@ -37,17 +40,38 @@ describe('recommendation eval scoring', () => {
     );
 
     expect(actualScenarioKeys).toEqual(expectedScenarioKeys);
-    expect(recommendationEvalFixtures).toHaveLength(
+    expect(recommendationEvalFixtures.length).toBeGreaterThanOrEqual(
       recommendationEvalAudiences.length *
         recommendationEvalDepths.length *
         recommendationEvalSourceStrategies.length,
     );
   });
 
+  it('covers the 0.2.0 taste-control fixture scenarios', () => {
+    expect(recommendationEvalTasteControlFixtures.map((fixture) => fixture.id)).toEqual([
+      'taste-dark-sci-fi-no-horror',
+      'taste-funny-date-night-not-obvious',
+      'taste-group-no-long-runtime',
+      'taste-surprise-no-gore',
+      'taste-feedback-memory-repeat-avoidance',
+    ]);
+
+    for (const fixture of recommendationEvalTasteControlFixtures) {
+      const result = scoreRecommendationEvalFixture(fixture, fixture.mockResponse);
+      expect(result.passed).toBe(true);
+      expect(result.checks.filter((check) => check.id.startsWith('taste-control-'))).toEqual([
+        expect.objectContaining({ id: 'taste-control-hard-avoids', passed: true }),
+        expect.objectContaining({ id: 'taste-control-discovery-appetite', passed: true }),
+        expect.objectContaining({ id: 'taste-control-optional-reference', passed: true }),
+        expect.objectContaining({ id: 'taste-control-feedback-memory', passed: true }),
+      ]);
+    }
+  });
+
   it('requires scenario metadata to be represented in deterministic fixture responses', () => {
-    const results = recommendationEvalFixtures.map((fixture) =>
-      scoreRecommendationEvalFixture(fixture, fixture.mockResponse),
-    );
+    const results = recommendationEvalFixtures
+      .filter((fixture) => !fixture.id.startsWith('taste-'))
+      .map((fixture) => scoreRecommendationEvalFixture(fixture, fixture.mockResponse));
 
     for (const result of results) {
       expect(
@@ -187,6 +211,85 @@ describe('recommendation eval scoring', () => {
     expect(result.checks.find((check) => check.id === 'repeat-avoidance')?.passed).toBe(false);
   });
 
+  it('fails when a hard-avoid candidate appears in a taste-control response', () => {
+    const fixture = getFixtureById('taste-dark-sci-fi-no-horror');
+    const result = scoreRecommendationEvalFixture(fixture, {
+      ...fixture.mockResponse,
+      title: 'PopChoice E2E Haunted Starship',
+      similarMovies: [
+        {
+          ...fixture.mockResponse.similarMovies![0]!,
+          aiDescription: 'A horror-leaning space thriller with haunted corridors.',
+          isMainRecommendation: true,
+          name: 'PopChoice E2E Haunted Starship',
+          year: 2022,
+        },
+        ...fixture.mockResponse.similarMovies!.slice(1),
+      ],
+    });
+
+    expect(result.passed).toBe(false);
+    expect(result.checks.find((check) => check.id === 'taste-control-hard-avoids')).toMatchObject({
+      passed: false,
+    });
+  });
+
+  it('fails when a runtime hard avoid is ignored', () => {
+    const fixture = getFixtureById('taste-group-no-long-runtime');
+    const result = scoreRecommendationEvalFixture(fixture, {
+      ...fixture.mockResponse,
+      similarMovies: [
+        {
+          ...fixture.mockResponse.similarMovies![0]!,
+          duration: 188,
+          name: 'PopChoice E2E Three-Hour Epic',
+          year: 2009,
+        },
+        ...fixture.mockResponse.similarMovies!.slice(1),
+      ],
+      title: 'PopChoice E2E Three-Hour Epic',
+    });
+
+    expect(result.passed).toBe(false);
+    expect(result.checks.find((check) => check.id === 'taste-control-hard-avoids')).toMatchObject({
+      passed: false,
+    });
+  });
+
+  it('fails when an optional reference fixture still depends on a missing reference movie', () => {
+    const fixture = getFixtureById('taste-dark-sci-fi-no-horror');
+    const result = scoreRecommendationEvalFixture(fixture, {
+      ...fixture.mockResponse,
+      description:
+        'For the solo viewer, this works because it follows the missing favorite movie reference movie and stays balanced.',
+    });
+
+    expect(result.passed).toBe(false);
+    expect(
+      result.checks.find((check) => check.id === 'taste-control-optional-reference'),
+    ).toMatchObject({
+      passed: false,
+    });
+  });
+
+  it('fails when feedback-derived memory expectations are not represented', () => {
+    const fixture = getFixtureById('taste-feedback-memory-repeat-avoidance');
+    const result = scoreRecommendationEvalFixture(
+      {
+        ...fixture,
+        userMemories: fixture.userMemories.filter((memory) => memory.kind !== 'wrong_mood'),
+      },
+      fixture.mockResponse,
+    );
+
+    expect(result.passed).toBe(false);
+    expect(
+      result.checks.find((check) => check.id === 'taste-control-feedback-memory'),
+    ).toMatchObject({
+      passed: false,
+    });
+  });
+
   it('summarizes eval reports in a machine-readable shape', () => {
     const results = recommendationEvalFixtures.map((fixture) =>
       scoreRecommendationEvalFixture(fixture, fixture.mockResponse),
@@ -220,5 +323,11 @@ function getFixture(
   if (!fixture) {
     throw new Error(`Missing eval fixture for ${audience}/${depth}/${sourceStrategy}`);
   }
+  return fixture;
+}
+
+function getFixtureById(id: string) {
+  const fixture = recommendationEvalFixtures.find((candidate) => candidate.id === id);
+  if (!fixture) throw new Error(`Missing eval fixture ${id}`);
   return fixture;
 }

--- a/apps/web/src/features/recommendation/evals/scoring.ts
+++ b/apps/web/src/features/recommendation/evals/scoring.ts
@@ -27,6 +27,7 @@ type ScoringContext = {
   fixture: RecommendationEvalFixture;
   mainTitle: string;
   response: ApiResponse;
+  responseCandidateText: string;
   responseMovieTitles: string[];
   responseText: string;
   sourceDistribution: CandidateSourceDistribution;
@@ -60,12 +61,18 @@ function normalizeTitle(value: string, year?: number): string {
 }
 
 function collectResponseText(response: ApiResponse): string {
+  return normalizeText(
+    [response.title, response.description, collectResponseCandidateText(response)].join(' '),
+  );
+}
+
+function collectResponseCandidateText(response: ApiResponse): string {
   const movieText =
     response.similarMovies
       ?.flatMap((movie) => [movie.name, movie.localizedName, movie.aiDescription])
       .filter((text): text is string => typeof text === 'string' && text.trim().length > 0)
       .join(' ') ?? '';
-  return normalizeText([response.title, response.description, movieText].join(' '));
+  return normalizeText([response.title, movieText].join(' '));
 }
 
 function textIncludesAnyTerm(text: string, terms: string[]): boolean {
@@ -126,6 +133,7 @@ function buildScoringContext(
     fixture,
     mainTitle: normalizeTitle(getMainRecommendationTitle(response)),
     response,
+    responseCandidateText: collectResponseCandidateText(response),
     responseMovieTitles: response.similarMovies?.map((movie) => normalizeTitle(movie.name)) ?? [],
     responseText: collectResponseText(response),
     sourceDistribution: getResponseSourceDistribution(response),
@@ -147,6 +155,10 @@ function buildRecommendationEvalChecks(context: ScoringContext): RecommendationE
     buildScenarioDepthCheck(context),
     buildScenarioSourceStrategyCheck(context),
     buildQualityThresholdCheck(context),
+    buildTasteControlHardAvoidsCheck(context),
+    buildTasteControlDiscoveryCheck(context),
+    buildTasteControlOptionalReferenceCheck(context),
+    buildTasteControlFeedbackMemoryCheck(context),
   ];
 }
 
@@ -549,6 +561,160 @@ function getQualityThresholdResult({
           .join('; '),
     passed,
   };
+}
+
+function buildTasteControlHardAvoidsCheck({
+  fixture,
+  response,
+  responseCandidateText,
+}: ScoringContext): RecommendationEvalCheck {
+  const tasteControl = fixture.expectations.tasteControl;
+  const hardAvoidTerms = tasteControl?.hardAvoidTerms ?? [];
+  const maxRuntimeMinutes = tasteControl?.maxRuntimeMinutes;
+  const foundHardAvoidTerms = getFoundHardAvoidTerms(hardAvoidTerms, responseCandidateText);
+  const overRuntimeMovies = getOverRuntimeMovies(response, maxRuntimeMinutes);
+  const passed = foundHardAvoidTerms.length === 0 && overRuntimeMovies.length === 0;
+
+  return buildCheck(
+    'taste-control-hard-avoids',
+    'Taste control: hard avoids',
+    0,
+    passed,
+    getHardAvoidDetails({
+      foundHardAvoidTerms,
+      hardAvoidTerms,
+      maxRuntimeMinutes,
+      overRuntimeMovies,
+      passed,
+    }),
+  );
+}
+
+function getFoundHardAvoidTerms(hardAvoidTerms: string[], responseCandidateText: string): string[] {
+  return hardAvoidTerms.filter((term) => responseCandidateText.includes(normalizeText(term)));
+}
+
+function getOverRuntimeMovies(
+  response: ApiResponse,
+  maxRuntimeMinutes: number | undefined,
+): string[] {
+  if (typeof maxRuntimeMinutes !== 'number') return [];
+
+  return (
+    response.similarMovies
+      ?.filter((movie) => movie.duration > maxRuntimeMinutes)
+      .map((movie) => `${movie.name} (${movie.duration}m)`) ?? []
+  );
+}
+
+function getHardAvoidDetails({
+  foundHardAvoidTerms,
+  hardAvoidTerms,
+  maxRuntimeMinutes,
+  overRuntimeMovies,
+  passed,
+}: {
+  foundHardAvoidTerms: string[];
+  hardAvoidTerms: string[];
+  maxRuntimeMinutes: number | undefined;
+  overRuntimeMovies: string[];
+  passed: boolean;
+}): string {
+  if (!passed) {
+    return joinFailureDetails([
+      foundHardAvoidTerms.length === 0
+        ? null
+        : `candidate text includes hard avoids: ${foundHardAvoidTerms.join(', ')}`,
+      overRuntimeMovies.length === 0
+        ? null
+        : `runtime over ${maxRuntimeMinutes}m: ${overRuntimeMovies.join(', ')}`,
+    ]);
+  }
+
+  return hardAvoidTerms.length > 0 || typeof maxRuntimeMinutes === 'number'
+    ? 'Recommended candidates respect explicit hard avoids and runtime constraints.'
+    : 'No explicit taste-control hard avoids configured for this fixture.';
+}
+
+function buildTasteControlDiscoveryCheck({
+  fixture,
+  responseText,
+}: ScoringContext): RecommendationEvalCheck {
+  const appetite = fixture.expectations.tasteControl?.discoveryAppetite;
+  const passed = !appetite || responseText.includes(normalizeText(appetite));
+
+  return buildCheck(
+    'taste-control-discovery-appetite',
+    'Taste control: discovery appetite',
+    0,
+    passed,
+    passed
+      ? appetite
+        ? `Response represents the ${appetite} discovery appetite.`
+        : 'No discovery appetite expectation configured for this fixture.'
+      : `Expected response text to represent discovery appetite: ${appetite}.`,
+  );
+}
+
+function buildTasteControlOptionalReferenceCheck({
+  fixture,
+  responseText,
+}: ScoringContext): RecommendationEvalCheck {
+  const expectsOptionalReference =
+    fixture.expectations.tasteControl?.optionalReferenceMovie === true;
+  const allReferenceMoviesBlank = fixture.people.every(
+    (person) => person.favoriteMovie.trim().length === 0,
+  );
+  const mentionsMissingReference =
+    responseText.includes('favorite movie') || responseText.includes('reference movie');
+  const passed =
+    !expectsOptionalReference || (allReferenceMoviesBlank && !mentionsMissingReference);
+
+  return buildCheck(
+    'taste-control-optional-reference',
+    'Taste control: optional reference movie',
+    0,
+    passed,
+    passed
+      ? expectsOptionalReference
+        ? 'Fixture runs with no reference movie and the response does not ask for one.'
+        : 'No optional-reference expectation configured for this fixture.'
+      : joinFailureDetails([
+          allReferenceMoviesBlank ? null : 'expected all favoriteMovie fields to be blank',
+          mentionsMissingReference ? 'response still leans on a missing reference movie' : null,
+        ]),
+  );
+}
+
+function buildTasteControlFeedbackMemoryCheck({
+  fixture,
+  responseText,
+}: ScoringContext): RecommendationEvalCheck {
+  const expectedKinds = fixture.expectations.tasteControl?.feedbackMemoryKinds ?? [];
+  const actualKinds = new Set(fixture.userMemories.map((memory) => memory.kind));
+  const missingKinds = expectedKinds.filter((kind) => !actualKinds.has(kind));
+  const responseMentionsAvoidance = responseText.includes('avoid');
+  const passed =
+    missingKinds.length === 0 && (expectedKinds.length === 0 || responseMentionsAvoidance);
+
+  return buildCheck(
+    'taste-control-feedback-memory',
+    'Taste control: feedback memory',
+    0,
+    passed,
+    passed
+      ? expectedKinds.length > 0
+        ? `Fixture covers feedback memory kinds: ${expectedKinds.join(', ')}.`
+        : 'No feedback-memory expectation configured for this fixture.'
+      : joinFailureDetails([
+          missingKinds.length === 0
+            ? null
+            : `missing feedback memory kinds: ${missingKinds.join(', ')}`,
+          responseMentionsAvoidance
+            ? null
+            : 'expected response text to mention avoiding feedback-memory repeats',
+        ]),
+  );
 }
 
 export function buildRecommendationEvalReport(

--- a/apps/web/src/features/recommendation/evals/types.ts
+++ b/apps/web/src/features/recommendation/evals/types.ts
@@ -39,6 +39,15 @@ export type RecommendationEvalExpectations = {
   minPassingScore?: number;
   minSimilarMovies?: number;
   requiredExplanationTerms?: string[];
+  tasteControl?: RecommendationEvalTasteControlExpectations;
+};
+
+export type RecommendationEvalTasteControlExpectations = {
+  discoveryAppetite?: 'balanced' | 'safe' | 'surprising';
+  feedbackMemoryKinds?: RecommendationEvalMemoryKind[];
+  hardAvoidTerms?: string[];
+  maxRuntimeMinutes?: number;
+  optionalReferenceMovie?: boolean;
 };
 
 export type RecommendationEvalFixture = {

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -226,6 +226,9 @@ The default eval path uses fixture prompts, fixture user-memory constraints, and
 - forbidden safety terms are absent
 - watched, rejected, and explicitly forbidden titles are not repeated
 - explanation text is specific enough for the fixture expectations
+- 0.2.0 taste-control signals remain visible and enforceable: explicit hard
+  avoids, runtime constraints, discovery appetite, optional reference movie
+  flows, and feedback-derived memory
 
 Run live-provider evals only when intentionally checking model/provider behavior:
 

--- a/docs/PRODUCT-BEHAVIOR.md
+++ b/docs/PRODUCT-BEHAVIOR.md
@@ -199,8 +199,8 @@ The `v0.2.0` Better Taste Control milestone is tracked by
       appetite for safe, balanced, and surprising picks.
 - [x] [#830](https://github.com/shchilkin/PopChoice/issues/830): result
       feedback loop v1.
-- [#831](https://github.com/shchilkin/PopChoice/issues/831): deterministic eval
-  coverage for taste-control signals.
+- [x] [#831](https://github.com/shchilkin/PopChoice/issues/831):
+      deterministic eval coverage for taste-control signals.
 - [#832](https://github.com/shchilkin/PopChoice/issues/832): product docs and
   release notes.
 

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -24,7 +24,9 @@ be.
 - Result feedback loop v1: completed results now expose all persisted feedback
   signals plus "More like this" and "Try same vibe" actions backed by the
   existing one-shot more-picks queue.
-- Deterministic recommendation eval cases for the new taste-control signals.
+- Deterministic recommendation eval cases for the new taste-control signals:
+  hard avoids, runtime limits, discovery appetite, optional reference movies,
+  and feedback-derived memory.
 - Product docs that keep current behavior separate from planned behavior until
   implementation lands.
 


### PR DESCRIPTION
## Summary
- add explicit 0.2.0 taste-control eval fixtures for hard avoids, runtime limits, discovery appetite, optional reference movies, and feedback-derived memory
- add zero-score pass/fail checks that make the specific taste-control signal visible in eval reports
- document the expanded deterministic eval coverage and mark #831 complete in the 0.2.0 docs

Closes #831

## Verification
- npx prettier --check docs/DEVELOPMENT.md docs/PRODUCT-BEHAVIOR.md docs/releases/v0.2.0.md apps/web/src/features/recommendation/evals/fixtures.ts apps/web/src/features/recommendation/evals/scoring.ts apps/web/src/features/recommendation/evals/scoring.test.ts apps/web/src/features/recommendation/evals/types.ts
- npm run test --workspace=apps/web -- src/features/recommendation/evals
- npm run eval:recommendations
- npm run type-check
- npm run quality:fallow:audit -- --changed-since origin/development --format compact
- git diff --check
- pre-push: lint, server tests, production build
