### PR TITLE
Polish result card chip contrast

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -207,6 +207,14 @@ Buttons are the most-touched element in the quiz flow — they need to feel sati
 
 **The No-Nested-Cards Rule.** Cards do not contain cards. If content needs a container within a card, use a tinted background (`--pc-gold-subtle`, `--pc-surface-hover`) or a border, not a nested card.
 
+### Chips / Badges
+
+- **Neutral chip:** `--pc-chip-bg`, `--pc-chip-bd`, and `--pc-chip-text`. Use for inactive filters, secondary actions, and low-emphasis metadata.
+- **Selected chip:** `--pc-chip-selected-bg`, `--pc-chip-selected-bd`, and `--pc-chip-selected-text`. Use for saved, selected, copied, or committed states where the user needs unmistakable confirmation.
+- **Poster overlay chip:** `--pc-poster-chip-bg`, `--pc-poster-chip-bd`, `--pc-poster-chip-text`, and `--pc-poster-chip-accent`. Use on image previews where gold text on translucent gold can disappear into the artwork.
+
+**The Context Rule.** Do not reuse `--pc-gold-subtle` as a universal pill background. Inline chips, selected states, and image overlays have different contrast needs.
+
 ### Inputs / Fields
 
 - **Style:** Filled, 12px radius (`rounded-xl`), `--pc-surface` background, 1px border `--pc-bd2`

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -61,6 +61,19 @@
   --pc-ai-bg: rgba(196, 149, 10, 0.05);
   --pc-ai-bd: rgba(196, 149, 10, 0.15);
 
+  /* Chips / badges */
+  --pc-chip-bg: rgba(0, 0, 0, 0.04);
+  --pc-chip-text: #424260;
+  --pc-chip-bd: rgba(0, 0, 0, 0.1);
+  --pc-chip-selected-bg: linear-gradient(135deg, #f5c518, #ff9f1c);
+  --pc-chip-selected-text: #09090f;
+  --pc-chip-selected-bd: rgba(245, 197, 24, 0.5);
+  --pc-poster-chip-bg: rgba(9, 9, 15, 0.74);
+  --pc-poster-chip-text: #f8f8ff;
+  --pc-poster-chip-muted: rgba(248, 248, 255, 0.78);
+  --pc-poster-chip-bd: rgba(248, 248, 255, 0.18);
+  --pc-poster-chip-accent: #f5c518;
+
   /* Image/poster overlays */
   --pc-poster-grad: linear-gradient(
     to bottom,
@@ -172,6 +185,19 @@
   /* AI content blocks */
   --pc-ai-bg: rgba(245, 197, 24, 0.05);
   --pc-ai-bd: rgba(245, 197, 24, 0.1);
+
+  /* Chips / badges */
+  --pc-chip-bg: rgba(255, 255, 255, 0.06);
+  --pc-chip-text: #b8b8d2;
+  --pc-chip-bd: rgba(255, 255, 255, 0.1);
+  --pc-chip-selected-bg: linear-gradient(135deg, #f5c518, #ff9f1c);
+  --pc-chip-selected-text: #09090f;
+  --pc-chip-selected-bd: rgba(245, 197, 24, 0.55);
+  --pc-poster-chip-bg: rgba(9, 9, 15, 0.78);
+  --pc-poster-chip-text: #f8f8ff;
+  --pc-poster-chip-muted: rgba(248, 248, 255, 0.78);
+  --pc-poster-chip-bd: rgba(248, 248, 255, 0.16);
+  --pc-poster-chip-accent: #f5c518;
 
   /* Image/poster overlays */
   --pc-poster-grad: linear-gradient(

--- a/apps/web/src/app/results/components/MainMovieCard.tsx
+++ b/apps/web/src/app/results/components/MainMovieCard.tsx
@@ -99,7 +99,7 @@ function MainPosterSection({
       <div className="absolute inset-0" style={{ background: 'var(--pc-poster-grad)' }} />
       <div className="absolute top-4 right-4 flex items-center gap-2">
         <PosterOpenButton label={view.openPosterLabel} onClick={onPosterOpen} />
-        <SimilarityBadge similarity={movie.similarity} />
+        <SimilarityBadge similarity={movie.similarity} tone="poster" />
       </div>
       <AiPickBadge label={view.aiPickLabel} />
       <MainPosterTitle view={view} />
@@ -116,10 +116,10 @@ function PosterOpenButton({ label, onClick }: { label: string; onClick: () => vo
       onClick={onClick}
       className="grid h-9 w-9 place-items-center rounded-full transition"
       style={{
-        background: 'var(--pc-overlay-bg)',
-        border: '1px solid var(--pc-bd3)',
-        color: 'var(--pc-overlay-text)',
-        backdropFilter: 'blur(8px)',
+        background: 'var(--pc-poster-chip-bg)',
+        border: '1px solid var(--pc-poster-chip-bd)',
+        color: 'var(--pc-poster-chip-text)',
+        backdropFilter: 'blur(10px)',
       }}
     >
       <ImageIcon size={15} />
@@ -204,7 +204,7 @@ function PosterLightboxContent({
             onClick={onClose}
             className="grid h-9 w-9 flex-none place-items-center rounded-full transition"
             style={{
-              background: 'var(--pc-surface-deep)',
+              background: 'var(--pc-chip-bg)',
               border: '1px solid var(--pc-bd3)',
               color: 'var(--pc-t2)',
             }}
@@ -250,15 +250,15 @@ function AiPickBadge({ label }: { label: string }) {
   return (
     <div className="absolute top-4 left-4">
       <div
-        className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs"
+        className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold"
         style={{
-          background: 'var(--pc-overlay-bg)',
-          border: `1px solid ${palette.gold}40`,
-          color: 'var(--pc-gold-text)',
-          backdropFilter: 'blur(8px)',
+          background: 'var(--pc-poster-chip-bg)',
+          border: '1px solid var(--pc-poster-chip-bd)',
+          color: 'var(--pc-poster-chip-text)',
+          backdropFilter: 'blur(10px)',
         }}
       >
-        <Sparkles size={10} />
+        <Sparkles size={10} style={{ color: 'var(--pc-poster-chip-accent)' }} />
         {label}
       </div>
     </div>
@@ -364,7 +364,10 @@ function MetaItems({
   return (
     <div
       className={`flex items-center gap-3 flex-wrap${className ? ` ${className}` : ''}`}
-      style={{ color: 'var(--pc-t2)', fontSize: '0.82rem' }}
+      style={{
+        color: overlay ? 'var(--pc-poster-chip-muted)' : 'var(--pc-t2)',
+        fontSize: '0.82rem',
+      }}
     >
       {items.map((item, index) => (
         <MetaItem
@@ -411,7 +414,10 @@ function renderOverlayRatingMetaItem(item: ResultMovieMetaItem): ReactNode {
   return (
     <span
       className="px-1.5 py-0.5 rounded"
-      style={{ border: '1px solid var(--pc-bd3)', color: 'var(--pc-t2)' }}
+      style={{
+        border: '1px solid var(--pc-poster-chip-bd)',
+        color: 'var(--pc-poster-chip-muted)',
+      }}
     >
       {item.label}
     </span>

--- a/apps/web/src/app/results/components/RecommendationFeedbackPanel.tsx
+++ b/apps/web/src/app/results/components/RecommendationFeedbackPanel.tsx
@@ -143,28 +143,30 @@ function getFeedbackButtonStyle({
 }) {
   const baseStyle = isSelected
     ? {
-        background: 'var(--pc-gold-subtle)',
-        color: 'var(--pc-gold-text)',
+        background: 'var(--pc-chip-selected-bg)',
+        color: 'var(--pc-chip-selected-text)',
+        borderColor: 'var(--pc-chip-selected-bd)',
       }
     : {
-        background: 'transparent',
-        color: 'var(--pc-t3)',
+        background: 'var(--pc-chip-bg)',
+        color: 'var(--pc-chip-text)',
+        borderColor: 'var(--pc-chip-bd)',
       };
 
   return {
     ...baseStyle,
-    border: '1px solid var(--pc-bd2)',
+    border: `1px solid ${baseStyle.borderColor}`,
     fontSize: '0.72rem',
     fontWeight: 600,
-    cursor: disabled ? 'wait' : 'pointer',
+    cursor: disabled ? 'not-allowed' : 'pointer',
   };
 }
 
 function getFollowUpButtonStyle({ disabled }: { disabled: boolean }) {
   return {
-    background: disabled ? 'var(--pc-bd1)' : 'var(--pc-gold-subtle)',
-    border: '1px solid var(--pc-bd2)',
-    color: disabled ? 'var(--pc-t4)' : 'var(--pc-gold-text)',
+    background: disabled ? 'var(--pc-chip-bg)' : 'var(--pc-chip-selected-bg)',
+    border: disabled ? '1px solid var(--pc-chip-bd)' : '1px solid var(--pc-chip-selected-bd)',
+    color: disabled ? 'var(--pc-t4)' : 'var(--pc-chip-selected-text)',
     cursor: disabled ? 'not-allowed' : 'pointer',
     fontSize: '0.74rem',
     fontWeight: 700,
@@ -201,7 +203,7 @@ function FeedbackOptionButton({
       type="button"
       onClick={() => void onFeedback(kind)}
       disabled={disabled}
-      className="inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 transition-colors duration-200 active:scale-95 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pc-gold)]"
+      className="inline-flex min-h-9 items-center gap-1.5 rounded-full px-3 py-1.5 transition-colors duration-200 active:scale-95 disabled:active:scale-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pc-gold)]"
       style={getFeedbackButtonStyle({ disabled, isSelected })}
     >
       <FeedbackOptionIcon Icon={Icon} isBusy={isBusy} />
@@ -241,7 +243,7 @@ function FeedbackFollowUpButton({
       type="button"
       onClick={() => void onFollowUp(kind)}
       disabled={disabled}
-      className="inline-flex items-center justify-center gap-1.5 rounded-full px-3 py-2 transition-colors duration-200 active:scale-95 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pc-gold)]"
+      className="inline-flex min-h-10 items-center justify-center gap-1.5 rounded-full px-3.5 py-2 transition-colors duration-200 active:scale-95 disabled:active:scale-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pc-gold)]"
       style={getFollowUpButtonStyle({ disabled })}
     >
       {isBusy ? <Loader2 size={13} className="animate-spin" /> : <Icon size={13} />}

--- a/apps/web/src/app/results/components/RecommendationFeedbackPanel.tsx
+++ b/apps/web/src/app/results/components/RecommendationFeedbackPanel.tsx
@@ -5,6 +5,8 @@ import { motion } from 'motion/react';
 
 import { useLanguage } from '@/i18n';
 
+import type { CSSProperties } from 'react';
+
 export type FeedbackKind =
   | 'useful'
   | 'already_watched'
@@ -31,6 +33,21 @@ type FeedbackFollowUpOption = {
 };
 
 type ResultsCopy = ReturnType<typeof useLanguage>['t']['results'];
+
+const followUpButtonStyle = {
+  enabled: {
+    background: 'var(--pc-chip-selected-bg)',
+    border: '1px solid var(--pc-chip-selected-bd)',
+    color: 'var(--pc-chip-selected-text)',
+    cursor: 'pointer',
+  },
+  disabled: {
+    background: 'var(--pc-chip-bg)',
+    border: '1px solid var(--pc-chip-bd)',
+    color: 'var(--pc-t4)',
+    cursor: 'not-allowed',
+  },
+} satisfies Record<'enabled' | 'disabled', CSSProperties>;
 
 function getFeedbackOptions(results: ResultsCopy): FeedbackOption[] {
   return [
@@ -163,11 +180,10 @@ function getFeedbackButtonStyle({
 }
 
 function getFollowUpButtonStyle({ disabled }: { disabled: boolean }) {
+  const buttonState = disabled ? 'disabled' : 'enabled';
+
   return {
-    background: disabled ? 'var(--pc-chip-bg)' : 'var(--pc-chip-selected-bg)',
-    border: disabled ? '1px solid var(--pc-chip-bd)' : '1px solid var(--pc-chip-selected-bd)',
-    color: disabled ? 'var(--pc-t4)' : 'var(--pc-chip-selected-text)',
-    cursor: disabled ? 'not-allowed' : 'pointer',
+    ...followUpButtonStyle[buttonState],
     fontSize: '0.74rem',
     fontWeight: 700,
   };

--- a/apps/web/src/app/results/components/ResultEvidencePanel.tsx
+++ b/apps/web/src/app/results/components/ResultEvidencePanel.tsx
@@ -10,18 +10,18 @@ import { buildResultEvidenceViewModel, type ResultEvidenceItem } from './resultE
 import type { RecommendationResultSignals } from '@/lib/db/recommendations';
 import type { MovieRecommendation } from '@/utils/client';
 
-function EvidencePill({ item }: { item: ResultEvidenceItem }) {
+function EvidenceRow({ item }: { item: ResultEvidenceItem }) {
   return (
     <li
-      className="flex min-h-12 items-start gap-3 rounded-lg px-3 py-2.5"
-      style={{
-        background: 'var(--pc-ghost)',
-        border: '1px solid var(--pc-bd2)',
-      }}
+      className="grid grid-cols-[1.25rem_1fr] items-start gap-3 py-2.5"
+      style={{ borderTop: '1px solid var(--pc-bd1)' }}
     >
       <span
         className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full"
-        style={{ background: 'var(--pc-gold-subtle)', color: 'var(--pc-gold-text)' }}
+        style={{
+          background: 'var(--pc-chip-selected-bg)',
+          color: 'var(--pc-chip-selected-text)',
+        }}
       >
         <CheckCircle2 size={12} />
       </span>
@@ -32,7 +32,7 @@ function EvidencePill({ item }: { item: ResultEvidenceItem }) {
         >
           {item.label}
         </span>
-        <span className="mt-0.5 block" style={{ color: 'var(--pc-t2)', fontSize: '0.82rem' }}>
+        <span className="mt-0.5 block" style={{ color: 'var(--pc-t2)', fontSize: '0.9rem' }}>
           {item.value}
         </span>
       </span>
@@ -52,7 +52,7 @@ function EvidenceColumn({
   const Icon = icon === 'sparkles' ? Sparkles : ListChecks;
 
   return (
-    <section>
+    <section className="min-w-0">
       <div className="mb-3 flex items-center gap-2">
         <Icon size={14} style={{ color: 'var(--pc-gold-text)' }} />
         <h3
@@ -62,9 +62,9 @@ function EvidenceColumn({
           {title}
         </h3>
       </div>
-      <ul className="grid gap-2">
+      <ul>
         {items.map((item) => (
-          <EvidencePill key={`${item.label}-${item.value}`} item={item} />
+          <EvidenceRow key={`${item.label}-${item.value}`} item={item} />
         ))}
       </ul>
     </section>
@@ -96,7 +96,7 @@ export function ResultEvidencePanel({
       initial={{ opacity: 0, y: 16 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.45, delay: 0.22 }}
-      className="mb-10 rounded-lg p-4 md:p-5"
+      className="mb-10 rounded-xl p-4 md:p-5"
       style={{
         background: 'var(--pc-surface)',
         border: '1px solid var(--pc-bd2)',
@@ -105,10 +105,10 @@ export function ResultEvidencePanel({
     >
       <div className="mb-5 flex items-start gap-3">
         <div
-          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg"
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl"
           style={{
-            background: 'var(--pc-gold-subtle)',
-            color: 'var(--pc-gold-text)',
+            background: 'var(--pc-chip-selected-bg)',
+            color: 'var(--pc-chip-selected-text)',
           }}
         >
           <SlidersHorizontal size={17} />

--- a/apps/web/src/app/results/components/ResultsHeader.tsx
+++ b/apps/web/src/app/results/components/ResultsHeader.tsx
@@ -6,9 +6,41 @@ import Link from 'next/link';
 
 import { useLanguage } from '@/i18n';
 
+import type { CSSProperties } from 'react';
+
 export type ShareState = 'idle' | 'copied';
 
 type ResultsCopy = ReturnType<typeof useLanguage>['t']['results'];
+
+const chipButtonStyle = {
+  idle: {
+    background: 'var(--pc-chip-bg)',
+    border: '1px solid var(--pc-chip-bd)',
+    color: 'var(--pc-chip-text)',
+  },
+  copied: {
+    background: 'var(--pc-chip-selected-bg)',
+    border: '1px solid var(--pc-chip-selected-bd)',
+    color: 'var(--pc-chip-selected-text)',
+  },
+} satisfies Record<ShareState, CSSProperties>;
+
+const shareButtonView = {
+  idle: {
+    Icon: Share2,
+    getLabel: (results: ResultsCopy) => results.shareResult,
+  },
+  copied: {
+    Icon: Check,
+    getLabel: (results: ResultsCopy) => results.shareCopied,
+  },
+} satisfies Record<
+  ShareState,
+  {
+    Icon: typeof Share2;
+    getLabel: (results: ResultsCopy) => string;
+  }
+>;
 
 function formatAudienceSubtitle({
   copy,
@@ -42,7 +74,8 @@ function ShareResultButton({
   shareState: ShareState;
   results: ResultsCopy;
 }) {
-  const didCopy = shareState === 'copied';
+  const view = shareButtonView[shareState];
+  const Icon = view.Icon;
 
   return (
     <button
@@ -50,15 +83,13 @@ function ShareResultButton({
       onClick={() => void onShare()}
       className="inline-flex items-center gap-2 rounded-full px-4 py-2 transition-colors duration-200 active:scale-95 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pc-gold)]"
       style={{
-        background: didCopy ? 'var(--pc-chip-selected-bg)' : 'var(--pc-chip-bg)',
-        border: didCopy ? '1px solid var(--pc-chip-selected-bd)' : '1px solid var(--pc-chip-bd)',
-        color: didCopy ? 'var(--pc-chip-selected-text)' : 'var(--pc-chip-text)',
+        ...chipButtonStyle[shareState],
         fontSize: '0.78rem',
         fontWeight: 600,
       }}
     >
-      {didCopy ? <Check size={13} /> : <Share2 size={13} />}
-      {didCopy ? results.shareCopied : results.shareResult}
+      <Icon size={13} />
+      {view.getLabel(results)}
     </button>
   );
 }

--- a/apps/web/src/app/results/components/ResultsHeader.tsx
+++ b/apps/web/src/app/results/components/ResultsHeader.tsx
@@ -50,9 +50,9 @@ function ShareResultButton({
       onClick={() => void onShare()}
       className="inline-flex items-center gap-2 rounded-full px-4 py-2 transition-colors duration-200 active:scale-95 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pc-gold)]"
       style={{
-        background: 'var(--pc-ghost)',
-        border: '1px solid var(--pc-bd2)',
-        color: didCopy ? 'var(--pc-gold-text)' : 'var(--pc-t2)',
+        background: didCopy ? 'var(--pc-chip-selected-bg)' : 'var(--pc-chip-bg)',
+        border: didCopy ? '1px solid var(--pc-chip-selected-bd)' : '1px solid var(--pc-chip-bd)',
+        color: didCopy ? 'var(--pc-chip-selected-text)' : 'var(--pc-chip-text)',
         fontSize: '0.78rem',
         fontWeight: 600,
       }}
@@ -76,9 +76,9 @@ function SaveCollectionButton({
         href="/account"
         className="inline-flex items-center gap-2 rounded-full px-4 py-2 transition-colors duration-200 active:scale-95 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pc-gold)]"
         style={{
-          background: 'var(--pc-gold-subtle)',
-          border: '1px solid var(--pc-gold-bd-subtle)',
-          color: 'var(--pc-gold-text)',
+          background: 'var(--pc-chip-selected-bg)',
+          border: '1px solid var(--pc-chip-selected-bd)',
+          color: 'var(--pc-chip-selected-text)',
           fontSize: '0.78rem',
           fontWeight: 600,
         }}
@@ -94,9 +94,9 @@ function SaveCollectionButton({
       href="/login"
       className="inline-flex items-center gap-2 rounded-full px-4 py-2 transition-colors duration-200 active:scale-95 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pc-gold)]"
       style={{
-        background: 'var(--pc-ghost)',
-        border: '1px solid var(--pc-bd2)',
-        color: 'var(--pc-t2)',
+        background: 'var(--pc-chip-bg)',
+        border: '1px solid var(--pc-chip-bd)',
+        color: 'var(--pc-chip-text)',
         fontSize: '0.78rem',
         fontWeight: 600,
       }}
@@ -163,8 +163,8 @@ export function ResultsDecisionNoteCard({
         <div
           className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full"
           style={{
-            background: 'var(--pc-gold-subtle)',
-            color: 'var(--pc-gold-text)',
+            background: 'var(--pc-chip-selected-bg)',
+            color: 'var(--pc-chip-selected-text)',
           }}
         >
           <DecisionNoteIcon isGroupResult={isGroupResult} />
@@ -186,8 +186,8 @@ export function ResultsDecisionNoteCard({
             <p
               className="mt-2 inline-flex items-center gap-1.5 rounded-full px-2.5 py-1"
               style={{
-                background: 'var(--pc-gold-subtle)',
-                color: 'var(--pc-gold-text)',
+                background: 'var(--pc-chip-selected-bg)',
+                color: 'var(--pc-chip-selected-text)',
                 fontSize: '0.72rem',
                 lineHeight: 1.4,
               }}

--- a/apps/web/src/app/results/components/SimilarityBadge.tsx
+++ b/apps/web/src/app/results/components/SimilarityBadge.tsx
@@ -7,25 +7,36 @@ import { useLanguage } from '@/i18n';
 import { buildResultMatchViewModel } from './resultMovieCardViewModel';
 
 export function SimilarityBadge({
+  tone = 'default',
   similarity,
   compact = false,
 }: {
+  tone?: 'default' | 'poster';
   similarity: number;
   compact?: boolean;
 }) {
   const { t } = useLanguage();
   const match = buildResultMatchViewModel(similarity, t.results);
+  const style =
+    tone === 'poster'
+      ? {
+          background: 'var(--pc-poster-chip-bg)',
+          border: '1px solid var(--pc-poster-chip-bd)',
+          color: 'var(--pc-poster-chip-accent)',
+          backdropFilter: 'blur(10px)',
+        }
+      : {
+          background: `${match.color}18`,
+          border: `1px solid ${match.color}35`,
+          color: match.color,
+        };
 
   return (
     <div
       className="flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs"
       title={match.exactLabel}
       aria-label={`${match.label}. ${match.exactLabel}`}
-      style={{
-        background: `${match.color}18`,
-        border: `1px solid ${match.color}35`,
-        color: match.color,
-      }}
+      style={style}
     >
       {!compact && <Sparkles size={10} />}
       {match.label}

--- a/docs/design-guidelines.md
+++ b/docs/design-guidelines.md
@@ -255,9 +255,12 @@ All visual values are driven by CSS custom properties prefixed with `--pc-*`, de
 
 - **Brand Badge:** Uppercase tracking-widest, gold tint bg + gold border, Sparkles icon
 - **Match Badge:** `{color}18` bg + `{color}35` border, Sparkles icon + "XX% match"
-- **Genre Pill:** `var(--pc-bd1)` bg + `var(--pc-bd2)` border, `var(--pc-t2)` text, `rounded-full`
+- **Neutral Chip:** `var(--pc-chip-bg)` bg + `var(--pc-chip-bd)` border, `var(--pc-chip-text)` text, `rounded-full`
+- **Selected Chip:** `var(--pc-chip-selected-bg)` bg + `var(--pc-chip-selected-bd)` border, `var(--pc-chip-selected-text)` text. Use for saved, copied, selected, and committed feedback states.
+- **Poster Overlay Chip:** `var(--pc-poster-chip-bg)` bg + `var(--pc-poster-chip-bd)` border, `var(--pc-poster-chip-text)` text, optional `var(--pc-poster-chip-accent)` icon. Use on poster/image previews instead of gold-on-gold translucent pills.
+- **Genre Pill:** Use the neutral chip treatment unless the genre itself carries a semantic color.
 - **NEW Badge:** `rgba(139,92,246,0.15)` bg, `#A78BFA` text, `rounded-full`
-- **AI Pick Label:** Frosted bg with `backdrop-filter: blur(8px)`, gold text
+- **AI Pick Label:** Poster overlay chip with gold icon and light text
 
 ### Cards
 


### PR DESCRIPTION
## What
- Added shared chip tokens for neutral, selected, and poster-overlay states.
- Made result poster badges/action pills readable over busy artwork, including AI pick and similarity tags.
- Reworked feedback pills so selected states are visibly selected on dark surfaces.
- Reworked the matching-logic card into lighter evidence rows instead of nested mini-cards.
- Documented the chip/badge rules in DESIGN.md and docs/design-guidelines.md.

## Design review
- Checked Mobbin references for detail/recommendation previews: Netflix, Paramount+, Google TV, IMDb. Main takeaway: artwork overlays need high-contrast scrims/chips, while title/meta/actions stay in a predictable readable stack.
- Ran impeccable context/audit pass for the result card, feedback pills, and matching-logic card.
- Ran impeccable detector on touched result components: no formal slop-pattern hits (`[]`).
- Visual smoke: Storybook dark-mode screenshot for `results-mainmoviecard--with-poster` at `/private/tmp/popchoice-main-card-dark.png`; no horizontal overflow, poster chips readable.

## Checks
- `npm run test --workspace=apps/web -- resultMovieCardViewModel resultEvidenceViewModel`
- `npm run lint:check`
- `npm run type-check --workspace=apps/web`
- `npm run build --workspace=apps/web`
- Pre-push hook passed: lint, server tests (85 files / 1166 tests), production build, Storybook tests (29 files / 98 tests).

Note: local build still prints the expected warning that `TMDB_API_KEY` is not set while generating static pages.