### PR TITLE
build: add Oxlint fast lint pass

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -59,7 +59,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Lint code
+      - name: Run Oxlint
+        run: npm run lint:fast
+
+      - name: Run ESLint leftovers
         run: npm run lint:check
 
       - name: Check Prettier formatting

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "plugins": [
+    "eslint",
+    "typescript",
+    "unicorn",
+    "oxc",
+    "import",
+    "react",
+    "jsx-a11y",
+    "nextjs",
+    "vitest"
+  ],
+  "ignorePatterns": ["storybook-static/**", "public/**", ".next/**", "node_modules/**"],
+  "rules": {
+    "import/no-anonymous-default-export": "warn",
+    "no-console": "error",
+    "no-duplicate-imports": [
+      "error",
+      {
+        "allowSeparateTypeImports": true
+      }
+    ],
+    "react/exhaustive-deps": "warn",
+    "react/rules-of-hooks": "error"
+  },
+  "overrides": [
+    {
+      "files": [
+        "apps/web/src/utils/**/*.{ts,js}",
+        "apps/web/src/app/api/**/*.{ts,js}",
+        "apps/web/src/lib/**/*.{ts,js}",
+        "apps/web/scripts/**/*.{ts,js}",
+        "apps/bull-board/**/*.{ts,js}",
+        "scripts/**/*.{ts,js,mjs,cjs}",
+        "services/**/*.{ts,js,mjs,cjs}"
+      ],
+      "rules": {
+        "no-console": "off"
+      }
+    }
+  ]
+}

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -1,8 +1,13 @@
+import { fileURLToPath } from 'node:url';
+
 // For more info, see https://github.com/storybookjs/eslint-plugin-storybook#configuration-flat-config-format
 import nextConfig from 'eslint-config-next/core-web-vitals';
 import prettierConfig from 'eslint-config-prettier';
+import oxlint from 'eslint-plugin-oxlint';
 import storybook from 'eslint-plugin-storybook';
 import unusedImports from 'eslint-plugin-unused-imports';
+
+const oxlintConfigFile = fileURLToPath(new URL('../../.oxlintrc.json', import.meta.url));
 
 const eslintConfig = [
   // Ignore build output, public assets, and service sub-packages
@@ -49,6 +54,8 @@ const eslintConfig = [
       'no-console': 'off',
     },
   },
+
+  ...oxlint.buildFromOxlintConfigFile(oxlintConfigFile),
 ];
 
 export default eslintConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -87,6 +87,7 @@
     "eslint": "^9",
     "eslint-config-next": "^16.2.10",
     "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-oxlint": "^1.73.0",
     "eslint-plugin-storybook": "^10.4.6",
     "eslint-plugin-unused-imports": "^4.4.1",
     "msw": "^2.14.6",

--- a/apps/web/src/app/account/page.tsx
+++ b/apps/web/src/app/account/page.tsx
@@ -724,7 +724,6 @@ function RecommendationPoster({ posterURL }: { posterURL: string | null }) {
       style={{ background: 'var(--pc-ghost)' }}
     >
       {posterURL ? (
-        // eslint-disable-next-line @next/next/no-img-element
         <img src={posterURL} alt="" className="h-full w-full object-cover" loading="lazy" />
       ) : (
         <Film size={22} style={{ color: 'var(--pc-t3)' }} />
@@ -1277,7 +1276,6 @@ function MovieMemoryCard({
         style={{ background: 'var(--pc-ghost)' }}
       >
         {item.posterURL ? (
-          // eslint-disable-next-line @next/next/no-img-element
           <img src={item.posterURL} alt="" className="h-full w-full object-cover" loading="lazy" />
         ) : (
           <Film size={18} style={{ color: 'var(--pc-t3)' }} />

--- a/apps/web/src/app/components/PosterBackground.tsx
+++ b/apps/web/src/app/components/PosterBackground.tsx
@@ -95,7 +95,6 @@ export function PosterBackground({ posters: initialPosters }: PosterBackgroundPr
         >
           {cells.map((src, i) => (
             <div key={i} className="overflow-hidden aspect-2/3">
-              {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
                 // key change on src remounts the element, resetting opacity-0
                 // so the SVG→real-poster swap fades in rather than snapping.

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -15,7 +15,7 @@ export default function Error({
   useEffect(() => {
     // The error has already been reported server-side via the Pino logger.
     // Log it client-side as well so it surfaces in browser dev-tools.
-    // eslint-disable-next-line no-console
+    // oxlint-disable-next-line no-console
     console.error(error);
   }, [error]);
 

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -11,7 +11,7 @@ export default function GlobalError({
   reset: () => void;
 }) {
   useEffect(() => {
-    // eslint-disable-next-line no-console
+    // oxlint-disable-next-line no-console
     console.error(error);
   }, [error]);
 

--- a/apps/web/src/components/BuildInfoConsole/BuildInfoConsole.tsx
+++ b/apps/web/src/components/BuildInfoConsole/BuildInfoConsole.tsx
@@ -40,7 +40,7 @@ async function fetchBuildInfo(): Promise<BuildInfo> {
 }
 
 function logBuildSummary(build: BuildInfo) {
-  // eslint-disable-next-line no-console
+  // oxlint-disable-next-line no-console
   console.info(
     '%c%s%c\n%cPopChoice%c %s (%s) - run %cPopChoice.info()%c for build data',
     BANNER_STYLE,
@@ -56,7 +56,7 @@ function logBuildSummary(build: BuildInfo) {
 }
 
 function logBuildDetails(build: BuildInfo) {
-  // eslint-disable-next-line no-console
+  // oxlint-disable-next-line no-console
   console.groupCollapsed(
     '%cPopChoice build data%c %s (%s)',
     BADGE_STYLE,
@@ -64,7 +64,7 @@ function logBuildDetails(build: BuildInfo) {
     build.version,
     build.commitShortSha ?? 'unknown',
   );
-  // eslint-disable-next-line no-console
+  // oxlint-disable-next-line no-console
   console.table({
     version: build.version,
     channel: build.channel,
@@ -77,7 +77,7 @@ function logBuildDetails(build: BuildInfo) {
     baseUrl: build.baseUrl,
     timestamp: build.timestamp,
   });
-  // eslint-disable-next-line no-console
+  // oxlint-disable-next-line no-console
   console.groupEnd();
 }
 

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -24,7 +24,7 @@ The PR validation workflows run automatically on pull requests targeting the `de
 | Workflow                             | Job                              | Purpose                                                                        |
 | ------------------------------------ | -------------------------------- | ------------------------------------------------------------------------------ |
 | `pr.yml`                             | `changes`                        | Classifies PR as docs-only vs code-changing                                    |
-| `pr.yml`                             | `lint`                           | ESLint code quality + Prettier formatting                                      |
+| `pr.yml`                             | `lint`                           | Oxlint fast pass, ESLint leftovers, and formatting                             |
 | `pr.yml`                             | `fallow-audit`                   | Required new-only Fallow audit for changed TypeScript/JavaScript quality risks |
 | `pr.yml`                             | `type-check`                     | TypeScript type safety (`tsc --noEmit`)                                        |
 | `pr.yml`                             | `server-tests`                   | Vitest server tests with coverage collection and artifact upload               |
@@ -384,6 +384,7 @@ To run the same checks locally before pushing:
 
 ```bash
 # Code quality
+npm run lint:fast
 npm run lint:check
 npm run format:check
 npm run type-check

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -26,6 +26,7 @@ For docs ownership, navigation, and issue hygiene, use **[Documentation Governan
 ### Code Quality
 
 - `npm run lint` or `npm run lint:check` - Run ESLint for code linting
+- `npm run lint:fast` - Run Oxlint as a fast supplemental lint pass
 - `npm run lint:fix` - Fix ESLint issues automatically
 - `npm run format:check` - Check code formatting with Oxfmt
 - `npm run format:write` - Fix code formatting with Oxfmt

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -25,8 +25,9 @@ For docs ownership, navigation, and issue hygiene, use **[Documentation Governan
 
 ### Code Quality
 
-- `npm run lint` or `npm run lint:check` - Run ESLint for code linting
-- `npm run lint:fast` - Run Oxlint as a fast supplemental lint pass
+- `npm run lint:fast` - Run Oxlint for the fast lint pass configured in `.oxlintrc.json`
+- `npm run lint` or `npm run lint:check` - Run ESLint for Storybook, unused-imports,
+  and React Compiler rules that Oxlint does not cover yet
 - `npm run lint:fix` - Fix ESLint issues automatically
 - `npm run format:check` - Check code formatting with Oxfmt
 - `npm run format:write` - Fix code formatting with Oxfmt
@@ -166,9 +167,11 @@ To switch to real data, add `DATABASE_URL` to your `.env` file and seed the data
 ## Code Style and Conventions
 
 - **TypeScript** - All new code should be TypeScript
-- **ESLint** - Follows Next.js and Prettier configurations
-- **Prettier** - Code formatting is enforced
-- **Import organization** - Auto-sorted with eslint-plugin-import
+- **Oxlint** - Runs the fast lint pass for supported ESLint, TypeScript, React,
+  Next.js, accessibility, import, and Vitest rules
+- **ESLint** - Covers Storybook, unused-imports, and React Compiler rules that
+  Oxlint does not support yet
+- **Oxfmt** - Code formatting is enforced
 
 ## Testing Strategy
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       "devDependencies": {
         "@vitest/browser": "^4.1.10",
         "@vitest/browser-playwright": "^4.1.10",
+        "eslint-plugin-oxlint": "^1.73.0",
         "fallow": "2.101.0",
         "husky": "^9.1.7",
         "lint-staged": "^17.0.8",
@@ -10341,6 +10342,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eslint-plugin-oxlint": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-oxlint/-/eslint-plugin-oxlint-1.73.0.tgz",
+      "integrity": "sha512-2qsGYkwpas99+jLmB7F3W8Gv+7QkHIr67AMw10UTs/QAMCm2eO0Z8B8ROMvAgyKaWIitkcvH8DwLfTrHMeXzCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsonc-parser": "^3.3.1"
+      },
+      "peerDependencies": {
+        "oxlint": "~1.73.0"
+      }
+    },
     "node_modules/eslint-plugin-react": {
       "version": "7.37.5",
       "dev": true,
@@ -12935,6 +12949,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jsonfile": {
       "version": "6.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "husky": "^9.1.7",
         "lint-staged": "^17.0.8",
         "oxfmt": "0.58.0",
+        "oxlint": "1.73.0",
         "turbo": "^2.10.3",
         "vitest": "^4.1.10"
       },
@@ -4214,6 +4215,353 @@
       "version": "0.58.0",
       "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.58.0.tgz",
       "integrity": "sha512-N/wUU4N5PZ2orBtI+Ko7MnMfYLfE7K91UrGMY/c/pYyHR3lA9kwst1XugkZx+92YcRh/Eo+iv2eTESSWXfiZPA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm-eabi": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.73.0.tgz",
+      "integrity": "sha512-HZQRN/UMBu+Ut+/9MiAChkbP4qZqrNOWBcNI45vOT40GVhbGR0JgHB87L48D4iAqFQIdVmeQYtV9RF89AjTKkg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm64": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.73.0.tgz",
+      "integrity": "sha512-Gp+KJRylv2aW7thRpG5p1KTxZq4ZJFbWowrKzufNq9d3ssl3r3JviYV45/+p+7CN1Nv0zDd1e8Ex0b/HUDq4TQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-arm64": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.73.0.tgz",
+      "integrity": "sha512-3de96NdtXhxERMjIz7wsp2HYMY6pMQycGxFWac2mFecAx6VeARF/IqFb1QIaqiCRIdfzBwzTed+pCTCoiS+CYA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-x64": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.73.0.tgz",
+      "integrity": "sha512-5zx/uPW32TiaOeVY1dQ/H5iOf0K1HOdFKOJhLqGl4o63+i1fpzoqqu/mKtd7OFgFjNCdhlyTGgjVkQTZm1ELcg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-freebsd-x64": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.73.0.tgz",
+      "integrity": "sha512-qNe4gKHaGnLuZJ8toUg90JAa0S2vTVvDw+0bRi3q1avXZXDT4u5mMeECf3nD4HYrbdn1O7dXqWut4onY/yx/Xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.73.0.tgz",
+      "integrity": "sha512-cCehYh5hTbfShm/fxTD6wwrGUWIpvX+N5OxmAMhFhDeTGXvw+BeNj889tpxsFQ9ZLatQ6wImuY8tsKLZ+FMz7w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-musleabihf": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.73.0.tgz",
+      "integrity": "sha512-d5j5GDU/2dMgjVhw7TQT9ITrsIr1Y02KEXKyVGIXUkD+KiaxE9TP65FS2ZdgTBemQvoRL+gSBdbrIm3cQIeacg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-gnu": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.73.0.tgz",
+      "integrity": "sha512-Eyf1SrP3+yR1DI3OJgOY2Pvrr9dWP9TK37xPaDYycwTtlGlI45erJAVIfH5/m/xosDt6BupJYEFi47bvbTuuyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-musl": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.73.0.tgz",
+      "integrity": "sha512-IlT/OJApEDKaMmCooHuncgJZbbCe7T5QIWmTZBEtYscWvzPQuuEinVcid6kwQRVQOUdb7PUCz4jQHnaYXdfJXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-ppc64-gnu": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.73.0.tgz",
+      "integrity": "sha512-L+JYcb/vdg5fmcH08V6o0YYLU28cTH1SPNulwJdvK9NK49aXSkYy6oNpKBmddArVOXYqNepriDGiZ04G54kh1Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-gnu": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.73.0.tgz",
+      "integrity": "sha512-Qtk0g3bKV6OwWjIm7R8kQN1uOZRKQt/MODK2a8QfkwhTpXBD53ozx5XLVWLGDQAVyp2otLW4D2wB98XfAfMPGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-musl": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.73.0.tgz",
+      "integrity": "sha512-wX0NQKZVxltkAOVmzFcpOaMpdaUvsq1Eqpx9tkAfl71UdkTlSo1R4AdAnGccR1Fm2+TzFgZ22CyyGuZ41RDr/A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-s390x-gnu": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.73.0.tgz",
+      "integrity": "sha512-vPe7UGBMWyiLTtnqS4xxgMQFSFGmtQwhwCxuiw6lXygaO6bVt0D8dFVg8Xv05eaiN3ybC0HXXHUAohFMFvqoCQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-gnu": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.73.0.tgz",
+      "integrity": "sha512-2CwIWr9cemFC/CbRBWZvuk5mffz6ObmfFkfcC/9rTQ7f+icNhYr2kOjf9Rt8lLvugvkdGDOmkoVoFFHh6ClCTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-musl": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.73.0.tgz",
+      "integrity": "sha512-nDadfJgg7NBBxG0N560wOe7LLX5QiYp6qBaI7viuk5EUORFBktU/NfV0MbTqU3gTqQDCh4VyxKdo5VADxk9w8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-openharmony-arm64": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.73.0.tgz",
+      "integrity": "sha512-wGjJC+NLH9xP+IKGn9RDW94ojJR/wPbg5WCnQjj/oReaOtCQthr8ws1zICe77JFmo4ouUdeTHHZL/ESGiF6Pmw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-arm64-msvc": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.73.0.tgz",
+      "integrity": "sha512-I7X47GPGljw225YUQ5SbC/rb1Kkdrd0yQf0x+hYxeKS6DpfjMbo9ccQPQ6LNY6BoJQ1sHhgDUGuMn5Vg5gHT6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-ia32-msvc": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.73.0.tgz",
+      "integrity": "sha512-5lWj+3h+74Fm1jYOO9qkJA4xkAlZA099DkXppuXsk7UpnpZLttsefrZU469vChGaG6hcSqrkKXQOvMTZtbjeNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-x64-msvc": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.73.0.tgz",
+      "integrity": "sha512-WaNRvh4f6zY9CvUQk2YoA1O90ieWrIklI84+HXFr9Isjz9CSESrdqo/RtIYt4Dll/cAchqGDMehfaZd0vqEFZw==",
       "cpu": [
         "x64"
       ],
@@ -15226,6 +15574,55 @@
       },
       "peerDependenciesMeta": {
         "svelte": {
+          "optional": true
+        },
+        "vite-plus": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/oxlint": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.73.0.tgz",
+      "integrity": "sha512-u91G9TJzU6yqKWNZUYprQB07W7YvntZXaRxQ6CkoytepYhLWUXWsr1M8zUJ34VatNPuUAr3Z8GH+O2A331CluQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "oxlint": "bin/oxlint"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxlint/binding-android-arm-eabi": "1.73.0",
+        "@oxlint/binding-android-arm64": "1.73.0",
+        "@oxlint/binding-darwin-arm64": "1.73.0",
+        "@oxlint/binding-darwin-x64": "1.73.0",
+        "@oxlint/binding-freebsd-x64": "1.73.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.73.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.73.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.73.0",
+        "@oxlint/binding-linux-arm64-musl": "1.73.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.73.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.73.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.73.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.73.0",
+        "@oxlint/binding-linux-x64-gnu": "1.73.0",
+        "@oxlint/binding-linux-x64-musl": "1.73.0",
+        "@oxlint/binding-openharmony-arm64": "1.73.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.73.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.73.0",
+        "@oxlint/binding-win32-x64-msvc": "1.73.0"
+      },
+      "peerDependencies": {
+        "oxlint-tsgolint": ">=0.24.0",
+        "vite-plus": "*"
+      },
+      "peerDependenciesMeta": {
+        "oxlint-tsgolint": {
           "optional": true
         },
         "vite-plus": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
       "devDependencies": {
         "@vitest/browser": "^4.1.10",
         "@vitest/browser-playwright": "^4.1.10",
-        "eslint-plugin-oxlint": "^1.73.0",
         "fallow": "2.101.0",
         "husky": "^9.1.7",
         "lint-staged": "^17.0.8",
@@ -177,6 +176,7 @@
         "eslint": "^9",
         "eslint-config-next": "^16.2.10",
         "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-oxlint": "^1.73.0",
         "eslint-plugin-storybook": "^10.4.6",
         "eslint-plugin-unused-imports": "^4.4.1",
         "msw": "^2.14.6",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "format:write": "oxfmt",
     "lint": "npm run lint --workspace=apps/web",
     "lint:check": "npm run lint:check --workspace=apps/web",
+    "lint:fast": "oxlint . --quiet --react-plugin --jsx-a11y-plugin --nextjs-plugin --vitest-plugin --import-plugin",
     "lint:fix": "npm run lint:fix --workspace=apps/web",
     "migrate:db": "bash scripts/migrate-db.sh",
     "prepare": "husky || true",
@@ -74,6 +75,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^17.0.8",
     "oxfmt": "0.58.0",
+    "oxlint": "1.73.0",
     "turbo": "^2.10.3",
     "vitest": "^4.1.10"
   },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "format:write": "oxfmt",
     "lint": "npm run lint --workspace=apps/web",
     "lint:check": "npm run lint:check --workspace=apps/web",
-    "lint:fast": "oxlint . --quiet --react-plugin --jsx-a11y-plugin --nextjs-plugin --vitest-plugin --import-plugin",
+    "lint:fast": "oxlint . --quiet",
     "lint:fix": "npm run lint:fix --workspace=apps/web",
     "migrate:db": "bash scripts/migrate-db.sh",
     "prepare": "husky || true",
@@ -71,6 +71,7 @@
   "devDependencies": {
     "@vitest/browser": "^4.1.10",
     "@vitest/browser-playwright": "^4.1.10",
+    "eslint-plugin-oxlint": "^1.73.0",
     "fallow": "2.101.0",
     "husky": "^9.1.7",
     "lint-staged": "^17.0.8",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
   "devDependencies": {
     "@vitest/browser": "^4.1.10",
     "@vitest/browser-playwright": "^4.1.10",
-    "eslint-plugin-oxlint": "^1.73.0",
     "fallow": "2.101.0",
     "husky": "^9.1.7",
     "lint-staged": "^17.0.8",


### PR DESCRIPTION
## Summary
- add oxlint as a root dev dependency
- add npm run lint:fast as a quiet fast lint pass with React, JSX a11y, Next.js, Vitest, and import plugins enabled
- document the new supplemental lint command

This does not replace the existing ESLint gate. It gives us a fast early pass while we evaluate gradual ESLint overlap removal.

## Validation
- npm ci
- npm run lint:fast
- npm run format:check
- npm run lint:check
- npm run type-check
- npm run build
- pre-commit hook: lint-staged + type-check
- pre-push hook: lint:check, test:server, build; Storybook skipped by hook because no Storybook-relevant changes