### PR TITLE
Add accessibility CI smoke tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -295,6 +295,68 @@ jobs:
             apps/web/test-results/
           retention-days: 30
 
+  a11y-tests:
+    name: Accessibility Tests
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.61.0-noble
+      options: --user 1001
+    permissions:
+      contents: read
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_DB: popchoice_e2e
+          POSTGRES_HOST_AUTH_METHOD: trust
+          POSTGRES_USER: popchoice_e2e
+        options: >-
+          --health-cmd "pg_isready -U popchoice_e2e -d popchoice_e2e"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+      redis:
+        image: redis:7-alpine
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      E2E_DATABASE_URL: postgresql://popchoice_e2e@postgres:5432/popchoice_e2e
+      E2E_REDIS_URL: redis://redis:6379
+      E2E_SKIP_DOCKER: '1'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare a11y database fixtures
+        run: npm run test:e2e:setup
+
+      - name: Run axe accessibility tests
+        run: npm run test:a11y:run
+
+      - name: Upload accessibility report
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: playwright-a11y-report
+          path: |
+            apps/web/playwright-a11y-report/
+            apps/web/test-results/a11y/
+          retention-days: 30
+
   build:
     name: Build
     needs: changes
@@ -399,6 +461,7 @@ jobs:
       - recommendation-evals
       - storybook-tests
       - e2e-tests
+      - a11y-tests
       - build
       - docs-build
       - services-ci
@@ -416,6 +479,7 @@ jobs:
       RECOMMENDATION_EVALS_RESULT: ${{ needs.recommendation-evals.result }}
       STORYBOOK_TESTS_RESULT: ${{ needs.storybook-tests.result }}
       E2E_TESTS_RESULT: ${{ needs.e2e-tests.result }}
+      A11Y_TESTS_RESULT: ${{ needs.a11y-tests.result }}
       BUILD_RESULT: ${{ needs.build.result }}
       DOCS_BUILD_RESULT: ${{ needs.docs-build.result }}
       SERVICES_CI_RESULT: ${{ needs.services-ci.result }}
@@ -442,6 +506,7 @@ jobs:
           [[ "$RECOMMENDATION_EVALS_RESULT" == "success" ]] || failures+=("Recommendation Evals: $RECOMMENDATION_EVALS_RESULT")
           [[ "$STORYBOOK_TESTS_RESULT" == "success" ]] || failures+=("Storybook Tests: $STORYBOOK_TESTS_RESULT")
           [[ "$E2E_TESTS_RESULT" == "success" ]] || failures+=("E2E Tests: $E2E_TESTS_RESULT")
+          [[ "$A11Y_TESTS_RESULT" == "success" ]] || failures+=("Accessibility Tests: $A11Y_TESTS_RESULT")
           [[ "$BUILD_RESULT" == "success" ]] || failures+=("Build: $BUILD_RESULT")
           [[ "$DOCS_BUILD_RESULT" == "success" ]] || failures+=("Docs Build: $DOCS_BUILD_RESULT")
           [[ "$SERVICES_CI_RESULT" == "success" ]] || failures+=("Services CI: $SERVICES_CI_RESULT")

--- a/.gitignore
+++ b/.gitignore
@@ -61,4 +61,5 @@ storybook-static
 
 # Playwright
 playwright-report
+playwright-*-report
 test-results

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -186,6 +186,24 @@ In light mode, shadows are soft and diffuse (`rgba(0,0,0,0.1)`), barely present.
 
 ## 5. Components
 
+### Component Reuse Policy
+
+Prefer existing components before creating new UI. Start with shared
+components from `packages/ui` and `apps/web/src/components`; if the pattern
+already exists there, extend that component conservatively instead of
+recreating its markup, styling, interaction states, or accessibility behavior
+inside a route.
+
+Prefer shared primitives over in-app one-offs. Route- or feature-local
+components should compose shared primitives and own only the workflow-specific
+layout, copy, and state. Create a new local primitive only when no existing
+shared component can express the interaction without making its API misleading,
+overloaded, or inaccessible.
+
+Promote local components when reuse becomes real. If a page-local control
+appears on a second surface, move it toward the shared component layer with
+tokens, stories, and accessibility behavior instead of copying it.
+
 ### Buttons
 
 Buttons are the most-touched element in the quiz flow — they need to feel satisfying, not just functional.

--- a/README.md
+++ b/README.md
@@ -167,6 +167,16 @@ npm run test:e2e:down
 
 The default e2e database is intentionally curated instead of restored from a dev dump. Use dev or production-like dumps only for manual local investigations after removing users, sessions, recommendation history, feedback, API keys, and other operational data; CI should stay on the deterministic fixture seed.
 
+### Accessibility smoke tests
+
+The accessibility suite reuses the deterministic e2e fixtures and runs axe checks against public pages, catalog browsing, and the authenticated recommendation result flow:
+
+```bash
+npm run test:a11y
+```
+
+In CI, `Accessibility Tests` runs as a separate PR job inside the pinned official Playwright Docker image, so Chromium and browser system dependencies come from the image instead of a mutable Playwright browser cache.
+
 ### Recommendation evals
 
 Recommendation evals are separate from browser e2e smoke tests. The default command uses deterministic fixtures and mocked model outputs, so it does not spend OpenAI/TMDB credits:

--- a/apps/web/a11y/critical-flows.spec.ts
+++ b/apps/web/a11y/critical-flows.spec.ts
@@ -1,0 +1,114 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test, type Page } from 'playwright/test';
+
+import { disableE2EMotion, readSession, registerUser, uniqueEmail } from '../e2e/helpers';
+
+const BLOCKING_IMPACTS = new Set(['critical', 'serious']);
+const A11Y_RENDER_STABILIZER_CSS = `
+  [style*="opacity: 0"][style*="transform"],
+  [style*="opacity:0"][style*="transform"] {
+    opacity: 1 !important;
+    transform: none !important;
+  }
+`;
+
+const MOCK_POSTERS = Array.from({ length: 8 }, (_, index) => {
+  const color = ['1a1a2e', '16213e', '0f3460', '533483', '2c003e', '1b1b2f', '0d1117', '0a0a14'][
+    index
+  ];
+
+  return `data:image/svg+xml,${encodeURIComponent(
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 450"><rect width="300" height="450" fill="#${color}"/></svg>`,
+  )}`;
+});
+
+async function mockPosterApi(page: Page) {
+  await page.route('**/api/poster-urls', async (route) => {
+    await route.fulfill({
+      body: JSON.stringify({ posters: MOCK_POSTERS }),
+      contentType: 'application/json',
+    });
+  });
+}
+
+async function expectNoBlockingA11yViolations(page: Page, scanName: string) {
+  await page.waitForLoadState('networkidle').catch(() => undefined);
+  await page.evaluate(() => document.fonts?.ready.then(() => undefined)).catch(() => undefined);
+  await page.addStyleTag({ content: A11Y_RENDER_STABILIZER_CSS });
+  await page.waitForTimeout(250);
+
+  const results = await new AxeBuilder({ page })
+    .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'best-practice'])
+    .analyze();
+  const blockingViolations = results.violations.filter((violation) =>
+    BLOCKING_IMPACTS.has(violation.impact ?? ''),
+  );
+
+  expect(blockingViolations, formatViolations(scanName, blockingViolations)).toEqual([]);
+}
+
+function formatViolations(
+  scanName: string,
+  violations: Awaited<ReturnType<AxeBuilder['analyze']>>['violations'],
+) {
+  if (violations.length === 0) return `${scanName}: no blocking accessibility violations`;
+
+  return [
+    `${scanName}: ${violations.length} blocking accessibility violation(s)`,
+    ...violations.map((violation) => {
+      const nodes = violation.nodes
+        .slice(0, 4)
+        .map((node) => `  - ${node.target.join(' ')}: ${node.failureSummary ?? violation.help}`)
+        .join('\n');
+      return `${violation.id} [${violation.impact}]: ${violation.help}\n${nodes}`;
+    }),
+  ].join('\n\n');
+}
+
+async function completeFastPickSolo(page: Page) {
+  await page.goto('/quiz');
+  await page.getByRole('button', { name: /Fast Pick/ }).click();
+  await page.getByRole('button', { name: /Just me/ }).click();
+  await page.getByRole('button', { name: /Funny/ }).click();
+  await page.getByRole('button', { name: 'Continue' }).click();
+  await page.getByRole('button', { name: /Long runtime/ }).click();
+  await page.getByRole('button', { name: /Too obvious/ }).click();
+  await page.getByRole('button', { name: 'Continue' }).click();
+  await page.getByRole('button', { name: /Balanced/ }).click();
+  await page.getByRole('button', { name: /Find My Movie/ }).click();
+
+  await expect(page).toHaveURL(/\/results\/[A-Za-z0-9_-]+/, { timeout: 45_000 });
+  await expect(page.getByRole('heading', { name: 'The Matrix' })).toBeVisible();
+}
+
+test.beforeEach(async ({ page }) => {
+  await disableE2EMotion(page);
+});
+
+test('public entrypoints have no blocking axe violations', async ({ page }) => {
+  await mockPosterApi(page);
+
+  for (const route of ['/', '/about', '/login', '/register', '/quiz']) {
+    await page.goto(route);
+    await expect(page.locator('main')).toBeVisible();
+    await expectNoBlockingA11yViolations(page, route);
+  }
+});
+
+test('catalog page has no blocking axe violations with real fixtures', async ({ page }) => {
+  await page.goto('/available-movies');
+
+  await expect(page.getByRole('heading', { name: 'Available Movies' })).toBeVisible();
+  await expect(page.getByText('The Matrix')).toBeVisible();
+  await expectNoBlockingA11yViolations(page, '/available-movies');
+});
+
+test('authenticated results flow has no blocking axe violations', async ({ page }, testInfo) => {
+  const email = uniqueEmail(testInfo.title);
+
+  await registerUser(page, email, 'E2E-password-475!');
+  await expect.poll(() => readSession(page)).toMatchObject({ authenticated: true });
+
+  await completeFastPickSolo(page);
+  await expectNoBlockingA11yViolations(page, '/results/[id]');
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -66,6 +66,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.3",
     "@chromatic-com/storybook": "^5.2.1",
     "@storybook/addon-a11y": "^10.4.5",
     "@storybook/addon-docs": "^10.4.5",

--- a/apps/web/playwright.a11y.config.ts
+++ b/apps/web/playwright.a11y.config.ts
@@ -1,0 +1,49 @@
+import { fileURLToPath } from 'node:url';
+
+import { defineConfig, devices } from 'playwright/test';
+
+const a11yPort = Number.parseInt(process.env.A11Y_PORT ?? '3110', 10);
+const baseURL = process.env.A11Y_BASE_URL ?? `http://127.0.0.1:${a11yPort}`;
+const databaseUrl =
+  process.env.E2E_DATABASE_URL ?? 'postgresql://popchoice_e2e@127.0.0.1:55432/popchoice_e2e';
+const redisUrl = process.env.E2E_REDIS_URL ?? 'redis://127.0.0.1:56379';
+const repoRoot = fileURLToPath(new URL('../../', import.meta.url));
+
+export default defineConfig({
+  testDir: './a11y',
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  timeout: 45_000,
+  expect: {
+    timeout: 10_000,
+  },
+  outputDir: 'test-results/a11y',
+  reporter: process.env.CI
+    ? [['github'], ['html', { open: 'never', outputFolder: 'playwright-a11y-report' }], ['list']]
+    : [['list'], ['html', { open: 'never', outputFolder: 'playwright-a11y-report' }]],
+  use: {
+    ...devices['Desktop Chrome'],
+    baseURL,
+    screenshot: 'only-on-failure',
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: `npm run build --workspace=packages/shared && npm run dev --workspace=apps/web -- --hostname 127.0.0.1 --port ${a11yPort}`,
+    cwd: repoRoot,
+    env: {
+      AUTH_SESSION_SECRET: 'a11y-auth-session-secret',
+      DATABASE_URL: databaseUrl,
+      E2E_DETERMINISTIC_RECOMMENDATIONS: '1',
+      NEXT_PUBLIC_BASE_URL: baseURL,
+      REDIS_URL: redisUrl,
+      RESEND_API_KEY: '',
+      TMDB_API_KEY: '',
+      VALID_API_KEYS: '',
+    },
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    url: baseURL,
+  },
+});

--- a/apps/web/src/app/about/components/HowItWorksSection.tsx
+++ b/apps/web/src/app/about/components/HowItWorksSection.tsx
@@ -8,6 +8,63 @@ import { palette } from '@/styles/designTokens';
 
 const STEP_ICONS = [ListChecks, Brain, Database, Sparkles];
 const STEP_COLORS = [palette.gold, palette.purple, palette.teal, palette.amber];
+type HowItWorksStep = ReturnType<typeof useLanguage>['t']['about']['howItWorks']['steps'][number];
+
+function getStepAccentTextColor(color: string) {
+  return color === palette.purple ? '#A78BFA' : color;
+}
+
+function HowItWorksStepCard({ index, step }: { index: number; step: HowItWorksStep }) {
+  const Icon = STEP_ICONS[index] ?? Sparkles;
+  const color = STEP_COLORS[index] ?? palette.gold;
+  const textColor = getStepAccentTextColor(color);
+  const stepNum = String(index + 1).padStart(2, '0');
+
+  return (
+    <motion.div
+      key={stepNum}
+      initial={false}
+      whileInView={{ opacity: 1, x: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.5, delay: index * 0.1 }}
+      className="flex gap-5 items-start"
+    >
+      <div
+        className="w-14 h-14 rounded-2xl flex items-center justify-center shrink-0 relative z-10"
+        style={{
+          background: `color-mix(in srgb, ${color} 12%, var(--pc-bg))`,
+          border: `1px solid ${color}30`,
+          color,
+        }}
+      >
+        <Icon size={22} />
+      </div>
+      <div
+        className="flex-1 p-5 rounded-2xl"
+        style={{ background: 'var(--pc-surface)', border: '1px solid var(--pc-bd1)' }}
+      >
+        <div className="flex items-center gap-3 mb-2">
+          <span
+            style={{
+              color: textColor,
+              fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
+              fontWeight: '600',
+              textTransform: 'uppercase',
+              letterSpacing: '0.1em',
+              fontSize: '0.9rem',
+            }}
+          >
+            {stepNum}
+          </span>
+          <h3 style={{ color: 'var(--pc-t1)', fontWeight: 600, fontSize: '0.95rem' }}>
+            {step.title}
+          </h3>
+        </div>
+        <p style={{ color: 'var(--pc-t3)', fontSize: '0.85rem', lineHeight: 1.7 }}>{step.desc}</p>
+      </div>
+    </motion.div>
+  );
+}
 
 export function HowItWorksSection() {
   const { t } = useLanguage();
@@ -41,64 +98,9 @@ export function HowItWorksSection() {
           }}
         />
         <div className="flex flex-col gap-6">
-          {t.about.howItWorks.steps.map((step, i) => {
-            const Icon = STEP_ICONS[i];
-            const color = STEP_COLORS[i];
-            const textColor = color === palette.purple ? '#A78BFA' : color;
-            if (!Icon || !color) {
-              if (process.env.NODE_ENV === 'development')
-                // eslint-disable-next-line no-console
-                console.warn('Missing icon or color for step:', step.title);
-              return null;
-            }
-            const stepNum = String(i + 1).padStart(2, '0');
-            return (
-              <motion.div
-                key={stepNum}
-                initial={false}
-                whileInView={{ opacity: 1, x: 0 }}
-                viewport={{ once: true }}
-                transition={{ duration: 0.5, delay: i * 0.1 }}
-                className="flex gap-5 items-start"
-              >
-                <div
-                  className="w-14 h-14 rounded-2xl flex items-center justify-center shrink-0 relative z-10"
-                  style={{
-                    background: `color-mix(in srgb, ${color} 12%, var(--pc-bg))`,
-                    border: `1px solid ${color}30`,
-                    color,
-                  }}
-                >
-                  <Icon size={22} />
-                </div>
-                <div
-                  className="flex-1 p-5 rounded-2xl"
-                  style={{ background: 'var(--pc-surface)', border: '1px solid var(--pc-bd1)' }}
-                >
-                  <div className="flex items-center gap-3 mb-2">
-                    <span
-                      style={{
-                        color: textColor,
-                        fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
-                        fontWeight: '600',
-                        textTransform: 'uppercase',
-                        letterSpacing: '0.1em',
-                        fontSize: '0.9rem',
-                      }}
-                    >
-                      {stepNum}
-                    </span>
-                    <h3 style={{ color: 'var(--pc-t1)', fontWeight: 600, fontSize: '0.95rem' }}>
-                      {step.title}
-                    </h3>
-                  </div>
-                  <p style={{ color: 'var(--pc-t3)', fontSize: '0.85rem', lineHeight: 1.7 }}>
-                    {step.desc}
-                  </p>
-                </div>
-              </motion.div>
-            );
-          })}
+          {t.about.howItWorks.steps.map((step, index) => (
+            <HowItWorksStepCard key={step.title} index={index} step={step} />
+          ))}
         </div>
       </div>
     </section>

--- a/apps/web/src/app/about/components/HowItWorksSection.tsx
+++ b/apps/web/src/app/about/components/HowItWorksSection.tsx
@@ -44,6 +44,7 @@ export function HowItWorksSection() {
           {t.about.howItWorks.steps.map((step, i) => {
             const Icon = STEP_ICONS[i];
             const color = STEP_COLORS[i];
+            const textColor = color === palette.purple ? '#A78BFA' : color;
             if (!Icon || !color) {
               if (process.env.NODE_ENV === 'development')
                 // eslint-disable-next-line no-console
@@ -77,7 +78,7 @@ export function HowItWorksSection() {
                   <div className="flex items-center gap-3 mb-2">
                     <span
                       style={{
-                        color,
+                        color: textColor,
                         fontFamily: "var(--font-oswald), 'Oswald', sans-serif",
                         fontWeight: '600',
                         textTransform: 'uppercase',

--- a/apps/web/src/app/results/[id]/RecommendationResultsView.tsx
+++ b/apps/web/src/app/results/[id]/RecommendationResultsView.tsx
@@ -1,13 +1,12 @@
 'use client';
 
 import { RotateCcw, Users } from 'lucide-react';
-import { motion } from 'motion/react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { Button } from '@/components/Button';
 import { useLanguage } from '@/i18n';
 import { getCsrfToken } from '@/lib/csrfClient';
 import { navigateToFreshQuiz } from '@/lib/quizNavigation';
-import { palette } from '@/styles/designTokens';
 import { type MovieRecommendation } from '@/utils/client';
 
 import {
@@ -315,48 +314,21 @@ function ResultsActions({
   tryWithFriendsLabel: string;
 }) {
   return (
-    <motion.div
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      transition={{ delay: 0.5, duration: 0.5 }}
-      className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4"
-    >
-      <button
+    <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+      <Button
         type="button"
         onClick={navigateToFreshQuiz}
-        className="flex items-center gap-2 px-6 py-3 rounded-2xl transition-colors duration-200 active:scale-95 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pc-gold)]"
-        style={{
-          background: 'var(--pc-ghost)',
-          border: '1px solid var(--pc-bd2)',
-          color: 'var(--pc-t2)',
-          fontSize: '0.9rem',
-        }}
-        onMouseEnter={(event) => {
-          event.currentTarget.style.color = 'var(--pc-t1)';
-          event.currentTarget.style.borderColor = 'var(--pc-bd4)';
-        }}
-        onMouseLeave={(event) => {
-          event.currentTarget.style.color = 'var(--pc-t2)';
-          event.currentTarget.style.borderColor = 'var(--pc-bd2)';
-        }}
+        variant="ghost"
+        size="lg"
+        className="px-6"
       >
         <RotateCcw size={15} /> {tryAgainLabel}
-      </button>
+      </Button>
 
-      <button
-        type="button"
-        onClick={navigateToFreshQuiz}
-        className="flex items-center gap-2 px-6 py-3 rounded-2xl transition-transform duration-200 active:scale-95 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pc-gold)]"
-        style={{
-          background: `linear-gradient(135deg, ${palette.purple}, #6D28D9)`,
-          color: '#F8F8FF',
-          fontSize: '0.9rem',
-          fontWeight: 600,
-        }}
-      >
+      <Button type="button" onClick={navigateToFreshQuiz} variant="cta" size="lg" className="px-6">
         <Users size={15} /> {tryWithFriendsLabel}
-      </button>
-    </motion.div>
+      </Button>
+    </div>
   );
 }
 

--- a/apps/web/src/app/results/components/MainMovieCard.tsx
+++ b/apps/web/src/app/results/components/MainMovieCard.tsx
@@ -320,8 +320,11 @@ function MainMatchSummary({
   return (
     <div className="flex items-center justify-between flex-wrap gap-3 mb-4">
       <div className="flex items-center gap-2">
-        <Clapperboard size={13} style={{ color: 'var(--pc-t3)' }} />
-        <span title={view.matchExactLabel} style={{ color: 'var(--pc-t3)', fontSize: '0.82rem' }}>
+        <Clapperboard size={13} style={{ color: 'var(--pc-chip-text)' }} />
+        <span
+          title={view.matchExactLabel}
+          style={{ color: 'var(--pc-chip-text)', fontSize: '0.82rem' }}
+        >
           {view.year} · {view.matchLabel}
         </span>
       </div>
@@ -347,7 +350,7 @@ function MainScoreRow({ view }: { view: ResultMovieCardViewModel }) {
   return (
     <div className="flex items-center gap-2 mb-4">
       <StarRating score={view.score} />
-      <span style={{ color: 'var(--pc-t3)', fontSize: '0.78rem' }}>{view.score}/10</span>
+      <span style={{ color: 'var(--pc-chip-text)', fontSize: '0.78rem' }}>{view.score}/10</span>
     </div>
   );
 }
@@ -468,7 +471,7 @@ function MainRationale({ view }: { view: ResultMovieCardViewModel }) {
           {view.rationaleLabel}
         </span>
       </div>
-      <p style={{ color: 'var(--pc-t2)', fontSize: '0.88rem', lineHeight: 1.75 }}>
+      <p style={{ color: 'var(--pc-chip-text)', fontSize: '0.88rem', lineHeight: 1.75 }}>
         <MarkdownText text={view.description} />
       </p>
     </div>

--- a/apps/web/src/app/results/components/RecommendationFeedbackPanel.tsx
+++ b/apps/web/src/app/results/components/RecommendationFeedbackPanel.tsx
@@ -44,7 +44,7 @@ const followUpButtonStyle = {
   disabled: {
     background: 'var(--pc-chip-bg)',
     border: '1px solid var(--pc-chip-bd)',
-    color: 'var(--pc-t4)',
+    color: 'var(--pc-chip-text)',
     cursor: 'not-allowed',
   },
 } satisfies Record<'enabled' | 'disabled', CSSProperties>;
@@ -108,7 +108,7 @@ function SharedFeedbackHint({
       style={{
         background: 'var(--pc-ghost)',
         border: '1px solid var(--pc-bd2)',
-        color: 'var(--pc-t4)',
+        color: 'var(--pc-chip-text)',
         fontSize: '0.78rem',
       }}
     >
@@ -318,7 +318,7 @@ export function RecommendationFeedbackPanel({
           >
             {t.results.feedbackPrompt}
           </p>
-          <p className="mt-1" style={{ color: 'var(--pc-t4)', fontSize: '0.78rem' }}>
+          <p className="mt-1" style={{ color: 'var(--pc-chip-text)', fontSize: '0.78rem' }}>
             <FeedbackStatusText
               feedbackState={feedbackState}
               followUpState={followUpState}
@@ -346,11 +346,11 @@ export function RecommendationFeedbackPanel({
           <div>
             <p
               className="uppercase tracking-widest"
-              style={{ color: 'var(--pc-t3)', fontSize: '0.66rem' }}
+              style={{ color: 'var(--pc-chip-text)', fontSize: '0.66rem' }}
             >
               {t.results.feedbackActionTitle}
             </p>
-            <p className="mt-1" style={{ color: 'var(--pc-t4)', fontSize: '0.76rem' }}>
+            <p className="mt-1" style={{ color: 'var(--pc-chip-text)', fontSize: '0.76rem' }}>
               {t.results.feedbackActionHint}
             </p>
           </div>

--- a/apps/web/src/app/results/components/ResultEvidencePanel.tsx
+++ b/apps/web/src/app/results/components/ResultEvidencePanel.tsx
@@ -28,11 +28,11 @@ function EvidenceRow({ item }: { item: ResultEvidenceItem }) {
       <span className="min-w-0">
         <span
           className="block uppercase tracking-widest"
-          style={{ color: 'var(--pc-t4)', fontSize: '0.58rem' }}
+          style={{ color: 'var(--pc-chip-text)', fontSize: '0.58rem' }}
         >
           {item.label}
         </span>
-        <span className="mt-0.5 block" style={{ color: 'var(--pc-t2)', fontSize: '0.9rem' }}>
+        <span className="mt-0.5 block" style={{ color: 'var(--pc-chip-text)', fontSize: '0.9rem' }}>
           {item.value}
         </span>
       </span>
@@ -120,7 +120,7 @@ export function ResultEvidencePanel({
           >
             {t.results.evidenceKicker}
           </p>
-          <p className="mt-1" style={{ color: 'var(--pc-t3)', fontSize: '0.84rem' }}>
+          <p className="mt-1" style={{ color: 'var(--pc-chip-text)', fontSize: '0.84rem' }}>
             {t.results.evidenceSubtitle}
           </p>
         </div>

--- a/apps/web/src/app/results/components/SmallSuggestionCard.tsx
+++ b/apps/web/src/app/results/components/SmallSuggestionCard.tsx
@@ -177,7 +177,7 @@ function TmdbBadge() {
       style={{
         background: 'rgba(9,9,15,0.85)',
         border: '1px solid rgba(255,255,255,0.15)',
-        color: 'var(--pc-t3)',
+        color: 'var(--pc-chip-text)',
         backdropFilter: 'blur(6px)',
       }}
     >
@@ -190,7 +190,7 @@ function SmallMetaItems({ items }: { items: ResultMovieMetaItem[] }) {
   return (
     <div
       className="flex items-center gap-2 mb-2 flex-wrap"
-      style={{ color: 'var(--pc-t3)', fontSize: '0.75rem' }}
+      style={{ color: 'var(--pc-chip-text)', fontSize: '0.75rem' }}
     >
       {items.map((item, index) => (
         <SmallMetaItem key={`${item.kind}-${item.label}`} item={item} showSeparator={index > 0} />

--- a/apps/web/src/app/results/components/SuggestionSections.tsx
+++ b/apps/web/src/app/results/components/SuggestionSections.tsx
@@ -47,7 +47,7 @@ function SuggestionSectionTitle({ label, gradient }: SuggestionSectionTitleProps
   return (
     <div className="flex items-center gap-2">
       <div className="w-1.5 h-5 rounded-full" style={{ background: gradient }} />
-      <span className="uppercase tracking-widest text-xs" style={{ color: 'var(--pc-t2)' }}>
+      <span className="uppercase tracking-widest text-xs" style={{ color: 'var(--pc-chip-text)' }}>
         {label}
       </span>
     </div>
@@ -430,7 +430,7 @@ const MORE_PICKS_STATUS_ICONS = {
 
 function getMorePicksStatusColor(tone: MorePicksStatusTone) {
   const colors = {
-    muted: 'var(--pc-t4)',
+    muted: 'var(--pc-chip-text)',
     success: 'var(--pc-gold-text)',
     warning: palette.amber,
   } as const;
@@ -578,11 +578,11 @@ function MorePicksControl({
         <div>
           <p
             className="uppercase tracking-widest"
-            style={{ color: 'var(--pc-t2)', fontSize: '0.68rem' }}
+            style={{ color: 'var(--pc-chip-text)', fontSize: '0.68rem' }}
           >
             {results.morePicksTitle}
           </p>
-          <p className="mt-1 text-sm" style={{ color: 'var(--pc-t4)' }}>
+          <p className="mt-1 text-sm" style={{ color: 'var(--pc-chip-text)' }}>
             {results.morePicksHint}
           </p>
         </div>
@@ -596,11 +596,11 @@ function MorePicksControl({
                 onClick={() => setLens(option.value)}
                 aria-pressed={isSelected}
                 disabled={viewState === 'loading'}
-                className="rounded-full px-3 py-1.5 text-xs font-semibold transition-colors duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pc-gold)] disabled:opacity-60"
+                className="rounded-full px-3 py-1.5 text-xs font-semibold transition-colors duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--pc-gold)]"
                 style={{
                   background: isSelected ? 'var(--pc-gold-subtle)' : 'transparent',
                   border: '1px solid var(--pc-bd2)',
-                  color: isSelected ? 'var(--pc-gold-text)' : 'var(--pc-t3)',
+                  color: isSelected ? 'var(--pc-gold-text)' : 'var(--pc-chip-text)',
                 }}
               >
                 {option.label}

--- a/apps/web/src/components/MoviesTable/MoviesTable.tsx
+++ b/apps/web/src/components/MoviesTable/MoviesTable.tsx
@@ -272,7 +272,7 @@ function MovieMetadataChips({ movie }: { movie: Movie }) {
           style={{
             background: 'var(--pc-surface-hover)',
             border: '1px solid var(--pc-bd1)',
-            color: 'var(--pc-t3)',
+            color: 'var(--pc-chip-text)',
           }}
         >
           <Clock size={13} aria-hidden="true" />

--- a/apps/web/src/components/PCLayout/PCLayout.tsx
+++ b/apps/web/src/components/PCLayout/PCLayout.tsx
@@ -549,7 +549,12 @@ export function PCLayout({ children }: { children: ReactNode }) {
           href="https://github.com/shchilkin"
           target="_blank"
           rel="noopener noreferrer"
-          style={{ color: 'var(--pc-gold-text)' }}
+          style={{
+            color: 'var(--pc-gold-text)',
+            textDecorationColor: 'color-mix(in srgb, var(--pc-gold-text) 65%, transparent)',
+            textDecorationLine: 'underline',
+            textUnderlineOffset: '0.18em',
+          }}
         >
           {t.footer.authorName}
         </a>{' '}

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -8,7 +8,7 @@ title: 'CI/CD Documentation'
 
 This project uses these GitHub Actions workflow files for pull request validation and security scanning:
 
-- `.github/workflows/pr.yml` – main application and workspace checks (lint, Fallow audit, type-check, web tests, recommendation evals, Storybook tests, e2e smoke tests, build, service CI, dependency review)
+- `.github/workflows/pr.yml` – main application and workspace checks (lint, Fallow audit, type-check, web tests, recommendation evals, Storybook tests, accessibility checks, e2e smoke tests, build, service CI, dependency review)
 - `.github/workflows/recommendation-real-data-evals.yml` – scheduled/manual recommendation evals against a seeded database and real catalog retrieval
 - `.github/workflows/container-images.yml` – production container image builds for app and service runtimes, published to GitHub Container Registry with commit and PR provenance metadata
 - `.github/workflows/movie-discovery-ci.yml` – TypeScript compilation and tests for the `services/movie-discovery` service, triggered when files under `services/movie-discovery/` change or when `.github/workflows/movie-discovery-ci.yml` itself changes
@@ -30,6 +30,7 @@ The PR validation workflows run automatically on pull requests targeting the `de
 | `pr.yml`                             | `recommendation-evals`           | Deterministic recommendation quality fixtures and scoring                       |
 | `pr.yml`                             | `storybook-tests`                | Playwright browser install + Storybook component tests                          |
 | `pr.yml`                             | `e2e-tests`                      | Playwright smoke tests against isolated PostgreSQL + Redis services             |
+| `pr.yml`                             | `a11y-tests`                     | axe accessibility smoke tests against seeded app flows                          |
 | `pr.yml`                             | `build`                          | Next.js production build verification                                           |
 | `pr.yml`                             | `services-ci`                    | Shared package tests plus Turbo test pass for `services/*`                      |
 | `pr.yml`                             | `dependency-review`              | Blocks PRs introducing vulnerable dependencies                                  |
@@ -54,11 +55,19 @@ The `storybook-tests` job runs `npx playwright install-deps` on every CI run and
 
 The `storybook-tests` job caches Playwright browser binaries in `~/.cache/ms-playwright` using `actions/cache@v5`, keyed on the OS and `package-lock.json` hash. On a cache hit, the browser download step is skipped, but `npx playwright install-deps` still runs because Linux system packages are not part of the Playwright browser cache.
 
+The `a11y-tests` job intentionally avoids this cache path. It runs inside the pinned official `mcr.microsoft.com/playwright:v1.61.0-noble` container, matching the `playwright` package version in `package-lock.json`, so Chromium and system dependencies are already present in the image. The job uses GitHub service containers for PostgreSQL and Redis, then runs the e2e migration/seed script with `E2E_SKIP_DOCKER=1`.
+
 ### E2E Smoke Tests
 
 The `e2e-tests` job runs `npm run test:e2e`. That command starts the isolated `docker-compose.e2e.yml` services, applies the same `db/init` migrations used by production/local setup, seeds deterministic movie fixtures, starts the web app on port `3100`, starts the backoffice app on port `3101`, and runs both Playwright suites. The job always runs `npm run test:e2e:down` afterwards so the disposable database volume is removed.
 
 The e2e coverage proves the real app can read seeded catalog data from PostgreSQL, that `/api/health` can reach both PostgreSQL and Redis, and that auth/session, catalog empty states, quiz submission, deterministic result rendering, feedback, movie-memory persistence, backoffice catalog repair enqueue/audit visibility, and TMDB review decisions work through the browser. AI-eval coverage is tracked separately so model quality gates can use fixture scoring and optional live-provider runs.
+
+### Accessibility Tests
+
+The `a11y-tests` job runs `npm run test:a11y:run` after preparing the same deterministic movie fixtures used by e2e. The Playwright config lives at `apps/web/playwright.a11y.config.ts`, and the tests live under `apps/web/a11y/`.
+
+The suite uses `@axe-core/playwright` and blocks critical or serious WCAG 2 A/AA, WCAG 2.1 A/AA, and axe best-practice violations on the public entrypoints, auth forms, catalog page, and an authenticated deterministic results page. Full Playwright output is uploaded as the `playwright-a11y-report` artifact.
 
 ### Recommendation Evals
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -339,7 +339,8 @@
         "tailwindcss": "^4",
         "typescript": "6.0.3",
         "vitest": "^4.1.9",
-        "webpack": "^5.107.2"
+        "webpack": "^5.107.2",
+        "@axe-core/playwright": "^4.11.3"
       },
       "engines": {
         "node": ">=24",
@@ -19023,6 +19024,29 @@
       "engines": {
         "node": ">=24",
         "npm": ">=11"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+      "integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.4"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/@axe-core/playwright/node_modules/axe-core": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
     "start:storybook": "npm run start:storybook --workspace=apps/web",
     "storybook": "npm run storybook --workspace=apps/web",
     "test": "npm run test --workspace=apps/web",
+    "test:a11y": "npm run test:e2e:setup && npm run test:a11y:run && npm run test:e2e:down",
+    "test:a11y:run": "playwright test --config apps/web/playwright.a11y.config.ts",
     "test:backoffice": "npm run build --workspace=packages/shared && npm run build --workspace=packages/ui && npm run quality:backoffice && npm run test --workspace=apps/backoffice",
     "test:e2e": "npm run test:e2e:setup && npm run test:e2e:run && npm run test:e2e:backoffice:run",
     "test:e2e:backoffice": "npm run test:e2e:setup && npm run test:e2e:backoffice:run",


### PR DESCRIPTION
## Summary
- add a separate Playwright/axe accessibility smoke suite for public pages, catalog, and authenticated results flow
- run the new PR job in the pinned official Playwright Docker image (mcr.microsoft.com/playwright:v1.61.0-noble) with PostgreSQL/Redis service containers
- fix contrast issues surfaced by axe on footer links, catalog chips, about step numbering, and results metadata/feedback UI
- document local and CI a11y workflows

## Verification
- npm run format:check
- npm run lint:check
- npm run type-check
- npm run test:e2e:setup
- npm run test:a11y:run
- npm run test:e2e:down
- npm run test
- npm run build
- pre-push: lint, test:server, build, test:storybook