### PR TITLE
Split OpenAI usage from recommendation evals

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ DATABASE_URL=postgresql://popchoice_e2e@127.0.0.1:55432/popchoice_e2e npm run ev
 npm run test:e2e:down
 ```
 
-Operators can also start deterministic mock and real-data eval runs from the backoffice `Recommendation evals` page when `DATABASE_URL`, `REDIS_URL`, and the web workers are configured. Backoffice live OpenAI evals are guarded by an explicit cost acknowledgement and confirmation phrase, and persist the provider response in the run report for inspection. Configure `OPENAI_ADMIN_API_KEY` to show aggregate OpenAI usage/costs by period and attach request/token usage plus an Admin Costs API interval snapshot to live eval reports.
+Operators can also start deterministic mock and real-data eval runs from the backoffice `Recommendation evals` page when `DATABASE_URL`, `REDIS_URL`, and the web workers are configured. Backoffice live OpenAI evals are guarded by an explicit cost acknowledgement and confirmation phrase, and persist the provider response in the run report for inspection. Configure `OPENAI_ADMIN_API_KEY` to show aggregate OpenAI usage/costs on the separate backoffice `OpenAI usage` page and attach request/token usage plus an Admin Costs API interval snapshot to individual live eval reports.
 
 ```bash
 npm run eval:recommendations -- --live

--- a/apps/backoffice/src/app/globals.css
+++ b/apps/backoffice/src/app/globals.css
@@ -2183,6 +2183,18 @@ input:disabled {
     margin: 0;
     white-space: normal;
   }
+  .openai-usage-panel .panel-header {
+    align-items: stretch;
+    flex-direction: column;
+  }
+  .openai-usage-panel .segmented-links {
+    display: flex;
+    width: 100%;
+  }
+  .openai-usage-panel .segmented-links a {
+    flex: 1;
+    min-width: 0;
+  }
   .toolbar-summary {
     padding-bottom: 0;
   }

--- a/apps/backoffice/src/app/openai-usage/page.tsx
+++ b/apps/backoffice/src/app/openai-usage/page.tsx
@@ -1,0 +1,24 @@
+import { BackofficeErrorPage, OpenAIUsagePage } from '../../components/backoffice';
+import { ensureBackofficeReady, logBackofficeError } from '../../lib/backoffice';
+import { getBackofficeOpenAIUsageState, parseOpenAIUsagePeriod } from '../../lib/openAIUsage';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+type OpenAIUsageRouteProps = {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function OpenAIUsageRoute({ searchParams }: OpenAIUsageRouteProps) {
+  try {
+    await ensureBackofficeReady();
+    const params = (await searchParams) ?? {};
+    const usagePeriod = parseOpenAIUsagePeriod(params.usagePeriod);
+    const openAIUsage = await getBackofficeOpenAIUsageState(usagePeriod);
+
+    return <OpenAIUsagePage openAIUsage={openAIUsage} />;
+  } catch (error) {
+    logBackofficeError('Failed to render OpenAI usage', error);
+    return <BackofficeErrorPage active="openai-usage" error={error} retryHref="/openai-usage" />;
+  }
+}

--- a/apps/backoffice/src/app/recommendation-evals/page.tsx
+++ b/apps/backoffice/src/app/recommendation-evals/page.tsx
@@ -6,7 +6,6 @@ import {
   logBackofficeError,
   parseRecommendationEvalListParams,
 } from '../../lib/backoffice';
-import { getBackofficeOpenAIUsageState, parseOpenAIUsagePeriod } from '../../lib/openAIUsage';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
@@ -22,16 +21,13 @@ export default async function RecommendationEvalsPage({
     await ensureBackofficeReady();
     const params = (await searchParams) ?? {};
     const pagination = parseRecommendationEvalListParams(params);
-    const usagePeriod = parseOpenAIUsagePeriod(params.usagePeriod);
     const runPage = await listRecommendationEvalRunPage({
       limit: pagination.limit,
       offset: pagination.offset,
     });
-    const openAIUsage = await getBackofficeOpenAIUsageState(usagePeriod);
 
     return (
       <RecommendationEvalListPage
-        openAIUsage={openAIUsage}
         runPage={runPage}
         status={typeof params.eval === 'string' ? params.eval : null}
       />

--- a/apps/backoffice/src/components/backoffice-home/index.test.tsx
+++ b/apps/backoffice/src/components/backoffice-home/index.test.tsx
@@ -14,10 +14,12 @@ describe('BackofficeHomePage', () => {
     expect(html).toContain('href="/queue"');
     expect(html).toContain('href="/repair-batches"');
     expect(html).toContain('href="/recommendation-evals"');
+    expect(html).toContain('href="/openai-usage"');
     expect(html).toContain('Catalog operations');
     expect(html).toContain('Quality');
     expect(html).toContain('Catalog health');
     expect(html).toContain('Data quality and repair work');
+    expect(html).toContain('Provider spend and token totals');
     expect(html).not.toContain('Recommended start');
     expect(html).not.toContain('Workspace');
     expect(html).not.toContain('Action');

--- a/apps/backoffice/src/components/backoffice-home/index.tsx
+++ b/apps/backoffice/src/components/backoffice-home/index.tsx
@@ -50,6 +50,11 @@ const GROUPS: BackofficeHomeGroup[] = [
         href: '/recommendation-evals',
         title: 'Recommendation evals',
       },
+      {
+        description: 'Provider spend and token totals',
+        href: '/openai-usage',
+        title: 'OpenAI usage',
+      },
     ],
   },
 ];

--- a/apps/backoffice/src/components/backoffice-layout/shell.tsx
+++ b/apps/backoffice/src/components/backoffice-layout/shell.tsx
@@ -19,6 +19,7 @@ const SECTION_BREADCRUMB_LABELS: Record<BackofficeSection, string> = {
   'catalog-seed': 'Catalog seed',
   health: 'Catalog health',
   home: 'Backoffice',
+  'openai-usage': 'OpenAI usage',
   queue: 'Queue',
   'recommendation-evals': 'Recommendation evals',
   'repair-batches': 'Repair batches',

--- a/apps/backoffice/src/components/backoffice-layout/types.ts
+++ b/apps/backoffice/src/components/backoffice-layout/types.ts
@@ -2,6 +2,7 @@ export type BackofficeSection =
   | 'home'
   | 'catalog-seed'
   | 'health'
+  | 'openai-usage'
   | 'queue'
   | 'repair-batches'
   | 'reviews'

--- a/apps/backoffice/src/components/backoffice.tsx
+++ b/apps/backoffice/src/components/backoffice.tsx
@@ -4,6 +4,7 @@ export { CatalogHealthPage } from './catalog-health';
 export { CatalogMaintenanceQueuePage } from './catalog-queue';
 export { CatalogSeedPage } from './catalog-seed';
 export { CatalogMovieDetailPage, CatalogMovieNotFoundPage } from './movie-detail';
+export { OpenAIUsagePage } from './openai-usage';
 export {
   RepairBatchDetailPage,
   RepairBatchListPage,

--- a/apps/backoffice/src/components/openai-usage/index.test.tsx
+++ b/apps/backoffice/src/components/openai-usage/index.test.tsx
@@ -1,0 +1,94 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { OpenAIUsagePage } from './index';
+
+import type { BackofficeOpenAIUsageState } from '../../lib/openAIUsage';
+
+function openAIUsage(
+  overrides: Partial<BackofficeOpenAIUsageState> = {},
+): BackofficeOpenAIUsageState {
+  return {
+    message: 'OPENAI_ADMIN_API_KEY is not configured for this backoffice environment.',
+    period: '7d',
+    status: 'not_configured',
+    ...overrides,
+  } as BackofficeOpenAIUsageState;
+}
+
+describe('OpenAIUsagePage', () => {
+  it('renders the missing-admin-key state on the dedicated usage page', () => {
+    const html = renderToStaticMarkup(<OpenAIUsagePage openAIUsage={openAIUsage()} />);
+
+    expect(html).toContain('OpenAI Usage');
+    expect(html).toContain('Provider spend');
+    expect(html).toContain('OPENAI_ADMIN_API_KEY is not configured');
+    expect(html).toContain('href="/recommendation-evals"');
+    expect(html).toContain('href="/openai-usage?usagePeriod=24h"');
+    expect(html).toContain('href="/openai-usage?usagePeriod=7d"');
+    expect(html).toContain('href="/openai-usage?usagePeriod=30d"');
+  });
+
+  it('renders aggregate OpenAI usage when admin telemetry is configured', () => {
+    const html = renderToStaticMarkup(
+      <OpenAIUsagePage
+        openAIUsage={openAIUsage({
+          status: 'available',
+          summary: {
+            costs: {
+              groups: [],
+              total: { currency: 'usd', value: 1.2345 },
+            },
+            period: {
+              bucketWidth: '1d',
+              endTime: '2026-06-20T10:00:00.000Z',
+              startTime: '2026-06-13T10:00:00.000Z',
+            },
+            usage: {
+              byCategory: {
+                completions: {
+                  cachedInputTokens: 3,
+                  inputTokens: 100,
+                  outputTokens: 20,
+                  requests: 4,
+                },
+                embeddings: {
+                  cachedInputTokens: 0,
+                  inputTokens: 200,
+                  outputTokens: 0,
+                  requests: 2,
+                },
+                images: { cachedInputTokens: 0, inputTokens: 0, outputTokens: 0, requests: 0 },
+                moderations: {
+                  cachedInputTokens: 0,
+                  inputTokens: 50,
+                  outputTokens: 0,
+                  requests: 1,
+                },
+                web_search_calls: {
+                  cachedInputTokens: 0,
+                  inputTokens: 0,
+                  outputTokens: 0,
+                  requests: 0,
+                },
+              },
+              groups: [],
+              total: {
+                cachedInputTokens: 3,
+                inputTokens: 350,
+                outputTokens: 20,
+                requests: 7,
+              },
+            },
+          },
+        })}
+      />,
+    );
+
+    expect(html).toContain('$1.23');
+    expect(html).toContain('completions');
+    expect(html).toContain('embeddings');
+    expect(html).toContain('moderations');
+    expect(html).toContain('350');
+  });
+});

--- a/apps/backoffice/src/components/openai-usage/index.tsx
+++ b/apps/backoffice/src/components/openai-usage/index.tsx
@@ -1,0 +1,129 @@
+import { ButtonLink } from '@pop-choice/ui';
+
+import { formatBackofficeDateTime } from '../../lib/backoffice';
+import { BackofficeLayout } from '../backoffice-layout';
+import { formatProviderUsageCost } from '../recommendation-evals/providerUsageViewModel';
+import { DataTable } from '../shared';
+
+import type { BackofficeOpenAIUsageState, OpenAIUsagePeriodKey } from '../../lib/openAIUsage';
+
+const USAGE_PERIOD_LABELS: Record<OpenAIUsagePeriodKey, string> = {
+  '24h': '24h',
+  '7d': '7d',
+  '30d': '30d',
+};
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
+function OpenAIUsagePeriodLinks({ active }: { active: OpenAIUsagePeriodKey }) {
+  return (
+    <div className="segmented-links" aria-label="OpenAI usage period">
+      {(Object.keys(USAGE_PERIOD_LABELS) as OpenAIUsagePeriodKey[]).map((period) => (
+        <a
+          aria-current={period === active ? 'page' : undefined}
+          className={period === active ? 'active' : undefined}
+          href={`/openai-usage?usagePeriod=${period}`}
+          key={period}
+        >
+          {USAGE_PERIOD_LABELS[period]}
+        </a>
+      ))}
+    </div>
+  );
+}
+
+function OpenAIUsageOverview({ state }: { state: BackofficeOpenAIUsageState }) {
+  if (state.status !== 'available') {
+    return (
+      <section className="panel openai-usage-panel">
+        <div className="panel-header">
+          <div>
+            <h2>OpenAI usage</h2>
+            <p className="panel-subtitle">Admin usage and cost telemetry</p>
+          </div>
+          <OpenAIUsagePeriodLinks active={state.period} />
+        </div>
+        <p className="empty">{state.message}</p>
+      </section>
+    );
+  }
+
+  const { summary } = state;
+  const categories = Object.entries(summary.usage.byCategory).filter(
+    ([, totals]) => totals.requests > 0 || totals.inputTokens > 0 || totals.outputTokens > 0,
+  );
+
+  return (
+    <section className="panel openai-usage-panel">
+      <div className="panel-header">
+        <div>
+          <h2>OpenAI usage</h2>
+          <p className="panel-subtitle">
+            {formatBackofficeDateTime(summary.period.startTime)} -{' '}
+            {formatBackofficeDateTime(summary.period.endTime)}
+          </p>
+        </div>
+        <OpenAIUsagePeriodLinks active={state.period} />
+      </div>
+      <div className="openai-usage-summary">
+        <div>
+          <span>Total cost</span>
+          <strong>{formatProviderUsageCost(summary.costs.total)}</strong>
+        </div>
+        <div>
+          <span>Requests</span>
+          <strong>{formatNumber(summary.usage.total.requests)}</strong>
+        </div>
+        <div>
+          <span>Input tokens</span>
+          <strong>{formatNumber(summary.usage.total.inputTokens)}</strong>
+        </div>
+        <div>
+          <span>Output tokens</span>
+          <strong>{formatNumber(summary.usage.total.outputTokens)}</strong>
+        </div>
+      </div>
+      {categories.length > 0 ? (
+        <DataTable
+          className="openai-usage-table"
+          columns={['Category', 'Requests', 'Input tokens', 'Output tokens', 'Cached input']}
+        >
+          {categories.map(([category, totals]) => (
+            <tr key={category}>
+              <td>{category}</td>
+              <td>{formatNumber(totals.requests)}</td>
+              <td>{formatNumber(totals.inputTokens)}</td>
+              <td>{formatNumber(totals.outputTokens)}</td>
+              <td>{formatNumber(totals.cachedInputTokens)}</td>
+            </tr>
+          ))}
+        </DataTable>
+      ) : (
+        <p className="empty">No OpenAI usage was reported for this period.</p>
+      )}
+    </section>
+  );
+}
+
+export function OpenAIUsagePage({ openAIUsage }: { openAIUsage: BackofficeOpenAIUsageState }) {
+  return (
+    <BackofficeLayout
+      active="openai-usage"
+      title="OpenAI Usage"
+      eyebrow="Provider spend"
+      description="Review aggregate OpenAI usage and cost telemetry by period."
+      actions={
+        <>
+          <ButtonLink href={`/openai-usage?usagePeriod=${openAIUsage.period}`}>Refresh</ButtonLink>
+          <ButtonLink variant="quiet" href="/recommendation-evals">
+            Eval runs
+          </ButtonLink>
+        </>
+      }
+    >
+      <OpenAIUsageOverview state={openAIUsage} />
+    </BackofficeLayout>
+  );
+}

--- a/apps/backoffice/src/components/recommendation-evals/list.test.tsx
+++ b/apps/backoffice/src/components/recommendation-evals/list.test.tsx
@@ -3,8 +3,54 @@ import { describe, expect, it } from 'vitest';
 
 import { RecommendationEvalListPage } from './list';
 
-import type { BackofficeOpenAIUsageState } from '../../lib/openAIUsage';
-import type { RecommendationEvalRunPage } from '@pop-choice/shared';
+import type { RecommendationEvalRun, RecommendationEvalRunPage } from '@pop-choice/shared';
+
+function evalRun(overrides: Partial<RecommendationEvalRun> = {}): RecommendationEvalRun {
+  return {
+    actor: 'lexi',
+    appVersion: '0.2.0',
+    completedAt: '2026-06-19T20:00:00.000Z',
+    createdAt: '2026-06-19T19:59:00.000Z',
+    errorMessage: null,
+    gitSha: 'abc1234',
+    id: '1dc6873b-d650-490a-a2da-65969eef3224',
+    jobId: 'recommendation-eval-1dc6873b',
+    jobName: 'run-recommendation-eval',
+    mode: 'live',
+    queueName: 'recommendation-evals',
+    queuedAt: '2026-06-19T19:59:02.000Z',
+    report: {
+      mode: 'live',
+      providerUsage: {
+        admin: {
+          attribution: 'interval',
+          status: 'available',
+          summary: {
+            costs: {
+              total: { currency: 'usd', value: 0.42 },
+            },
+          },
+        },
+        observed: {
+          total: {
+            cachedInputTokens: 5,
+            inputTokens: 1234,
+            outputTokens: 567,
+            requests: 8,
+          },
+        },
+        provider: 'openai',
+      },
+    },
+    requestedOptions: { trigger: 'backoffice' },
+    source: 'backoffice',
+    startedAt: '2026-06-19T19:59:03.000Z',
+    status: 'completed',
+    summary: { failed: 0, fixtureCount: 1, passed: 1 },
+    updatedAt: '2026-06-19T20:00:00.000Z',
+    ...overrides,
+  };
+}
 
 function runPage(overrides: Partial<RecommendationEvalRunPage> = {}): RecommendationEvalRunPage {
   return {
@@ -16,25 +62,15 @@ function runPage(overrides: Partial<RecommendationEvalRunPage> = {}): Recommenda
   };
 }
 
-function openAIUsage(
-  overrides: Partial<BackofficeOpenAIUsageState> = {},
-): BackofficeOpenAIUsageState {
-  return {
-    message: 'OPENAI_ADMIN_API_KEY is not configured for this backoffice environment.',
-    period: '7d',
-    status: 'not_configured',
-    ...overrides,
-  } as BackofficeOpenAIUsageState;
-}
-
 describe('RecommendationEvalListPage', () => {
   it('separates non-provider evals from explicit live OpenAI evals', () => {
     const html = renderToStaticMarkup(
-      <RecommendationEvalListPage openAIUsage={openAIUsage()} runPage={runPage()} status={null} />,
+      <RecommendationEvalListPage runPage={runPage()} status={null} />,
     );
 
-    expect(html).toContain('OpenAI usage');
-    expect(html).toContain('OPENAI_ADMIN_API_KEY is not configured');
+    expect(html).toContain('href="/openai-usage"');
+    expect(html).not.toContain('OPENAI_ADMIN_API_KEY is not configured');
+    expect(html).not.toContain('Admin usage and cost telemetry');
     expect(html).toContain('class="eval-safe-form"');
     expect(html).toContain('class="eval-run-panel"');
     expect(html).toContain('Seeded catalog retrieval - no OpenAI');
@@ -49,7 +85,7 @@ describe('RecommendationEvalListPage', () => {
 
   it('renders a single empty recent-runs state without duplicate pagination or table chrome', () => {
     const html = renderToStaticMarkup(
-      <RecommendationEvalListPage openAIUsage={openAIUsage()} runPage={runPage()} status={null} />,
+      <RecommendationEvalListPage runPage={runPage()} status={null} />,
     );
 
     expect(html).toContain('No recommendation eval runs have been recorded yet.');
@@ -58,68 +94,22 @@ describe('RecommendationEvalListPage', () => {
     expect(html).not.toContain('Page 1 / 1');
   });
 
-  it('renders aggregate OpenAI usage when admin telemetry is configured', () => {
+  it('keeps aggregate OpenAI usage out of eval history', () => {
     const html = renderToStaticMarkup(
       <RecommendationEvalListPage
-        openAIUsage={openAIUsage({
-          status: 'available',
-          summary: {
-            costs: {
-              groups: [],
-              total: { currency: 'usd', value: 1.2345 },
-            },
-            period: {
-              bucketWidth: '1d',
-              endTime: '2026-06-20T10:00:00.000Z',
-              startTime: '2026-06-13T10:00:00.000Z',
-            },
-            usage: {
-              byCategory: {
-                completions: {
-                  cachedInputTokens: 3,
-                  inputTokens: 100,
-                  outputTokens: 20,
-                  requests: 4,
-                },
-                embeddings: {
-                  cachedInputTokens: 0,
-                  inputTokens: 200,
-                  outputTokens: 0,
-                  requests: 2,
-                },
-                images: { cachedInputTokens: 0, inputTokens: 0, outputTokens: 0, requests: 0 },
-                moderations: {
-                  cachedInputTokens: 0,
-                  inputTokens: 50,
-                  outputTokens: 0,
-                  requests: 1,
-                },
-                web_search_calls: {
-                  cachedInputTokens: 0,
-                  inputTokens: 0,
-                  outputTokens: 0,
-                  requests: 0,
-                },
-              },
-              groups: [],
-              total: {
-                cachedInputTokens: 3,
-                inputTokens: 350,
-                outputTokens: 20,
-                requests: 7,
-              },
-            },
-          },
+        runPage={runPage({
+          runs: [evalRun()],
+          totalCount: 1,
         })}
-        runPage={runPage()}
         status={null}
       />,
     );
 
-    expect(html).toContain('$1.23');
-    expect(html).toContain('completions');
-    expect(html).toContain('embeddings');
-    expect(html).toContain('moderations');
-    expect(html).toContain('350');
+    expect(html).toContain('OpenAI cost');
+    expect(html).toContain('OpenAI usage');
+    expect(html).toContain('$0.42');
+    expect(html).toContain('8 req, 1,234 in / 567 out');
+    expect(html).not.toContain('Total cost');
+    expect(html).not.toContain('Cached input');
   });
 });

--- a/apps/backoffice/src/components/recommendation-evals/list.tsx
+++ b/apps/backoffice/src/components/recommendation-evals/list.tsx
@@ -11,18 +11,7 @@ import {
 } from './providerUsageViewModel';
 import { buildRecommendationEvalPageHref, RecommendationEvalStatusBadge } from './shared';
 
-import type { BackofficeOpenAIUsageState, OpenAIUsagePeriodKey } from '../../lib/openAIUsage';
 import type { RecommendationEvalRun, RecommendationEvalRunPage } from '@pop-choice/shared';
-
-const USAGE_PERIOD_LABELS: Record<OpenAIUsagePeriodKey, string> = {
-  '24h': '24h',
-  '7d': '7d',
-  '30d': '30d',
-};
-
-function formatNumber(value: number): string {
-  return new Intl.NumberFormat('en-US').format(value);
-}
 
 function runOpenAIUsage(run: RecommendationEvalRun): { cost: string; usage: string } {
   const usage = providerUsageViewFromReport(run.report);
@@ -31,96 +20,6 @@ function runOpenAIUsage(run: RecommendationEvalRun): { cost: string; usage: stri
     cost: formatProviderUsageCost(usage?.cost ?? null),
     usage: providerUsageText(usage),
   };
-}
-
-function OpenAIUsagePeriodLinks({ active }: { active: OpenAIUsagePeriodKey }) {
-  return (
-    <div className="segmented-links" aria-label="OpenAI usage period">
-      {(Object.keys(USAGE_PERIOD_LABELS) as OpenAIUsagePeriodKey[]).map((period) => (
-        <a
-          aria-current={period === active ? 'page' : undefined}
-          className={period === active ? 'active' : undefined}
-          href={`/recommendation-evals?usagePeriod=${period}`}
-          key={period}
-        >
-          {USAGE_PERIOD_LABELS[period]}
-        </a>
-      ))}
-    </div>
-  );
-}
-
-function OpenAIUsageOverview({ state }: { state: BackofficeOpenAIUsageState }) {
-  if (state.status !== 'available') {
-    return (
-      <section className="panel openai-usage-panel">
-        <div className="panel-header">
-          <div>
-            <h2>OpenAI usage</h2>
-            <p className="panel-subtitle">Admin usage and cost telemetry</p>
-          </div>
-          <OpenAIUsagePeriodLinks active={state.period} />
-        </div>
-        <p className="empty">{state.message}</p>
-      </section>
-    );
-  }
-
-  const { summary } = state;
-  const categories = Object.entries(summary.usage.byCategory).filter(
-    ([, totals]) => totals.requests > 0 || totals.inputTokens > 0 || totals.outputTokens > 0,
-  );
-
-  return (
-    <section className="panel openai-usage-panel">
-      <div className="panel-header">
-        <div>
-          <h2>OpenAI usage</h2>
-          <p className="panel-subtitle">
-            {formatBackofficeDateTime(summary.period.startTime)} -{' '}
-            {formatBackofficeDateTime(summary.period.endTime)}
-          </p>
-        </div>
-        <OpenAIUsagePeriodLinks active={state.period} />
-      </div>
-      <div className="openai-usage-summary">
-        <div>
-          <span>Total cost</span>
-          <strong>{formatProviderUsageCost(summary.costs.total)}</strong>
-        </div>
-        <div>
-          <span>Requests</span>
-          <strong>{formatNumber(summary.usage.total.requests)}</strong>
-        </div>
-        <div>
-          <span>Input tokens</span>
-          <strong>{formatNumber(summary.usage.total.inputTokens)}</strong>
-        </div>
-        <div>
-          <span>Output tokens</span>
-          <strong>{formatNumber(summary.usage.total.outputTokens)}</strong>
-        </div>
-      </div>
-      {categories.length > 0 ? (
-        <DataTable
-          className="openai-usage-table"
-          columns={['Category', 'Requests', 'Input tokens', 'Output tokens', 'Cached input']}
-        >
-          {categories.map(([category, totals]) => (
-            <tr key={category}>
-              <td>{category}</td>
-              <td>{formatNumber(totals.requests)}</td>
-              <td>{formatNumber(totals.inputTokens)}</td>
-              <td>{formatNumber(totals.outputTokens)}</td>
-              <td>{formatNumber(totals.cachedInputTokens)}</td>
-            </tr>
-          ))}
-        </DataTable>
-      ) : (
-        <p className="empty">No OpenAI usage was reported for this period.</p>
-      )}
-    </section>
-  );
 }
 
 function RecommendationEvalRows({ runs }: { runs: RecommendationEvalRun[] }) {
@@ -222,11 +121,9 @@ function RecommendationEvalFlash({ status }: { status: string | null }) {
 }
 
 export function RecommendationEvalListPage({
-  openAIUsage,
   runPage,
   status,
 }: {
-  openAIUsage: BackofficeOpenAIUsageState;
   runPage: RecommendationEvalRunPage;
   status: string | null;
 }) {
@@ -239,6 +136,9 @@ export function RecommendationEvalListPage({
       actions={
         <>
           <ButtonLink href="/recommendation-evals">Refresh</ButtonLink>
+          <ButtonLink variant="quiet" href="/openai-usage">
+            OpenAI usage
+          </ButtonLink>
           <ButtonLink variant="quiet" href="/api/recommendation-evals">
             JSON
           </ButtonLink>
@@ -246,7 +146,6 @@ export function RecommendationEvalListPage({
       }
     >
       <RecommendationEvalFlash status={status} />
-      <OpenAIUsageOverview state={openAIUsage} />
       <section className="eval-run-panel" aria-labelledby="recommendation-eval-run-title">
         <div className="eval-run-panel-heading">
           <h2 id="recommendation-eval-run-title">Run eval</h2>
@@ -274,7 +173,6 @@ export function RecommendationEvalListPage({
                 buildRecommendationEvalPageHref({
                   page,
                   pageSize: runPage.limit,
-                  usagePeriod: openAIUsage.period,
                 })
               }
             />
@@ -307,7 +205,6 @@ export function RecommendationEvalListPage({
                 buildRecommendationEvalPageHref({
                   page,
                   pageSize: runPage.limit,
-                  usagePeriod: openAIUsage.period,
                 })
               }
             />

--- a/apps/backoffice/src/components/recommendation-evals/shared.tsx
+++ b/apps/backoffice/src/components/recommendation-evals/shared.tsx
@@ -27,18 +27,13 @@ export function RecommendationEvalStatusBadge({ status }: { status: Recommendati
 export function buildRecommendationEvalPageHref({
   page,
   pageSize,
-  usagePeriod,
 }: {
   page: number;
   pageSize: number;
-  usagePeriod?: string;
 }) {
   const params = new URLSearchParams();
   params.set('page', String(page));
   params.set('pageSize', String(pageSize));
-  if (usagePeriod) {
-    params.set('usagePeriod', usagePeriod);
-  }
   return `/recommendation-evals?${params.toString()}`;
 }
 

--- a/docs/BACKOFFICE.md
+++ b/docs/BACKOFFICE.md
@@ -7,8 +7,9 @@ title: 'Backoffice Plan'
 PopChoice backoffice work is tracked under
 [#493](https://github.com/shchilkin/PopChoice/issues/493). The backoffice is an
 operational app for catalog health, TMDB match review, queued catalog repair,
-catalog seeding, queue visibility, and recommendation eval operations. It must
-not be implemented inside the user-facing `apps/web` app.
+catalog seeding, queue visibility, OpenAI usage telemetry, and recommendation
+eval operations. It must not be implemented inside the user-facing `apps/web`
+app.
 Post-MVP operator hardening is tracked under
 [#660](https://github.com/shchilkin/PopChoice/issues/660).
 
@@ -186,6 +187,8 @@ The app needs:
   mutating catalog rows inline;
 - `OPERATOR_AUTH_USERNAME` and `OPERATOR_AUTH_PASSWORD` when testing protected
   operator routes locally;
+- `OPENAI_ADMIN_API_KEY` for the aggregate OpenAI usage page and live eval cost
+  snapshots;
 - `CATALOG_HEALTH_SAMPLE_LIMIT` and `CATALOG_HEALTH_STALE_DAYS` when tuning the
   report shape.
 

--- a/docs/SERVICES.md
+++ b/docs/SERVICES.md
@@ -372,10 +372,10 @@ queue for processing. Live OpenAI evals are available only through an explicit
 cost acknowledgement and confirmation phrase because they can spend provider
 credits and depend on live OpenAI/TMDB behavior. Completed live evals persist
 the provider response alongside each fixture result so operators can inspect the
-actual recommendation output. When `OPENAI_ADMIN_API_KEY` is configured,
-backoffice also shows aggregate OpenAI usage/costs by period, and live eval
-reports include worker-observed OpenAI request/token usage plus an Admin Costs
-API interval snapshot for the run.
+actual recommendation output. When `OPENAI_ADMIN_API_KEY` is configured, the
+separate `/openai-usage` page shows aggregate OpenAI usage/costs by period,
+while live eval reports include worker-observed OpenAI request/token usage plus
+an Admin Costs API interval snapshot for that run.
 
 Useful options:
 


### PR DESCRIPTION
## Summary
- move aggregate OpenAI usage/cost telemetry to a dedicated Backoffice OpenAI usage page
- keep Recommendation evals focused on run actions/history and per-run OpenAI cost/usage columns
- add navigation, docs, and tests for the separated usage surface

## Verification
- npm run format:check
- npm run check:backoffice
- npm run type-check (commit hook)
- pre-push: npm run lint:check, npm run test:server, npm run build
- Playwright smoke: /openai-usage desktop/mobile and /recommendation-evals desktop on local Backoffice dev server

## Notes
- No Coolify/dev/prod secrets changed in this PR.
