### PR TITLE
Refresh roadmap milestones and active issue frontier

### DIFF
--- a/docs/MAINTAINABILITY-CHECKLIST.md
+++ b/docs/MAINTAINABILITY-CHECKLIST.md
@@ -86,6 +86,8 @@ Use this checklist for lightweight, periodic maintainability reviews of PopChoic
 
 - [x] Refactor the quiz submit/results handoff so navigation state is explicit.
 - [ ] Keep API route handlers thin and move growing account/movie-memory logic into `src/features` when needed.
-- [ ] Use positive `liked` memory as a ranking signal, not only stored history.
-- [ ] Add catalog-health reporting for missing posters, localized metadata, duplicate identities, and stale TMDB data.
+- [x] Use positive `liked` memory as a ranking signal, not only stored history.
+- [x] Add catalog-health reporting for missing posters, localized metadata, duplicate identities, and stale TMDB data.
 - [ ] Standardize conventions shared by `apps/web`, `packages/shared`, and root `services/*` packages.
+- [ ] Complete the Recommendation V2 quality gate in [#606](https://github.com/shchilkin/PopChoice/issues/606) before landing the remaining Normal Match compromise work in [#608](https://github.com/shchilkin/PopChoice/issues/608).
+- [ ] Keep new implementation work inside the focused [active roadmap milestones](./ROADMAP-ARCHITECTURE.md#active-roadmap-milestones) instead of adding untracked bullets to broad legacy milestones.

--- a/docs/PRODUCT-BEHAVIOR.md
+++ b/docs/PRODUCT-BEHAVIOR.md
@@ -180,10 +180,12 @@ has distinct empty states for an empty catalog versus active filters with no
 matches.
 
 Current #82 scope is partially complete because title, actor/director, genre,
-runtime, score, age-rating, and year filtering are present. Remaining #82 work
-should be treated as planned until split into smaller issues, for example richer
-autocomplete, search history, more explicit multi-genre UX, keyword search,
-sorting, or a broader TMDB-backed discovery surface.
+runtime, score, age-rating, and year filtering are present. Remaining work is
+split into [#921](https://github.com/shchilkin/PopChoice/issues/921) for live
+title suggestions/reset behavior and
+[#922](https://github.com/shchilkin/PopChoice/issues/922) for multi-genre,
+keyword, and sorting controls. Those capabilities remain planned until their
+focused issues are complete.
 
 ## Current Group Mode
 
@@ -232,8 +234,25 @@ work should move the current structured-text bridge into a first-class backend
 contract so avoids, constraints, discovery appetite, and feedback no longer
 need to travel through legacy request fields.
 
+The active recommendation sequence is tracked through:
+
+- [v0.3.0 Recommendation V2 Foundation](https://github.com/shchilkin/PopChoice/milestone/6):
+  complete the cross-mode quality gate in
+  [#606](https://github.com/shchilkin/PopChoice/issues/606), then finish
+  participant-specific Normal Match compromise behavior in
+  [#608](https://github.com/shchilkin/PopChoice/issues/608); Curated Picks
+  [#613](https://github.com/shchilkin/PopChoice/issues/613) can proceed in
+  parallel.
+- [v0.4.0 Taste Swipe MVP](https://github.com/shchilkin/PopChoice/milestone/7):
+  ship the anonymous swipe-to-result slice in
+  [#920](https://github.com/shchilkin/PopChoice/issues/920), then persist
+  signed-in reactions into movie memory in
+  [#923](https://github.com/shchilkin/PopChoice/issues/923).
+
 Group rooms are a larger milestone under
-[#359](https://github.com/shchilkin/PopChoice/issues/359), split into:
+[#359](https://github.com/shchilkin/PopChoice/issues/359) and the
+[Group Rooms milestone](https://github.com/shchilkin/PopChoice/milestone/8),
+split into:
 
 - [#467](https://github.com/shchilkin/PopChoice/issues/467): room persistence,
   TTL, cleanup, and participant storage.

--- a/docs/RECOMMENDATION-ROADMAP.md
+++ b/docs/RECOMMENDATION-ROADMAP.md
@@ -22,6 +22,21 @@ This should be done in stages. A full rewrite is not the goal.
 - If the work is too large for one PR, keep the original issue as an epic/umbrella and split focused implementation issues underneath it.
 - Prefer linked roadmap entries so completed work can be checked off without losing context.
 
+## Active Milestones
+
+The roadmap was refreshed on 2026-07-17. GitHub issues are the execution source
+of truth; this document explains the product sequence and keeps completed work
+separate from the active frontier.
+
+| Milestone                                                                                   | Purpose                                                                                                                           |
+| ------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| [v0.3.0 Recommendation V2 Foundation](https://github.com/shchilkin/PopChoice/milestone/6)   | Complete the scenario quality gate, participant-specific Normal Match compromise behavior, and visitor-facing Curated Picks mode. |
+| [v0.4.0 Taste Swipe MVP](https://github.com/shchilkin/PopChoice/milestone/7)                | Ship an anonymous TMDB-backed swipe-to-result path, then persist signed-in reactions into movie memory.                           |
+| [Group Rooms](https://github.com/shchilkin/PopChoice/milestone/8)                           | Add multi-device room persistence, join/readiness, one recommendation run, and finally QR/projector presentation.                 |
+| [Catalog & Recommendation Intelligence](https://github.com/shchilkin/PopChoice/milestone/9) | Improve Available Movies discovery, provider availability UI, and evidence-based embedding evolution.                             |
+| [Backoffice Hardening](https://github.com/shchilkin/PopChoice/milestone/10)                 | Make operator workflows more testable, resilient, consistent, observable, and safe.                                               |
+| [Platform Operations](https://github.com/shchilkin/PopChoice/milestone/11)                  | Extract shared observability, formalize release gates, and attribute paid-provider usage.                                         |
+
 ## Current Quiz Flow
 
 The current quiz first asks for match depth (`Fast Pick` or `Normal Match`), then
@@ -49,8 +64,13 @@ signals still bridge through the legacy request shape rather than a canonical
 - The favorite movie prompt is optional and lower-friction, but supplied titles
   can still over-anchor a result if they outweigh tonight-specific signals.
 - Mood options are partly genre labels, which makes them too broad for accurate ranking.
-- The quiz does not capture enough negative intent, such as "not slow", "not horror", "not long", "not subtitles", or "not something obvious".
-- The app has started using signed-in movie memory for exclusions, down-ranking, and exact liked-candidate boosts, but watched/liked/not-interested signals are still not unified behind a first-class recommendation signal model.
+- The quiz captures explicit negative intent, but the public request contract still
+  bridges several signals through legacy fields instead of accepting canonical
+  taste signals directly.
+- The app uses signed-in movie memory for exclusions, down-ranking, and exact
+  liked-candidate boosts, and has an internal `TasteSignal` adapter. Quiz,
+  account, result-feedback, and future swipe inputs are not yet one complete
+  end-to-end request contract.
 - Group mode currently collects individual preferences, but the recommendation model should eventually optimize for overlap and compromise explicitly.
 - The embedded/local movie catalog is too small to produce consistently satisfying real-world results.
 
@@ -170,7 +190,10 @@ Duo/group Fast Pick reuses the same short question set per participant after aud
 
 ### 2. Taste Swipe
 
-Tinder-style mode for movie-heavy users who do not want questions.
+Tinder-style mode for movie-heavy users who do not want questions. The first
+anonymous vertical slice is tracked by
+[#920](https://github.com/shchilkin/PopChoice/issues/920); durable signed-in
+reactions follow in [#923](https://github.com/shchilkin/PopChoice/issues/923).
 
 Show a stream of movie cards and collect simple reactions:
 
@@ -209,7 +232,10 @@ The model should optimize for overlap and acceptable compromise, not only averag
 
 ### 5. Group Rooms
 
-Room-backed group mode should become the larger milestone behind [#359](https://github.com/shchilkin/PopChoice/issues/359), separate from the current same-device group flow.
+Room-backed group mode is tracked by the
+[Group Rooms milestone](https://github.com/shchilkin/PopChoice/milestone/8)
+behind [#359](https://github.com/shchilkin/PopChoice/issues/359), separate from
+the current same-device group flow.
 
 Implementation should be sequenced as:
 
@@ -236,14 +262,20 @@ This keeps the high-risk data and orchestration work ahead of visual polish. The
 - Make favorite/reference movie optional.
 - Keep the API compatible by translating new answers into current recommendation input.
 - Improve group-mode copy so users understand whether PopChoice is balancing or optimizing for one person.
+- Complete participant-specific compromise scoring and explanation behavior in
+  [#608](https://github.com/shchilkin/PopChoice/issues/608), gated by the
+  scenario matrix in [#606](https://github.com/shchilkin/PopChoice/issues/606).
 
 ### Stage 3: Taste Swipe MVP
 
-- Add an entry choice: "Answer a few questions" or "Swipe movies".
-- Build a swipe screen backed by TMDB and local cached metadata.
-- Store signed-in reactions in movie memory.
-- For anonymous users, keep session-local reactions long enough to produce one recommendation.
-- Translate swipe reactions into current recommendation inputs before introducing a deeper backend rewrite.
+- [#920](https://github.com/shchilkin/PopChoice/issues/920): add an alternate
+  Taste Swipe entry, a bounded TMDB-backed card deck, anonymous session-local
+  reactions, and one persisted recommendation result.
+- [#923](https://github.com/shchilkin/PopChoice/issues/923): persist signed-in
+  reactions idempotently into movie memory and verify their effect on later
+  recommendations.
+- Keep the anonymous slice account-optional and preserve Fast Pick and Normal
+  Match while swipe mode proves its value.
 
 ### Stage 4: Signal-based recommendation backend
 
@@ -306,37 +338,33 @@ Implementation should be split in this order:
 - Use feedback to learn the user's taste profile over time.
 - Consider gamified taste history, achievements, and "taste map" views only after the core memory model is reliable.
 
-## Near-Term PR Candidates
+## Active Work Frontier
 
-Good next PRs, in order:
+The following issues have no unfinished blockers and can start independently:
 
-1. [x] [#484](https://github.com/shchilkin/PopChoice/issues/484): refactor the quiz submit/results handoff so navigation state is explicit and the quiz page does not need short-lived reset guards.
-2. [x] [#492](https://github.com/shchilkin/PopChoice/issues/492): move TMDB discovery/backfill/enrichment into a shared rate-limited BullMQ catalog worker before scaling catalog volume.
-3. [x] [#618](https://github.com/shchilkin/PopChoice/issues/618): classify/refactor current seeded real-data checks before adding backoffice eval execution.
-4. [x] [#616](https://github.com/shchilkin/PopChoice/issues/616): persist eval run/result history for backoffice and worker reports.
-5. [x] [#617](https://github.com/shchilkin/PopChoice/issues/617): add non-live environment retrieval/source-strategy eval jobs.
-6. [x] [#619](https://github.com/shchilkin/PopChoice/issues/619): expose recommendation eval runs in backoffice.
-7. Replace the current quiz copy and options with a more "tonight" oriented flow while preserving existing API shape.
-8. Add a small taste-swipe prototype behind a feature flag or alternate quiz entry path.
-9. Add TMDB-backed candidate-card sourcing for swipe mode.
-10. Continue the `TasteSignal` domain model by adding swipe reaction adapters after the v1 quiz plus feedback/movie-memory slice.
-11. [x] [#620](https://github.com/shchilkin/PopChoice/issues/620): add guarded live-provider evals after safe backoffice evals exist.
-12. [x] Start [#612](https://github.com/shchilkin/PopChoice/issues/612) with first-class candidate source provenance, source-strategy policy, route/job/pipeline metadata, and eval assertions for curated showcase, hybrid fast, and TMDB-first behavior.
-13. [x] Connect [#612](https://github.com/shchilkin/PopChoice/issues/612) source strategy to initial retrieval behavior: `hybrid-fast` and `compromise-hybrid` use bounded TMDB fallback, while curated/local-only strategies block external lookup.
-14. [x] Add `experienceMode` request/job/pipeline metadata so `fast-pick` can select `hybrid-fast` while current requests default to `normal-match`.
-15. [x] Add a first Fast Pick quiz intro entry that sends the `fast-pick` wrapper into the existing recommendation API.
-16. [x] Add the first short solo Fast Pick guided flow for intent, hard avoids, and discovery appetite under [#609](https://github.com/shchilkin/PopChoice/issues/609).
-17. [x] Extend Fast Pick to Duo/Group by adding an audience layer before the short question flow.
-18. [x] Start [#608](https://github.com/shchilkin/PopChoice/issues/608) by adding an optional Normal-mode hard-avoids step and carrying those negative signals into the current recommendation payload.
-19. [x] Make Duo first-class in the guided UI: separate Normal/Fast audience entry, two-person setup copy, Duo result copy, and deterministic e2e coverage.
-20. [x] Connect the first `tmdb-first` retrieval slice: Normal solo now attempts TMDB discover as a primary candidate-discovery path, then score-ranks TMDB and strong local matches together.
-21. [x] Deepen the first `tmdb-first` query-shaping slice: Normal/Fast hard avoids and discovery appetite now shape TMDB discover params, and eval fixtures include source/metadata quality thresholds.
-22. [x] Deepen `tmdb-first` JIT enrichment before making it the Normal quality default: fetch richer TMDB details for strong direct candidates, persist/cache useful runtime/rating/provider metadata, and calibrate backoffice real-data thresholds.
-23. [#655](https://github.com/shchilkin/PopChoice/issues/655): add provider-aware result UI and user-facing availability copy once product behavior decides whether availability is informational, a soft preference, or a hard constraint.
-24. [#656](https://github.com/shchilkin/PopChoice/issues/656): evaluate a movie embedding text v2 contract before adding metadata such as genres, keywords, cast, director, language, popularity, or certification to retrieval embeddings.
-25. [x] [#680](https://github.com/shchilkin/PopChoice/issues/680): calibrate recommendation match percentages and user-facing score copy before treating raw percentages as precise quality claims.
-26. [x] [#681](https://github.com/shchilkin/PopChoice/issues/681): rework the quiz entry flow so users choose match depth first, then Solo/Duo/Group audience, then answer the matching short or normal question set.
-27. Add manual-review logging for ambiguous TMDB/local identity matches.
+1. [#606](https://github.com/shchilkin/PopChoice/issues/606): complete the
+   Recommendation V2 audience/depth/source scenario quality gate.
+2. [#613](https://github.com/shchilkin/PopChoice/issues/613): expose Curated
+   Picks as an intentional visitor-facing product mode.
+3. [#920](https://github.com/shchilkin/PopChoice/issues/920): ship the anonymous
+   TMDB-backed Taste Swipe recommendation slice.
+4. [#921](https://github.com/shchilkin/PopChoice/issues/921): add Available
+   Movies live title suggestions and a complete reset flow.
+5. [#922](https://github.com/shchilkin/PopChoice/issues/922): add multi-genre,
+   keyword, and sorting controls to Available Movies.
+6. [#655](https://github.com/shchilkin/PopChoice/issues/655): add
+   provider-aware availability UI after confirming its informational product
+   role.
+7. [#656](https://github.com/shchilkin/PopChoice/issues/656): evaluate movie
+   embedding text v2 before changing the production embedding format.
+
+Blocked follow-ups:
+
+- [#608](https://github.com/shchilkin/PopChoice/issues/608) follows #606 and
+  completes participant-specific Normal Match compromise behavior.
+- [#923](https://github.com/shchilkin/PopChoice/issues/923) follows #920 and
+  persists signed-in swipe reactions into movie memory.
+- Group Rooms remains the explicit #467 -> #468 -> #469 -> #470 sequence.
 
 ## Non-Goals For Now
 

--- a/docs/ROADMAP-ARCHITECTURE.md
+++ b/docs/ROADMAP-ARCHITECTURE.md
@@ -76,7 +76,11 @@ The main remaining risks are:
 
 ### Issues Still Present
 
-- The current quiz is still a first-generation guided flow. It should evolve toward a signal-based recommendation model with explicit Solo/Duo/Group audience modes, Fast/Normal effort modes, a shorter "tonight" quiz, a swipe-based mode for movie-heavy users, and a TMDB-first catalog strategy. See [RECOMMENDATION-ROADMAP.md](/docs/RECOMMENDATION-ROADMAP).
+- The guided flow now has explicit Solo/Duo/Group audiences, Fast/Normal depth,
+  TMDB-first source policy, and an internal taste-signal adapter. It still needs
+  participant-specific compromise behavior, the full Recommendation V2 quality
+  matrix, and a visitor-facing swipe mode. See
+  [RECOMMENDATION-ROADMAP.md](/docs/RECOMMENDATION-ROADMAP).
 - Route-local compatibility re-export files still exist under `src/app/api/movie-recommendation`; future recommendation changes should continue moving real logic into `src/features/recommendation`.
 - Account settings/profile/provider identity remain intentionally thin.
 
@@ -88,6 +92,23 @@ Reference: use [BOUNDARIES.md](/docs/BOUNDARIES) as the current ownership baseli
 - If a roadmap item is too large for one PR, keep the original issue as an epic/umbrella and create focused child issues for implementation-sized work.
 - Link roadmap items to concrete issues whenever possible so completed work can be checked off and future agents do not have to rediscover context.
 - Keep unlinked bullets for direction-setting only; convert them into issues once they become actionable.
+
+### Active Roadmap Milestones
+
+The roadmap was refreshed on 2026-07-17. Focused GitHub milestones now separate
+product releases from longer-running operator and platform tracks:
+
+- [v0.3.0 Recommendation V2 Foundation](https://github.com/shchilkin/PopChoice/milestone/6)
+- [v0.4.0 Taste Swipe MVP](https://github.com/shchilkin/PopChoice/milestone/7)
+- [Group Rooms](https://github.com/shchilkin/PopChoice/milestone/8)
+- [Catalog & Recommendation Intelligence](https://github.com/shchilkin/PopChoice/milestone/9)
+- [Backoffice Hardening](https://github.com/shchilkin/PopChoice/milestone/10)
+- [Platform Operations](https://github.com/shchilkin/PopChoice/milestone/11)
+
+The old `Security` milestone is closed because all tracked issues are complete.
+The old `App improvements` milestone is retained as `Legacy App Improvements`
+for historical umbrella issues; new implementation work belongs in focused
+milestones and dependency-declared child issues.
 
 ## Target Direction
 
@@ -306,7 +327,7 @@ work implementation-sized:
 - [x] Cover the current recommendation entry matrix in browser smoke tests: Normal Solo, Normal Duo, Normal Group, Fast Pick Solo, Fast Pick Duo, and Fast Pick Group.
 - [x] [#476](https://github.com/shchilkin/PopChoice/issues/476): add an AI recommendation eval harness with deterministic fixtures by default and optional live model/provider runs.
 - [x] [#490](https://github.com/shchilkin/PopChoice/issues/490): add a scheduled or manually triggered real-data recommendation eval workflow with seeded database data and real catalog retrieval.
-- Add [#606](https://github.com/shchilkin/PopChoice/issues/606) deterministic recommendation scenarios that validate audience behavior, match-depth behavior, source-strategy behavior, and meaningful-pick quality, not only response shape.
+- Add [#606](https://github.com/shchilkin/PopChoice/issues/606) deterministic recommendation scenarios that validate audience behavior, match-depth behavior, source-strategy behavior, and meaningful-pick quality, not only response shape. This is the unblocked quality gate for the remaining Normal Match compromise work in #608.
 - [x] [#618](https://github.com/shchilkin/PopChoice/issues/618): classify and refactor the current seeded `--real-data` checks so they are clearly catalog retrieval/candidate-availability evals and can be reused by worker jobs.
 - [x] [#616](https://github.com/shchilkin/PopChoice/issues/616): persist recommendation eval run/result history for backoffice and worker reports.
 - [x] [#617](https://github.com/shchilkin/PopChoice/issues/617): add bounded non-live BullMQ jobs for environment retrieval and source-strategy evals against the configured database.
@@ -351,47 +372,41 @@ work implementation-sized:
 ### Recommendation Experience Track
 
 - Define Recommendation V2 in [#610](https://github.com/shchilkin/PopChoice/issues/610) around three independent axes: audience context, match depth, and candidate source strategy.
-- Treat quiz answers, swipe reactions, account memory, and result feedback as inputs into a shared taste-signal model.
-- Rework the guided quiz around "what do you want tonight?" instead of relying on a favorite movie, broad genre labels, and optional actor input.
-- Build [#609](https://github.com/shchilkin/PopChoice/issues/609) as the Fast Pick guided flow with minimal intent, hard avoids, and discovery appetite. The current flow separates audience selection from match depth, supports Solo/Duo/Group, and sends `experienceMode: fast-pick`.
-- Build [#608](https://github.com/shchilkin/PopChoice/issues/608) as the Normal mode flow with richer positive/negative signals, optional reference movies, and first-class Duo compromise handling. The first slices add Normal-mode hard avoids, carry those negative signals through the existing recommendation payload, and expose Duo as a separate two-person entry/results path.
-- Add an alternate taste-swipe mode for users who have watched many films and prefer to react to concrete movie cards instead of answering abstract questions.
-- Start [#612](https://github.com/shchilkin/PopChoice/issues/612) by carrying candidate source provenance through recommendation results, persistence, logs, eval reports, a source-strategy policy, and route/job/pipeline metadata before changing retrieval defaults.
-- Connect [#612](https://github.com/shchilkin/PopChoice/issues/612) to retrieval behavior in stages: bounded `hybrid-fast`/`compromise-hybrid` fallback first, then `tmdb-first` generation with hard-avoid/discovery-aware TMDB query shaping and source/metadata eval thresholds before making it the Normal quality default.
-- Add `experienceMode` as the product-facing selector for this policy layer, defaulting existing traffic to `normal-match` while letting Fast Pick requests choose `fast-pick`.
-- Move toward TMDB-first candidate generation: use TMDB for broad discovery and keep the local database as a cache/enrichment/reranking layer rather than the whole movie universe.
+- [x] Build [#609](https://github.com/shchilkin/PopChoice/issues/609) as the Fast Pick guided flow with minimal intent, hard avoids, discovery appetite, and explicit Solo/Duo/Group audience selection.
+- [x] Complete [#612](https://github.com/shchilkin/PopChoice/issues/612) with source provenance, persisted source policy, and initial curated, hybrid, compromise, and TMDB-first retrieval behavior.
+- Complete the cross-mode scenario quality gate in [#606](https://github.com/shchilkin/PopChoice/issues/606), then finish participant-specific overlap, tradeoff, and dealbreaker behavior in [#608](https://github.com/shchilkin/PopChoice/issues/608).
+- Expose the already-supported curated-only policy as an intentional visitor-facing Curated Picks mode in [#613](https://github.com/shchilkin/PopChoice/issues/613).
+- Ship the anonymous Taste Swipe path in [#920](https://github.com/shchilkin/PopChoice/issues/920), then persist signed-in reactions through movie memory in [#923](https://github.com/shchilkin/PopChoice/issues/923).
+- Continue treating quiz answers, swipe reactions, account memory, and result feedback as inputs into one shared taste-signal model without requiring a broad rewrite.
 - Keep TMDB ids as the preferred movie identity and log ambiguous title/year matches for later admin/back-office review.
 - See [RECOMMENDATION-ROADMAP.md](/docs/RECOMMENDATION-ROADMAP) for the staged plan.
 
 ### Group Recommendation Rooms Track
 
-- Keep [#359](https://github.com/shchilkin/PopChoice/issues/359) as the umbrella for the group-room milestone instead of treating it as a single implementation PR.
+- Keep [#359](https://github.com/shchilkin/PopChoice/issues/359) as the umbrella for the [Group Rooms milestone](https://github.com/shchilkin/PopChoice/milestone/8) instead of treating it as a single implementation PR.
 - [#467](https://github.com/shchilkin/PopChoice/issues/467): build room persistence, TTL, cleanup, and participant storage first.
 - [#468](https://github.com/shchilkin/PopChoice/issues/468): add share links, participant join flow, and readiness state.
 - [#469](https://github.com/shchilkin/PopChoice/issues/469): run the recommendation pipeline from completed room answers and persist a stable shared result.
 - [#470](https://github.com/shchilkin/PopChoice/issues/470): add QR invite and projector mode only after the core room flow works.
 - Preserve the current same-device group mode until room-backed group mode is complete enough to replace it intentionally.
 
-## Priority Items for the Next 30 Days
+## Current Priority Frontier
 
-1. [x] Complete [#81](https://github.com/shchilkin/PopChoice/issues/81) with available-movies runtime, score, and age-rating filters on the existing catalog fields.
-2. [x] Refactor the quiz submit/results handoff in [#484](https://github.com/shchilkin/PopChoice/issues/484) so navigation state is explicit and the quiz page does not need short-lived reset guards.
-3. [x] Start [#474](https://github.com/shchilkin/PopChoice/issues/474) so full e2e work has a real isolated DB foundation before adding many browser scenarios.
-4. [x] Add [#475](https://github.com/shchilkin/PopChoice/issues/475) auth, catalog, quiz, and recommendation smoke flows on top of the isolated e2e harness.
-5. [x] Add [#476](https://github.com/shchilkin/PopChoice/issues/476) deterministic recommendation eval fixtures and scoring.
-6. [x] Add [#490](https://github.com/shchilkin/PopChoice/issues/490) scheduled/manual real-data recommendation evals for seeded DB and catalog-retrieval changes.
-7. [x] Decide the catalog metadata model in [#471](https://github.com/shchilkin/PopChoice/issues/471) before expanding #82 into actor/director/genre search.
-8. [x] Populate the catalog metadata model in [#472](https://github.com/shchilkin/PopChoice/issues/472) from TMDB backfill/discovery before expanding #82 into actor/director/genre search.
-9. [x] Expand available-movies search in [#473](https://github.com/shchilkin/PopChoice/issues/473) across title, actor/director, and genre metadata populated by #472.
-10. [x] Move TMDB discovery/backfill/metadata refresh into shared rate-limited BullMQ catalog workers in [#492](https://github.com/shchilkin/PopChoice/issues/492) before increasing catalog expansion volume.
-11. [x] Plan and split the [#493](https://github.com/shchilkin/PopChoice/issues/493) backoffice/catalog-health epic, including shared login protection for it and `apps/bull-board`.
-12. [x] Clarify production migration/versioning expectations in [#494](https://github.com/shchilkin/PopChoice/issues/494) for schema changes, rollbacks, and preview volume recreation.
-13. [x] Complete the first self-hosted observability track in [#498](https://github.com/shchilkin/PopChoice/issues/498) with uptime, logs, metrics, traces, alerts, retention, backups, and runbooks.
-14. [x] Deploy the self-hosted observability stack to production in [#508](https://github.com/shchilkin/PopChoice/issues/508) and verify metrics, logs, traces, alerts, access control, and backups on the VPS.
-15. [x] Improve Grafana Telegram alert formatting in [#525](https://github.com/shchilkin/PopChoice/issues/525) after the first production alert examples.
-16. [x] Reclassify deploy-sensitive app metrics target alerts in [#526](https://github.com/shchilkin/PopChoice/issues/526) so P1 remains reserved for user-facing or core dependency outages.
-17. [x] Plan deploy-aware alert silences and post-deploy verification in [#527](https://github.com/shchilkin/PopChoice/issues/527).
-18. [x] Define the `local -> development -> production` deployment model in [#556](https://github.com/shchilkin/PopChoice/issues/556), including domain layout, GHCR image-tag policy, preview cleanup, certificate-rate-limit notes, and production promotion/rollback expectations.
+The previous 30-day list is complete and remains visible in issue/release
+history. The current unblocked frontier is:
+
+1. [#606](https://github.com/shchilkin/PopChoice/issues/606): Recommendation V2 scenario quality gate.
+2. [#613](https://github.com/shchilkin/PopChoice/issues/613): visitor-facing Curated Picks mode.
+3. [#920](https://github.com/shchilkin/PopChoice/issues/920): anonymous Taste Swipe recommendation slice.
+4. [#921](https://github.com/shchilkin/PopChoice/issues/921): Available Movies live title suggestions and reset flow.
+5. [#922](https://github.com/shchilkin/PopChoice/issues/922): Available Movies multi-genre, keyword, and sorting controls.
+6. [#655](https://github.com/shchilkin/PopChoice/issues/655): provider-aware result availability UI.
+7. [#656](https://github.com/shchilkin/PopChoice/issues/656): evidence-based movie embedding text v2 evaluation.
+
+Dependency-gated follow-ups are #608 after #606, #923 after #920, and the
+Group Rooms chain #467 -> #468 -> #469 -> #470. Backoffice and platform work
+continue in their focused milestones rather than competing for product release
+version numbers.
 
 ## Working Checklist
 
@@ -409,7 +424,7 @@ work implementation-sized:
 - [x] Queueing, DB writes, and response mapping are separated cleanly from recommendation decision logic.
 - [x] Similarity thresholds and related calibration docs point to the same source of truth.
 - [x] Positive user memory (`liked`) influences ranking.
-- [ ] Quiz submit handoff no longer depends on route-local reset timing.
+- [x] Quiz submit handoff no longer depends on route-local reset timing.
 
 ### Documentation Alignment
 


### PR DESCRIPTION
## What changed

- adds the six focused roadmap milestones and their live GitHub links to the product and architecture docs
- replaces completed historical priority lists with the current unblocked frontier and explicit dependency-gated follow-ups
- links the new Taste Swipe issues #920 and #923 and the focused Available Movies issues #921 and #922
- updates shipped-versus-planned descriptions for TasteSignal, Normal Match, Group Rooms, catalog health, liked-memory ranking, and quiz handoff

## Why

The repository roadmap still mixed completed 2025/early-2026 work with current product direction, while GitHub milestones had collapsed into legacy Security and App improvements buckets. The refreshed docs now match the issue-backed execution plan created on 2026-07-17.

## Impact

Documentation only. No runtime, schema, UI, worker, or deployment behavior changes.

## Validation

- `npx --yes oxfmt@0.58.0 --check docs/MAINTAINABILITY-CHECKLIST.md docs/PRODUCT-BEHAVIOR.md docs/RECOMMENDATION-ROADMAP.md docs/ROADMAP-ARCHITECTURE.md`
- `git diff --check`
- direct GitHub API verification of milestone assignment and `ready-for-agent` labels for all 26 focused issues