### PR TITLE
Add TasteSignal v1 foundation

### DIFF
--- a/apps/web/src/features/recommendation/candidateFilters.test.ts
+++ b/apps/web/src/features/recommendation/candidateFilters.test.ts
@@ -7,6 +7,7 @@ import {
   excludeFeedbackTMDBMovies,
   getFeedbackCandidateSignals,
   getMentionedMovieTitleKeys,
+  getTasteSignalCandidateSignals,
   isMentionedMovieTitle,
 } from './candidateFilters';
 
@@ -299,5 +300,41 @@ describe('candidateFilters', () => {
         signals,
       ).map((candidate) => candidate.title),
     ).toEqual(['Princess Mononoke']);
+  });
+
+  it('applies movie taste signals while ignoring trait-only signals', () => {
+    const signals = getTasteSignalCandidateSignals([
+      {
+        type: 'desired_trait',
+        source: 'quiz',
+        value: 'warm',
+        weight: 0.5,
+      },
+      {
+        type: 'seen_movie',
+        source: 'movie-memory',
+        title: 'Paddington 2',
+        year: 2017,
+        weight: 1,
+      },
+      {
+        type: 'liked_movie',
+        source: 'movie-memory',
+        title: 'After Yang',
+        year: 2021,
+        weight: 1,
+      },
+    ]);
+
+    expect(
+      applyFeedbackToLocalMovies(
+        [
+          { ...movie('Paddington 2'), similarity: 0.95 },
+          { ...movie('Columbus'), similarity: 0.82 },
+          { ...movie('After Yang'), similarity: 0.79 },
+        ],
+        signals,
+      ).map((candidate) => candidate.name),
+    ).toEqual(['After Yang', 'Columbus']);
   });
 });

--- a/apps/web/src/features/recommendation/candidateFilters.ts
+++ b/apps/web/src/features/recommendation/candidateFilters.ts
@@ -1,20 +1,12 @@
 import { getMovieIdentityKey, getMovieTitleKey, getYearFromReleaseDate } from '@/lib/movieIdentity';
 
+import { getTasteSignalsFromFeedbackPreferences } from './tasteSignals';
+
+import type { FeedbackTastePreference, MovieTasteSignal, TasteSignal } from './tasteSignals';
 import type { TMDBDiscoverMovie } from './tmdb';
 import type { EnhancedMovieMatch, PersonFormData } from './types';
-import type {
-  RecommendationFeedbackKind,
-  UserRecommendationMemoryKind,
-  UserMovieInteractionKind,
-} from '@/lib/db/recommendations';
 
-export type FeedbackMoviePreference = {
-  kind: RecommendationFeedbackKind | UserMovieInteractionKind | UserRecommendationMemoryKind;
-  movieKey?: string | null;
-  tmdbId?: number | null;
-  movieName: string;
-  movieYear: number | null;
-};
+export type FeedbackMoviePreference = FeedbackTastePreference;
 
 export type FeedbackCandidateSignals = {
   excludedMovieKeys: Set<string>;
@@ -27,15 +19,6 @@ export type FeedbackCandidateSignals = {
 
 const FEEDBACK_DOWNRANK_AMOUNT = 0.08;
 const LIKED_MEMORY_BOOST_AMOUNT = 0.04;
-
-const EXCLUDED_FEEDBACK_KINDS = new Set<FeedbackMoviePreference['kind']>([
-  'already_watched',
-  'not_interested',
-  'recently_recommended',
-  'too_obscure',
-  'too_obvious',
-  'watched',
-]);
 
 export function getMentionedMovieTitleKeys(allPeopleData: PersonFormData[]): Set<string> {
   return new Set(
@@ -70,10 +53,16 @@ export function excludeMentionedTMDBMovies(
 export function getFeedbackCandidateSignals(
   preferences: FeedbackMoviePreference[],
 ): FeedbackCandidateSignals {
+  return getTasteSignalCandidateSignals(getTasteSignalsFromFeedbackPreferences(preferences));
+}
+
+export function getTasteSignalCandidateSignals(
+  signalsToApply: TasteSignal[],
+): FeedbackCandidateSignals {
   const signals = createEmptyFeedbackCandidateSignals();
 
-  for (const preference of preferences) {
-    addPreferenceToSignals(signals, preference);
+  for (const tasteSignal of signalsToApply) {
+    addTasteSignalToCandidateSignals(signals, tasteSignal);
   }
 
   return signals;
@@ -90,12 +79,16 @@ function createEmptyFeedbackCandidateSignals(): FeedbackCandidateSignals {
   };
 }
 
-function addPreferenceToSignals(
+function addTasteSignalToCandidateSignals(
   signals: FeedbackCandidateSignals,
-  preference: FeedbackMoviePreference,
+  tasteSignal: TasteSignal,
 ) {
-  const keys = getPreferenceKeys(preference);
-  const targets = getSignalTargets(signals, preference.kind);
+  if (!isMovieTasteSignal(tasteSignal)) {
+    return;
+  }
+
+  const keys = getTasteSignalMovieKeys(tasteSignal);
+  const targets = getSignalTargets(signals, tasteSignal.type);
 
   if (!targets) {
     return;
@@ -104,32 +97,33 @@ function addPreferenceToSignals(
   addFeedbackKeys(targets.movieKeys, targets.titleKeys, keys);
 }
 
-function getPreferenceKeys(preference: FeedbackMoviePreference) {
+function isMovieTasteSignal(signal: TasteSignal): signal is MovieTasteSignal {
+  return 'title' in signal;
+}
+
+function getTasteSignalMovieKeys(signal: MovieTasteSignal) {
   return {
     movieKey:
-      preference.movieKey ??
+      signal.movieKey ??
       getMovieIdentityKey({
-        tmdbId: preference.tmdbId,
-        title: preference.movieName,
-        year: preference.movieYear,
+        tmdbId: signal.tmdbId,
+        title: signal.title,
+        year: signal.year,
       }),
-    titleKey: getMovieTitleKey(preference.movieName),
+    titleKey: getMovieTitleKey(signal.title),
   };
 }
 
-function getSignalTargets(
-  signals: FeedbackCandidateSignals,
-  kind: FeedbackMoviePreference['kind'],
-) {
-  if (EXCLUDED_FEEDBACK_KINDS.has(kind)) {
+function getSignalTargets(signals: FeedbackCandidateSignals, kind: MovieTasteSignal['type']) {
+  if (kind === 'seen_movie' || kind === 'not_interested_movie') {
     return { movieKeys: signals.excludedMovieKeys, titleKeys: signals.excludedTitleKeys };
   }
 
-  if (kind === 'wrong_mood') {
+  if (kind === 'wrong_mood_movie') {
     return { movieKeys: signals.downrankMovieKeys, titleKeys: signals.downrankTitleKeys };
   }
 
-  if (kind === 'liked') {
+  if (kind === 'liked_movie') {
     return { movieKeys: signals.boostMovieKeys, titleKeys: signals.boostTitleKeys };
   }
 

--- a/apps/web/src/features/recommendation/pipeline.ts
+++ b/apps/web/src/features/recommendation/pipeline.ts
@@ -36,6 +36,11 @@ import {
 } from './recommendation';
 import { resolveRecommendationSourceStrategy } from './sourceStrategyPolicy';
 import {
+  getTasteSignalsFromFeedbackPreferences,
+  getTasteSignalsFromQuiz,
+  summarizeTasteSignals,
+} from './tasteSignals';
+import {
   MAX_TOTAL_MOVIES,
   enrichTMDBMatchesWithDetails,
   fetchTMDBDiscoverMovies,
@@ -251,6 +256,19 @@ async function prepareRecommendationInputs(
     getDbMovieCount(),
     getFeedbackPreferences(userId),
   ]);
+  const tasteSignals = [
+    ...getTasteSignalsFromQuiz(allPeopleData),
+    ...getTasteSignalsFromFeedbackPreferences(feedbackPreferences),
+  ];
+  const tasteSignalSummary = summarizeTasteSignals(tasteSignals);
+
+  setActiveTraceAttributes({
+    'recommendation.taste_signal_count': tasteSignals.length,
+  });
+  logger.info(
+    { tasteSignalCount: tasteSignals.length, tasteSignalSummary },
+    'Recommendation taste signals prepared',
+  );
 
   return {
     dbMovieCount,

--- a/apps/web/src/features/recommendation/tasteSignals.test.ts
+++ b/apps/web/src/features/recommendation/tasteSignals.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getTasteSignalsFromFeedbackPreferences,
+  getTasteSignalsFromQuiz,
+  summarizeTasteSignals,
+} from './tasteSignals';
+
+import type { PersonFormData } from './types';
+
+const person = (overrides: Partial<PersonFormData> = {}): PersonFormData => ({
+  name: 'Sam',
+  favoriteMovie: 'Arrival',
+  favoriteMovieWhy: 'Thoughtful sci-fi. Avoid: gore, three-hour runtime.',
+  newVsClassic: 'Both new and classic',
+  moodPreference: ['Sci-Fi', 'Reflective'],
+  tonePreference: 'Tense but humane',
+  favoriteActor: 'Amy Adams',
+  ...overrides,
+});
+
+describe('tasteSignals', () => {
+  it('maps quiz answers into reusable taste signals', () => {
+    const signals = getTasteSignalsFromQuiz([person()]);
+
+    expect(signals).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'liked_movie',
+          source: 'quiz',
+          title: 'Arrival',
+          participantName: 'Sam',
+        }),
+        expect.objectContaining({
+          type: 'constraint',
+          source: 'quiz',
+          value: 'Both new and classic',
+        }),
+        expect.objectContaining({
+          type: 'desired_trait',
+          source: 'quiz',
+          value: 'Sci-Fi',
+        }),
+        expect.objectContaining({
+          type: 'desired_trait',
+          source: 'quiz',
+          value: 'Amy Adams',
+        }),
+        expect.objectContaining({
+          type: 'avoid_trait',
+          source: 'quiz',
+          value: 'gore',
+        }),
+        expect.objectContaining({
+          type: 'avoid_trait',
+          source: 'quiz',
+          value: 'three-hour runtime',
+        }),
+      ]),
+    );
+  });
+
+  it('omits blank optional quiz signals', () => {
+    const signals = getTasteSignalsFromQuiz([
+      person({
+        favoriteMovie: '   ',
+        favoriteActor: '   ',
+        favoriteMovieWhy: 'Avoid: no hard avoids.',
+      }),
+    ]);
+
+    expect(signals.some((signal) => signal.type === 'liked_movie')).toBe(false);
+    expect(signals).not.toContainEqual(expect.objectContaining({ value: 'no hard avoids' }));
+  });
+
+  it('maps feedback and memory rows into movie taste signals', () => {
+    const signals = getTasteSignalsFromFeedbackPreferences([
+      {
+        kind: 'liked',
+        movieKey: 'tmdb:603',
+        tmdbId: 603,
+        movieName: 'The Matrix',
+        movieYear: 1999,
+      },
+      {
+        kind: 'wrong_mood',
+        movieName: 'Arrival',
+        movieYear: 2016,
+      },
+      {
+        kind: 'recently_recommended',
+        movieKey: 'title:past-lives:2023',
+        movieName: 'Past Lives',
+        movieYear: 2023,
+      },
+      {
+        kind: 'not_seen',
+        movieName: 'Heat',
+        movieYear: 1995,
+      },
+    ]);
+
+    expect(signals).toEqual([
+      expect.objectContaining({
+        type: 'liked_movie',
+        source: 'movie-memory',
+        title: 'The Matrix',
+        movieKey: 'tmdb:603',
+      }),
+      expect.objectContaining({
+        type: 'wrong_mood_movie',
+        source: 'feedback',
+        title: 'Arrival',
+        movieKey: 'title:arrival:2016',
+      }),
+      expect.objectContaining({
+        type: 'seen_movie',
+        source: 'recommendation-history',
+        title: 'Past Lives',
+        weight: 0.55,
+      }),
+    ]);
+  });
+
+  it('summarizes signal counts by type for logs and eval metadata', () => {
+    expect(
+      summarizeTasteSignals([
+        ...getTasteSignalsFromQuiz([person()]),
+        ...getTasteSignalsFromFeedbackPreferences([
+          { kind: 'watched', movieName: 'Heat', movieYear: 1995 },
+        ]),
+      ]),
+    ).toMatchObject({
+      avoid_trait: 2,
+      constraint: 1,
+      desired_trait: 4,
+      liked_movie: 1,
+      seen_movie: 1,
+    });
+  });
+});

--- a/apps/web/src/features/recommendation/tasteSignals.ts
+++ b/apps/web/src/features/recommendation/tasteSignals.ts
@@ -1,0 +1,222 @@
+import { getMovieIdentityKey } from '@/lib/movieIdentity';
+import { getAvoidSignalsFromReason } from '@/utils/tasteSignals';
+
+import type { PersonFormData } from './types';
+import type {
+  RecommendationFeedbackKind,
+  UserMovieInteractionKind,
+  UserRecommendationMemoryKind,
+} from '@/lib/db/recommendations';
+
+export type TasteSignalSource = 'quiz' | 'feedback' | 'movie-memory' | 'recommendation-history';
+
+export type TasteSignalType =
+  | 'liked_movie'
+  | 'seen_movie'
+  | 'not_interested_movie'
+  | 'wrong_mood_movie'
+  | 'desired_trait'
+  | 'avoid_trait'
+  | 'constraint';
+
+export type MovieTasteSignal = {
+  type: Extract<
+    TasteSignalType,
+    'liked_movie' | 'seen_movie' | 'not_interested_movie' | 'wrong_mood_movie'
+  >;
+  source: TasteSignalSource;
+  title: string;
+  year?: number | null;
+  tmdbId?: number | null;
+  movieKey?: string | null;
+  participantName?: string;
+  weight: number;
+};
+
+export type TraitTasteSignal = {
+  type: Extract<TasteSignalType, 'desired_trait' | 'avoid_trait' | 'constraint'>;
+  source: TasteSignalSource;
+  value: string;
+  participantName?: string;
+  weight: number;
+};
+
+export type TasteSignal = MovieTasteSignal | TraitTasteSignal;
+
+export type FeedbackTastePreference = {
+  kind: RecommendationFeedbackKind | UserMovieInteractionKind | UserRecommendationMemoryKind;
+  movieKey?: string | null;
+  tmdbId?: number | null;
+  movieName: string;
+  movieYear?: number | null;
+};
+
+export type TasteSignalSummary = Partial<Record<TasteSignalType, number>>;
+
+const QUIZ_REFERENCE_MOVIE_WEIGHT = 0.7;
+const QUIZ_DESIRED_TRAIT_WEIGHT = 0.55;
+const QUIZ_CONSTRAINT_WEIGHT = 0.5;
+const QUIZ_AVOID_TRAIT_WEIGHT = 0.75;
+const FEEDBACK_SIGNAL_WEIGHT = 1;
+const RECENT_RECOMMENDATION_WEIGHT = 0.55;
+const MOVIE_SIGNAL_TYPES = {
+  already_watched: 'seen_movie',
+  close: null,
+  liked: 'liked_movie',
+  not_interested: 'not_interested_movie',
+  not_seen: null,
+  recently_recommended: 'seen_movie',
+  too_obscure: 'not_interested_movie',
+  too_obvious: 'not_interested_movie',
+  useful: 'liked_movie',
+  watched: 'seen_movie',
+  wrong_mood: 'wrong_mood_movie',
+} satisfies Record<FeedbackTastePreference['kind'], MovieTasteSignal['type'] | null>;
+
+function cleanSignalString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim().replace(/\s+/g, ' ');
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function getParticipantName(person: PersonFormData): string | undefined {
+  return cleanSignalString(person.name) ?? undefined;
+}
+
+function addTraitSignal(
+  signals: TasteSignal[],
+  input: {
+    participantName?: string;
+    source: TasteSignalSource;
+    type: TraitTasteSignal['type'];
+    value: unknown;
+    weight: number;
+  },
+): void {
+  const value = cleanSignalString(input.value);
+  if (!value) return;
+
+  signals.push({
+    type: input.type,
+    source: input.source,
+    value,
+    weight: input.weight,
+    ...(input.participantName ? { participantName: input.participantName } : {}),
+  });
+}
+
+export function getTasteSignalsFromQuiz(people: PersonFormData[]): TasteSignal[] {
+  const signals: TasteSignal[] = [];
+
+  for (const person of people) {
+    const participantName = getParticipantName(person);
+    const favoriteMovie = cleanSignalString(person.favoriteMovie);
+
+    if (favoriteMovie) {
+      signals.push({
+        type: 'liked_movie',
+        source: 'quiz',
+        title: favoriteMovie,
+        weight: QUIZ_REFERENCE_MOVIE_WEIGHT,
+        ...(participantName ? { participantName } : {}),
+      });
+    }
+
+    addTraitSignal(signals, {
+      participantName,
+      source: 'quiz',
+      type: 'constraint',
+      value: person.newVsClassic,
+      weight: QUIZ_CONSTRAINT_WEIGHT,
+    });
+    addTraitSignal(signals, {
+      participantName,
+      source: 'quiz',
+      type: 'desired_trait',
+      value: person.tonePreference,
+      weight: QUIZ_DESIRED_TRAIT_WEIGHT,
+    });
+    addTraitSignal(signals, {
+      participantName,
+      source: 'quiz',
+      type: 'desired_trait',
+      value: person.favoriteActor,
+      weight: QUIZ_DESIRED_TRAIT_WEIGHT,
+    });
+
+    for (const mood of person.moodPreference) {
+      addTraitSignal(signals, {
+        participantName,
+        source: 'quiz',
+        type: 'desired_trait',
+        value: mood,
+        weight: QUIZ_DESIRED_TRAIT_WEIGHT,
+      });
+    }
+
+    for (const avoid of getAvoidSignalsFromReason(person.favoriteMovieWhy)) {
+      addTraitSignal(signals, {
+        participantName,
+        source: 'quiz',
+        type: 'avoid_trait',
+        value: avoid,
+        weight: QUIZ_AVOID_TRAIT_WEIGHT,
+      });
+    }
+  }
+
+  return signals;
+}
+
+function getMovieSignalType(
+  kind: FeedbackTastePreference['kind'],
+): MovieTasteSignal['type'] | null {
+  return MOVIE_SIGNAL_TYPES[kind];
+}
+
+function getFeedbackSignalSource(kind: FeedbackTastePreference['kind']): TasteSignalSource {
+  if (kind === 'recently_recommended') return 'recommendation-history';
+  if (kind === 'watched' || kind === 'liked' || kind === 'not_interested' || kind === 'not_seen') {
+    return 'movie-memory';
+  }
+  return 'feedback';
+}
+
+function getFeedbackSignalWeight(kind: FeedbackTastePreference['kind']): number {
+  return kind === 'recently_recommended' ? RECENT_RECOMMENDATION_WEIGHT : FEEDBACK_SIGNAL_WEIGHT;
+}
+
+export function getTasteSignalsFromFeedbackPreferences(
+  preferences: FeedbackTastePreference[],
+): TasteSignal[] {
+  return preferences.flatMap((preference) => {
+    const signalType = getMovieSignalType(preference.kind);
+    const title = cleanSignalString(preference.movieName);
+    if (!signalType || !title) return [];
+
+    return [
+      {
+        type: signalType,
+        source: getFeedbackSignalSource(preference.kind),
+        title,
+        year: preference.movieYear ?? null,
+        tmdbId: preference.tmdbId ?? null,
+        movieKey:
+          preference.movieKey ??
+          getMovieIdentityKey({
+            tmdbId: preference.tmdbId,
+            title,
+            year: preference.movieYear ?? null,
+          }),
+        weight: getFeedbackSignalWeight(preference.kind),
+      },
+    ];
+  });
+}
+
+export function summarizeTasteSignals(signals: TasteSignal[]): TasteSignalSummary {
+  return signals.reduce<TasteSignalSummary>((summary, signal) => {
+    summary[signal.type] = (summary[signal.type] ?? 0) + 1;
+    return summary;
+  }, {});
+}

--- a/apps/web/src/lib/db/recommendations.ts
+++ b/apps/web/src/lib/db/recommendations.ts
@@ -21,6 +21,7 @@ import {
   hasFavoriteActorSignal,
 } from '@/features/recommendation/groupResultInsights';
 import { getMovieIdentityKey } from '@/lib/movieIdentity';
+import { getAvoidSignalsFromReason } from '@/utils/tasteSignals';
 
 import type { RecommendationStage } from '@/features/recommendation/stages';
 import type {
@@ -272,18 +273,6 @@ function getInteractionKindForFeedback(
 
 function isQuizPersonRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function getAvoidSignalsFromReason(reason: unknown): string[] {
-  const value = cleanString(reason);
-  if (!value) return [];
-
-  return Array.from(value.matchAll(/Avoid:\s*([^.]*)\./gi)).flatMap((match) =>
-    (match[1] ?? '')
-      .split(',')
-      .map((item) => item.trim())
-      .filter((item) => item.length > 0 && item.toLocaleLowerCase() !== 'no hard avoids'),
-  );
 }
 
 function getRecommendationResultSignals(quizData: unknown): RecommendationResultSignals {

--- a/apps/web/src/utils/tasteSignals.ts
+++ b/apps/web/src/utils/tasteSignals.ts
@@ -1,0 +1,17 @@
+function cleanSignalString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim().replace(/\s+/g, ' ');
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function getAvoidSignalsFromReason(reason: unknown): string[] {
+  const value = cleanSignalString(reason);
+  if (!value) return [];
+
+  return Array.from(value.matchAll(/Avoid:\s*([^.]*)\./gi)).flatMap((match) =>
+    (match[1] ?? '')
+      .split(',')
+      .map((item) => item.trim())
+      .filter((item) => item.length > 0 && item.toLocaleLowerCase() !== 'no hard avoids'),
+  );
+}

--- a/docs/RECOMMENDATION-ROADMAP.md
+++ b/docs/RECOMMENDATION-ROADMAP.md
@@ -240,6 +240,7 @@ This keeps the high-risk data and orchestration work ahead of visual polish. The
 
 - Add a canonical recommendation request shape based on `TasteSignal[]`.
 - Convert quiz answers, swipe reactions, and account memory into signals.
+- First slice: `TasteSignal` v1 now maps quiz answers plus feedback/movie-memory rows into shared signal types, and existing candidate filtering consumes feedback-derived movie signals through that adapter.
 - Update ranking to use positive signals, negative signals, constraints, and TMDB candidate expansion together.
 - Keep generated explanations aware of which signals actually existed, so copy does not mention actors, genres, or constraints the user never provided.
 
@@ -309,7 +310,7 @@ Good next PRs, in order:
 7. Replace the current quiz copy and options with a more "tonight" oriented flow while preserving existing API shape.
 8. Add a small taste-swipe prototype behind a feature flag or alternate quiz entry path.
 9. Add TMDB-backed candidate-card sourcing for swipe mode.
-10. Add a `TasteSignal` domain model and adapters from quiz answers and swipe reactions.
+10. Continue the `TasteSignal` domain model by adding swipe reaction adapters after the v1 quiz plus feedback/movie-memory slice.
 11. [x] [#620](https://github.com/shchilkin/PopChoice/issues/620): add guarded live-provider evals after safe backoffice evals exist.
 12. [x] Start [#612](https://github.com/shchilkin/PopChoice/issues/612) with first-class candidate source provenance, source-strategy policy, route/job/pipeline metadata, and eval assertions for curated showcase, hybrid fast, and TMDB-first behavior.
 13. [x] Connect [#612](https://github.com/shchilkin/PopChoice/issues/612) source strategy to initial retrieval behavior: `hybrid-fast` and `compromise-hybrid` use bounded TMDB fallback, while curated/local-only strategies block external lookup.


### PR DESCRIPTION
## Summary
- add TasteSignal v1 types plus adapters for quiz answers and feedback/movie-memory rows
- route existing recommendation memory filtering through feedback-derived movie taste signals
- log taste signal counts in the recommendation pipeline and update the roadmap slice

## Verification
- npm run test --workspace=apps/web -- tasteSignals.test.ts candidateFilters.test.ts
- npm run type-check
- npm run eval:recommendations
- npm run test --workspace=apps/web -- --run
- npm run lint:check --workspace=apps/web
- npx prettier --check docs/RECOMMENDATION-ROADMAP.md apps/web/src/features/recommendation/tasteSignals.ts apps/web/src/features/recommendation/tasteSignals.test.ts apps/web/src/features/recommendation/candidateFilters.ts apps/web/src/features/recommendation/candidateFilters.test.ts apps/web/src/features/recommendation/pipeline.ts
- pre-push hook: lint, server tests, production build