### PR TITLE
Add provider usage attribution roadmap item

### DIFF
--- a/docs/BACKOFFICE.md
+++ b/docs/BACKOFFICE.md
@@ -382,12 +382,18 @@ Completed runs store the report summary and per-case rows in
 `recommendation_eval_results`, so operators can inspect failures without
 recovering transient worker logs or local JSON artifacts.
 
-When `OPENAI_ADMIN_API_KEY` is configured, the page also shows OpenAI Admin
-Usage/Costs telemetry for 24h, 7d, and 30d periods. Live eval runs attach
-`providerUsage` to the persisted report: worker-observed request/token usage is
-attributed to that eval job, while Admin Costs API data is an interval snapshot
-for the eval runtime and can include concurrent OpenAI traffic from the same
-organization/project.
+When `OPENAI_ADMIN_API_KEY` is configured, the separate `OpenAI usage` page
+shows OpenAI Admin Usage/Costs telemetry for 24h, 7d, and 30d periods. Live eval
+runs attach `providerUsage` to the persisted report: worker-observed
+request/token usage is attributed to that eval job, while Admin Costs API data
+is an interval snapshot for the eval runtime and can include concurrent OpenAI
+traffic from the same organization/project.
+
+Provider-agnostic, per-action usage attribution is tracked as follow-up
+[#903](https://github.com/shchilkin/PopChoice/issues/903). That work should add
+an internal `provider_usage_events` layer so future Backoffice usage views can
+filter spend and quota usage by provider, environment, actor, operation, and
+period instead of relying only on aggregate billing APIs.
 
 ## Visual QA Checklist
 

--- a/docs/ROADMAP-ARCHITECTURE.md
+++ b/docs/ROADMAP-ARCHITECTURE.md
@@ -277,6 +277,12 @@ work implementation-sized:
 - [#668](https://github.com/shchilkin/PopChoice/issues/668): improve backoffice
   developer experience with reusable fixtures, deterministic realtime/action
   test helpers, and clearer local validation docs.
+- [#903](https://github.com/shchilkin/PopChoice/issues/903): add
+  provider-agnostic usage attribution for paid APIs, starting with an
+  idempotent `provider_usage_events` schema, OpenAI event instrumentation for
+  live evals/generation/embeddings, and Backoffice filtering by provider,
+  environment, actor, operation, and period. Keep provider aggregate billing
+  APIs as reconciliation data, not the only source of per-action attribution.
 
 ### Account Platform Track
 


### PR DESCRIPTION
## Summary
- add follow-up roadmap item for provider-agnostic usage attribution across paid APIs
- link the new issue #903 from the Backoffice maturity track
- clarify Backoffice docs after #902: aggregate OpenAI usage lives on the separate OpenAI usage page, while eval reports keep per-run usage

## Verification
- npm run format:check
- commit hook: type-check
- pre-push: lint, server tests, production build

Docs-only follow-up for the conversation about scaling usage/cost tracking across operators and providers.
