### PR TITLE
Bump release version to 0.2.0

### DIFF
--- a/apps/backoffice/package.json
+++ b/apps/backoffice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pop-choice/backoffice",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/bull-board/package.json
+++ b/apps/bull-board/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pop-choice/bull-board",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pop-choice/docs",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pop-choice/web",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/web/src/lib/buildInfo.test.ts
+++ b/apps/web/src/lib/buildInfo.test.ts
@@ -56,7 +56,7 @@ describe('getBuildInfo', () => {
 
     expect(info).toMatchObject({
       app: 'PopChoice',
-      version: '0.1.0',
+      version: '0.2.0',
       channel: 'development',
       commitSha: null,
       commitShortSha: null,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pop-choice",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pop-choice",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "workspaces": [
         "apps/*",
         "packages/*",
@@ -27,7 +27,7 @@
     },
     "apps/backoffice": {
       "name": "@pop-choice/backoffice",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@pop-choice/shared": "*",
         "@pop-choice/ui": "*",
@@ -55,7 +55,7 @@
     },
     "apps/bull-board": {
       "name": "@pop-choice/bull-board",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@bull-board/api": "^7.1.5",
         "@bull-board/express": "^7.1.5",
@@ -88,7 +88,7 @@
     },
     "apps/docs": {
       "name": "@pop-choice/docs",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@types/mdx": "^2.0.14",
         "fumadocs-core": "^16.10.0",
@@ -269,7 +269,7 @@
     },
     "apps/web": {
       "name": "@pop-choice/web",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@langchain/core": "^1.1.49",
         "@opentelemetry/api": "^1.9.1",
@@ -19763,7 +19763,7 @@
     },
     "packages/shared": {
       "name": "@pop-choice/shared",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "openai": "^6.42.0",
         "pg": "^8.21.0",
@@ -19778,7 +19778,7 @@
     },
     "packages/ui": {
       "name": "@pop-choice/ui",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.16"
       },
@@ -19796,7 +19796,7 @@
       }
     },
     "services/db-migrate": {
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "pg": "^8.21.0"
       },
@@ -19806,7 +19806,7 @@
       }
     },
     "services/movie-backfill": {
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@pop-choice/shared": "*",
         "zod": "^4.4.3"
@@ -19819,7 +19819,7 @@
       }
     },
     "services/movie-discovery": {
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@pop-choice/shared": "*",
         "node-cron": "^4.2.1"
@@ -19838,7 +19838,7 @@
       }
     },
     "services/movie-seed": {
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@pop-choice/shared": "*"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pop-choice",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "workspaces": [

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pop-choice/shared",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pop-choice/ui",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "exports": {

--- a/services/db-migrate/package.json
+++ b/services/db-migrate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "db-migrate",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/movie-backfill/package.json
+++ b/services/movie-backfill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "movie-backfill",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/movie-discovery/package.json
+++ b/services/movie-discovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "movie-discovery",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/services/movie-seed/package.json
+++ b/services/movie-seed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "movie-seed",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump root and workspace package versions to 0.2.0
- sync package-lock workspace metadata so runtime build info reports the v0.2.0 release

## Verification
- npm run type-check
- npm run build --workspace=apps/web