### PR TITLE
Fix real-fixture e2e follow-up

### DIFF
--- a/apps/backoffice/e2e/catalog-health.spec.ts
+++ b/apps/backoffice/e2e/catalog-health.spec.ts
@@ -8,9 +8,7 @@ test('renders deterministic catalog health data without desktop overflow', async
 
   await expect(page.getByRole('heading', { name: 'Catalog Health' })).toBeVisible();
   await expect(page.locator('#issue-missing_poster_url')).toContainText('Missing poster_url');
-  await expect(page.locator('#issue-missing_poster_url')).toContainText(
-    'PopChoice E2E Space Opera',
-  );
+  await expect(page.locator('#issue-missing_poster_url')).toContainText('Arrival');
   const resolvedChecks = page.getByRole('region', { name: 'No affected rows' });
   await expect(resolvedChecks).toContainText('Missing tmdb_id');
   await expect(resolvedChecks.getByLabel('Missing tmdb_id: clear')).toBeVisible();
@@ -28,7 +26,7 @@ test('queues a focused catalog repair through the enhanced form path', async ({ 
   await page.goto('/catalog-health?issue=missing_poster_url');
 
   const row = page.locator('[data-repair-row][data-issue-key="missing_poster_url"]').first();
-  await expect(row).toContainText('PopChoice E2E Space Opera');
+  await expect(row).toContainText('Arrival');
 
   const responsePromise = page.waitForResponse(
     (response) =>
@@ -51,7 +49,7 @@ test('does not redirect action responses to a bind-address host', async ({ reque
     form: {
       action: 'enqueue_backfill',
       issue_key: 'missing_poster_url',
-      movie_id: '1',
+      movie_id: '7',
     },
     headers: {
       ...operatorHeaders(),

--- a/apps/backoffice/e2e/tmdb-review-flow.spec.ts
+++ b/apps/backoffice/e2e/tmdb-review-flow.spec.ts
@@ -20,14 +20,12 @@ test('operator queues a catalog repair and sees the queued job and audit row', a
   await expect(page.getByRole('heading', { name: 'Missing poster_url' })).toBeVisible();
   await expect(page.locator('html')).toHaveAttribute('data-catalog-repair-enhanced', 'true');
   await expect(
-    page
-      .locator('#issue-missing_poster_url')
-      .getByRole('link', { name: 'PopChoice E2E Space Opera' }),
+    page.locator('#issue-missing_poster_url').getByRole('link', { name: 'Arrival' }),
   ).toBeVisible();
 
   const queueButton = page
     .locator('#issue-missing_poster_url')
-    .getByRole('row', { name: /#1 PopChoice E2E Space Opera/ })
+    .getByRole('row', { name: /#7 Arrival/ })
     .getByRole('button', { name: 'Queue backfill' });
   const [actionResponse] = await Promise.all([
     page.waitForResponse(
@@ -47,7 +45,7 @@ test('operator queues a catalog repair and sees the queued job and audit row', a
   const queuedJobRow = page
     .getByRole('row')
     .filter({ hasText: 'backfill-movie' })
-    .filter({ hasText: 'Movie: 1' })
+    .filter({ hasText: 'Movie: 7' })
     .first();
   await expect(queuedJobRow).toBeVisible();
   await expect(queuedJobRow).toContainText('Reason: missing_metadata');
@@ -58,7 +56,7 @@ test('operator queues a catalog repair and sees the queued job and audit row', a
   const auditRow = page
     .locator('#repair-audit')
     .getByRole('row')
-    .filter({ hasText: 'Movie #1' })
+    .filter({ hasText: 'Movie #7' })
     .filter({ hasText: 'Enqueue Backfill' })
     .first();
   await expect(auditRow).toBeVisible();
@@ -73,10 +71,8 @@ test('operator applies a seeded TMDB review candidate from queue to audit histor
   await page.goto('/tmdb-reviews');
 
   await expect(page.getByRole('heading', { name: 'TMDB Match Reviews' })).toBeVisible();
-  await expect(page.getByText('PopChoice E2E Space Opera', { exact: true })).toBeVisible();
-  await expect(
-    page.getByText('PopChoice E2E Space Opera Definitive Match', { exact: false }),
-  ).toBeVisible();
+  await expect(page.getByText('The Matrix', { exact: true }).first()).toBeVisible();
+  await expect(page.getByText('The Matrix (1999)', { exact: false })).toBeVisible();
   await expect(page.getByText(/Showing 1-1 of 1 reviews/).first()).toBeVisible();
 
   await page.getByRole('link', { name: '#1' }).click();
@@ -84,12 +80,14 @@ test('operator applies a seeded TMDB review candidate from queue to audit histor
   await expect(page.getByRole('heading', { name: 'TMDB Review #1' })).toBeVisible();
   await expect(page.locator('.page-description').getByText('Ambiguous match')).toBeVisible();
   await expect(
-    page.getByText('E2E fixture for the backoffice TMDB review decision flow.'),
+    page.getByText(
+      'E2E fixture for the backoffice TMDB review decision flow using real movie metadata.',
+    ),
   ).toBeVisible();
   await expect(page.getByRole('heading', { name: 'Candidates' })).toBeVisible();
 
   const bestCandidate = page.getByRole('article').filter({
-    has: page.getByRole('heading', { name: 'PopChoice E2E Space Opera Definitive Match' }),
+    has: page.getByRole('heading', { exact: true, name: 'The Matrix' }),
   });
   await bestCandidate
     .getByPlaceholder('Why this candidate is correct')
@@ -98,7 +96,7 @@ test('operator applies a seeded TMDB review candidate from queue to audit histor
 
   await expect(page.getByRole('heading', { name: 'TMDB Review #1' })).toBeVisible();
   await expect(page.locator('.page-description').getByText('Resolved')).toBeVisible();
-  await expect(page.getByText('990001').first()).toBeVisible();
+  await expect(page.getByText('603').first()).toBeVisible();
   await expect(page.getByText('apply candidate')).toBeVisible();
   await expect(page.getByText('Verified by e2e operator flow.')).toBeVisible();
 
@@ -106,6 +104,6 @@ test('operator applies a seeded TMDB review candidate from queue to audit histor
 
   await expect(page.getByRole('heading', { name: 'TMDB Match Reviews' })).toBeVisible();
   await expect(page.getByText(/Showing 1-1 of 1 reviews/).first()).toBeVisible();
-  await expect(page.getByText('PopChoice E2E Space Opera', { exact: true })).toBeVisible();
+  await expect(page.getByText('The Matrix', { exact: true }).first()).toBeVisible();
   await expect(page.locator('.review-table').getByText('Resolved')).toBeVisible();
 });

--- a/apps/web/e2e/helpers.ts
+++ b/apps/web/e2e/helpers.ts
@@ -10,6 +10,35 @@ export function uniqueEmail(testTitle: string): string {
   return `e2e-${slug}-${Date.now()}@example.com`;
 }
 
+export async function disableE2EMotion(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const styleId = '__popchoice-e2e-disable-motion';
+    const css = `
+      *, *::before, *::after {
+        animation-delay: 0s !important;
+        animation-duration: 1ms !important;
+        scroll-behavior: auto !important;
+        transition-delay: 0s !important;
+        transition-duration: 1ms !important;
+      }
+    `;
+
+    const install = () => {
+      if (document.getElementById(styleId)) return;
+      const style = document.createElement('style');
+      style.id = styleId;
+      style.textContent = css;
+      (document.head ?? document.documentElement).appendChild(style);
+    };
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', install, { once: true });
+    } else {
+      install();
+    }
+  });
+}
+
 export async function registerUser(page: Page, email: string, password: string): Promise<void> {
   await page.goto('/register');
   await page.getByLabel('Email address').fill(email);

--- a/apps/web/e2e/recommendation.spec.ts
+++ b/apps/web/e2e/recommendation.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'playwright/test';
 
-import { readSession, registerUser, uniqueEmail } from './helpers';
+import { disableE2EMotion, readSession, registerUser, uniqueEmail } from './helpers';
 
 import type { Page } from 'playwright/test';
 
@@ -77,6 +77,10 @@ async function completeFastPickQuestions(
   await page.getByRole('button', { name: /Balanced/ }).click();
   await page.getByRole('button', { name: finalButtonName }).click();
 }
+
+test.beforeEach(async ({ page }) => {
+  await disableE2EMotion(page);
+});
 
 test('submits the solo quiz, renders deterministic results, and records feedback', async ({
   page,

--- a/scripts/e2e/setup-db.mjs
+++ b/scripts/e2e/setup-db.mjs
@@ -98,7 +98,7 @@ const movieFixtures = [
     scoreRating: 7.6,
     year: 2016,
     tmdbId: 329865,
-    posterUrl: `${tmdbPosterBase}/x2FJsf1ElAgr63Y3PNPtJrcmpoe.jpg`,
+    posterUrl: null,
     localizedName: 'Arrival',
   },
 ];


### PR DESCRIPTION
## Summary
- align backoffice e2e expectations with the real-movie e2e seed merged in #859
- keep one real seeded movie with a missing poster to exercise catalog repair flows
- disable motion in recommendation e2e to avoid Playwright actionability flakes on animated quiz controls

## Verification
- npm run test:e2e:setup
- npm run test:e2e:run (15 passed)
- npm run test:e2e:backoffice:run (6 passed)
- npm run test:e2e:down
- npx prettier --check apps/backoffice/e2e/catalog-health.spec.ts apps/backoffice/e2e/tmdb-review-flow.spec.ts apps/web/e2e/helpers.ts apps/web/e2e/recommendation.spec.ts scripts/e2e/setup-db.mjs
- npm run lint:check
- npm run type-check --workspace=apps/web
- npm run type-check --workspace=apps/backoffice
- pre-push: lint, server tests, production build