### PR TITLE
Fix catalog seed worker file path

### DIFF
--- a/apps/backoffice/src/app/globals.css
+++ b/apps/backoffice/src/app/globals.css
@@ -647,21 +647,91 @@ input:disabled {
   justify-content: flex-end;
   flex-wrap: wrap;
 }
-.catalog-seed-summary {
-  grid-template-columns: repeat(2, minmax(220px, 1fr));
+.catalog-seed-console {
+  display: grid;
+  grid-template-columns: minmax(260px, 0.82fr) minmax(320px, 1.18fr);
+  gap: 0;
+  overflow: hidden;
+  margin-bottom: 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
 }
-.catalog-seed-panel {
+.catalog-seed-console.healthy {
+  border-color: color-mix(in srgb, var(--good), var(--border) 70%);
+}
+.catalog-seed-console.warning {
+  border-color: color-mix(in srgb, var(--warn), var(--border) 55%);
+}
+.catalog-seed-state,
+.catalog-seed-action {
   display: grid;
   gap: 16px;
+  padding: 18px;
 }
-.catalog-seed-form {
+.catalog-seed-state {
+  align-content: start;
+  border-right: 1px solid var(--border);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.018), transparent), #12151a;
+}
+.catalog-seed-action {
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  background: var(--surface-2);
+}
+.catalog-seed-action p {
+  max-width: 720px;
+  margin: 4px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 700;
+}
+.catalog-seed-kicker {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 850;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.catalog-seed-status-row {
   display: flex;
-  gap: 12px;
+  gap: 10px;
   align-items: center;
   flex-wrap: wrap;
 }
-.catalog-seed-form .small-note {
-  max-width: 760px;
+.catalog-seed-status-row h2 {
+  font-size: 30px;
+  line-height: 1.05;
+}
+.catalog-seed-facts {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+}
+.catalog-seed-facts div {
+  display: grid;
+  grid-template-columns: 96px minmax(0, 1fr);
+  gap: 10px;
+  align-items: baseline;
+}
+.catalog-seed-facts dt,
+.catalog-seed-facts dd {
+  font-size: 12px;
+}
+.catalog-seed-facts dd {
+  color: var(--text);
+  font-weight: 850;
+}
+.catalog-seed-form {
+  display: flex;
+  justify-content: flex-end;
+}
+.catalog-seed-trigger {
+  min-height: 40px;
+  white-space: nowrap;
 }
 .queue-diagnostic,
 .queue-diagnostic-action {
@@ -1911,6 +1981,18 @@ input:disabled {
   }
   .summary {
     grid-template-columns: 1fr 1fr;
+  }
+  .catalog-seed-console,
+  .catalog-seed-action {
+    grid-template-columns: 1fr;
+  }
+  .catalog-seed-state {
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+  }
+  .catalog-seed-form,
+  .catalog-seed-trigger {
+    width: 100%;
   }
   .next-action {
     align-items: stretch;

--- a/apps/backoffice/src/components/catalog-seed/index.test.tsx
+++ b/apps/backoffice/src/components/catalog-seed/index.test.tsx
@@ -1,0 +1,42 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { CatalogSeedPage } from './index';
+
+describe('CatalogSeedPage', () => {
+  it('renders a compact ready-state seed console', () => {
+    const html = renderToStaticMarkup(
+      <CatalogSeedPage
+        seedStatus={{
+          queueConfigured: true,
+          queueName: 'movie-seed',
+        }}
+      />,
+    );
+
+    expect(html).toContain('catalog-seed-console healthy');
+    expect(html).toContain('Configured');
+    expect(html).toContain('Ready');
+    expect(html).toContain('movie-seed');
+    expect(html).toContain('seed-movies');
+    expect(html).toContain('Trigger movie seed');
+    expect(html).not.toContain('Configuration required');
+  });
+
+  it('renders a clear unavailable state when Redis is missing', () => {
+    const html = renderToStaticMarkup(
+      <CatalogSeedPage
+        seedStatus={{
+          queueConfigured: false,
+          queueName: 'movie-seed',
+        }}
+      />,
+    );
+
+    expect(html).toContain('catalog-seed-console warning');
+    expect(html).toContain('Missing');
+    expect(html).toContain('Needs Redis');
+    expect(html).toContain('Configuration required');
+    expect(html).toContain('disabled=""');
+  });
+});

--- a/apps/backoffice/src/components/catalog-seed/index.tsx
+++ b/apps/backoffice/src/components/catalog-seed/index.tsx
@@ -1,14 +1,9 @@
 import { BackofficeLayout } from '../backoffice-layout';
-import { CatalogStat } from '../shared';
 
 import type { CatalogSeedStatus } from '../../lib/backoffice';
 
 function statusLabel(value: boolean): string {
   return value ? 'Configured' : 'Missing';
-}
-
-function statusState(value: boolean): 'healthy' | 'warning' {
-  return value ? 'healthy' : 'warning';
 }
 
 function getFlashMessage(status: string | undefined): string | null {
@@ -34,6 +29,7 @@ export function CatalogSeedPage({
 }) {
   const flashMessage = getFlashMessage(actionStatus);
   const canTrigger = seedStatus.queueConfigured;
+  const statusClassName = canTrigger ? 'healthy' : 'warning';
 
   return (
     <BackofficeLayout
@@ -57,37 +53,53 @@ export function CatalogSeedPage({
         </div>
       ) : null}
 
-      <div className="summary catalog-seed-summary">
-        <CatalogStat
-          label="Seed queue"
-          value={statusLabel(seedStatus.queueConfigured)}
-          meta={seedStatus.queueName}
-          state={statusState(seedStatus.queueConfigured)}
-        />
-      </div>
-
-      <section className="panel catalog-seed-panel">
-        <div className="panel-header">
-          <div>
-            <h2>Run curated seed</h2>
-            <div className="issue-hint">
-              This queues a BullMQ job for the workers service. Backoffice does not run the seed
-              process inline.
-            </div>
+      <section className={`catalog-seed-console ${statusClassName}`}>
+        <div className="catalog-seed-state">
+          <div className="catalog-seed-kicker">
+            <span className={`queue-dot ${canTrigger ? '' : 'warning'}`} />
+            Seed queue
           </div>
+          <div className="catalog-seed-status-row">
+            <h2>{statusLabel(seedStatus.queueConfigured)}</h2>
+            <span className={`status ${statusClassName}`}>
+              {canTrigger ? 'Ready' : 'Needs Redis'}
+            </span>
+          </div>
+          <dl className="catalog-seed-facts">
+            <div>
+              <dt>Queue</dt>
+              <dd>{seedStatus.queueName}</dd>
+            </div>
+            <div>
+              <dt>Worker job</dt>
+              <dd>seed-movies</dd>
+            </div>
+            <div>
+              <dt>Mode</dt>
+              <dd>deduped</dd>
+            </div>
+          </dl>
         </div>
 
-        <form className="catalog-seed-form" action="/catalog-seed/actions" method="post">
-          <input type="hidden" name="action" value="trigger_movie_seed" />
-          <button className="button success" type="submit" disabled={!canTrigger}>
-            Trigger movie seed
-          </button>
-          <p className="small-note">
-            Use this after creating a fresh environment or when the catalog is unexpectedly empty.
-            The seed job is idempotent, skips movies already present in the database, and dedupes
-            concurrent clicks.
-          </p>
-        </form>
+        <div className="catalog-seed-action">
+          <div>
+            <h2>Run curated seed</h2>
+            <p>
+              Queues the curated movie file for workers. Existing movies are skipped, so retrying is
+              safe.
+            </p>
+          </div>
+          <form className="catalog-seed-form" action="/catalog-seed/actions" method="post">
+            <input type="hidden" name="action" value="trigger_movie_seed" />
+            <button
+              className="button success catalog-seed-trigger"
+              type="submit"
+              disabled={!canTrigger}
+            >
+              Trigger movie seed
+            </button>
+          </form>
+        </div>
 
         {!canTrigger ? (
           <div className="next-action warning">

--- a/apps/web/src/lib/workers/curatedMovieSeed.test.ts
+++ b/apps/web/src/lib/workers/curatedMovieSeed.test.ts
@@ -1,0 +1,52 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { resolveDefaultMoviesFilePath } from '@/lib/workers/curatedMovieSeed';
+
+describe('resolveDefaultMoviesFilePath', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const tempDir of tempDirs.splice(0)) {
+      rmSync(tempDir, { force: true, recursive: true });
+    }
+  });
+
+  function createRepoFixture(): { appsWebPath: string; repoPath: string; serviceFilePath: string } {
+    const repoPath = mkdtempSync(path.join(tmpdir(), 'popchoice-movies-path-'));
+    tempDirs.push(repoPath);
+
+    const appsWebPath = path.join(repoPath, 'apps/web');
+    const servicePath = path.join(repoPath, 'services/movie-seed');
+    const serviceFilePath = path.join(servicePath, 'movies.txt');
+
+    mkdirSync(appsWebPath, { recursive: true });
+    mkdirSync(servicePath, { recursive: true });
+    writeFileSync(serviceFilePath, 'Casablanca: 1942 | PG | 1h 42m | 8.5 rating\nDescription.');
+
+    return { appsWebPath, repoPath, serviceFilePath };
+  }
+
+  it('finds the curated movie file when workers run from apps/web', () => {
+    const { appsWebPath, serviceFilePath } = createRepoFixture();
+
+    expect(resolveDefaultMoviesFilePath(appsWebPath)).toBe(serviceFilePath);
+  });
+
+  it('finds the curated movie file when workers run from the repo root', () => {
+    const { repoPath, serviceFilePath } = createRepoFixture();
+
+    expect(resolveDefaultMoviesFilePath(repoPath)).toBe(serviceFilePath);
+  });
+
+  it('prefers a movies.txt file in the current working directory', () => {
+    const { appsWebPath } = createRepoFixture();
+    const localFilePath = path.join(appsWebPath, 'movies.txt');
+    writeFileSync(localFilePath, 'Arrival: 2016 | PG-13 | 116m | 7.9 rating\nDescription.');
+
+    expect(resolveDefaultMoviesFilePath(appsWebPath)).toBe(localFilePath);
+  });
+});

--- a/apps/web/src/lib/workers/curatedMovieSeed.ts
+++ b/apps/web/src/lib/workers/curatedMovieSeed.ts
@@ -55,14 +55,15 @@ async function ensureMovieSeedSchema(): Promise<void> {
   await schemaReadyPromise;
 }
 
-function resolveDefaultMoviesFilePath(): string {
-  const cwdPath = path.resolve(process.cwd(), 'movies.txt');
-  if (existsSync(cwdPath)) return cwdPath;
+export function resolveDefaultMoviesFilePath(cwd = process.cwd()): string {
+  const candidates = [
+    path.resolve(cwd, 'movies.txt'),
+    path.resolve(cwd, '../../services/movie-seed/movies.txt'),
+    path.resolve(cwd, 'services/movie-seed/movies.txt'),
+  ];
+  const existingPath = candidates.find((candidate) => existsSync(candidate));
 
-  const serviceLocalPath = path.resolve(process.cwd(), 'services/movie-seed/movies.txt');
-  if (existsSync(serviceLocalPath)) return serviceLocalPath;
-
-  return cwdPath;
+  return existingPath ?? candidates[0];
 }
 
 function resolveMoviesFilePath(explicitPath: string | undefined): string {

--- a/apps/web/workers.Dockerfile
+++ b/apps/web/workers.Dockerfile
@@ -22,6 +22,7 @@ RUN npm run build --workspace=packages/shared
 FROM node:24-slim
 
 ENV NODE_ENV=production
+ENV MOVIES_FILE_PATH=/app/services/movie-seed/movies.txt
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- fix curated movie seed worker path resolution when the worker runs from /app/apps/web in Docker
- set MOVIES_FILE_PATH in the worker image to the copied services/movie-seed/movies.txt file
- polish the backoffice Catalog seed page into a compact status/action console
- add focused tests for seed file resolution and the backoffice seed console states

## Verification
- npm run test --workspace=apps/web -- curatedMovieSeed
- npm run test --workspace=apps/backoffice -- catalog-seed/index.test.tsx catalogSeedActions.test.ts
- npm run type-check --workspace=apps/web
- npm run type-check --workspace=apps/backoffice
- npm run build --workspace=apps/web
- npm run build:backoffice
- pre-push: npm run lint:check, npm run test:server, npm run build
- Impeccable detector: no findings for apps/backoffice/src/components/catalog-seed/index.tsx

## Notes
- Local browser render of /catalog-seed hit the existing backoffice preflight because fixture PostgreSQL/Redis were not running, so the PR relies on component render tests plus production builds for this pass.