### PR TITLE
[codex] Fix recommendation eval worker DB lifecycle

### DIFF
--- a/apps/web/src/features/recommendation/evals/runner.test.ts
+++ b/apps/web/src/features/recommendation/evals/runner.test.ts
@@ -1,9 +1,50 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  closeDatabase: vi.fn(),
+  getCatalogHealthReport: vi.fn(),
+  getMoviesPage: vi.fn(),
+  initDatabase: vi.fn(),
+}));
+
+vi.mock('@/features/movies/catalog', () => ({
+  getMoviesPage: mocks.getMoviesPage,
+}));
+
+vi.mock('@pop-choice/shared', () => ({
+  closeDatabase: mocks.closeDatabase,
+  getCatalogHealthReport: mocks.getCatalogHealthReport,
+  initDatabase: mocks.initDatabase,
+}));
 
 import { recommendationEvalFixtures } from './fixtures';
 import { runRecommendationEvals } from './runner';
 
 describe('recommendation eval runner', () => {
+  beforeEach(() => {
+    vi.stubEnv('DATABASE_URL', 'postgres://localhost/test');
+    mocks.closeDatabase.mockResolvedValue(undefined);
+    mocks.getCatalogHealthReport.mockResolvedValue({ issues: [] });
+    mocks.getMoviesPage.mockImplementation(
+      async (_page: number, _pageSize: number, filters: Record<string, unknown>) => {
+        const fixture = recommendationEvalFixtures[0]!;
+        const mainTitle = fixture.expectations.allowedMainTitles[0]!;
+        const firstCandidate = fixture.candidates[0]!;
+        const movies =
+          filters && 'query' in filters
+            ? [{ name: mainTitle, year: firstCandidate.year }]
+            : fixture.candidates.map((movie) => ({ name: movie.name, year: movie.year }));
+
+        return { movies, totalCount: movies.length };
+      },
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+  });
+
   it('returns a reusable report for deterministic mock evals', async () => {
     const report = await runRecommendationEvals({ mode: 'mock' });
 
@@ -31,5 +72,20 @@ describe('recommendation eval runner', () => {
         passed: 0,
       },
     });
+  });
+
+  it('does not close the shared database pool after real-data catalog checks', async () => {
+    const report = await runRecommendationEvals({
+      fixtures: [recommendationEvalFixtures[0]!],
+      mode: 'real-data',
+    });
+
+    expect(report.summary.fixtureCount).toBe(1);
+    expect(mocks.initDatabase).toHaveBeenCalledWith('postgres://localhost/test');
+    expect(mocks.getCatalogHealthReport).toHaveBeenCalledWith({
+      sampleLimit: 0,
+      staleAfterDays: 180,
+    });
+    expect(mocks.closeDatabase).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/features/recommendation/evals/runner.ts
+++ b/apps/web/src/features/recommendation/evals/runner.ts
@@ -120,19 +120,14 @@ async function getCatalogRetrievalCandidateAvailabilityChecks(
 }
 
 async function getCatalogMetadataQualityMetricsCheck(): Promise<RecommendationEvalCheck> {
-  const { closeDatabase, getCatalogHealthReport, initDatabase } =
-    await import('@pop-choice/shared');
+  const { getCatalogHealthReport, initDatabase } = await import('@pop-choice/shared');
   const databaseUrl = process.env.DATABASE_URL;
   if (!databaseUrl) {
     throw new Error('Catalog metadata quality evals require DATABASE_URL.');
   }
 
   initDatabase(databaseUrl);
-  const report = await getCatalogHealthReport({ sampleLimit: 0, staleAfterDays: 180 }).finally(
-    async () => {
-      await closeDatabase();
-    },
-  );
+  const report = await getCatalogHealthReport({ sampleLimit: 0, staleAfterDays: 180 });
   const interestingIssues = report.issues
     .filter((issue) =>
       [

--- a/apps/web/src/lib/workers/recommendationEvalWorker.test.ts
+++ b/apps/web/src/lib/workers/recommendationEvalWorker.test.ts
@@ -166,6 +166,7 @@ describe('createRecommendationEvalWorker', () => {
     expect(capturedProcessor.current).not.toBeNull();
     await capturedProcessor.current!(makeJob());
 
+    expect(mockInitDatabase).toHaveBeenCalledTimes(2);
     expect(mockInitDatabase).toHaveBeenCalledWith('postgres://localhost/test');
     expect(mockEnsureRecommendationEvalRunSchema).toHaveBeenCalled();
     expect(mockMarkRecommendationEvalRunProcessing).toHaveBeenCalledWith(
@@ -185,6 +186,9 @@ describe('createRecommendationEvalWorker', () => {
       response: { title: 'Paddington 2' },
       score: 100,
     });
+    expect(mockInitDatabase.mock.invocationCallOrder[1]).toBeLessThan(
+      mockCompleteRecommendationEvalRun.mock.invocationCallOrder[0],
+    );
   });
 
   it('allows guarded live eval jobs to run through the same persisted worker path', async () => {
@@ -217,11 +221,15 @@ describe('createRecommendationEvalWorker', () => {
     createRecommendationEvalWorker();
 
     await expect(capturedProcessor.current!(makeJob())).rejects.toThrow('catalog unavailable');
+    expect(mockInitDatabase).toHaveBeenCalledTimes(2);
     expect(mockFailRecommendationEvalRun).toHaveBeenCalledWith({
       errorMessage: 'catalog unavailable',
       runId: '11111111-1111-4111-8111-111111111111',
       status: 'failed',
     });
+    expect(mockInitDatabase.mock.invocationCallOrder[1]).toBeLessThan(
+      mockFailRecommendationEvalRun.mock.invocationCallOrder[0],
+    );
   });
 
   it('records queue metrics for completed and failed events', () => {

--- a/apps/web/src/lib/workers/recommendationEvalWorker.ts
+++ b/apps/web/src/lib/workers/recommendationEvalWorker.ts
@@ -34,7 +34,6 @@ type RecommendationEvalWorker = Worker<RecommendationEvalJobData, void, Recommen
 const DEFAULT_CONCURRENCY = 1;
 const MAX_ATTEMPTS = RECOMMENDATION_EVAL_JOB_OPTIONS.attempts;
 
-let databaseInitialized = false;
 let schemaReadyPromise: Promise<void> | null = null;
 
 function parsePositiveIntEnv(name: string, fallback: number): number {
@@ -45,15 +44,12 @@ function parsePositiveIntEnv(name: string, fallback: number): number {
 }
 
 function ensureDatabase(): void {
-  if (databaseInitialized) return;
-
   const databaseUrl = process.env.DATABASE_URL;
   if (!databaseUrl) {
     throw new Error('DATABASE_URL is required for recommendation eval jobs');
   }
 
   initDatabase(databaseUrl);
-  databaseInitialized = true;
 }
 
 async function ensureEvalSchema(): Promise<void> {
@@ -131,6 +127,7 @@ async function processRecommendationEvalJob(
 
   try {
     const report = await runRecommendationEvals({ mode: job.data.mode });
+    ensureDatabase();
     await completeRecommendationEvalRun({
       report: reportToJson(report),
       results: toStoredResults(report),
@@ -149,6 +146,7 @@ async function processRecommendationEvalJob(
     );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
+    ensureDatabase();
     await failRecommendationEvalRun({
       errorMessage: message,
       runId: job.data.runId,


### PR DESCRIPTION
## Summary
- stop real-data recommendation eval checks from closing the shared database pool owned by the worker
- make the eval worker idempotently re-initialize the DB pool before final success/failure persistence
- add regression coverage for DB lifecycle ownership and worker completion/failure writes

## Root cause
The real-data eval runner imported and called closeDatabase() after catalog health checks. In the worker path this closed the shared pool before the worker persisted run completion/failure, producing `Database pool not initialized — call initDatabase() first` and leaving runs stuck around processing/failed jobs.

## Validation
- npm run test:server --workspace=apps/web -- recommendationEvalWorker runner
- npm run type-check --workspace=apps/web
- npm run eval:recommendations
- npm run type-check
- npm run lint:check
- pre-push: full apps/web server tests, production build