### PR TITLE
Clarify catalog maintenance services overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ npm run setup:local-db      # spin up local PostgreSQL + Redis via Docker
 npm run copy:env            # copy root .env into apps/services workspaces
 npm run dev                 # start the dev server at http://localhost:3000
 # in a second terminal:
-cd apps/web && npm run start:workers
+npm run start:workers --workspace=apps/web
 # in a third terminal:
 npm run dev:backoffice      # open Catalog seed and trigger the curated seed
 ```
@@ -131,9 +131,8 @@ Run the web app and the BullMQ workers in separate terminals:
 # terminal 1, repo root
 npm run dev
 
-# terminal 2, apps/web workspace
-cd apps/web
-npm run start:workers
+# terminal 2, repo root
+npm run start:workers --workspace=apps/web
 
 # terminal 3, repo root
 npm run dev:backoffice
@@ -236,14 +235,14 @@ as a separate Coolify service for design review.
 
 ### Troubleshooting
 
-| Problem                             | Solution                                                  |
-| ----------------------------------- | --------------------------------------------------------- |
-| `DATABASE_URL is not set`           | Run `npm run setup:local-db`, then `npm run copy:env`     |
-| Recommendations stay pending        | Start workers with `cd apps/web && npm run start:workers` |
-| App or workers use stale env values | Re-run `npm run copy:env` after editing the root `.env`   |
-| Docker container not starting       | Ensure Docker Desktop is running                          |
-| OpenAI errors when seeding          | Verify `OPENAI_API_KEY` is correct in `.env`              |
-| Missing movie posters               | Add a valid `TMDB_API_KEY` to `.env`                      |
+| Problem                             | Solution                                                |
+| ----------------------------------- | ------------------------------------------------------- |
+| `DATABASE_URL is not set`           | Run `npm run setup:local-db`, then `npm run copy:env`   |
+| Recommendations stay pending        | Run `npm run start:workers --workspace=apps/web`        |
+| App or workers use stale env values | Re-run `npm run copy:env` after editing the root `.env` |
+| Docker container not starting       | Ensure Docker Desktop is running                        |
+| OpenAI errors when seeding          | Verify `OPENAI_API_KEY` is correct in `.env`            |
+| Missing movie posters               | Add a valid `TMDB_API_KEY` to `.env`                    |
 
 ## 📖 Documentation
 
@@ -290,10 +289,12 @@ apps/
 │       └── utils/         # Reusable utilities and data helpers
 ├── bull-board/            # Queue monitoring app
 packages/
-└── shared/                # Shared package reused by background services
+├── shared/                # Shared database, embedding, logging, and utility code
+└── ui/                    # Shared shadcn-derived UI primitives
 services/
 ├── movie-discovery/       # Continuous TMDB movie discovery service
-└── movie-backfill/        # One-shot service to backfill missing movie metadata
+├── movie-backfill/        # Manual TMDB metadata maintenance CLI / fallback
+└── db-migrate/            # Containerized database migration runtime
 db/                        # Database migrations / schema
 ```
 
@@ -306,7 +307,7 @@ For ownership rules inside `apps/web/src`, see [docs/BOUNDARIES.md](./docs/BOUND
   `apps/web/data/movies.txt`, generate OpenAI embeddings, insert missing rows,
   and optionally queue bounded catalog repair work for TMDB ids/posters.
 - **movie-discovery** (`services/movie-discovery/`) — Continuous TMDB-driven service that discovers new movies, applies quality filters (vote count, rating, overview length), generates embeddings, and inserts them into the database. Supports scheduled and one-shot modes. See [`services/movie-discovery/README.md`](./services/movie-discovery/README.md).
-- **movie-backfill** (`services/movie-backfill/`) — One-shot script that backfills missing `duration` and `age_rating` data for movies already in the database, re-generating their embeddings. Supports dry-run mode. See [`services/movie-backfill/README.md`](./services/movie-backfill/README.md).
+- **movie-backfill** (`services/movie-backfill/`) — Manual maintenance CLI for inspecting catalog gaps, backfilling missing TMDB metadata, and exporting fallback SQL patches. The primary day-to-day repair path is Backoffice plus the BullMQ `catalog-maintenance` queue. See [`services/movie-backfill/README.md`](./services/movie-backfill/README.md).
 
 ## 🧪 Development Scripts
 
@@ -325,7 +326,7 @@ npm run build:backoffice            # Build the backoffice app
 npm run build:storybook             # Build static Storybook
 npm run check:backoffice            # Shared build + backoffice structure/type/test checks
 npm run start --workspace=apps/web  # Start production server (apps/web)
-cd apps/web && npm run start:workers # Start BullMQ workers (apps/web)
+npm run start:workers --workspace=apps/web # Start BullMQ workers
 npm run bull-board                  # Launch BullMQ dashboard (apps/bull-board)
 
 # Testing
@@ -347,8 +348,8 @@ npm run copy:env             # Sync root .env into apps/services workspaces
 npm run migrate:db           # Apply idempotent SQL migrations
 npm run setup:backoffice:local-data # Run setup:local-db and copy:env
 npm run catalog:health       # Report catalog metadata coverage and likely duplicates
-npm run analyze-movies       # Analyze movie data for embeddings
-npm run calibrate-similarity # Calibrate vector similarity thresholds
+npm run analyze-movies --workspace=apps/web       # Analyze movie data for embeddings
+npm run calibrate-similarity --workspace=apps/web # Calibrate vector similarity thresholds
 npm run test:services        # Run shared package and service test scripts
 ```
 

--- a/docs/BACKOFFICE.md
+++ b/docs/BACKOFFICE.md
@@ -6,8 +6,9 @@ title: 'Backoffice Plan'
 
 PopChoice backoffice work is tracked under
 [#493](https://github.com/shchilkin/PopChoice/issues/493). The backoffice is an
-operational app for catalog health, TMDB match review, and later manual data
-repair. It must not be implemented inside the user-facing `apps/web` app.
+operational app for catalog health, TMDB match review, queued catalog repair,
+catalog seeding, queue visibility, and recommendation eval operations. It must
+not be implemented inside the user-facing `apps/web` app.
 Post-MVP operator hardening is tracked under
 [#660](https://github.com/shchilkin/PopChoice/issues/660).
 
@@ -43,14 +44,15 @@ Coolify service. New interactive operator workflows should use React/Next route
 handlers and shared PopChoice UI conventions instead of adding hand-written
 HTML pages.
 
-## Initial Scope
+## Current Scope
 
-The first backoffice release should be read-only:
+The initial backoffice slice was read-only and established the dedicated
+operator surface:
 
 - [#549](https://github.com/shchilkin/PopChoice/issues/549): catalog-health
   overview for missing metadata, duplicate identities, stale TMDB data, and
   missing cast/director/genre/keyword coverage. This is implemented as the
-  first read-only `apps/backoffice` screen.
+  first `apps/backoffice` screen.
 - [#550](https://github.com/shchilkin/PopChoice/issues/550): TMDB match review
   queue for `tmdb_match_reviews` rows. This is implemented as a protected queue
   and detail view with status/reason filters, risk sorting, local-vs-candidate
@@ -117,8 +119,8 @@ Shared operator auth is the login model for public exposure:
 
 - [#548](https://github.com/shchilkin/PopChoice/issues/548): shared login
   protection for `apps/backoffice` and `apps/bull-board`.
-- `OPERATOR_AUTH_USERNAME` and `OPERATOR_AUTH_PASSWORD` protect Bull Board now
-  and should be reused by the future backoffice app.
+- `OPERATOR_AUTH_USERNAME` and `OPERATOR_AUTH_PASSWORD` protect Bull Board and
+  Backoffice public operator routes.
 - User-facing app login stays separate; operator credentials must not be added
   to normal `apps/web` routes.
 

--- a/docs/BOUNDARIES.md
+++ b/docs/BOUNDARIES.md
@@ -10,11 +10,12 @@ This document defines the intended ownership boundaries for PopChoice in its cur
 
 - `apps/web` owns the user-facing Next.js app, API routes, page composition, and app-specific runtime wiring.
 - `apps/bull-board` owns queue monitoring UI and operational tooling for BullMQ.
-- Future admin/backoffice screens should live in a dedicated `apps/backoffice`
-  app, deployed like `apps/bull-board`, not in `apps/web`. See
+- `apps/backoffice` owns operator/admin screens and should stay deployed as a
+  dedicated app like `apps/bull-board`, not as routes inside `apps/web`. See
   [Backoffice Plan](/docs/BACKOFFICE).
 - `services/*` own background and offline processes that can run independently from the web app.
 - `packages/shared` owns low-level shared helpers already reused across root services.
+- `packages/ui` owns shared domain-free UI primitives reused across apps.
 
 ## apps/web/src Boundaries
 

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -6,13 +6,14 @@ title: 'CI/CD Documentation'
 
 ## GitHub Actions Workflow
 
-This project uses these GitHub Actions workflow files for pull request validation and security scanning:
+This project uses these GitHub Actions workflow files for pull request validation, image publishing, deploy promotion, security scanning, scheduled evals, and dependency automation:
 
 - `.github/workflows/pr.yml` – main application and workspace checks (lint, Fallow audit, type-check, web tests, recommendation evals, Storybook tests, accessibility checks, e2e smoke tests, build, service CI, dependency review)
 - `.github/workflows/recommendation-real-data-evals.yml` – scheduled/manual recommendation evals against a seeded database and real catalog retrieval
 - `.github/workflows/container-images.yml` – production container image builds for app and service runtimes, published to GitHub Container Registry with commit and PR provenance metadata
 - `.github/workflows/movie-discovery-ci.yml` – TypeScript compilation and tests for the `services/movie-discovery` service, triggered when files under `services/movie-discovery/` change or when `.github/workflows/movie-discovery-ci.yml` itself changes
 - `.github/workflows/codeql.yml` – CodeQL analysis for GitHub Actions and JavaScript/TypeScript on pushes, pull requests, and a weekly schedule
+- `.github/workflows/dependabot-auto-merge.yml` – enables auto-squash merge for Dependabot minor and patch update PRs after required checks pass
 
 ## Workflow Overview
 
@@ -20,26 +21,31 @@ The PR validation workflows run automatically on pull requests targeting the `de
 
 ### Jobs
 
-| Workflow                             | Job                              | Purpose                                                                         |
-| ------------------------------------ | -------------------------------- | ------------------------------------------------------------------------------- |
-| `pr.yml`                             | `changes`                        | Classifies PR as docs-only vs code-changing                                     |
-| `pr.yml`                             | `lint`                           | ESLint code quality + Prettier formatting                                       |
-| `pr.yml`                             | `fallow-audit`                   | Required new-only Fallow audit for changed TypeScript/JavaScript quality risks  |
-| `pr.yml`                             | `type-check`                     | TypeScript type safety (`tsc --noEmit`)                                         |
-| `pr.yml`                             | `server-tests`                   | Vitest server tests with coverage collection and artifact upload                |
-| `pr.yml`                             | `recommendation-evals`           | Deterministic recommendation quality fixtures and scoring                       |
-| `pr.yml`                             | `storybook-tests`                | Playwright browser install + Storybook component tests                          |
-| `pr.yml`                             | `e2e-tests`                      | Playwright smoke tests against isolated PostgreSQL + Redis services             |
-| `pr.yml`                             | `a11y-tests`                     | axe accessibility smoke tests against seeded app flows                          |
-| `pr.yml`                             | `build`                          | Next.js production build verification                                           |
-| `pr.yml`                             | `services-ci`                    | Shared package tests plus Turbo test pass for `services/*`                      |
-| `pr.yml`                             | `dependency-review`              | Blocks PRs introducing vulnerable dependencies                                  |
-| `pr.yml`                             | `pr-validation`                  | Stable required check that always runs on every PR                              |
-| `container-images.yml`               | `build-images`                   | Builds and publishes GHCR production images with provenance                     |
-| `container-images.yml`               | `deploy-coolify`                 | Optionally triggers the Coolify deploy webhook after development images publish |
-| `movie-discovery-ci.yml`             | `movie-discovery-ci`             | TypeScript compilation and tests for `services/movie-discovery`                 |
-| `codeql.yml`                         | `analyze`                        | CodeQL static analysis for Actions and JavaScript/TypeScript                    |
-| `recommendation-real-data-evals.yml` | `recommendation-real-data-evals` | Manual/scheduled seeded-database catalog retrieval evals                        |
+| Workflow                             | Job                              | Purpose                                                                        |
+| ------------------------------------ | -------------------------------- | ------------------------------------------------------------------------------ |
+| `pr.yml`                             | `changes`                        | Classifies PR as docs-only vs code-changing                                    |
+| `pr.yml`                             | `lint`                           | ESLint code quality + Prettier formatting                                      |
+| `pr.yml`                             | `fallow-audit`                   | Required new-only Fallow audit for changed TypeScript/JavaScript quality risks |
+| `pr.yml`                             | `type-check`                     | TypeScript type safety (`tsc --noEmit`)                                        |
+| `pr.yml`                             | `server-tests`                   | Vitest server tests with coverage collection and artifact upload               |
+| `pr.yml`                             | `backoffice-tests`               | Shared/UI builds, backoffice quality checks, and backoffice Vitest suite       |
+| `pr.yml`                             | `recommendation-evals`           | Deterministic recommendation quality fixtures and scoring                      |
+| `pr.yml`                             | `storybook-tests`                | Playwright browser install + Storybook component tests                         |
+| `pr.yml`                             | `e2e-tests`                      | Playwright smoke tests against isolated PostgreSQL + Redis services            |
+| `pr.yml`                             | `a11y-tests`                     | axe accessibility smoke tests against seeded app flows                         |
+| `pr.yml`                             | `build`                          | Next.js production build verification                                          |
+| `pr.yml`                             | `docs-build`                     | Documentation type-check and production docs build                             |
+| `pr.yml`                             | `services-ci`                    | Shared package tests plus Turbo test pass for `services/*`                     |
+| `pr.yml`                             | `dependency-review`              | Blocks PRs introducing vulnerable dependencies                                 |
+| `pr.yml`                             | `pr-validation`                  | Stable required check that always runs on every PR                             |
+| `container-images.yml`               | `validate-deploy-request`        | Resolves manual deploy target and enforces matching release refs               |
+| `container-images.yml`               | `build-images`                   | Builds and publishes GHCR production images with provenance                    |
+| `container-images.yml`               | `deploy-development`             | Triggers the development Coolify deploy after development images publish       |
+| `container-images.yml`               | `deploy-production`              | Promotes production tags and triggers the gated production Coolify deploy      |
+| `movie-discovery-ci.yml`             | `movie-discovery-ci`             | TypeScript compilation and tests for `services/movie-discovery`                |
+| `codeql.yml`                         | `analyze`                        | CodeQL static analysis for Actions and JavaScript/TypeScript                   |
+| `recommendation-real-data-evals.yml` | `recommendation-real-data-evals` | Manual/scheduled seeded-database catalog retrieval evals                       |
+| `dependabot-auto-merge.yml`          | `auto-merge`                     | Enables auto-squash merge for Dependabot minor and patch update PRs            |
 
 ## Workflow Features
 
@@ -86,6 +92,14 @@ Agents and reviewers should explicitly consider these layers when a PR changes r
 ### Code Coverage
 
 Server tests run with `--coverage` via `@vitest/coverage-v8`. Coverage reports (HTML, JSON, LCOV) are uploaded as a GitHub Actions artifact named `coverage-report` and retained for 30 days. Coverage is configured in `vitest.config.ts`.
+
+### Backoffice Tests
+
+The `backoffice-tests` job runs `npm run test:backoffice` for code-changing PRs. That root script builds `packages/shared`, builds `packages/ui`, runs the backoffice quality gate, and then runs the `apps/backoffice` Vitest suite.
+
+### Docs Build
+
+The `docs-build` job always runs from `pr.yml`, including docs-only PRs. It runs `npm run type-check:docs` and `npm run build:docs` so documentation routing, MDX compilation, and production build behavior are verified before merge.
 
 ### Fallow Code Quality Audit
 
@@ -287,7 +301,7 @@ on:
     branches: ['development']
 ```
 
-If the PR is docs-only (`docs/**` and root-level `*.md`), heavy CI jobs are skipped and the lightweight `PR Validation` job still reports success. For non-doc PRs, the full CI suite runs and `PR Validation` verifies all required CI jobs succeeded.
+If the PR is docs-only (`docs/**` and root-level `*.md`), code-focused jobs are skipped, `docs-build` still verifies the documentation app, and the lightweight `PR Validation` job still reports success. For non-doc PRs, the full CI suite runs and `PR Validation` verifies all required CI jobs succeeded.
 
 **`container-images.yml`** triggers on pull requests to `development`, pushes
 to `development`, and manual dispatches. Manual runs expose a
@@ -336,11 +350,14 @@ The PR validation workflows are triggered on:
 `pr.yml` always runs and classifies docs-only PRs inside the workflow so `PR Validation` is always reported.
 `container-images.yml` builds production images on pull requests and on pushes
 to `development`; manual runs can also publish `development` or `production`
-promotion tags before triggering the matching Coolify resource. `movie-discovery-ci.yml`
+promotion tags before triggering the matching Coolify resource. Its
+`validate-deploy-request` job enforces that development deploys run from the
+`development` ref and production deploys run from `main`. `movie-discovery-ci.yml`
 additionally **only runs** when at least one file under `services/movie-discovery/**` changes or when
 `.github/workflows/movie-discovery-ci.yml` itself changes. `codeql.yml` runs on
 pushes and pull requests targeting `development`, plus its weekly scheduled
-scan.
+scan. `dependabot-auto-merge.yml` runs on pull requests to `development`, but
+its `auto-merge` job only executes for PRs opened by `dependabot[bot]`.
 
 ## Dependabot
 
@@ -351,6 +368,10 @@ Dependabot is configured in `.github/dependabot.yml` to monitor:
 - **GitHub Actions** – workflow action versions
 
 All groups cover `minor` and `patch` updates. Major updates still require manual review.
+
+Minor and patch Dependabot PRs are eligible for auto-squash merge through
+`.github/workflows/dependabot-auto-merge.yml`. Branch protection still controls
+when the queued auto-merge can complete because required checks must pass first.
 
 ## Local Testing
 
@@ -366,7 +387,7 @@ npm run type-check
 npx vitest --project=server --run --coverage
 
 # Storybook tests (requires Playwright browsers)
-npm run pretest:storybook
+npm run pretest:storybook --workspace=apps/web
 npm run test:storybook
 
 # Verify build

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -55,11 +55,11 @@ For docs ownership, navigation, and issue hygiene, use **[Documentation Governan
 - `npm run copy:env` - Copy the root `.env` into `apps/*`, `services/*`, and `packages/shared`
 - `npm run migrate:db` - Apply all idempotent SQL migrations from `db/init`
 - `npm run storybook` - Start Storybook development server
-- `npm run build-storybook` - Build Storybook for production
+- `npm run build:storybook` - Build Storybook for production
 
 Workspace-local scripts used during app development:
 
-- `cd apps/web && npm run start:workers` - Start BullMQ workers for async recommendations
+- `npm run start:workers --workspace=apps/web` - Start BullMQ workers for async recommendations
 - `npm run bull-board` - Open the BullMQ dashboard locally
   (`OPERATOR_AUTH_USERNAME` and `OPERATOR_AUTH_PASSWORD` enable the same login
   used in production)
@@ -70,8 +70,8 @@ Workspace-local scripts used during app development:
 
 - `npm run setup:local-db` - Start local PostgreSQL + Redis via Docker and write credentials to `.env`
 - `npm run cleanup:local-db` - Stop containers and remove the database volume (full reset)
-- `npm run analyze-movies` - Analyze movie data chunks for embedding optimization
-- `npm run calibrate-similarity` - Recalibrate recommendation similarity thresholds against the live DB
+- `npm run analyze-movies --workspace=apps/web` - Analyze movie data chunks for embedding optimization
+- `npm run calibrate-similarity --workspace=apps/web` - Recalibrate recommendation similarity thresholds against the live DB
 
 ## Database Setup Workflow
 
@@ -79,7 +79,7 @@ The project includes scripts to help you set up and manage your movie recommenda
 
 1. **Start the DB** - Run `npm run setup:local-db` to spin up PostgreSQL + Redis and initialize credentials
 2. **Sync env files** - Run `npm run copy:env` so the web app and services use the updated root `.env`
-3. **Run the app and workers** - Start `npm run dev` from the repo root and `cd apps/web && npm run start:workers` in a second terminal
+3. **Run the app and workers** - Start `npm run dev` from the repo root and `npm run start:workers --workspace=apps/web` in a second terminal
 4. **Seed the DB** - Start `npm run dev:backoffice`, open the Catalog seed page, and trigger the curated seed job
 5. **Reset** - Run `npm run cleanup:local-db` to wipe everything, then repeat from step 1
 
@@ -122,8 +122,7 @@ Then run the app in separate terminals:
 npm run dev
 
 # terminal 2
-cd apps/web
-npm run start:workers
+npm run start:workers --workspace=apps/web
 
 # optional terminal 3
 npm run bull-board
@@ -262,6 +261,7 @@ Use three eval levels when changing AI-related code:
 
 ```text
 apps/
+├── docs/                  # Fumadocs documentation site rendering docs/
 ├── web/
 │   └── src/
 │       ├── app/           # Next.js route and page boundaries
@@ -278,10 +278,12 @@ apps/
 ├── bull-board/            # Queue monitoring app
 ├── backoffice/            # Operator app for catalog health and review
 packages/
-└── shared/                # Shared helpers reused by root services
+├── shared/                # Shared database, embedding, logging, and utility code
+└── ui/                    # Shared shadcn-derived UI primitives
 services/
 ├── movie-discovery/       # Scheduled or one-shot TMDB discovery process
-└── movie-backfill/        # Metadata backfill process
+├── movie-backfill/        # Manual TMDB metadata maintenance CLI / fallback
+└── db-migrate/            # Containerized database migration runtime
 db/                        # SQL scripts and DB initialization assets
 ```
 

--- a/docs/ROADMAP-ARCHITECTURE.md
+++ b/docs/ROADMAP-ARCHITECTURE.md
@@ -18,6 +18,7 @@ What is already true:
 - the web app and supporting apps already live under `apps/`
 - background jobs and sync processes already live under root `services/*`
 - a shared package already exists in `packages/shared`
+- a shared UI primitives package already exists in `packages/ui`
 - recommendation orchestration now lives in reusable feature-owned modules outside route ownership
 - account, password reset, recommendation feedback, and movie-memory flows exist for signed-in users
 
@@ -33,6 +34,7 @@ The main remaining risks are:
 
 - [x] Workspace layout exists: `apps/`, `packages/`, and `services/` are already in place.
 - [x] Shared package extraction has started with `packages/shared` reused by root services.
+- [x] Shared UI primitive extraction has started with `packages/ui` reused across app workspaces.
 - [x] Background service responsibilities are partially separated into `services/movie-discovery`, `services/movie-backfill`, and BullMQ worker queues.
 - [x] Recommendation orchestration is extracted into reusable feature-owned modules instead of living only inside route handlers.
 - [x] Some recommendation thresholds/constants are separated into dedicated helper modules instead of being embedded directly in route handlers.
@@ -92,20 +94,23 @@ Reference: use [BOUNDARIES.md](/docs/BOUNDARIES) as the current ownership baseli
 PopChoice should continue evolving within the current workspace layout toward clearer ownership and easier extractability, for example:
 
 - `apps/web`
+- `apps/docs`
 - `apps/bull-board`
+- `apps/backoffice`
 - `services/movie-discovery`
 - `services/movie-backfill`
+- `services/db-migrate`
 - `packages/domain`
 - `packages/config`
 - `packages/clients`
 - `packages/shared`
-- optional: `packages/ui`
+- `packages/ui`
 
 This is an extraction direction, not a mandate for large-scale file moves right now. Current work should optimize for clean boundaries inside the existing workspace first.
 
 UI extraction should follow [UI Development](./UI-DEVELOPMENT.md): one Storybook runner loads
-stories from app workspaces and future `packages/ui`, while shadcn-derived primitives move into the
-shared UI package only after a second real consumer appears.
+stories from app workspaces and `packages/ui`, while shadcn-derived primitives move into the
+shared UI package when reuse is real and the primitive stays domain-free.
 
 ## Guiding Principles
 

--- a/docs/SERVICES.md
+++ b/docs/SERVICES.md
@@ -10,15 +10,23 @@ This document describes the background services that populate and maintain the m
 
 ## Services Overview
 
-| Service / Tool               | Type                   | Trigger                                                 | Source        |
-| ---------------------------- | ---------------------- | ------------------------------------------------------- | ------------- |
-| `movie-discovery`            | Scheduled service      | Cron / manual one-shot                                  | TMDB API      |
-| `movie-backfill`             | Manual maintenance CLI | Operator fallback / dry-run                             | TMDB API      |
-| `catalog:health`             | Read-only report       | Manual / CI                                             | PostgreSQL    |
-| BullMQ `recommendation`      | Per-request            | HTTP POST to /api/recommendations                       | TMDB + OpenAI |
-| BullMQ `more-picks`          | On demand              | HTTP POST to /api/recommendations/[id]/more-picks       | TMDB + OpenAI |
-| BullMQ `movie-seed`          | Worker queue           | Recommendation JIT seeding, Backoffice curated seed     | TMDB + file   |
-| BullMQ `catalog-maintenance` | Maintenance jobs       | Recommendation JIT, discovery enqueue, backfill enqueue | TMDB + OpenAI |
+### Services And CLI Tools
+
+| Tool              | Role                   | Trigger                     | Source     |
+| ----------------- | ---------------------- | --------------------------- | ---------- |
+| `movie-discovery` | Scheduled service      | Cron / manual one-shot      | TMDB API   |
+| `movie-backfill`  | Manual maintenance CLI | Operator fallback / dry-run | TMDB API   |
+| `catalog:health`  | Read-only report       | Manual / CI                 | PostgreSQL |
+
+### BullMQ Queues
+
+| Queue                  | Role                          | Trigger                                                 | Source        |
+| ---------------------- | ----------------------------- | ------------------------------------------------------- | ------------- |
+| `recommendation`       | Async recommendation creation | HTTP POST to /api/recommendations                       | TMDB + OpenAI |
+| `more-picks`           | On-demand follow-up picks     | HTTP POST to /api/recommendations/[id]/more-picks       | TMDB + OpenAI |
+| `movie-seed`           | Catalog seed jobs             | Recommendation JIT seeding, Backoffice curated seed     | TMDB + file   |
+| `catalog-maintenance`  | Catalog maintenance jobs      | Recommendation JIT, discovery enqueue, backfill enqueue | TMDB + OpenAI |
+| `recommendation-evals` | Recommendation eval runs      | Backoffice / operator-triggered eval runs               | Eval fixtures |
 
 Backoffice and the BullMQ `catalog-maintenance` worker are the primary path for
 catalog discovery and backfill work. The `movie-backfill` CLI remains available

--- a/docs/SERVICES.md
+++ b/docs/SERVICES.md
@@ -78,8 +78,8 @@ When `REDIS_URL` is not set (e.g., local dev without Redis), `startMorePicksRequ
 ### Starting workers
 
 ```bash
-# From apps/web
-npm run start:workers
+# From repo root
+npm run start:workers --workspace=apps/web
 ```
 
 Or via Docker Compose (workers.Dockerfile).
@@ -497,7 +497,7 @@ If the DB grows substantially, a new embedding model is adopted, or scores shift
 1. Run the built-in calibration tool (requires `OPENAI_API_KEY` and `DATABASE_URL` in `.env`):
 
    ```bash
-   npm run calibrate-similarity
+   npm run calibrate-similarity --workspace=apps/web
    ```
 
    The script embeds 5 representative queries, queries the live DB, and prints ranked results with cosine scores. It also prints the highest observed score and a suggested threshold (~2/3 of ceiling).
@@ -511,7 +511,7 @@ If the DB grows substantially, a new embedding model is adopted, or scores shift
    npx vitest --project=server run src/app/api/movie-recommendation/route.test.ts
    ```
 
-To add or edit calibration queries, modify the `QUERIES` array in `scripts/calibrate-similarity.ts`.
+To add or edit calibration queries, modify the `QUERIES` array in `apps/web/scripts/calibrate-similarity.ts`.
 
 ### Constants (`apps/web/src/features/recommendation/config.ts`)
 

--- a/docs/SERVICES.md
+++ b/docs/SERVICES.md
@@ -10,15 +10,20 @@ This document describes the background services that populate and maintain the m
 
 ## Services Overview
 
-| Service / Tool               | Type             | Trigger                                                 | Source        |
-| ---------------------------- | ---------------- | ------------------------------------------------------- | ------------- |
-| `movie-discovery`            | Scheduled        | Cron / One-shot                                         | TMDB API      |
-| `movie-backfill`             | One-shot         | Manual                                                  | TMDB API      |
-| `catalog:health`             | Read-only report | Manual / CI                                             | PostgreSQL    |
-| BullMQ `recommendation`      | Per-request      | HTTP POST to /api/recommendations                       | TMDB + OpenAI |
-| BullMQ `more-picks`          | On demand        | HTTP POST to /api/recommendations/[id]/more-picks       | TMDB + OpenAI |
-| BullMQ `movie-seed`          | Worker queue     | Recommendation JIT seeding, Backoffice curated seed     | TMDB + file   |
-| BullMQ `catalog-maintenance` | Maintenance jobs | Recommendation JIT, discovery enqueue, backfill enqueue | TMDB + OpenAI |
+| Service / Tool               | Type                   | Trigger                                                 | Source        |
+| ---------------------------- | ---------------------- | ------------------------------------------------------- | ------------- |
+| `movie-discovery`            | Scheduled service      | Cron / manual one-shot                                  | TMDB API      |
+| `movie-backfill`             | Manual maintenance CLI | Operator fallback / dry-run                             | TMDB API      |
+| `catalog:health`             | Read-only report       | Manual / CI                                             | PostgreSQL    |
+| BullMQ `recommendation`      | Per-request            | HTTP POST to /api/recommendations                       | TMDB + OpenAI |
+| BullMQ `more-picks`          | On demand              | HTTP POST to /api/recommendations/[id]/more-picks       | TMDB + OpenAI |
+| BullMQ `movie-seed`          | Worker queue           | Recommendation JIT seeding, Backoffice curated seed     | TMDB + file   |
+| BullMQ `catalog-maintenance` | Maintenance jobs       | Recommendation JIT, discovery enqueue, backfill enqueue | TMDB + OpenAI |
+
+Backoffice and the BullMQ `catalog-maintenance` worker are the primary path for
+catalog discovery and backfill work. The `movie-backfill` CLI remains available
+for bounded manual maintenance, dry-runs, and local/operator fallback flows
+where queue visibility, retries, or Backoffice controls are not required.
 
 ---
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -192,8 +192,7 @@ If you are using the repo's local setup flow, run `npm run copy:env` after chang
 Run background workers in a separate terminal:
 
 ```bash
-cd apps/web
-npm run start:workers
+npm run start:workers --workspace=apps/web
 ```
 
 Optional queue monitoring dashboard:
@@ -251,7 +250,7 @@ You can run a fully-configured local PostgreSQL instance with pgvector using Doc
 
    ```bash
    # terminal 1
-   cd apps/web && npm run start:workers
+   npm run start:workers --workspace=apps/web
 
    # terminal 2, repo root
    npm run dev:backoffice
@@ -267,9 +266,8 @@ You can run a fully-configured local PostgreSQL instance with pgvector using Doc
    # terminal 1, repo root
    npm run dev
 
-   # terminal 2, apps/web
-   cd apps/web
-   npm run start:workers
+   # terminal 2, repo root
+   npm run start:workers --workspace=apps/web
    ```
 
    For the async recommendation flow, keep the workers running while you use the app.

--- a/docs/UI-DEVELOPMENT.md
+++ b/docs/UI-DEVELOPMENT.md
@@ -37,7 +37,9 @@ and `apps/backoffice`. Keep it dependency-light and extract only reusable interf
 packages/ui
 ├── src
 │   ├── badge.tsx
+│   ├── breadcrumb.tsx
 │   ├── button.tsx
+│   ├── dialog.tsx
 │   ├── table.tsx
 │   ├── tabs.tsx
 │   ├── utils.ts
@@ -52,7 +54,12 @@ Use package exports such as:
   "exports": {
     ".": "./src/index.ts",
     "./button": "./src/button.tsx",
-    "./badge": "./src/badge.tsx"
+    "./badge": "./src/badge.tsx",
+    "./breadcrumb": "./src/breadcrumb.tsx",
+    "./dialog": "./src/dialog.tsx",
+    "./tabs": "./src/tabs.tsx",
+    "./table": "./src/table.tsx",
+    "./utils": "./src/utils.ts"
   }
 }
 ```
@@ -78,6 +85,10 @@ Current shadcn-derived primitives:
 
 - `Button`, `ButtonLink`, `buttonVariants`
 - `Badge`
+- `Breadcrumb`, `BreadcrumbList`, `BreadcrumbItem`, `BreadcrumbLink`,
+  `BreadcrumbPage`, `BreadcrumbSeparator`, `BreadcrumbEllipsis`
+- `Dialog`, `DialogContent`, `DialogHeader`, `DialogFooter`, `DialogTitle`,
+  `DialogDescription`, `DialogTrigger`, `DialogClose`
 - `TabsNav`, `TabsLink`
 - `TableScroll`, `Table`, `DataTable`, `TableEmptyRow`
 
@@ -85,7 +96,7 @@ Next likely primitives:
 
 - `tooltip`
 - `field`, `input`, `textarea`, `select`, `checkbox`, `switch`
-- `dialog` or `alert-dialog` for destructive/batch confirmations
+- `alert-dialog` for destructive/batch confirmations when the base dialog contract is not enough
 - `dropdown-menu`, `popover`, `command`/`combobox` for operator search and filters
 - `pagination`, `skeleton`, `empty`
 


### PR DESCRIPTION
## Summary
- clarify that catalog-maintenance is the primary queue-backed path for discovery/backfill work
- reframe movie-backfill as a manual maintenance CLI fallback rather than the main operator path

## Validation
- git diff --check

Note: local prettier via npx could not run in the fresh worktree because dependencies are not installed and registry DNS is unavailable; PR CI should run the normal docs/format checks.