### PR TITLE
Record rejected controlled Duo live result

### DIFF
--- a/docs/portfolio-evidence/CONTROLLED-DUO-QUALITY.md
+++ b/docs/portfolio-evidence/CONTROLLED-DUO-QUALITY.md
@@ -7,10 +7,10 @@ description: 'A fixed-candidate protocol for reviewing how PopChoice balances tw
 
 ## Current status
 
-**Shipped in development — protocol ready, provider run not performed.** The
-protocol is validated without calling OpenAI. A live run is intentionally
-separate because it spends provider credits and still requires owner review
-before it can support a recommendation-quality claim.
+**Development verified — first provider run rejected.** The protocol was first
+validated without calling OpenAI, then run once with explicit budget approval.
+The live response passed six of seven automated checks but selected the
+deliberately weaker comparison candidate. The owner rejected the compromise.
 
 The question is narrow: can the production ranking prompt choose one plausible
 bridge between two contrasting profiles and explain the compromise without
@@ -63,6 +63,30 @@ still answer:
    prompt keywords?
 3. Is the recommendation credible for the stated night?
 
+## Recorded live result
+
+The first controlled live run was recorded on 2026-07-16 and made exactly one
+provider call. The complete sanitized report is stored in
+[`results/controlled-duo-live-2026-07-16.json`](https://github.com/shchilkin/PopChoice/blob/development/docs/portfolio-evidence/results/controlled-duo-live-2026-07-16.json).
+
+| Field            | Result                                                                |
+| ---------------- | --------------------------------------------------------------------- |
+| Selected film    | `The Grand Budapest Hotel`                                            |
+| Automated checks | 6 of 7 passed                                                         |
+| Failed check     | `bridge-selection`                                                    |
+| Review status    | `blocked-by-automated-checks`                                         |
+| Owner verdict    | Rejected: too little kinetic overlap for Sam despite fluent reasoning |
+
+The result stayed inside the fixed set, respected the shared constraints,
+named Alex and Sam, represented terms from both profiles, and provided a
+detailed explanation. It still failed the central compromise test. The
+explanation made the weaker overlap sound resolved instead of demonstrating
+that the selected film was a strong bridge.
+
+This is useful negative evidence, not a recommendation-quality success. The
+next live run should wait until bridge fit is represented explicitly in the
+ranking policy.
+
 ## Reproduce without provider spend
 
 ```bash
@@ -91,8 +115,9 @@ not emit a final recommendation-quality pass.
 
 **Proven now:** the protocol is executable, bounded, credit-free by default,
 uses valid production-shaped inputs, and can separate machine-checkable
-constraints from subjective review.
+constraints from subjective review. One controlled provider response also
+showed that fluent reasoning can overstate a weak taste overlap.
 
-**Not yet proven:** that the configured provider selects a convincing bridge,
-that the owner accepts the explanation, or that production users receive better
-recommendations.
+**Not yet proven:** that the configured provider selects convincing bridges
+consistently, that the ranking policy prevents weak compromises, or that
+production users receive better recommendations.

--- a/docs/portfolio-evidence/PORTFOLIO-HANDOFF.md
+++ b/docs/portfolio-evidence/PORTFOLIO-HANDOFF.md
@@ -30,6 +30,7 @@ This does not verify every development feature on the live product.
 | Feedback affects durable signed-in movie memory                       | **Shipped in development** | [feedback API](https://github.com/shchilkin/PopChoice/blob/development/apps/web/src/app/api/recommendations/%5Bid%5D/feedback/route.ts), [recommendation e2e](https://github.com/shchilkin/PopChoice/blob/development/apps/web/e2e/recommendation.spec.ts)              |
 | PopChoice has deterministic recommendation regression gates           | **Shipped in development** | [fixtures](https://github.com/shchilkin/PopChoice/blob/development/apps/web/src/features/recommendation/evals/fixtures.ts), [CI](https://github.com/shchilkin/PopChoice/blob/development/.github/workflows/pr.yml)                                                      |
 | A fixed-candidate Duo quality-review protocol is executable           | **Shipped in development** | [protocol](/docs/portfolio-evidence/CONTROLLED-DUO-QUALITY), [implementation](https://github.com/shchilkin/PopChoice/blob/development/apps/web/src/features/recommendation/evals/controlledDuoQuality.ts)                                                               |
+| One controlled live Duo run exposed a weak bridge selection           | **Development verified**   | [recorded result](https://github.com/shchilkin/PopChoice/blob/development/docs/portfolio-evidence/results/controlled-duo-live-2026-07-16.json), [review](/docs/portfolio-evidence/CONTROLLED-DUO-QUALITY#recorded-live-result)                                          |
 | Protected operator surfaces are live and routinely used               | **Anecdotal / unverified** | Code map in [Operations](/docs/portfolio-evidence/OPERATIONS); no authenticated live inspection performed                                                                                                                                                               |
 | The recommendation engine improved conversion, accuracy, or retention | **Anecdotal / unverified** | No product analytics dataset or approved metric was found                                                                                                                                                                                                               |
 
@@ -45,10 +46,10 @@ production when deterministic local evidence was used.
 
 Use [feedback-memory repeat avoidance](/docs/portfolio-evidence/RECOMMENDATION-SCENARIO)
 for the reproducible deterministic regression example. Use the
-[Controlled Duo protocol](/docs/portfolio-evidence/CONTROLLED-DUO-QUALITY) only
-to describe how the next quality review is structured. The protocol is ready,
-but a real-provider result and owner verdict remain blocked on explicit budget
-approval.
+[Controlled Duo protocol](/docs/portfolio-evidence/CONTROLLED-DUO-QUALITY) to
+describe the fixed compromise test and its first recorded failure. The single
+live run selected the deliberately weaker comparison candidate and was rejected
+by the owner; it does not demonstrate general recommendation quality.
 
 ## 5. Screenshot and asset manifest
 
@@ -82,6 +83,8 @@ evidence that BullMQ retried successfully.
   without spending provider credits.”
 - “PopChoice v0.2.0 is deployed in production; the public build endpoint exposes
   version and commit provenance.”
+- “One controlled live run passed six of seven formal checks and was still
+  rejected because its fluent explanation overstated a weak taste overlap.”
 
 ## 7. What not to claim without more data
 
@@ -108,11 +111,9 @@ roadmap item.
    screenshotted in a public case study?
 2. Was the mascot redrawn in Figma, Affinity Designer, or another tool?
 3. Which protected operator surfaces may be captured, with what redaction?
-4. Is there an approved staging budget for one live-provider recommendation
-   scenario?
-5. Are there attributable friend/family quotes that may be used as qualitative
+4. Are there attributable friend/family quotes that may be used as qualitative
    observations, with consent and without presenting them as research?
-6. Is the design-system route intentionally private, or should its broken
+5. Is the design-system route intentionally private, or should its broken
    `/style-guide` internal links and public navigation status be completed first?
 
 ## 10. Recommended next step in `portfolio-2025`

--- a/docs/portfolio-evidence/README.md
+++ b/docs/portfolio-evidence/README.md
@@ -13,6 +13,7 @@ This directory is a compact handoff for a future PopChoice case-study update in
 | Label                      | Meaning                                                                                                       |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------- |
 | **Production verified**    | Observed on the public production surface on the stated date.                                                 |
+| **Development verified**   | Observed in a controlled run against development code; not production behavior.                               |
 | **Shipped in development** | Implemented and backed by code/tests on `development`; not automatically claimed as live production behavior. |
 | **Planned**                | Documented future work or issue-backed direction, not current behavior.                                       |
 | **Anecdotal / unverified** | Owner recollection or a plausible historical statement without enough primary evidence.                       |
@@ -24,8 +25,8 @@ This directory is a compact handoff for a future PopChoice case-study update in
 - [Recommendation scenario](/docs/portfolio-evidence/RECOMMENDATION-SCENARIO): one
   reproducible deterministic, memory-aware scenario.
 - [Controlled Duo quality](/docs/portfolio-evidence/CONTROLLED-DUO-QUALITY): a
-  fixed-candidate compromise protocol with a credit-free validation mode and an
-  explicitly manual quality-review boundary.
+  fixed-candidate compromise protocol with a credit-free validation mode, one
+  recorded rejected live result, and an explicitly manual quality-review boundary.
 - [Persisted lifecycle](/docs/portfolio-evidence/PERSISTED-LIFECYCLE): API,
   persistence, queue, polling, terminal states, and recovery evidence.
 - [Operations](/docs/portfolio-evidence/OPERATIONS): operator surfaces and their

--- a/docs/portfolio-evidence/results/controlled-duo-live-2026-07-16.json
+++ b/docs/portfolio-evidence/results/controlled-duo-live-2026-07-16.json
@@ -1,0 +1,87 @@
+{
+  "automatedChecksPassed": false,
+  "generatedAt": "2026-07-16T13:43:29.367Z",
+  "manualReviewQuestions": [
+    "Does the selected film feel like a fair bridge rather than a win for only Alex or Sam?",
+    "Does the explanation connect concrete qualities of the film to both profiles instead of listing prompt keywords?",
+    "Would the owner accept this as a credible recommendation for the stated night?"
+  ],
+  "mode": "live",
+  "protocolChecks": [
+    {
+      "details": "Both participant records match the production quiz input schema.",
+      "id": "valid-people",
+      "label": "Valid participant inputs",
+      "passed": true
+    },
+    {
+      "details": "4 candidate titles are unique.",
+      "id": "unique-candidates",
+      "label": "Unique bounded candidates",
+      "passed": true
+    },
+    {
+      "details": "Every candidate avoids horror and is at most 125 minutes.",
+      "id": "candidate-hard-constraints",
+      "label": "Candidate hard constraints",
+      "passed": true
+    },
+    {
+      "details": "3 candidates are pre-declared as plausible bridges with signals for both profiles.",
+      "id": "bridge-candidate-coverage",
+      "label": "Bridge candidate coverage",
+      "passed": true
+    }
+  ],
+  "providerCallCount": 1,
+  "response": {
+    "description": "Movie night mission accepted! The best pick for Alex and Sam is The Grand Budapest Hotel. It’s a great bridge between Alex’s love of whimsical, romantic, humane charm and Sam’s taste for stylish, energetic momentum. The compromise works through tone and visual style: it’s warm, playful, and carefully crafted, but it also moves with real comic caper energy. With its whimsical comedy, elegant pacing, and charming friendship at the center, it fits the group’s shared wish for something stylish, engaging, and under 125 minutes.",
+    "title": "The Grand Budapest Hotel"
+  },
+  "responseChecks": [
+    {
+      "details": "The provider response matches the production ranking response schema.",
+      "id": "response-shape",
+      "label": "Response shape",
+      "passed": true
+    },
+    {
+      "details": "Selected title \"The Grand Budapest Hotel\" belongs to the fixed candidate set.",
+      "id": "bounded-selection",
+      "label": "Bounded selection",
+      "passed": true
+    },
+    {
+      "details": "The selected title is not one of the pre-declared bridge candidates.",
+      "id": "bridge-selection",
+      "label": "Bridge selection",
+      "passed": false
+    },
+    {
+      "details": "The explanation names both participants.",
+      "id": "participant-names",
+      "label": "Participant names",
+      "passed": true
+    },
+    {
+      "details": "The explanation represents at least one Alex taste signal.",
+      "id": "alex-representation",
+      "label": "Alex taste representation",
+      "passed": true
+    },
+    {
+      "details": "The explanation represents at least one Sam taste signal.",
+      "id": "sam-representation",
+      "label": "Sam taste representation",
+      "passed": true
+    },
+    {
+      "details": "Explanation is at least 120 characters.",
+      "id": "specific-explanation",
+      "label": "Specific explanation",
+      "passed": true
+    }
+  ],
+  "reviewStatus": "blocked-by-automated-checks",
+  "status": "automated-checks-failed"
+}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "dev:docs": "npm run dev --workspace=apps/docs",
     "dev:shared": "npm run dev --workspace=packages/shared",
     "eval:recommendations": "npm run eval:recommendations --workspace=apps/web",
-    "eval:recommendations:duo": "npm run eval:recommendations:duo --workspace=apps/web",
+    "eval:recommendations:duo": "npm run eval:recommendations:duo --workspace=apps/web --",
     "eval:recommendations:real-data": "npm run eval:recommendations --workspace=apps/web -- --real-data",
     "fix": "npm run lint:fix && npm run format:write",
     "format:check": "oxfmt --check",


### PR DESCRIPTION
## What changed

- store the sanitized one-call controlled Duo report as durable portfolio evidence
- update the protocol and portfolio handoff with the 6/7 automated result and rejected owner verdict
- add a `Development verified` evidence status for controlled local runs
- fix the root `eval:recommendations:duo` script so `--live` and `--help` reach the workspace command

## Why

The first approved live evaluation selected the deliberately weaker comparison candidate. The result is useful negative evidence, but it was previously available only as an ignored local test artifact. The documented root command also swallowed `--live` as npm configuration and made zero provider calls.

## Impact

The portfolio evidence pack can now link to the exact sanitized report without presenting the run as production behavior or recommendation-quality success. Future provider runs remain manual and should wait until bridge fit becomes an explicit ranking-policy constraint.

## Checks

- `npm run eval:recommendations:duo` — protocol ready, 0 provider calls
- `npm run eval:recommendations:duo -- --help` — flag reaches workspace script
- controlled Duo unit tests — 5 passed
- docs production build — 41 pages generated
- full pre-push gate — lint, 86 server test files / 1172 tests, production build
- Fallow audit — no changed-file issues
- format check — clean