### PR TITLE
[codex] Fix backoffice bind-host redirects

### DIFF
--- a/apps/backoffice/src/app/catalog-seed/actions/route.test.ts
+++ b/apps/backoffice/src/app/catalog-seed/actions/route.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createBackofficeFormRequest,
+  expectBackofficeActionFailureJson,
+  expectBackofficeActionJson,
+} from '../../../test/backofficeActionRoute';
+
+const mocks = vi.hoisted(() => ({
+  ensureBackofficeReady: vi.fn(),
+  getBackofficeErrorStatus: vi.fn(),
+  isSameOriginRequest: vi.fn(),
+  logBackofficeError: vi.fn(),
+  performCatalogSeedAction: vi.fn(),
+}));
+
+vi.mock('../../../lib/backoffice', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../lib/backoffice')>();
+  return {
+    ...actual,
+    ensureBackofficeReady: mocks.ensureBackofficeReady,
+    getBackofficeErrorStatus: mocks.getBackofficeErrorStatus,
+    logBackofficeError: mocks.logBackofficeError,
+    performCatalogSeedAction: mocks.performCatalogSeedAction,
+  };
+});
+
+vi.mock('../../../lib/sameOriginRequest', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../lib/sameOriginRequest')>();
+  return {
+    ...actual,
+    isSameOriginRequest: mocks.isSameOriginRequest,
+  };
+});
+
+import { POST } from './route';
+
+function createSeedActionRequest({
+  fetch = true,
+  fields = { action: 'trigger_movie_seed' },
+  url = 'https://backoffice.test/catalog-seed/actions',
+}: {
+  fetch?: boolean;
+  fields?: Record<string, string>;
+  url?: string;
+} = {}) {
+  return createBackofficeFormRequest({
+    fetch,
+    fields,
+    url,
+  });
+}
+
+describe('catalog seed form action route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.ensureBackofficeReady.mockResolvedValue(undefined);
+    mocks.getBackofficeErrorStatus.mockReturnValue(500);
+    mocks.isSameOriginRequest.mockReturnValue(true);
+  });
+
+  it('returns the JSON forbidden contract for cross-origin fetches', async () => {
+    mocks.isSameOriginRequest.mockReturnValue(false);
+
+    const response = await POST(createSeedActionRequest() as never);
+
+    await expectBackofficeActionFailureJson(response, { message: 'Forbidden.', status: 403 });
+    expect(mocks.performCatalogSeedAction).not.toHaveBeenCalled();
+  });
+
+  it('returns the JSON trigger contract for fetch requests', async () => {
+    mocks.performCatalogSeedAction.mockResolvedValue({
+      message: 'Movie seed queued.',
+      status: 'triggered',
+    });
+
+    const response = await POST(createSeedActionRequest() as never);
+
+    await expectBackofficeActionJson(response, {
+      body: {
+        message: 'Movie seed queued.',
+        ok: true,
+        status: 'triggered',
+      },
+      status: 202,
+    });
+    expect(mocks.performCatalogSeedAction).toHaveBeenCalledWith({
+      formData: expect.any(FormData),
+      headers: expect.any(Headers),
+    });
+  });
+
+  it('does not redirect browser form posts to a bind address', async () => {
+    mocks.performCatalogSeedAction.mockResolvedValue({
+      message: 'Movie seed queued.',
+      status: 'triggered',
+    });
+
+    const response = await POST(
+      createSeedActionRequest({
+        fetch: false,
+        url: 'http://0.0.0.0:3000/catalog-seed/actions',
+      }) as never,
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get('location')).toBe(
+      'http://localhost:3000/catalog-seed?seed=triggered',
+    );
+  });
+
+  it('keeps forbidden browser redirects off bind addresses', async () => {
+    mocks.isSameOriginRequest.mockReturnValue(false);
+
+    const response = await POST(
+      createSeedActionRequest({
+        fetch: false,
+        url: 'http://0.0.0.0:3000/catalog-seed/actions',
+      }) as never,
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get('location')).toBe(
+      'http://localhost:3000/catalog-seed?seed=forbidden',
+    );
+    expect(mocks.performCatalogSeedAction).not.toHaveBeenCalled();
+  });
+
+  it('keeps failed browser redirects off bind addresses', async () => {
+    const error = new Error('boom');
+    mocks.getBackofficeErrorStatus.mockReturnValue(503);
+    mocks.performCatalogSeedAction.mockRejectedValue(error);
+
+    const response = await POST(
+      createSeedActionRequest({
+        fetch: false,
+        url: 'http://0.0.0.0:3000/catalog-seed/actions',
+      }) as never,
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get('location')).toBe(
+      'http://localhost:3000/catalog-seed?seed=failed&code=503',
+    );
+    expect(mocks.logBackofficeError).toHaveBeenCalledWith(
+      'Failed to apply catalog seed action',
+      error,
+    );
+  });
+});

--- a/apps/backoffice/src/app/catalog-seed/actions/route.ts
+++ b/apps/backoffice/src/app/catalog-seed/actions/route.ts
@@ -20,6 +20,8 @@ function statusCodeFor(status: string): number {
 }
 
 export async function POST(request: NextRequest) {
+  let trustRequestEvidence = false;
+
   try {
     if (!isSameOriginRequest(request)) {
       if (wantsBackofficeJsonResponse(request)) {
@@ -31,6 +33,8 @@ export async function POST(request: NextRequest) {
         303,
       );
     }
+
+    trustRequestEvidence = true;
 
     const [, formData] = await Promise.all([ensureBackofficeReady(), request.formData()]);
     const result = await performCatalogSeedAction({
@@ -50,7 +54,9 @@ export async function POST(request: NextRequest) {
     }
 
     return NextResponse.redirect(
-      backofficeRedirectUrl(request, `/catalog-seed?seed=${result.status}`),
+      backofficeRedirectUrl(request, `/catalog-seed?seed=${result.status}`, {
+        trustRequestEvidence,
+      }),
       303,
     );
   } catch (error) {
@@ -66,6 +72,7 @@ export async function POST(request: NextRequest) {
       backofficeRedirectUrl(
         request,
         `/catalog-seed?seed=failed&code=${getBackofficeErrorStatus(error)}`,
+        { trustRequestEvidence },
       ),
       303,
     );

--- a/apps/backoffice/src/app/recommendation-evals/actions/route.test.ts
+++ b/apps/backoffice/src/app/recommendation-evals/actions/route.test.ts
@@ -23,23 +23,29 @@ vi.mock('../../../lib/backoffice', async (importOriginal) => {
   };
 });
 
-vi.mock('../../../lib/sameOriginRequest', () => ({
-  isSameOriginRequest: mocks.isSameOriginRequest,
-}));
+vi.mock('../../../lib/sameOriginRequest', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../lib/sameOriginRequest')>();
+  return {
+    ...actual,
+    isSameOriginRequest: mocks.isSameOriginRequest,
+  };
+});
 
 import { POST } from './route';
 
 function createEvalActionRequest({
   fetch = true,
   fields = { mode: 'mock' },
+  url = 'https://backoffice.test/recommendation-evals/actions',
 }: {
   fetch?: boolean;
   fields?: Record<string, string>;
+  url?: string;
 } = {}) {
   return createBackofficeFormRequest({
     fetch,
     fields,
-    url: 'https://backoffice.test/recommendation-evals/actions',
+    url,
   });
 }
 
@@ -101,6 +107,45 @@ describe('recommendation eval form action route', () => {
     );
   });
 
+  it('does not redirect browser form posts to a bind address', async () => {
+    mocks.performRecommendationEvalAction.mockResolvedValue({
+      errorMessage: 'queue unavailable',
+      mode: 'real-data',
+      runId: 'run-2',
+      status: 'unavailable',
+    });
+
+    const response = await POST(
+      createEvalActionRequest({
+        fetch: false,
+        fields: { mode: 'real-data' },
+        url: 'http://0.0.0.0:3000/recommendation-evals/actions',
+      }) as never,
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get('location')).toBe(
+      'http://localhost:3000/recommendation-evals?eval=unavailable',
+    );
+  });
+
+  it('keeps forbidden browser redirects off bind addresses', async () => {
+    mocks.isSameOriginRequest.mockReturnValue(false);
+
+    const response = await POST(
+      createEvalActionRequest({
+        fetch: false,
+        url: 'http://0.0.0.0:3000/recommendation-evals/actions',
+      }) as never,
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get('location')).toBe(
+      'http://localhost:3000/recommendation-evals?eval=forbidden',
+    );
+    expect(mocks.performRecommendationEvalAction).not.toHaveBeenCalled();
+  });
+
   it('returns the JSON error contract when the action throws', async () => {
     const error = new Error('boom');
     mocks.getBackofficeErrorStatus.mockReturnValue(422);
@@ -119,6 +164,23 @@ describe('recommendation eval form action route', () => {
     expect(mocks.logBackofficeError).toHaveBeenCalledWith(
       'Failed to apply recommendation eval action',
       error,
+    );
+  });
+
+  it('keeps failed browser redirects off bind addresses', async () => {
+    const error = new Error('boom');
+    mocks.performRecommendationEvalAction.mockRejectedValue(error);
+
+    const response = await POST(
+      createEvalActionRequest({
+        fetch: false,
+        url: 'http://0.0.0.0:3000/recommendation-evals/actions',
+      }) as never,
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get('location')).toBe(
+      'http://localhost:3000/recommendation-evals?eval=failed',
     );
   });
 });

--- a/apps/backoffice/src/app/recommendation-evals/actions/route.ts
+++ b/apps/backoffice/src/app/recommendation-evals/actions/route.ts
@@ -7,7 +7,7 @@ import {
   logBackofficeError,
   performRecommendationEvalAction,
 } from '../../../lib/backoffice';
-import { isSameOriginRequest } from '../../../lib/sameOriginRequest';
+import { backofficeRedirectUrl, isSameOriginRequest } from '../../../lib/sameOriginRequest';
 
 export const dynamic = 'force-dynamic';
 
@@ -17,7 +17,19 @@ function wantsJsonResponse(request: NextRequest): boolean {
   return accept.includes('application/json') || requestedWith.toLowerCase() === 'fetch';
 }
 
+function recommendationEvalRedirectUrl(
+  request: NextRequest,
+  status: string,
+  { trustRequestEvidence = false }: { trustRequestEvidence?: boolean } = {},
+) {
+  const url = backofficeRedirectUrl(request, '/recommendation-evals', { trustRequestEvidence });
+  url.searchParams.set('eval', status);
+  return url;
+}
+
 export async function POST(request: NextRequest) {
+  let trustRequestEvidence = false;
+
   try {
     if (!isSameOriginRequest(request)) {
       if (wantsJsonResponse(request)) {
@@ -27,11 +39,10 @@ export async function POST(request: NextRequest) {
         );
       }
 
-      return NextResponse.redirect(
-        new URL('/recommendation-evals?eval=forbidden', request.url),
-        303,
-      );
+      return NextResponse.redirect(recommendationEvalRedirectUrl(request, 'forbidden'), 303);
     }
+
+    trustRequestEvidence = true;
 
     const formData = await request.formData();
     const result = await performRecommendationEvalAction(formData, request.headers);
@@ -43,7 +54,7 @@ export async function POST(request: NextRequest) {
     }
 
     return NextResponse.redirect(
-      new URL(`/recommendation-evals?eval=${result.status}`, request.url),
+      recommendationEvalRedirectUrl(request, result.status, { trustRequestEvidence }),
       303,
     );
   } catch (error) {
@@ -60,6 +71,9 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    return NextResponse.redirect(new URL('/recommendation-evals?eval=failed', request.url), 303);
+    return NextResponse.redirect(
+      recommendationEvalRedirectUrl(request, 'failed', { trustRequestEvidence }),
+      303,
+    );
   }
 }

--- a/apps/backoffice/src/app/repair-batches/[id]/actions/route.test.ts
+++ b/apps/backoffice/src/app/repair-batches/[id]/actions/route.test.ts
@@ -21,22 +21,34 @@ vi.mock('../../../../lib/backoffice', async (importOriginal) => {
   };
 });
 
-vi.mock('../../../../lib/sameOriginRequest', () => ({
-  isSameOriginRequest: mocks.isSameOriginRequest,
-}));
+vi.mock('../../../../lib/sameOriginRequest', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../lib/sameOriginRequest')>();
+  return {
+    ...actual,
+    isSameOriginRequest: mocks.isSameOriginRequest,
+  };
+});
 
 import { POST } from './route';
 
-function createRetryRequest(fields: Record<string, string> = {}) {
+function createRetryRequest({
+  fetch = true,
+  fields = {},
+  url = 'https://backoffice.test/repair-batches/batch-1/actions',
+}: {
+  fetch?: boolean;
+  fields?: Record<string, string>;
+  url?: string;
+} = {}) {
   return createBackofficeFormRequest({
-    fetch: true,
+    fetch,
     fields: {
       action: 'retry_item',
       item_id: 'item-1',
       return_to: '/repair-batches/batch-1?status=needs_review',
       ...fields,
     },
-    url: 'https://backoffice.test/repair-batches/batch-1/actions',
+    url,
   });
 }
 
@@ -80,7 +92,7 @@ describe('repair batch action route', () => {
       status: 'queued',
     });
 
-    const response = await POST(createRetryRequest({ batch_id: '' }) as never, {
+    const response = await POST(createRetryRequest({ fields: { batch_id: '' } }) as never, {
       params: Promise.resolve({ id: 'batch-1' }),
     });
 
@@ -127,5 +139,50 @@ describe('repair batch action route', () => {
       }),
       status: 503,
     });
+  });
+
+  it('does not redirect browser form posts to a bind address', async () => {
+    mocks.retryCatalogRepairBatchItem.mockResolvedValue({
+      batchId: 'batch-1',
+      issueKey: 'missing_poster_url',
+      item: { batchId: 'batch-1', id: 'item-1', status: 'queued' },
+      job: null,
+      status: 'queued',
+    });
+
+    const response = await POST(
+      createRetryRequest({
+        fetch: false,
+        url: 'http://0.0.0.0:3000/repair-batches/batch-1/actions',
+      }) as never,
+      {
+        params: Promise.resolve({ id: 'batch-1' }),
+      },
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get('location')).toBe(
+      'http://localhost:3000/repair-batches/batch-1?status=needs_review&item_retry=queued',
+    );
+  });
+
+  it('keeps forbidden browser redirects off bind addresses', async () => {
+    mocks.isSameOriginRequest.mockReturnValue(false);
+
+    const response = await POST(
+      createRetryRequest({
+        fetch: false,
+        url: 'http://0.0.0.0:3000/repair-batches/batch-1/actions',
+      }) as never,
+      {
+        params: Promise.resolve({ id: 'batch-1' }),
+      },
+    );
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get('location')).toBe(
+      'http://localhost:3000/repair-batches/batch-1?item_retry=forbidden',
+    );
+    expect(mocks.retryCatalogRepairBatchItem).not.toHaveBeenCalled();
   });
 });

--- a/apps/backoffice/src/app/repair-batches/[id]/actions/route.ts
+++ b/apps/backoffice/src/app/repair-batches/[id]/actions/route.ts
@@ -8,7 +8,7 @@ import {
   retryCatalogRepairBatchItem,
   wantsBackofficeJsonResponse,
 } from '../../../../lib/backoffice';
-import { isSameOriginRequest } from '../../../../lib/sameOriginRequest';
+import { backofficeRedirectUrl, isSameOriginRequest } from '../../../../lib/sameOriginRequest';
 
 export const dynamic = 'force-dynamic';
 
@@ -22,12 +22,14 @@ function buildRepairBatchRedirectUrl({
   request,
   returnPath,
   status,
+  trustRequestEvidence = false,
 }: {
   request: NextRequest;
   returnPath: string;
   status: string;
+  trustRequestEvidence?: boolean;
 }) {
-  const url = new URL(returnPath, request.url);
+  const url = backofficeRedirectUrl(request, returnPath, { trustRequestEvidence });
   url.searchParams.set('item_retry', status);
   return url;
 }
@@ -36,12 +38,17 @@ function buildRepairBatchActionRedirect({
   request,
   returnPath,
   status,
+  trustRequestEvidence = false,
 }: {
   request: NextRequest;
   returnPath: string;
   status: string;
+  trustRequestEvidence?: boolean;
 }) {
-  return NextResponse.redirect(buildRepairBatchRedirectUrl({ request, returnPath, status }), 303);
+  return NextResponse.redirect(
+    buildRepairBatchRedirectUrl({ request, returnPath, status, trustRequestEvidence }),
+    303,
+  );
 }
 
 function ensureRepairBatchFormBatchId(formData: FormData, batchId: string): void {
@@ -111,17 +118,21 @@ async function handleRepairBatchRetryRequest({
     request,
     returnPath: parsedReturnPath,
     status: result.status,
+    trustRequestEvidence: true,
   });
 }
 
 export async function POST(request: NextRequest, context: RepairBatchActionContext) {
   const { id } = await context.params;
   let returnPath = `/repair-batches/${encodeURIComponent(id)}`;
+  let trustRequestEvidence = false;
 
   try {
     if (!isSameOriginRequest(request)) {
       return buildRepairBatchForbiddenResponse(request, returnPath);
     }
+
+    trustRequestEvidence = true;
 
     return await handleRepairBatchRetryRequest({ batchId: id, request, returnPath });
   } catch (error) {
@@ -133,6 +144,11 @@ export async function POST(request: NextRequest, context: RepairBatchActionConte
       );
     }
 
-    return buildRepairBatchActionRedirect({ request, returnPath, status: 'failed' });
+    return buildRepairBatchActionRedirect({
+      request,
+      returnPath,
+      status: 'failed',
+      trustRequestEvidence,
+    });
   }
 }

--- a/apps/backoffice/src/lib/sameOriginRequest.test.ts
+++ b/apps/backoffice/src/lib/sameOriginRequest.test.ts
@@ -119,6 +119,6 @@ describe('backofficeRedirectUrl', () => {
         '/?repair=queued',
         { trustRequestEvidence: true },
       ).toString(),
-    ).toBe('http://localhost/?repair=queued');
+    ).toBe('http://localhost:3000/?repair=queued');
   });
 });

--- a/apps/backoffice/src/lib/sameOriginRequest.ts
+++ b/apps/backoffice/src/lib/sameOriginRequest.ts
@@ -58,6 +58,11 @@ function isBindableHost(host: string): boolean {
   return hostname === '0.0.0.0' || hostname === '::' || hostname === '';
 }
 
+function localhostOriginForBindableUrl(url: URL): string {
+  const port = url.port ? `:${url.port}` : '';
+  return `${url.protocol}//localhost${port}`;
+}
+
 export function backofficeRedirectUrl(
   request: NextRequest,
   path: string,
@@ -84,5 +89,5 @@ export function backofficeRedirectUrl(
     return new URL(path, requestUrl);
   }
 
-  return new URL(path, 'http://localhost');
+  return new URL(path, localhostOriginForBindableUrl(requestUrl));
 }


### PR DESCRIPTION
## Summary

Fixes backoffice form-action redirects that could send operators to `0.0.0.0` or another bind/local origin after submitting forms from bind-host dev/proxy contexts.

## Root Cause

Some action routes built browser redirect URLs directly from `request.url`, or used the shared redirect helper without preserving the useful localhost port / validated request evidence. When the incoming request URL was based on the bind address, the `Location` header could point at `http://0.0.0.0:...` instead of an operator-usable origin.

## Changes

- Preserve the port when `backofficeRedirectUrl` falls back from bind hosts to `localhost`.
- Route recommendation eval, catalog seed, and repair batch browser redirects through the shared bind-host-safe helper.
- Keep forbidden redirects from trusting cross-origin Origin/Referer evidence.
- Add regression coverage for success, forbidden, and failed browser redirects from `http://0.0.0.0:3000/...`.
- Audited remaining backoffice links/redirects; remaining `request.url` usage is query/SSE parsing, and UI links are relative or explicit external destinations.

## Validation

- `npm run test --workspace=apps/backoffice -- sameOriginRequest catalog-seed/actions catalog-health/actions 'movies/[id]/actions' 'tmdb-reviews/[id]/actions' recommendation-evals/actions repair-batches`
- `npm run test --workspace=apps/backoffice`
- `npm run type-check`
- `npm run lint:check`
- `npm run eval:recommendations` -> 32/32 passed
- pre-push hook: lint, server tests, production build; Storybook skipped because no Storybook-relevant changes were detected