### PR TITLE
[codex] Improve recommendation eval report UX

### DIFF
--- a/apps/backoffice/src/app/globals.css
+++ b/apps/backoffice/src/app/globals.css
@@ -341,6 +341,10 @@ dd {
   min-width: 74px;
   min-height: 36px;
 }
+.json-copy-button {
+  justify-content: center;
+  min-width: 74px;
+}
 .button:disabled,
 input:disabled {
   opacity: 0.5;
@@ -1796,6 +1800,38 @@ input:disabled {
   border-top: 1px solid var(--border);
   font-size: 12px;
   line-height: 1.55;
+}
+.json-panel-toolbar {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: center;
+  padding: 10px 14px;
+  color: var(--muted);
+  background: rgba(255, 255, 255, 0.012);
+  border-top: 1px solid var(--border);
+  font-size: 12px;
+  font-weight: 850;
+}
+.json-panel-toolbar + .json-block {
+  border-top: 1px solid var(--border);
+}
+.eval-result-issue {
+  display: grid;
+  gap: 3px;
+  min-width: 280px;
+  max-width: 680px;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+.eval-result-issue strong {
+  color: var(--text);
+}
+.eval-result-issue em {
+  color: var(--bad);
+  font-style: normal;
+  font-weight: 800;
 }
 .review-table .movie-title {
   display: grid;

--- a/apps/backoffice/src/components/recommendation-evals/copyJsonButton.tsx
+++ b/apps/backoffice/src/components/recommendation-evals/copyJsonButton.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@pop-choice/ui';
+
+type CopyState = 'idle' | 'copied' | 'failed';
+
+function fallbackCopy(text: string): boolean {
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.top = '-9999px';
+  document.body.appendChild(textarea);
+  textarea.select();
+
+  try {
+    return document.execCommand('copy');
+  } catch {
+    return false;
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}
+
+export function CopyJsonButton({ label, text }: { label: string; text: string }) {
+  const [copyState, setCopyState] = useState<CopyState>('idle');
+
+  async function copyJson() {
+    let didCopy = false;
+
+    try {
+      if (navigator.clipboard) {
+        await navigator.clipboard.writeText(text);
+        didCopy = true;
+      }
+    } catch {
+      didCopy = false;
+    }
+
+    if (!didCopy) {
+      didCopy = fallbackCopy(text);
+    }
+
+    setCopyState(didCopy ? 'copied' : 'failed');
+    window.setTimeout(() => setCopyState('idle'), 1800);
+  }
+
+  const copyLabel =
+    copyState === 'copied' ? 'Copied' : copyState === 'failed' ? 'Copy failed' : 'Copy';
+
+  return (
+    <Button
+      aria-label={`Copy ${label}`}
+      aria-live="polite"
+      className="json-copy-button"
+      onClick={copyJson}
+      size="sm"
+      type="button"
+      variant="quiet"
+    >
+      {copyLabel}
+    </Button>
+  );
+}

--- a/apps/backoffice/src/components/recommendation-evals/detail.test.tsx
+++ b/apps/backoffice/src/components/recommendation-evals/detail.test.tsx
@@ -1,0 +1,95 @@
+import type { RecommendationEvalRunDetail } from '@pop-choice/shared';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { RecommendationEvalDetailPage } from './detail';
+
+function detail(overrides: Partial<RecommendationEvalRunDetail> = {}): RecommendationEvalRunDetail {
+  return {
+    results: [],
+    run: {
+      actor: 'lexi',
+      appVersion: '0.2.0',
+      completedAt: '2026-06-19T20:00:00.000Z',
+      createdAt: '2026-06-19T19:59:00.000Z',
+      errorMessage: null,
+      gitSha: 'abc1234',
+      id: '1dc6873b-d650-490a-a2da-65969eef3224',
+      jobId: 'recommendation-eval-1dc6873b',
+      jobName: 'run-recommendation-eval',
+      mode: 'real-data',
+      queueName: 'recommendation-evals',
+      queuedAt: '2026-06-19T19:59:02.000Z',
+      report: { mode: 'real-data', passed: false },
+      requestedOptions: { trigger: 'backoffice' },
+      source: 'backoffice',
+      startedAt: '2026-06-19T19:59:03.000Z',
+      status: 'completed',
+      summary: { failed: 1, fixtureCount: 1, passed: 0 },
+      updatedAt: '2026-06-19T20:00:00.000Z',
+    },
+    ...overrides,
+  };
+}
+
+describe('RecommendationEvalDetailPage', () => {
+  it('renders copy controls for requested options and report JSON', () => {
+    const html = renderToStaticMarkup(<RecommendationEvalDetailPage detail={detail()} />);
+
+    expect(html).toContain('Copy JSON');
+    expect(html).toContain('aria-label="Copy JSON"');
+    expect(html).toContain('&quot;trigger&quot;: &quot;backoffice&quot;');
+    expect(html).toContain('&quot;passed&quot;: false');
+  });
+
+  it('surfaces failed required zero-score checks next to 100 point fixture scores', () => {
+    const html = renderToStaticMarkup(
+      <RecommendationEvalDetailPage
+        detail={detail({
+          results: [
+            {
+              checks: [
+                {
+                  details: 'Response matches the ApiResponse schema.',
+                  id: 'output-shape',
+                  label: 'Output shape',
+                  maxScore: 20,
+                  passed: true,
+                  score: 20,
+                },
+                {
+                  details: 'Catalog search did not retrieve expected main title.',
+                  id: 'catalog-search-retrieval',
+                  label: 'Catalog search retrieval',
+                  maxScore: 0,
+                  passed: false,
+                  score: 0,
+                },
+              ],
+              createdAt: '2026-06-19T20:00:00.000Z',
+              errorMessage: null,
+              fixtureId: 'solo-focused-curated-showcase',
+              fixtureName: 'solo / focused / curated-showcase',
+              fixtureSnapshot: {},
+              id: '1',
+              maxScore: 100,
+              minPassingScore: 90,
+              passed: false,
+              response: {},
+              result: {},
+              runId: '1dc6873b-d650-490a-a2da-65969eef3224',
+              score: 100,
+              status: 'failed',
+            },
+          ],
+        })}
+      />,
+    );
+
+    expect(html).toContain('1 required zero-score check failed');
+    expect(html).toContain('These checks do not change the numeric score');
+    expect(html).toContain('100/100');
+    expect(html).toContain('Catalog search retrieval');
+    expect(html).toContain('Catalog search did not retrieve expected main title.');
+  });
+});

--- a/apps/backoffice/src/components/recommendation-evals/detail.tsx
+++ b/apps/backoffice/src/components/recommendation-evals/detail.tsx
@@ -9,6 +9,45 @@ import { BackofficeLayout } from '../backoffice-layout';
 import { CatalogStat, DataTable } from '../shared';
 import { JsonBlock, recommendationEvalStatusLabel, RecommendationEvalStatusBadge } from './shared';
 
+type EvalCheck = {
+  id: string;
+  label: string;
+  passed: boolean;
+  details: string;
+  maxScore: number;
+};
+
+function toEvalCheck(value: unknown): EvalCheck | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  const id = typeof record.id === 'string' ? record.id : 'unknown-check';
+  const label = typeof record.label === 'string' ? record.label : id;
+  const details = typeof record.details === 'string' ? record.details : '';
+  const maxScore = typeof record.maxScore === 'number' ? record.maxScore : 0;
+
+  return {
+    id,
+    label,
+    passed: record.passed === true,
+    details,
+    maxScore,
+  };
+}
+
+function failedChecksFor(result: RecommendationEvalResult): EvalCheck[] {
+  return result.checks
+    .map((check) => toEvalCheck(check))
+    .filter((check): check is EvalCheck => check !== null && !check.passed);
+}
+
+function hardGateFailureCount(results: RecommendationEvalResult[]): number {
+  return results.reduce(
+    (count, result) =>
+      count + failedChecksFor(result).filter((check) => check.maxScore === 0).length,
+    0,
+  );
+}
+
 function EvalRunSummary({ run }: { run: RecommendationEvalRun }) {
   return (
     <section className="summary batch-summary" aria-label="Recommendation eval run summary">
@@ -57,26 +96,46 @@ function EvalResultRows({ results }: { results: RecommendationEvalResult[] }) {
 
   return (
     <>
-      {results.map((result) => (
-        <tr key={result.id}>
-          <td>{result.fixtureId}</td>
-          <td>{result.fixtureName}</td>
-          <td>
-            <span className={`status eval-result-${result.status}`}>{result.status}</span>
-          </td>
-          <td>
-            {result.score}/{result.maxScore}
-          </td>
-          <td>{result.checks.length}</td>
-          <td>{result.errorMessage ?? '-'}</td>
-        </tr>
-      ))}
+      {results.map((result) => {
+        const failedChecks = failedChecksFor(result);
+        const firstFailedCheck = failedChecks[0];
+        const issue = result.errorMessage ?? firstFailedCheck?.details ?? null;
+        const issueTitle = result.errorMessage ? 'Error' : firstFailedCheck?.label;
+
+        return (
+          <tr key={result.id}>
+            <td>{result.fixtureId}</td>
+            <td>{result.fixtureName}</td>
+            <td>
+              <span className={`status eval-result-${result.status}`}>{result.status}</span>
+            </td>
+            <td>
+              {result.score}/{result.maxScore}
+            </td>
+            <td>{result.checks.length}</td>
+            <td>
+              {issue ? (
+                <span className="eval-result-issue">
+                  {issueTitle ? <strong>{issueTitle}</strong> : null}
+                  <span>{issue}</span>
+                  {failedChecks.length > 1 ? (
+                    <em>+{failedChecks.length - 1} more failed checks</em>
+                  ) : null}
+                </span>
+              ) : (
+                '-'
+              )}
+            </td>
+          </tr>
+        );
+      })}
     </>
   );
 }
 
 export function RecommendationEvalDetailPage({ detail }: { detail: RecommendationEvalRunDetail }) {
   const { run, results } = detail;
+  const hardFailures = hardGateFailureCount(results);
 
   return (
     <BackofficeLayout
@@ -151,12 +210,20 @@ export function RecommendationEvalDetailPage({ detail }: { detail: Recommendatio
       </section>
       <section className="panel">
         <div className="panel-header">
-          <h2>Fixture results</h2>
+          <div>
+            <h2>Fixture results</h2>
+            {hardFailures > 0 ? (
+              <p className="issue-hint">
+                {hardFailures} required zero-score check{hardFailures === 1 ? '' : 's'} failed.
+                These checks do not change the numeric score, but they still fail the fixture.
+              </p>
+            ) : null}
+          </div>
           <span className="count">{results.length}</span>
         </div>
         <DataTable
           className="recommendation-eval-table"
-          columns={['Fixture', 'Name', 'Status', 'Score', 'Checks', 'Error']}
+          columns={['Fixture', 'Name', 'Status', 'Score', 'Checks', 'Issue']}
         >
           <EvalResultRows results={results} />
         </DataTable>

--- a/apps/backoffice/src/components/recommendation-evals/shared.tsx
+++ b/apps/backoffice/src/components/recommendation-evals/shared.tsx
@@ -1,5 +1,7 @@
 import type { RecommendationEvalRunStatus } from '@pop-choice/shared';
 
+import { CopyJsonButton } from './copyJsonButton';
+
 export function recommendationEvalStatusLabel(status: RecommendationEvalRunStatus): string {
   const labels: Record<RecommendationEvalRunStatus, string> = {
     canceled: 'Canceled',
@@ -35,6 +37,24 @@ export function buildRecommendationEvalPageHref({
   return `/recommendation-evals?${params.toString()}`;
 }
 
+function stringifyJsonBlock(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
 export function JsonBlock({ value }: { value: unknown }) {
-  return <pre className="json-block">{JSON.stringify(value, null, 2)}</pre>;
+  const serializedValue = stringifyJsonBlock(value);
+
+  return (
+    <div className="json-panel">
+      <div className="json-panel-toolbar">
+        <span>JSON</span>
+        <CopyJsonButton label="JSON" text={serializedValue} />
+      </div>
+      <pre className="json-block">{serializedValue}</pre>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add a Copy JSON button to recommendation eval JSON panels, including the full report
- surface required zero-score hard gate failures in fixture results so failed 100/100 rows explain themselves
- add detail page regression coverage for copy controls and hard-gate issue text

## Why
The eval report was rendered as a raw pre block with no copy affordance. Real-data eval fixtures can also fail required checks that carry 0 score, so a row can legitimately show 100/100 and failed; the UI did not explain that distinction.

## Validation
- npm run test --workspace=apps/backoffice -- recommendation-evals
- npm run type-check --workspace=apps/backoffice
- npm run quality:backoffice
- npm run build:backoffice
- npm run test:backoffice
- pre-push: npm run lint:check, npm run test:server, npm run build
-  critique apps/backoffice/src/components/recommendation-evals/detail.tsx: detector clean, score 32/40; issues addressed in this PR