### PR TITLE
Finalize v0.2.0 release docs

### DIFF
--- a/docs/PRODUCT-BEHAVIOR.md
+++ b/docs/PRODUCT-BEHAVIOR.md
@@ -176,20 +176,11 @@ group-oriented copy and insights when the persisted result includes them. The
 current model does not create room records, invite links, readiness state, QR
 codes, projector mode, or independent participant sessions.
 
-## Planned Product Direction
-
-Planned behavior should remain issue-backed and should not be described as
-current product behavior until implemented.
-
-Recommendation experience direction is tracked in
-[/docs/RECOMMENDATION-ROADMAP](/docs/RECOMMENDATION-ROADMAP). The likely next
-shape is a shared taste-signal model that can combine quiz answers, swipe
-reactions, account memory, and result feedback. Future quiz work should make
-favorite/reference movies less mandatory, capture more explicit avoid signals,
-and use more concrete "tonight" language.
+## Current 0.2.0 Taste-Control Scope
 
 The `v0.2.0` Better Taste Control milestone is tracked by
-[#826](https://github.com/shchilkin/PopChoice/issues/826). Planned scope:
+[#826](https://github.com/shchilkin/PopChoice/issues/826). The completed scope
+is:
 
 - [x] [#827](https://github.com/shchilkin/PopChoice/issues/827): explicit avoids
       and constraints in Fast Pick and Normal Match.
@@ -201,11 +192,24 @@ The `v0.2.0` Better Taste Control milestone is tracked by
       feedback loop v1.
 - [x] [#831](https://github.com/shchilkin/PopChoice/issues/831):
       deterministic eval coverage for taste-control signals.
-- [#832](https://github.com/shchilkin/PopChoice/issues/832): product docs and
-  release notes.
+- [x] [#832](https://github.com/shchilkin/PopChoice/issues/832): product docs
+      and release notes.
 
-Until those issues are implemented and verified, this section is planned
-behavior, not the current product contract.
+Release notes live in
+[/docs/releases/v0.2.0](/docs/releases/v0.2.0).
+
+## Planned Product Direction
+
+Planned behavior should remain issue-backed and should not be described as
+current product behavior until implemented.
+
+Recommendation experience direction is tracked in
+[/docs/RECOMMENDATION-ROADMAP](/docs/RECOMMENDATION-ROADMAP). The likely next
+shape is a shared taste-signal model that can combine quiz answers, swipe
+reactions, account memory, and result feedback. Future quiz and recommendation
+work should move the current structured-text bridge into a first-class backend
+contract so avoids, constraints, discovery appetite, and feedback no longer
+need to travel through legacy request fields.
 
 Group rooms are a larger milestone under
 [#359](https://github.com/shchilkin/PopChoice/issues/359), split into:

--- a/docs/RECOMMENDATION-ROADMAP.md
+++ b/docs/RECOMMENDATION-ROADMAP.md
@@ -52,29 +52,31 @@ This creates a usable first recommendation, but the data is coarse. It asks user
 - Normal Match is producing promising qualitative results for specific intent prompts. A Russian dystopian/post-apocalyptic survival prompt returned a strong `Blade Runner`-style selection and explanation.
 - Duo and Group need more manual product QA after the entry-flow ordering is fixed, especially to verify whether compromise results feel meaningfully different from solo recommendations.
 
-## 0.2.0 Better Taste Control Release Plan
+## 0.2.0 Better Taste Control
 
-The next product release is tracked by
-[#826](https://github.com/shchilkin/PopChoice/issues/826). The release should
-make PopChoice more controllable without turning the quiz into a technical
-filter form. Users should be able to say what they want, what they want to
-avoid, and how safe or surprising the pick should feel.
+The Better Taste Control release is tracked by
+[#826](https://github.com/shchilkin/PopChoice/issues/826). It makes PopChoice
+more controllable without turning the quiz into a technical filter form. Users
+can say what they want, what they want to avoid, and how safe or surprising the
+pick should feel.
 
-The planned PR sequence is:
+Completed scope:
 
-1. [#827](https://github.com/shchilkin/PopChoice/issues/827): add explicit
-   avoids and constraints to Fast Pick and Normal Match.
-2. [#828](https://github.com/shchilkin/PopChoice/issues/828): make reference
-   movie input optional and lower-friction.
-3. [#829](https://github.com/shchilkin/PopChoice/issues/829): add discovery
-   appetite control for safe, balanced, and surprising recommendations.
-4. [#830](https://github.com/shchilkin/PopChoice/issues/830): improve the
-   result feedback loop so feedback can guide follow-up recommendations.
-5. [#831](https://github.com/shchilkin/PopChoice/issues/831): expand
-   deterministic recommendation eval coverage for the new taste-control
-   signals.
-6. [#832](https://github.com/shchilkin/PopChoice/issues/832): keep product docs
-   and release notes aligned as behavior lands.
+- [x] [#827](https://github.com/shchilkin/PopChoice/issues/827): add explicit
+      avoids and constraints to Fast Pick and Normal Match.
+- [x] [#828](https://github.com/shchilkin/PopChoice/issues/828): make reference
+      movie input optional and lower-friction.
+- [x] [#829](https://github.com/shchilkin/PopChoice/issues/829): add discovery
+      appetite control for safe, balanced, and surprising recommendations.
+- [x] [#830](https://github.com/shchilkin/PopChoice/issues/830): improve the
+      result feedback loop so feedback can guide follow-up recommendations.
+- [x] [#831](https://github.com/shchilkin/PopChoice/issues/831): expand
+      deterministic recommendation eval coverage for the new taste-control
+      signals.
+- [x] [#832](https://github.com/shchilkin/PopChoice/issues/832): keep product
+      docs and release notes aligned as behavior lands.
+
+Release notes: [/docs/releases/v0.2.0](/docs/releases/v0.2.0).
 
 Out of scope for `v0.2.0`:
 

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -4,9 +4,9 @@ title: 'PopChoice v0.2.0'
 
 # PopChoice v0.2.0
 
-Draft release notes for the Better Taste Control milestone.
+Better Taste Control release.
 
-Status: in progress. Tracked by
+Status: release candidate. Tracked by
 [#826](https://github.com/shchilkin/PopChoice/issues/826).
 
 ## Release Goal
@@ -15,7 +15,7 @@ Make PopChoice feel more controllable by letting users describe what they want,
 what they want to avoid, and how safe or surprising the recommendation should
 be.
 
-## Planned Highlights
+## Highlights
 
 - Explicit avoids and constraints in Fast Pick and Normal Match.
 - Optional, lower-friction reference movie UX.
@@ -27,8 +27,23 @@ be.
 - Deterministic recommendation eval cases for the new taste-control signals:
   hard avoids, runtime limits, discovery appetite, optional reference movies,
   and feedback-derived memory.
-- Product docs that keep current behavior separate from planned behavior until
-  implementation lands.
+- Product docs now describe the completed 0.2.0 behavior as the current product
+  contract and keep future signal-model work separate.
+
+## Implementation Scope
+
+- [#827](https://github.com/shchilkin/PopChoice/issues/827): explicit avoids
+  and constraints.
+- [#828](https://github.com/shchilkin/PopChoice/issues/828): optional reference
+  movie.
+- [#829](https://github.com/shchilkin/PopChoice/issues/829): discovery
+  appetite.
+- [#830](https://github.com/shchilkin/PopChoice/issues/830): result feedback
+  loop v1.
+- [#831](https://github.com/shchilkin/PopChoice/issues/831): deterministic
+  eval coverage.
+- [#832](https://github.com/shchilkin/PopChoice/issues/832): product docs and
+  release notes.
 
 ## Out Of Scope
 
@@ -38,12 +53,46 @@ be.
 
 ## Verification Before Promotion
 
-- Run the standard checks required by the implementation PRs.
-- Run `npm run eval:recommendations` for prompt, ranking, candidate filtering,
-  feedback-signal, or eval-fixture changes.
-- Run product e2e coverage for changed quiz, recommendation, result feedback,
-  and movie-memory flows.
-- Verify the deployed `development` environment before promoting to
-  `production`.
-- Confirm `/api/build` reports `version: 0.2.0`, the expected channel, and the
-  expected source branch or commit after release promotion.
+- Confirm every 0.2.0 implementation PR passed the normal PR gate: lint,
+  type-check, build, server tests, deterministic recommendation evals, and
+  relevant e2e/storybook coverage.
+- Confirm `npm run eval:recommendations` passes with the 0.2.0 taste-control
+  fixture set.
+- Let the merged `development` branch deploy to the Coolify development
+  resource, then verify:
+
+  ```bash
+  curl -fsS https://dev.pop-choice.shchilkin.dev/api/health | jq .
+  curl -fsS https://dev.pop-choice.shchilkin.dev/api/build | jq .
+  ```
+
+  `/api/build` should report `version: 0.2.0`, `channel: development`,
+  `environment: development`, and `branch: development`.
+
+- Smoke-test development manually:
+  - Fast Pick with at least one hard avoid.
+  - Normal Match with an empty reference movie.
+  - Safe, balanced, and surprise discovery appetite.
+  - Completed-result feedback plus "More like this" or "Try same vibe".
+
+- Promote production only after development is accepted: merge `development`
+  into `main`, run the `Container Images` workflow on `main` with
+  `deploy_environment=production`, approve the GitHub `production` Environment,
+  and wait for Coolify deploy verification.
+- Verify production after promotion:
+
+  ```bash
+  curl -fsS https://pop-choice.shchilkin.dev/api/health | jq .
+  curl -fsS https://pop-choice.shchilkin.dev/api/build | jq .
+  ```
+
+  `/api/build` should report `version: 0.2.0`, `channel: production`,
+  `environment: production`, `branch: main`, and the expected release commit or
+  image tag.
+
+- Do not set `APP_VERSION` in Coolify project, environment, resource, or preview
+  variables. The deployed image should provide the package version.
+
+## Full Changelog
+
+https://github.com/shchilkin/PopChoice/compare/v0.1.0...v0.2.0


### PR DESCRIPTION
## Summary
- mark the completed 0.2.0 Better Taste Control scope as current product behavior
- update the recommendation roadmap from planned sequence to completed scope
- finalize v0.2.0 release notes with development and production promotion verification

Closes #832

## Verification
- npx prettier --check docs/PRODUCT-BEHAVIOR.md docs/RECOMMENDATION-ROADMAP.md docs/releases/v0.2.0.md
- npm run build:docs
- git diff --check
- pre-push: lint, server tests, production build; Storybook tests skipped as not relevant