### PR TITLE
[codex] Expose GitHub deployment environments

### DIFF
--- a/.github/workflows/container-images.yml
+++ b/.github/workflows/container-images.yml
@@ -219,9 +219,12 @@ jobs:
     if: github.ref_name == 'development' && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.deploy_environment == 'development'))
     needs: build-images
     runs-on: ubuntu-latest
-    environment: development
+    environment:
+      name: development
+      url: https://dev.pop-choice.shchilkin.dev
     permissions:
       contents: read
+      deployments: write
     env:
       COOLIFY_DEPLOY_WEBHOOK: ${{ secrets.COOLIFY_DEPLOY_WEBHOOK }}
       COOLIFY_TOKEN: ${{ secrets.COOLIFY_TOKEN }}
@@ -272,9 +275,12 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && github.ref_name == 'main' && inputs.deploy_environment == 'production'
     needs: build-images
     runs-on: ubuntu-latest
-    environment: production
+    environment:
+      name: production
+      url: https://pop-choice.shchilkin.dev
     permissions:
       contents: read
+      deployments: write
       packages: write
     env:
       COOLIFY_DEPLOY_WEBHOOK: ${{ secrets.COOLIFY_DEPLOY_WEBHOOK }}

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -201,6 +201,11 @@ environment so the same workflow can deploy either resource without sharing
 webhook URLs. `COOLIFY_TOKEN` must be a Coolify API token with deploy permission
 because the deploy webhook is authenticated with `Authorization: Bearer
 <token>`. The production GitHub Environment should require manual reviewers.
+The deploy jobs set explicit environment URLs and request `deployments: write`
+so GitHub shows the latest `development` and `production` deployments on the
+repository Deployments/Environments surfaces. `development` points at
+`https://dev.pop-choice.shchilkin.dev`; `production` points at
+`https://pop-choice.shchilkin.dev`.
 When the webhook secret is absent, images are still published, but deployment
 is skipped for the `development` Environment. Production promotions fail when
 either production deploy secret is missing, because updating the `production`

--- a/docs/COOLIFY.md
+++ b/docs/COOLIFY.md
@@ -89,6 +89,11 @@ The current long-lived VPS layout is:
 image matrix succeeds. `production` is promoted manually from `main` after
 staging has been accepted.
 
+The GitHub Actions deploy jobs use the same `development` and `production`
+environment names with these public app URLs. Keep those names stable so the
+GitHub repository Deployments/Environments surfaces show the current staging and
+production deployments.
+
 ## Service Links
 
 Keep the long-lived operator and review surfaces on stable, memorable domains.


### PR DESCRIPTION
## What changed

- Updated the `Container Images` deploy jobs to use explicit `development` and `production` environment URLs.
- Granted the deploy jobs `deployments: write` so GitHub can create deployment records for those environments.
- Documented the GitHub Deployments/Environments visibility contract in the CI/CD and Coolify docs.

## Why

PopChoice already had separate Coolify deploy jobs for long-lived `development` and `production`, but GitHub did not have the deployment permission and URL metadata needed to show those deploys cleanly in the repository deployment surfaces like `shchilkin/vantaa-underground-website`.

## Validation

- `/Users/shchilkin/dev/PopChoice/node_modules/.bin/prettier --check .github/workflows/container-images.yml docs/CI-CD.md docs/COOLIFY.md`
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/container-images.yml"); puts "yaml ok"'`