### PR TITLE
Document Recommendation V2 TMDB-first domain and delivery plan

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,297 @@
+# PopChoice Recommendation
+
+The language of turning one or more participants' current intent and taste into a movie recommendation they can accept for this viewing occasion.
+
+## Language
+
+**Audience Context**:
+The participant configuration whose preferences and constraints a recommendation represents: Solo, Duo, or Group.
+_Avoid_: Audience size, people mode
+
+**Recommendation Experience**:
+The user-facing way participants provide intent and receive a recommendation: Fast Pick, Normal Match, Taste Swipe, or Curated Picks.
+_Avoid_: Match depth, experience mode axis
+
+**Taste Swipe MVP**:
+The Solo-only first release of Taste Swipe for anonymous and signed-in participants. Duo and Group swipe interactions remain a separate future product slice.
+_Avoid_: Group Swipe, all-audience swipe
+
+**Anonymous Swipe Session**:
+A resumable, non-profile Taste Swipe workspace retained for at most 24 hours so a visitor can reach first recommendation value without registration.
+_Avoid_: Anonymous profile, durable movie memory
+
+**Recommendation Intent Snapshot**:
+A minimized, versioned record of the TMDB IDs and normalized signal types used to create a recommendation. For anonymous Taste Swipe it replaces the working session without creating Movie Memory.
+_Avoid_: Raw interaction log, user profile
+
+**Recommendation Attempt**:
+One immutable execution of a normalized recommendation intent using a specific Audience Context, Recommendation Experience, effective Retrieval Plan, and Policy Version Bundle.
+_Avoid_: User session, recommendation row only
+
+**Canonical Recommendation Intent**:
+The versioned internal request contract containing Audience Context, Recommendation Experience, participant-owned Hard Constraints, Preferences, current intent, and memory references independently of the UI payload that produced it.
+_Avoid_: Quiz form data, API v2 body
+
+**Recommendation Engine Version**:
+The persisted identifier of the engine that executed a Recommendation Attempt, allowing V1 and V2 to share the same public recommendation lifecycle during migration.
+_Avoid_: Endpoint version, deployment version
+
+**Legacy Intent Adapter**:
+The temporary boundary that keeps pre-V2 quiz payloads on V1 during migration. It never infers Hard Constraints from free text and is removed with V1 after all UI flows adopt the Canonical Recommendation Intent.
+_Avoid_: Automatic V2 conversion, permanent compatibility layer
+
+**V2 Tracer Slice**:
+The first end-to-end Recommendation V2 implementation: Normal Match for Solo, covering normalized intent, typed constraints, multi-lane TMDB retrieval, deterministic shortlisting, bounded AI reranking, quality gate, trace, and V1 comparison.
+_Avoid_: Foundation-only refactor, all-mode migration
+
+**Policy Version Bundle**:
+The identifiers and configuration hashes for the Query Planner mappings, Retrieval Plan, ranking, diversity, Recommendation Quality Gate, active model IDs, and optional Collection Version used by a Recommendation Attempt.
+_Avoid_: Deployment version, copied source code
+
+**Bounded Candidate Trace**:
+The durable Recommendation Attempt evidence containing per-lane query and count summaries plus detailed eligibility and score breakdowns only for the Candidate Shortlist and displayed results.
+_Avoid_: Raw provider response archive, full candidate log
+
+**Debug Candidate Trace**:
+A sampled, short-TTL diagnostic record that may retain the full candidate progression for troubleshooting and policy calibration.
+_Avoid_: Standard recommendation history, permanent audit record
+
+**Memory Adoption**:
+An explicit, one-time, idempotent action after signup that converts eligible reactions from an Anonymous Swipe Session into signed-in Movie Memory Events.
+_Avoid_: Automatic account merge, anonymous profiling
+
+**Diagnostic Deck**:
+The opening Taste Swipe card set stratified across genre, era, popularity, and mainstream-to-niche familiarity to learn broad taste coverage rather than propose recommendation finalists.
+_Avoid_: Candidate shortlist, popular feed
+
+**Adaptive Deck**:
+The later Taste Swipe card stream shaped by accumulated reactions while retaining an exploration share outside the strongest inferred taste cluster.
+_Avoid_: Personalized recommendations, filter bubble
+
+**Exploration Card**:
+An Adaptive Deck card deliberately sampled outside the currently strongest taste cluster to test uncertain or uncovered preferences.
+_Avoid_: Random card, low-quality candidate
+
+**Retrieval Plan**:
+An internal policy derived from Audience Context and Recommendation Experience that controls query breadth, enrichment, ranking, and latency budget without changing the promised candidate universe.
+_Avoid_: Candidate source strategy, user-selected source
+
+**Bounded Retrieval**:
+A Retrieval Plan with an explicit limit on query breadth, enrichment work, ranking work, or elapsed time. It limits how much of the candidate universe is examined, not which universe is available.
+_Avoid_: Small catalog, local-only fast mode
+
+**Fast Pick Budget**:
+The Bounded Retrieval timing contract for Fast Pick: target a result within five seconds and stop Fast Pick work after eight seconds.
+_Avoid_: Best-effort fast, provider timeout
+
+**Deepen Search**:
+An explicit transition from Fast Pick to Normal Match that preserves the current answers, Hard Constraints, and Audience Context while allowing a larger Retrieval Plan.
+_Avoid_: Silent retry, automatic widening
+
+**Hard Constraint**:
+A structured, participant-confirmed requirement that every valid recommendation must satisfy. A candidate that violates any participant's hard constraint is invalid.
+_Avoid_: Hard avoid, dealbreaker, veto
+
+**Constraint Owner**:
+The participant who confirmed a Hard Constraint and is the only participant who may revise or remove it.
+_Avoid_: Room owner, host, constraint author
+
+**Maximum Runtime**:
+A Hard Constraint that sets the greatest acceptable movie duration in minutes for the current viewing occasion.
+_Avoid_: Long-runtime preference, duration wish
+
+**Excluded Genre**:
+A Hard Constraint naming a movie genre that an eligible candidate must not have.
+_Avoid_: Disliked genre, genre penalty
+
+**Eligible Candidate**:
+A movie known to satisfy every participant's Hard Constraints. Missing evidence for any Hard Constraint makes the movie ineligible.
+_Avoid_: Valid candidate, safe candidate
+
+**Candidate Shortlist**:
+The bounded set of Eligible Candidates selected by deterministic scoring from the TMDB Retrieval Set for optional AI reranking.
+_Avoid_: AI candidate list, final six
+
+**Recommendation Quality Gate**:
+A deterministic, eval-calibrated minimum-fit policy applied after eligibility. It prevents PopChoice from presenting the best available candidate when that candidate is still a weak match.
+_Avoid_: Hard Constraint, AI confidence
+
+**Recommendation V2 Release Gate**:
+The blocking evidence contract requiring perfect invariant checks, no deterministic baseline regression, required scenario coverage, and explicit live-provider plus manual product evidence before rollout.
+_Avoid_: CI green, subjective sign-off
+
+**Recommendation Comparison Harness**:
+A Backoffice and eval capability that runs the same versioned intent through V1 and V2 and presents candidate, quality, fairness, latency, and trace differences without relying on production traffic.
+_Avoid_: Shadow traffic, A/B test
+
+**Recommendation Kill Switch**:
+A temporary operator control that restores V1 as the default after V2 release when an invariant, latency, or provider regression is observed.
+_Avoid_: Permanent dual pipeline, percentage rollout
+
+**Confident Match**:
+An Eligible Candidate that passes the Recommendation Quality Gate for the current Audience Context and Recommendation Experience.
+_Avoid_: Valid candidate, model-approved pick
+
+**AI Reranking**:
+Reordering a Candidate Shortlist and explaining the selection while referring only to supplied TMDB IDs. It cannot add candidates, change eligibility, or override deterministic fallback order.
+_Avoid_: AI recommendation generation, title generation
+
+**Primary Pick**:
+The highest-ranked Eligible Candidate after deterministic scoring and valid AI Reranking.
+_Avoid_: Main AI title, winner
+
+**Alternative Pick**:
+An Eligible Candidate selected after the Primary Pick using diversity-aware ordering across genre, era, and discovery familiarity while retaining a minimum acceptable fit.
+_Avoid_: Next result, runner-up
+
+**Result Diversity**:
+The controlled variation among Alternative Picks that reduces near-duplicate choices without weakening Hard Constraints or the minimum fit requirement.
+_Avoid_: Randomness, genre quota
+
+**TMDB Candidate Universe**:
+The broad movie universe from which every non-curated recommendation mode discovers candidates.
+_Avoid_: TMDB fallback, external candidates
+
+**TMDB Retrieval Set**:
+The bounded set of TMDB movie IDs returned for the current Retrieval Plan. Non-curated ranking may only consider movies in this set; local search cannot inject additional candidates.
+_Avoid_: Local plus TMDB merge, final six
+
+**Retrieval Lane**:
+One bounded TMDB query path contributing movie IDs to a TMDB Retrieval Set, such as constraint-aware Discover, reference-movie Similar/Recommendations, or a genre/keyword query.
+_Avoid_: Fallback stage, candidate source
+
+**Query Planner**:
+The component that converts confirmed structured answers, a reference movie, and free-text intent into a bounded set of Retrieval Lanes. Deterministic inputs use maintained mappings; AI may only propose taste-oriented genres or keywords that resolve to real TMDB IDs.
+_Avoid_: Movie generator, prompt-only search
+
+**Query Proposal**:
+An AI-suggested taste-oriented genre or keyword awaiting successful resolution to a real TMDB identifier before it may create a Retrieval Lane. It cannot create a Hard Constraint.
+_Avoid_: AI filter, inferred veto
+
+**TMDB Query Cache**:
+A reusable result of a specific TMDB retrieval query. A fresh cached result may avoid a live TMDB call without changing the TMDB Candidate Universe.
+_Avoid_: Local catalog, database-first retrieval
+
+**Degraded Retrieval**:
+A provider-outage path that may reuse TMDB Query Cache entries no older than seven days, then revalidates every Hard Constraint from cached evidence. If it cannot produce enough Eligible Candidates, it reports technical unavailability rather than a no-match result.
+_Avoid_: Local fallback, best-effort match
+
+**Local Movie Cache**:
+The local set of known movies and recommendation metadata used for identity, enrichment, embeddings, memory-aware ranking, and reuse. It does not bound the TMDB Candidate Universe.
+_Avoid_: Local candidate universe, primary catalog
+
+**Cache Admission**:
+The bounded act of adding an enriched TMDB candidate to the Local Movie Cache after it reaches final ranking or is shown as a recommendation. Raw discovery results remain only in the TMDB Query Cache.
+_Avoid_: Catalog sync, discovery import
+
+**Curated Collection**:
+An intentionally bounded set of locally known movies that defines the candidate universe for Curated Picks.
+_Avoid_: Local cache, full catalog
+
+**Collection Version**:
+An immutable published revision of a Curated Collection with localized editorial copy and an ordered set of TMDB movie IDs. Editors change a collection by preparing and publishing a new version.
+_Avoid_: Mutable collection row, cache revision
+
+**Collection Metadata Snapshot**:
+The publish-time copy of identity, runtime, genres, title, year, poster metadata, and localized display data required to serve and constraint-check every movie in a Collection Version without live TMDB.
+_Avoid_: Local movie cache, live enrichment
+
+**Collection Lifecycle**:
+The Backoffice-controlled states Draft, Published, and Archived. Draft versions support preview; Published versions serve users; Archived versions remain reproducible for historical results but cannot start new attempts.
+_Avoid_: Enabled flag, cache status
+
+**Collection Mismatch**:
+The Curated Picks outcome in which Hard Constraints remove every movie in the selected Curated Collection. It offers another collection or an explicit switch to Normal Match without widening the collection itself.
+_Avoid_: TMDB fallback, global no-match
+
+**Memory Exclusion**:
+A durable movie-memory signal that removes a movie from the default candidate pool. Unlike a Hard Constraint, a Memory Exclusion may be overridden by an explicit current intent where the signal permits it.
+_Avoid_: Permanent ban, hard constraint
+
+**Watch Status**:
+The durable, independently updateable knowledge of whether a participant has seen a movie: Seen, Not Seen, or Unknown.
+_Avoid_: Movie-memory kind, taste reaction
+
+**Movie Memory Event**:
+An immutable signed-in record of a movie-memory change with its source, occurrence time, and available session or recommendation provenance.
+_Avoid_: Current memory row, audit log only
+
+**Movie Memory Snapshot**:
+The current per-user, per-movie projection of Watch Status and Taste Status used by product reads and recommendation filtering.
+_Avoid_: Interaction history, source event
+
+**Taste Status**:
+The durable, independently updateable relationship between a participant and a movie: Liked, Not Interested, or Unknown.
+_Avoid_: Watch status, current intent
+
+**Occasion Feedback**:
+Feedback whose meaning belongs to one recommendation occasion, such as Wrong Mood. It may inform future ranking with context but does not become a permanent Taste Status by itself.
+_Avoid_: Durable dislike, movie memory
+
+**Preference**:
+A participant desire used to compare otherwise valid candidates. Preferences may be traded against one another when finding a group compromise.
+_Avoid_: Soft constraint
+
+**Preference Refinement**:
+The single targeted follow-up question available after Normal Match finds Eligible Candidates but no Confident Match. It preserves prior answers and Hard Constraints, then permits one new retrieval and ranking attempt.
+_Avoid_: Quiz restart, constraint relaxation, retry loop
+
+**Informative Swipe Reaction**:
+A Taste Swipe reaction that contributes current recommendation evidence: Seen, Loved It, Not for Me, or Maybe Tonight. Skip controls deck progression but is not taste evidence.
+_Avoid_: Card viewed, swipe count
+
+**Seen Reaction**:
+An Informative Swipe Reaction that excludes the exact movie from the current attempt without expressing positive or negative taste.
+_Avoid_: Dislike, watched preference
+
+**Loved Reaction**:
+An Informative Swipe Reaction that supplies strong positive taste evidence and marks the exact movie as watched and therefore excluded from the current attempt.
+_Avoid_: Maybe tonight, recommendation candidate
+
+**Not for Me Reaction**:
+An Informative Swipe Reaction that supplies strong negative taste evidence and excludes the exact movie from the current attempt.
+_Avoid_: Skip, hard constraint
+
+**Maybe Tonight Reaction**:
+An Informative Swipe Reaction that supplies strong current positive evidence while keeping the exact movie eligible to become a recommendation.
+_Avoid_: Durable like, watched
+
+**Direct Intent Candidate**:
+A movie explicitly kept in the TMDB Retrieval Set by a Maybe Tonight Reaction. It still passes ordinary eligibility, quality, and ranking and is not guaranteed to become a result.
+_Avoid_: Pinned result, guaranteed recommendation
+
+**Skip Reaction**:
+A deck-control action that advances Taste Swipe without creating taste or movie-memory evidence.
+_Avoid_: Neutral preference, weak dislike
+
+**Swipe Readiness**:
+The adaptive Taste Swipe state reached after at least eight Informative Swipe Reactions. PopChoice may suggest recommending once evidence is sufficient and treats twelve informative reactions as ready for retrieval.
+_Avoid_: Fixed card count, deck completion
+
+**Participant Score**:
+A deterministic estimate of how well an Eligible Candidate satisfies one participant's Preferences for the current viewing occasion.
+_Avoid_: Vote, personal constraint score
+
+**Compromise Score**:
+The Duo or Group ordering that first maximizes the lowest Participant Score and then uses the group's average Participant Score as a tie-breaker. Every participant has equal weight.
+_Avoid_: Average score, host score, majority score
+
+**Group Fit Explanation**:
+An owner-anonymous, non-numeric explanation of why a recommendation balances the group's Preferences. Participant Scores and preference attribution remain internal.
+_Avoid_: Participant breakdown, compromise leaderboard
+
+**Proposed Constraint**:
+A structured Hard Constraint inferred from free text but not yet confirmed by the participant. Until confirmed, it has only Preference semantics.
+_Avoid_: Parsed constraint, automatic constraint
+
+**Shared Constraint Summary**:
+An owner-anonymous explanation of the constraint categories preventing an eligible group recommendation.
+_Avoid_: Blocking participant, constraint blame
+
+**Constraint Review**:
+A private interaction in which a Constraint Owner inspects, revises, or retains their own Hard Constraints after no eligible recommendation is found.
+_Avoid_: Host override, group edit
+
+**Rewatch Intent**:
+An explicit current-viewing intent that makes previously watched movies eligible for this recommendation.
+_Avoid_: Watched override, repeat mode

--- a/docs/RECOMMENDATION-V2-PLAN.md
+++ b/docs/RECOMMENDATION-V2-PLAN.md
@@ -1,0 +1,44 @@
+# Recommendation V2 delivery plan
+
+Recommendation V2 replaces DB-first candidate generation with a TMDB-first policy engine. The accepted domain language lives in [CONTEXT.md](../CONTEXT.md), and the decisions behind it live in [docs/adr](./adr).
+
+## Product contract
+
+- Audience Context is Solo, Duo, or Group.
+- Recommendation Experience is Fast Pick, Normal Match, Taste Swipe, or Curated Picks.
+- Every non-curated experience discovers candidates from TMDB. The Local Movie Cache enriches and reranks matching TMDB IDs but does not define or inject the candidate set.
+- Hard Constraints are structured, participant-confirmed vetoes. Missing required evidence makes a candidate ineligible.
+- Deterministic eligibility, shortlisting, group fairness, diversity, and quality gates run before bounded AI reranking.
+- Curated Picks is the explicit editorial exception and stays inside an immutable published Collection Version.
+- Movie memory stores independent watch and taste dimensions as immutable events plus a current snapshot.
+
+The tracker source of truth is [epic #610](https://github.com/shchilkin/PopChoice/issues/610).
+
+## v0.3.0 Recommendation V2 Foundation
+
+Work in blocker order:
+
+1. [#925](https://github.com/shchilkin/PopChoice/issues/925) upgrades the active OpenAI model roles independently of the retrieval redesign.
+2. [#606](https://github.com/shchilkin/PopChoice/issues/606) freezes the V1 baseline and executable V2 quality contract.
+3. [#927](https://github.com/shchilkin/PopChoice/issues/927) introduces canonical intent and versioned engine routing.
+4. [#929](https://github.com/shchilkin/PopChoice/issues/929) ships the Normal Match Solo TMDB-first tracer.
+5. [#931](https://github.com/shchilkin/PopChoice/issues/931) adds controlled V1/V2 comparison and release evidence.
+6. [#932](https://github.com/shchilkin/PopChoice/issues/932) migrates Fast Pick to bounded retrieval and Deepen Search.
+7. [#608](https://github.com/shchilkin/PopChoice/issues/608) adds Duo/Group maximin compromise and private constraint recovery.
+8. [#934](https://github.com/shchilkin/PopChoice/issues/934) retires V1 and the legacy intent adapter after the rollback window.
+
+Curated Picks can progress in parallel: [#926](https://github.com/shchilkin/PopChoice/issues/926) publishes immutable collection versions, then [#613](https://github.com/shchilkin/PopChoice/issues/613) exposes the visitor experience after the V2 release evidence in #931.
+
+## v0.4.0 Taste Swipe MVP
+
+Two workstreams converge:
+
+1. [#928](https://github.com/shchilkin/PopChoice/issues/928) expands movie memory into events and snapshots.
+2. [#930](https://github.com/shchilkin/PopChoice/issues/930) migrates product reads and corrections to snapshots.
+3. [#920](https://github.com/shchilkin/PopChoice/issues/920) ships anonymous Solo Taste Swipe on the released V2 core.
+4. [#923](https://github.com/shchilkin/PopChoice/issues/923) adds signed-in persistence and explicit anonymous Memory Adoption after #920 and #930.
+5. [#933](https://github.com/shchilkin/PopChoice/issues/933) removes the legacy single-kind memory contract.
+
+## Release evidence
+
+PopChoice does not currently have enough traffic for meaningful percentage rollout or A/B statistics. Release evidence therefore comes from deterministic scenarios, saved provider runs, Backoffice V1/V2 comparison, and manual dogfooding. V1 remains temporarily available through a kill switch and is removed only after the recorded rollback window closes.

--- a/docs/adr/0001-treat-hard-constraints-as-candidate-vetoes.md
+++ b/docs/adr/0001-treat-hard-constraints-as-candidate-vetoes.md
@@ -1,0 +1,14 @@
+---
+status: accepted
+---
+
+# Treat hard constraints as candidate vetoes
+
+Recommendation V2 treats every participant's Hard Constraint as a candidate-validity rule, not a ranking penalty. A movie that violates any participant's Hard Constraint cannot be recommended, and missing evidence counts as ineligible rather than assumed-safe. If no candidate is known to satisfy every Hard Constraint, PopChoice should report that no valid match exists and ask the participants to relax a constraint rather than silently violating one. This preserves trust at the cost of sometimes returning no recommendation.
+
+## Consequences
+
+- Ranking compares only candidates that satisfy every participant's Hard Constraints.
+- Missing or inconclusive evidence for a Hard Constraint excludes the candidate.
+- The product needs an explicit no-valid-match state and a way to revise constraints.
+- Inputs that cannot be evaluated reliably must not be presented as Hard Constraints.

--- a/docs/adr/0002-current-rewatch-intent-can-override-watched-memory.md
+++ b/docs/adr/0002-current-rewatch-intent-can-override-watched-memory.md
@@ -1,0 +1,13 @@
+---
+status: accepted
+---
+
+# Current rewatch intent can override watched memory
+
+A `watched` movie-memory signal excludes a movie by default but is not a Hard Constraint. Explicit Rewatch Intent for the current viewing occasion makes watched movies eligible again, allowing current intent to override historical viewing state without deleting that history. A `not_interested` signal remains excluded until the user explicitly corrects their movie memory.
+
+## Consequences
+
+- Candidate eligibility must distinguish current Hard Constraints from durable Memory Exclusions.
+- Rewatch Intent changes eligibility only for watched movies, not for every negative memory signal.
+- Movie memory remains truthful history even when current intent temporarily changes candidate selection.

--- a/docs/adr/0003-only-confirmed-structured-inputs-are-hard-constraints.md
+++ b/docs/adr/0003-only-confirmed-structured-inputs-are-hard-constraints.md
@@ -1,0 +1,14 @@
+---
+status: accepted
+---
+
+# Only confirmed structured inputs are hard constraints
+
+Recommendation V2 grants veto semantics only to structured constraints explicitly selected or confirmed by the participant. Free text may produce a Proposed Constraint, but it remains a Preference until confirmation; legacy text fields must not silently create Hard Constraints. This gives up some automatic interpretation in exchange for predictable filtering and an honest product promise.
+
+## Consequences
+
+- The recommendation request needs a typed Hard Constraint contract separate from free-text context.
+- The product may suggest a Proposed Constraint extracted from text, but must obtain confirmation before enforcing it.
+- Compatibility adapters can preserve legacy text as Preferences while callers migrate.
+- Eligibility filtering consumes confirmed structured values, not prompt wording or inferred string weights.

--- a/docs/adr/0004-participants-own-their-hard-constraints.md
+++ b/docs/adr/0004-participants-own-their-hard-constraints.md
@@ -1,0 +1,14 @@
+---
+status: accepted
+---
+
+# Participants own their hard constraints
+
+Each Hard Constraint belongs to the participant who confirmed it, and only that Constraint Owner may revise or remove it. A host may request reconsideration after a no-valid-match result but cannot override another participant's veto. This adds coordination steps to group recovery while preserving the meaning of participant confirmation and preventing host authority from silently weakening individual boundaries.
+
+## Consequences
+
+- Same-device flows must return control to the Constraint Owner for revision.
+- Room-backed flows must associate each Hard Constraint with a participant session.
+- Group constraint evaluation applies every participant's confirmed constraints regardless of who created the room.
+- A no-valid-match recovery flow may suggest changes but cannot apply them without the Constraint Owner's confirmation.

--- a/docs/adr/0005-keep-group-constraint-recovery-owner-private.md
+++ b/docs/adr/0005-keep-group-constraint-recovery-owner-private.md
@@ -1,0 +1,14 @@
+---
+status: accepted
+---
+
+# Keep group constraint recovery owner-private
+
+When no eligible group recommendation exists, the shared view shows a Shared Constraint Summary without identifying which participant owns each blocking constraint. Exact constraints and revision controls remain private to their Constraint Owner, who may choose to disclose or change them. This reduces the social transparency of recovery but avoids blaming participants or exposing potentially sensitive answers in shared and projector views.
+
+## Consequences
+
+- Shared result and projector surfaces show constraint categories, not owner names or private answers.
+- Each Constraint Owner needs a private Constraint Review path.
+- Hosts can request review and observe readiness but cannot inspect another participant's exact constraints by default.
+- Same-device flows should preserve the same privacy model even when privacy is procedural rather than technically isolated.

--- a/docs/adr/0006-use-tmdb-as-the-non-curated-candidate-universe.md
+++ b/docs/adr/0006-use-tmdb-as-the-non-curated-candidate-universe.md
@@ -1,0 +1,19 @@
+---
+status: accepted
+---
+
+# Use TMDB as the non-curated candidate universe
+
+Every recommendation mode except Curated Picks discovers candidates from the TMDB Candidate Universe. The Local Movie Cache accelerates and enriches retrieval but never gates whether TMDB is queried or defines the full set of possible movies. Curated Picks remains the deliberate exception because its bounded Curated Collection is part of that mode's product promise. This accepts TMDB availability and request-budget costs in exchange for avoiding the severe coverage ceiling of a DB-first recommendation system.
+
+## Consequences
+
+- Local candidate counts must not decide whether a non-curated mode may query TMDB.
+- Fast Pick, Normal Match, Taste Swipe, Duo, and Group all start from the same broad candidate universe even when their retrieval budgets differ.
+- A non-curated final ranking may only contain movies from the current TMDB Retrieval Set; local vector search cannot inject candidates that TMDB retrieval did not return.
+- A fresh TMDB Query Cache entry may satisfy a retrieval query without a live provider call; the candidate universe remains TMDB-derived.
+- The mere presence of local movie rows is not equivalent to a cached TMDB query and must not suppress provider retrieval.
+- Hard Constraints should shape TMDB discovery and be rechecked after enrichment before ranking.
+- Local embeddings, identity, movie memory, recommendation history, and cached metadata remain valuable enrichment and reranking inputs for matching TMDB IDs.
+- Raw TMDB discovery pages belong in the TMDB Query Cache and are not imported into the movie catalog.
+- Cache Admission is limited to enriched candidates that reach final ranking and movies shown as recommendations.

--- a/docs/adr/0007-derive-retrieval-from-audience-and-experience.md
+++ b/docs/adr/0007-derive-retrieval-from-audience-and-experience.md
@@ -1,0 +1,15 @@
+---
+status: accepted
+---
+
+# Derive retrieval from audience and experience
+
+Recommendation V2 exposes two product dimensions: Audience Context and Recommendation Experience. Candidate source is not a third user-facing axis; an internal Retrieval Plan is derived from the selected experience and audience to control query breadth, enrichment, compromise ranking, and latency. Curated Picks remains an experience with a deliberately bounded Curated Collection, while every other experience uses the TMDB Candidate Universe. This removes source-strategy complexity from the product contract while retaining operational control inside the recommendation system.
+
+## Consequences
+
+- Fast Pick, Normal Match, Taste Swipe, and Curated Picks are Recommendation Experiences rather than combinations of depth and source flags.
+- Solo, Duo, and Group remain orthogonal Audience Contexts.
+- Internal identifiers such as `hybrid-fast`, `tmdb-first`, and `compromise-hybrid` may survive as Retrieval Plan implementations but are not product concepts.
+- Persistence and eval reports should record Audience Context, Recommendation Experience, and the effective Retrieval Plan separately.
+- The Recommendation V2 epic should no longer describe candidate source as an independent product axis.

--- a/docs/adr/0008-bound-fast-pick-retrieval-not-its-candidate-universe.md
+++ b/docs/adr/0008-bound-fast-pick-retrieval-not-its-candidate-universe.md
@@ -1,0 +1,16 @@
+---
+status: accepted
+---
+
+# Bound Fast Pick retrieval, not its candidate universe
+
+Fast Pick uses the same TMDB Candidate Universe as other non-curated Recommendation Experiences, but applies Bounded Retrieval to protect its speed and cost promise. Its target is to return a result within five seconds, and it must stop Fast Pick work after eight seconds. If that bounded plan cannot find an Eligible Candidate, PopChoice does not silently widen the search. It presents the result honestly and offers Deepen Search, an explicit transition to Normal Match that preserves the participants' current answers, Hard Constraints, and Audience Context.
+
+## Consequences
+
+- Fast Pick is fast because it asks less and spends a smaller retrieval budget, not because it searches a smaller catalog.
+- Fast Pick metrics should measure the five-second target separately from the eight-second hard limit.
+- The system must distinguish “no eligible candidate found within this retrieval budget” from “no eligible candidate exists.”
+- Deepen Search reuses the current recommendation intent instead of starting a new questionnaire.
+- Metrics and evals should record the effective Retrieval Plan, whether Bounded Retrieval was exhausted, and whether the user chose Deepen Search.
+- The product must not silently change Recommendation Experience or incur Normal Match work while presenting the request as Fast Pick.

--- a/docs/adr/0009-distinguish-provider-degradation-from-no-match.md
+++ b/docs/adr/0009-distinguish-provider-degradation-from-no-match.md
@@ -1,0 +1,15 @@
+---
+status: accepted
+---
+
+# Distinguish provider degradation from no match
+
+When TMDB is unavailable, non-curated Recommendation Experiences may enter Degraded Retrieval using cached TMDB query results no older than seven days. Cached candidates must still be revalidated against every active Hard Constraint using available evidence. If the degraded path cannot produce enough Eligible Candidates, PopChoice reports technical unavailability. It must not claim that no matching movie exists or ask participants to relax constraints when provider failure prevented a trustworthy search.
+
+## Consequences
+
+- Provider failure, retrieval-budget exhaustion, and a completed no-match search are distinct outcomes in APIs, persistence, metrics, and UI copy.
+- Degraded Retrieval may use stale query results but does not turn the Local Movie Cache into a separate candidate universe.
+- Missing cached evidence for a Hard Constraint keeps a candidate ineligible.
+- Seven days is the maximum age for a degraded TMDB query result; normal freshness policy may be shorter.
+- Constraint Review is not shown solely because TMDB is unavailable.

--- a/docs/adr/0010-build-candidate-sets-from-multiple-tmdb-retrieval-lanes.md
+++ b/docs/adr/0010-build-candidate-sets-from-multiple-tmdb-retrieval-lanes.md
@@ -1,0 +1,17 @@
+---
+status: accepted
+---
+
+# Build candidate sets from multiple TMDB retrieval lanes
+
+A non-curated Retrieval Plan builds its TMDB Retrieval Set by unioning multiple bounded Retrieval Lanes rather than relying on one Discover request. The available lanes include constraint-aware Discover, Similar or Recommendations for a reference movie, and genre or keyword retrieval derived from current intent. Results are deduplicated by TMDB ID, enriched as required, revalidated against Hard Constraints, and only then ranked.
+
+Fast Pick and Normal Match use the same lane model and candidate universe. Fast Pick selects fewer lanes and gives them smaller page, enrichment, and timing budgets; Normal Match may explore more lanes more deeply.
+
+## Consequences
+
+- Retrieval breadth is an explicit part of the effective Retrieval Plan and must be observable.
+- A lane may fail without automatically invalidating the entire request if other lanes can still produce enough Eligible Candidates.
+- Hard Constraints shape each lane where TMDB supports them and are always rechecked after enrichment.
+- Duplicate movies from different lanes retain provenance so ranking and evals can inspect which intents retrieved them.
+- The system needs deterministic merge and budget-allocation rules rather than a sequential local-first fallback chain.

--- a/docs/adr/0011-bound-ai-to-resolvable-taste-query-proposals.md
+++ b/docs/adr/0011-bound-ai-to-resolvable-taste-query-proposals.md
@@ -1,0 +1,15 @@
+---
+status: accepted
+---
+
+# Bound AI to resolvable taste query proposals
+
+The Query Planner uses deterministic mappings for structured quiz answers and TMDB Similar or Recommendations endpoints for a resolved reference movie. Free-text intent may ask AI for taste-oriented genre or keyword Query Proposals, but every proposal must resolve to a real TMDB identifier before it can create a Retrieval Lane. AI does not generate candidate movie titles and cannot create or modify Hard Constraints.
+
+## Consequences
+
+- Maintained mappings from structured product answers to TMDB identifiers become versioned recommendation assets.
+- AI output for retrieval is structured, validated, and observable rather than treated as a free-form candidate list.
+- An unresolved Query Proposal is discarded without weakening confirmed constraints.
+- Prompt and model changes can affect taste expansion but cannot alter the candidate contract or constraint semantics.
+- Retrieval evals should distinguish deterministic lanes, reference-movie lanes, accepted Query Proposals, and rejected proposals.

--- a/docs/adr/0012-use-deterministic-shortlisting-before-ai-reranking.md
+++ b/docs/adr/0012-use-deterministic-shortlisting-before-ai-reranking.md
@@ -1,0 +1,15 @@
+---
+status: accepted
+---
+
+# Use deterministic shortlisting before AI reranking
+
+After retrieval and enrichment, PopChoice deterministically applies Hard Constraints and scores the remaining Eligible Candidates into a bounded Candidate Shortlist. AI may then rerank that shortlist and produce explanations, but it must return only supplied TMDB IDs. AI cannot introduce movie titles, restore an ineligible candidate, or change Hard Constraint outcomes. If AI is unavailable or its structured output is invalid, the deterministic shortlist order becomes the recommendation order.
+
+## Consequences
+
+- Candidate eligibility and fallback behavior remain testable without a live AI provider.
+- AI prompt changes affect ordering and explanation quality, not candidate membership or safety guarantees.
+- The shortlist contract must include stable TMDB IDs and enough normalized evidence for reranking and explanation.
+- Invalid, missing, duplicate, or out-of-set AI IDs trigger deterministic fallback behavior.
+- Evals should measure deterministic retrieval and shortlisting separately from AI reranking quality.

--- a/docs/adr/0013-rank-group-compromises-by-maximin-then-average.md
+++ b/docs/adr/0013-rank-group-compromises-by-maximin-then-average.md
@@ -1,0 +1,17 @@
+---
+status: accepted
+---
+
+# Rank group compromises by maximin, then average
+
+For Duo and Group, PopChoice calculates a Participant Score for every Eligible Candidate and participant. It ranks candidates lexicographically: first maximize the lowest Participant Score, then use the group average as a tie-breaker. Every participant has equal weight; the host receives no ranking priority. Hard Constraints remain eligibility vetoes applied before compromise scoring.
+
+## Consequences
+
+- A majority favorite that performs badly for one participant ranks below a broadly acceptable compromise.
+- Participant-level scoring must remain available through deterministic ranking and AI reranking inputs.
+- Shared results use a Group Fit Explanation without participant names, preference attribution, or numeric Participant Scores.
+- Detailed Participant Scores remain internal to evals and observability in v1.
+- Group evals need explicit fairness checks for the least-satisfied participant, not only aggregate relevance.
+- Adding participants may legitimately change the winner even when the group's average preference remains similar.
+- AI reranking must preserve the maximin fairness contract or be rejected in favor of deterministic order.

--- a/docs/adr/0014-select-alternatives-for-diversity-after-the-primary-pick.md
+++ b/docs/adr/0014-select-alternatives-for-diversity-after-the-primary-pick.md
@@ -1,0 +1,15 @@
+---
+status: accepted
+---
+
+# Select alternatives for diversity after the primary pick
+
+PopChoice selects the Primary Pick as the highest-ranked Eligible Candidate after deterministic scoring and any valid AI Reranking. It then selects Alternative Picks with a diversity-aware policy across genre, era, and discovery familiarity instead of returning the next candidates by score alone. Every alternative must still satisfy all Hard Constraints and a minimum acceptable fit; diversity cannot rehabilitate a weak or ineligible candidate.
+
+## Consequences
+
+- Primary ranking quality and alternative-set usefulness are separate eval dimensions.
+- Alternative selection runs after the Primary Pick and must not change it.
+- Diversity logic needs normalized genre, release-era, and familiarity evidence.
+- The system should avoid near-duplicate alternatives even when they occupy adjacent score positions.
+- The exact diversity tradeoff and minimum fit remain calibratable policy values rather than AI discretion.

--- a/docs/adr/0015-separate-candidate-eligibility-from-recommendation-quality.md
+++ b/docs/adr/0015-separate-candidate-eligibility-from-recommendation-quality.md
@@ -1,0 +1,15 @@
+---
+status: accepted
+---
+
+# Separate candidate eligibility from recommendation quality
+
+Hard Constraints determine whether a movie is an Eligible Candidate. A separate Recommendation Quality Gate determines whether an eligible movie is a Confident Match worth presenting. If no candidate passes the gate, PopChoice does not force a recommendation by returning the best of a weak set. Fast Pick offers Deepen Search; Normal Match asks participants to refine Preferences. Quality thresholds are calibrated through evals for each Audience Context and Recommendation Experience and are not chosen or overridden by AI.
+
+## Consequences
+
+- Eligibility rate and confident-match rate are separate metrics.
+- A completed retrieval can return eligible candidates without producing a recommendation.
+- APIs and persisted results need a distinct low-confidence outcome separate from provider degradation, retrieval-budget exhaustion, and constraint no-match.
+- Eval fixtures must include weak-but-eligible candidate sets that fail the gate.
+- Threshold changes are versioned ranking policy changes and require regression evaluation.

--- a/docs/adr/0016-allow-one-targeted-preference-refinement.md
+++ b/docs/adr/0016-allow-one-targeted-preference-refinement.md
@@ -1,0 +1,15 @@
+---
+status: accepted
+---
+
+# Allow one targeted preference refinement
+
+When Normal Match completes retrieval but no Eligible Candidate passes the Recommendation Quality Gate, PopChoice may ask one targeted Preference Refinement question. It preserves the current Audience Context, all prior answers, and every Hard Constraint, then performs one new retrieval and ranking attempt. If the second attempt still yields no Confident Match, the experience ends honestly without a recommendation and offers manual answer editing. It does not restart the quiz, silently relax constraints, or enter an unbounded clarification loop.
+
+## Consequences
+
+- The low-confidence result must identify one useful ambiguity or missing high-impact Preference.
+- Recommendation intent needs a new revision while preserving provenance from the original request.
+- Metrics should distinguish first-pass success, refinement offered, refinement accepted, and second-pass success.
+- The refinement answer may change Preferences and Retrieval Lanes but not participant-owned Hard Constraints.
+- A second failed quality gate produces a terminal no-confident-match state for that attempt.

--- a/docs/adr/0017-use-adaptive-signal-readiness-for-taste-swipe.md
+++ b/docs/adr/0017-use-adaptive-signal-readiness-for-taste-swipe.md
@@ -1,0 +1,15 @@
+---
+status: accepted
+---
+
+# Use adaptive signal readiness for Taste Swipe
+
+Taste Swipe does not complete after a fixed number of displayed cards. Seen, Loved It, Not for Me, and Maybe Tonight are Informative Swipe Reactions; Skip advances the deck without contributing taste evidence. A participant may request a recommendation after eight informative reactions. PopChoice may suggest completion between eight and twelve when the accumulated evidence is sufficient, and twelve informative reactions establish Swipe Readiness for retrieval.
+
+## Consequences
+
+- Card impressions, skipped cards, and informative reactions are separate metrics.
+- The deck may need to show more than twelve cards when a participant frequently skips.
+- Readiness evaluation must inspect signal coverage, not only count reactions.
+- Anonymous session state must preserve reaction identity and order until the recommendation attempt completes.
+- Recommendation Quality Gate still determines whether a ready swipe session produces a Confident Match.

--- a/docs/adr/0018-give-each-taste-swipe-reaction-distinct-semantics.md
+++ b/docs/adr/0018-give-each-taste-swipe-reaction-distinct-semantics.md
@@ -1,0 +1,17 @@
+---
+status: accepted
+---
+
+# Give each Taste Swipe reaction distinct semantics
+
+Taste Swipe reactions are not values on one generic like-dislike scale. Seen excludes the exact movie from the current attempt without taste valence. Loved It contributes strong positive taste evidence, marks the movie as watched, and excludes it from the current attempt. Not for Me contributes strong negative evidence and excludes the movie. Maybe Tonight contributes strong current positive evidence while keeping that movie eligible for recommendation. Skip only advances the deck and creates no taste or movie-memory evidence.
+
+Signed-in reactions may persist through the corresponding movie-memory representation. Anonymous reactions remain session-local for the recommendation attempt.
+
+## Consequences
+
+- Recommendation inputs must preserve reaction type rather than collapsing reactions to one numeric value too early.
+- Loved It requires both positive evidence and exact-movie exclusion.
+- Maybe Tonight is the only positive swipe reaction that keeps the reacted movie eligible for the current result.
+- Skip may suppress immediate card repetition inside the session but must not become durable memory or ranking evidence.
+- Movie-memory persistence needs to represent the reaction semantics without losing the distinction between durable taste and current intent.

--- a/docs/adr/0019-scope-taste-swipe-mvp-to-solo.md
+++ b/docs/adr/0019-scope-taste-swipe-mvp-to-solo.md
@@ -1,0 +1,15 @@
+---
+status: accepted
+---
+
+# Scope Taste Swipe MVP to Solo
+
+The first Taste Swipe release supports only the Solo Audience Context for both anonymous and signed-in participants. Signed-in persistence is a follow-up slice built on the same reaction semantics. Duo and Group swipe experiences are excluded because they require explicit interaction ownership, privacy, turn-taking, and compromise-scoring product decisions. The domain model should preserve participant ownership so a later Group Swipe can extend it without redefining reaction semantics.
+
+## Consequences
+
+- Issue #920 must not imply Duo or Group acceptance criteria.
+- Issue #923 adds signed-in persistence without changing the Solo card interaction.
+- Audience and experience remain separate domain concepts even though the MVP compatibility matrix does not expose every combination.
+- Group Swipe needs its own design and implementation issue before it becomes a supported Recommendation Experience combination.
+- MVP browser coverage includes anonymous Solo and later signed-in Solo, not pass-the-phone or shared voting.

--- a/docs/adr/0020-use-a-diagnostic-then-adaptive-taste-swipe-deck.md
+++ b/docs/adr/0020-use-a-diagnostic-then-adaptive-taste-swipe-deck.md
@@ -1,0 +1,15 @@
+---
+status: accepted
+---
+
+# Use a diagnostic then adaptive Taste Swipe deck
+
+Taste Swipe begins with a Diagnostic Deck stratified across genre, era, popularity, and mainstream-to-niche familiarity. Its purpose is to gather broad taste evidence, not to preview the final Candidate Shortlist. After enough reactions, the experience transitions to an Adaptive Deck shaped by observed taste while reserving an exploration share for uncertain or uncovered preferences. A card's presence in either deck does not itself increase that movie's recommendation score.
+
+## Consequences
+
+- Deck selection and recommendation retrieval are separate policies with separate evals.
+- The opening deck requires maintained coverage buckets rather than a single popularity sort.
+- Adaptive selection needs reaction-derived taste clusters plus explicit exploration accounting.
+- Exploration Cards should be purposeful and observable, not indistinguishable random noise.
+- Deck exposure alone creates no Preference, movie-memory, or ranking signal.

--- a/docs/adr/0021-include-maybe-tonight-as-direct-intent-without-guaranteeing-it.md
+++ b/docs/adr/0021-include-maybe-tonight-as-direct-intent-without-guaranteeing-it.md
@@ -1,0 +1,15 @@
+---
+status: accepted
+---
+
+# Include Maybe Tonight as direct intent without guaranteeing it
+
+A Maybe Tonight Reaction adds that movie to the current TMDB Retrieval Set as a Direct Intent Candidate even if no other Retrieval Lane returns it. Direct inclusion does not guarantee selection: the movie must satisfy every Hard Constraint, pass the Recommendation Quality Gate, and compete in ordinary ranking against other candidates. Multiple Maybe Tonight movies follow the same comparison.
+
+## Consequences
+
+- The retrieval merge must preserve direct-intent provenance for the reacted TMDB ID.
+- A Direct Intent Candidate cannot be dropped merely because lane budgets are full.
+- Ineligible or low-quality direct-intent movies need an honest explanation rather than silent disappearance.
+- Maybe Tonight strength is a ranking input, not an eligibility override.
+- Evals should cover direct-intent wins, losses, hard-constraint rejection, and quality-gate rejection.

--- a/docs/adr/0022-store-watch-and-taste-as-independent-movie-memory-dimensions.md
+++ b/docs/adr/0022-store-watch-and-taste-as-independent-movie-memory-dimensions.md
@@ -1,0 +1,17 @@
+---
+status: accepted
+---
+
+# Store watch and taste as independent movie-memory dimensions
+
+Movie memory stores Watch Status and Taste Status as independent dimensions rather than one mutually exclusive interaction kind. Loved It sets Watch Status to Seen and Taste Status to Liked. Seen sets only Watch Status. Not for Me sets Taste Status to Not Interested and excludes the exact movie according to current memory policy. Maybe Tonight remains session-scoped current intent rather than durable memory. Wrong Mood is Occasion Feedback and does not become a permanent Taste Status by itself.
+
+Existing single-kind records must migrate without losing their known meaning.
+
+## Consequences
+
+- The current one-row, one-`kind` schema cannot remain the canonical movie-memory contract.
+- APIs and UI filters must allow watch and taste facts to coexist for the same movie.
+- Existing `watched` and `not_seen` rows map to Watch Status; `liked` and `not_interested` map to Taste Status; `wrong_mood` remains occasion-scoped evidence.
+- Candidate filtering reads exact-movie exclusions independently from taste similarity signals.
+- Current intent can override an allowed Memory Exclusion without rewriting durable memory.

--- a/docs/adr/0023-project-current-movie-memory-from-immutable-events.md
+++ b/docs/adr/0023-project-current-movie-memory-from-immutable-events.md
@@ -1,0 +1,16 @@
+---
+status: accepted
+---
+
+# Project current movie memory from immutable events
+
+Signed-in movie-memory changes are recorded as immutable Movie Memory Events carrying source, occurrence time, and available session or recommendation provenance. A Movie Memory Snapshot projects the current Watch Status and Taste Status for each user and movie and serves latency-sensitive product reads. A user correction appends a new event and updates the snapshot instead of overwriting the only historical fact. Existing interaction rows migrate into baseline events and equivalent snapshots.
+
+## Consequences
+
+- Recommendation reads do not need to replay the full event history.
+- Projection rules can evolve and snapshots can be rebuilt from events.
+- Event writes and snapshot updates require transactional consistency or an explicitly recoverable projection path.
+- APIs that mutate movie memory must record source and preserve movie identity by TMDB ID where available.
+- Account deletion must remove both events and snapshots.
+- Anonymous session reactions are not Movie Memory Events unless attached to a signed-in participant.

--- a/docs/adr/0024-keep-anonymous-taste-swipe-ephemeral-until-first-value.md
+++ b/docs/adr/0024-keep-anonymous-taste-swipe-ephemeral-until-first-value.md
@@ -1,0 +1,17 @@
+---
+status: accepted
+---
+
+# Keep anonymous Taste Swipe ephemeral until first value
+
+Anonymous Taste Swipe is a no-account path from reactions to one stable recommendation. Its purpose is to solve cold start, remove signup friction before first value, and let PopChoice evaluate the swipe experience independently of accumulated account memory. The working Anonymous Swipe Session is resumable for at most 24 hours. When recommendation processing begins, PopChoice creates a minimized Recommendation Intent Snapshot containing TMDB IDs, normalized signal types, and policy version, then deletes the working session. Expiry also deletes an unfinished session.
+
+Anonymous use does not create Movie Memory Events, a Movie Memory Snapshot, or an implicit profile.
+
+## Consequences
+
+- Issue #920 remains valuable as the proof of the complete swipe-to-result loop without an account dependency.
+- Long-term personalization remains the responsibility of signed-in persistence in issue #923.
+- The completed result may remain stable without retaining UI action order or the anonymous session token.
+- Signup is offered after first value as a way to save useful reactions, not required before recommendation.
+- Anonymous session storage needs TTL enforcement and data-minimization tests.

--- a/docs/adr/0025-require-explicit-consent-to-adopt-anonymous-swipe-memory.md
+++ b/docs/adr/0025-require-explicit-consent-to-adopt-anonymous-swipe-memory.md
@@ -1,0 +1,15 @@
+---
+status: accepted
+---
+
+# Require explicit consent to adopt anonymous swipe memory
+
+After an anonymous participant receives a result and creates an account, PopChoice may offer an explicit “Save my taste” Memory Adoption action. Seen, Loved It, and Not for Me become signed-in Movie Memory Events using their established Watch Status and Taste Status semantics. Maybe Tonight remains occasion-scoped and Skip remains non-evidence. Without explicit action, no anonymous reaction is attached to the account. Adoption is one-time and idempotent.
+
+## Consequences
+
+- Signup alone does not authorize importing anonymous reaction data.
+- The adoption token must be short-lived, scoped to one anonymous session, and unusable after successful import.
+- Repeated requests cannot create duplicate Movie Memory Events or change the resulting snapshot.
+- UI copy must distinguish account creation from optional taste-memory import.
+- Audit and privacy tests should prove that Maybe Tonight and Skip never enter durable movie memory through adoption.

--- a/docs/adr/0026-keep-curated-picks-inside-an-editorial-collection.md
+++ b/docs/adr/0026-keep-curated-picks-inside-an-editorial-collection.md
@@ -1,0 +1,15 @@
+---
+status: accepted
+---
+
+# Keep Curated Picks inside an editorial collection
+
+Curated Picks is an editorial Recommendation Experience in which the participant explicitly selects a named Curated Collection. That collection is the complete candidate universe for the attempt. Preferences and movie memory may reorder its movies, and Hard Constraints may remove movies, but retrieval never adds candidates from TMDB or another collection. If no movie remains, PopChoice reports a Collection Mismatch and offers another collection or an explicit transition to Normal Match.
+
+## Consequences
+
+- Curated Picks must not share non-curated TMDB Retrieval Plans.
+- Collection membership and editorial intent are product data, not cache state.
+- Personalization can change ordering but cannot undermine the collection's promise.
+- Collection Mismatch is distinct from provider degradation, quality-gate failure, and non-curated constraint no-match.
+- Switching to Normal Match creates a new explicit experience attempt while preserving compatible participant constraints.

--- a/docs/adr/0027-version-curated-collections-through-a-publish-lifecycle.md
+++ b/docs/adr/0027-version-curated-collections-through-a-publish-lifecycle.md
@@ -1,0 +1,17 @@
+---
+status: accepted
+---
+
+# Version curated collections through a publish lifecycle
+
+Curated Collections are versioned Backoffice entities. Editors prepare a Draft Collection Version, preview it, and publish it. A Published version is immutable and serves new Curated Picks attempts. Further editorial changes create a new Draft and eventually a new Published version. Archived versions cannot start new attempts but remain addressable so historical recommendation results reproduce the exact collection contract they used.
+
+Collection membership uses TMDB IDs. Each version carries localized title, description, and editorial rationale alongside its ordered membership.
+
+## Consequences
+
+- Curated recommendation records persist the exact Collection Version identifier.
+- Backoffice needs draft editing, preview, publish, archive, and version-history capabilities.
+- Publishing is an explicit state transition rather than an in-place update.
+- Local movie-cache rows may enrich collection items but do not define collection identity or membership.
+- Localization changes to published editorial copy require a new Collection Version.

--- a/docs/adr/0028-snapshot-required-tmdb-metadata-when-publishing-collections.md
+++ b/docs/adr/0028-snapshot-required-tmdb-metadata-when-publishing-collections.md
@@ -1,0 +1,17 @@
+---
+status: accepted
+---
+
+# Snapshot required TMDB metadata when publishing collections
+
+Publishing a Collection Version resolves every member by TMDB ID and materializes a Collection Metadata Snapshot containing the identity, runtime, genres, title, year, poster metadata, and localized display data required for Curated Picks. Missing movies, duplicate TMDB IDs, or missing evidence required to evaluate supported Hard Constraints block publication. Runtime Curated Picks reads the immutable snapshot and does not require live TMDB.
+
+Refreshing changed TMDB metadata produces a new Collection Version instead of mutating a published snapshot.
+
+## Consequences
+
+- Draft preview can expose unresolved or incomplete items, while publish validation cannot.
+- Curated Picks remains available during TMDB provider outages.
+- Published collection membership and constraint evidence are reproducible together.
+- Backoffice needs explicit validation errors per collection item.
+- Poster or localization refreshes are versioned editorial changes for published collections.

--- a/docs/adr/0029-version-the-effective-policy-of-every-recommendation-attempt.md
+++ b/docs/adr/0029-version-the-effective-policy-of-every-recommendation-attempt.md
@@ -1,0 +1,15 @@
+---
+status: accepted
+---
+
+# Version the effective policy of every recommendation attempt
+
+Every Recommendation Attempt persists a Policy Version Bundle identifying the Query Planner mappings, effective Retrieval Plan, deterministic ranking, Result Diversity, Recommendation Quality Gate, active model IDs, and any Collection Version used. The attempt also retains its normalized Recommendation Intent Snapshot and final TMDB IDs. Policy identifiers and configuration hashes are stored instead of copying implementation source.
+
+## Consequences
+
+- Results and eval regressions can be attributed to specific policy or model changes.
+- Retries with a changed policy become new Recommendation Attempts rather than mutating historical execution context.
+- Model aliases should record the resolved response model where available in addition to the requested ID.
+- Analytics dimensions must avoid unbounded raw configuration labels; stable version identifiers belong in metrics and full hashes belong in persisted traces.
+- Policy changes require an explicit version bump and representative eval comparison.

--- a/docs/adr/0030-persist-bounded-candidate-traces-and-sample-full-debug-traces.md
+++ b/docs/adr/0030-persist-bounded-candidate-traces-and-sample-full-debug-traces.md
@@ -1,0 +1,15 @@
+---
+status: accepted
+---
+
+# Persist bounded candidate traces and sample full debug traces
+
+Every Recommendation Attempt persists a Bounded Candidate Trace with each Retrieval Lane's query identity, candidate counts, filter counts, and rejection categories. Detailed eligibility evidence and score breakdowns are retained only for the Candidate Shortlist and displayed results. Raw TMDB pages are not copied into recommendation history. A sampled Debug Candidate Trace may retain the complete candidate progression for troubleshooting and calibration, but it has a short TTL.
+
+## Consequences
+
+- Ordinary recommendation storage grows with lane and shortlist size rather than raw provider result volume.
+- Operators can distinguish retrieval scarcity, hard-constraint rejection, quality-gate rejection, and ranking outcomes.
+- Debug sampling rate and TTL are operational configuration recorded outside high-cardinality metrics labels.
+- Sensitive free text should be referenced through the minimized intent snapshot rather than duplicated across trace rows.
+- Expired debug traces do not affect the reproducibility of durable policy and shortlist decisions.

--- a/docs/adr/0031-block-recommendation-v2-release-on-invariants-and-measured-quality.md
+++ b/docs/adr/0031-block-recommendation-v2-release-on-invariants-and-measured-quality.md
@@ -1,0 +1,17 @@
+---
+status: accepted
+---
+
+# Block Recommendation V2 release on invariants and measured quality
+
+Recommendation V2 cannot roll out unless its Release Gate passes. Hard Constraint enforcement, supplied-TMDB-ID membership, privacy boundaries, and deterministic fallback behavior must pass at 100%. The deterministic recommendation eval must show no regression from the current baseline and cover required Solo, Duo, Group, no-match, provider-degradation, Fast Pick budget, and Taste Swipe scenarios. Live-provider evaluation and manual product QA are required release evidence but remain scheduled or manual rather than flaky CI jobs.
+
+Numeric relevance and fairness thresholds are set only after measuring representative baselines; they are not invented during architecture planning.
+
+## Consequences
+
+- Invariant failures cannot be traded for higher average relevance scores.
+- Baseline capture is an implementation prerequisite before policy tuning.
+- Deterministic evals remain the CI-blocking layer; live-provider runs report evidence separately.
+- Release evidence records the effective Policy Version Bundle and model IDs.
+- Threshold calibration becomes a versioned, reviewable artifact linked to issue #606.

--- a/docs/adr/0032-use-controlled-comparisons-for-a-zero-traffic-rollout.md
+++ b/docs/adr/0032-use-controlled-comparisons-for-a-zero-traffic-rollout.md
@@ -1,0 +1,17 @@
+---
+status: accepted
+---
+
+# Use controlled comparisons for a zero-traffic rollout
+
+PopChoice does not have enough user traffic to produce meaningful shadow-run or percentage-rollout evidence. Recommendation V2 therefore uses a Recommendation Comparison Harness to run deterministic personas, saved provider scenarios, and manual dogfood intents through V1 and V2 with trace and quality comparison. After the Release Gate passes, V2 becomes the default. V1 remains temporarily available through a Recommendation Kill Switch for rapid rollback.
+
+Percentage rollout, experiment allocation, and traffic-based statistical infrastructure are deferred until real usage can support them.
+
+## Consequences
+
+- The project does not build an A/B system for portfolio appearance without statistical value.
+- Comparison evidence must be reproducible and tied to both pipelines' Policy Version Bundles.
+- Backoffice should make candidate, invariant, quality, fairness, latency, and provider differences inspectable.
+- V1 and V2 dual maintenance has a planned end date after V2 stability is demonstrated.
+- Dogfood observations remain qualitative evidence and must not be presented as user-traffic outcomes.

--- a/docs/adr/0033-use-normal-match-solo-as-the-first-v2-tracer-slice.md
+++ b/docs/adr/0033-use-normal-match-solo-as-the-first-v2-tracer-slice.md
@@ -1,0 +1,17 @@
+---
+status: accepted
+---
+
+# Use Normal Match Solo as the first V2 tracer slice
+
+After issue #606 establishes the executable Release Gate and V1 comparison baseline, the first end-to-end Recommendation V2 implementation is Normal Match for the Solo Audience Context. The slice includes normalized intent, typed Hard Constraints, multi-lane TMDB retrieval, deterministic shortlisting, bounded AI Reranking with fallback, Recommendation Quality Gate, Bounded Candidate Trace, and comparison against V1.
+
+Fast Pick, Duo and Group compromise, Taste Swipe, and Curated Picks remain later slices built on the proven core.
+
+## Consequences
+
+- The tracer validates broad recommendation quality without initially carrying Fast Pick's eight-second hard budget.
+- Solo avoids group fairness and privacy mechanics while preserving the same candidate and policy architecture.
+- The slice must be user-complete and comparable, not only a set of internal interfaces.
+- Fast Pick becomes a bounded Retrieval Plan over the same core instead of a separate pipeline.
+- Ticket dependencies should place #606 before the Normal Match Solo V2 implementation issue.

--- a/docs/adr/0034-version-recommendation-intent-within-the-existing-api-lifecycle.md
+++ b/docs/adr/0034-version-recommendation-intent-within-the-existing-api-lifecycle.md
@@ -1,0 +1,15 @@
+---
+status: accepted
+---
+
+# Version recommendation intent within the existing API lifecycle
+
+Recommendation V2 continues to use `POST /api/recommendations` and the existing persisted status, polling, result, feedback, and stable-link lifecycle. UI-specific payloads are adapted into a versioned Canonical Recommendation Intent. Each Recommendation Attempt persists its Recommendation Engine Version and Policy Version Bundle. The temporary Recommendation Kill Switch changes internal engine routing without changing the client endpoint or result URL contract.
+
+## Consequences
+
+- A separate `/api/v2` route is not required for the recommendation-engine migration.
+- Quiz, Taste Swipe, and future clients share one canonical domain contract through input adapters.
+- Engine-specific execution data stays behind the feature boundary rather than leaking into route components.
+- Existing result links remain readable after V1 retirement because attempts retain engine and policy provenance.
+- Public response compatibility and internal semantic versioning require separate tests.

--- a/docs/adr/0035-opt-ui-flows-into-v2-through-versioned-intent.md
+++ b/docs/adr/0035-opt-ui-flows-into-v2-through-versioned-intent.md
@@ -1,0 +1,15 @@
+---
+status: accepted
+---
+
+# Opt UI flows into V2 through versioned intent
+
+During migration, only a Canonical Recommendation Intent with `intentVersion: 2` runs Recommendation V2. Existing quiz payloads continue to route to V1 through the Legacy Intent Adapter. Each UI flow adopts V2 deliberately. The adapter never promotes legacy free text into Hard Constraints. After every supported flow emits canonical intent and the rollback window closes, PopChoice removes V1 engine routing and the legacy adapter.
+
+## Consequences
+
+- V1/V2 comparisons use explicit engine selection rather than inferred request shape.
+- Semantic changes cannot silently affect old clients or partially migrated UI flows.
+- The V2 Tracer Slice includes its UI-to-intent adapter, not only engine internals.
+- Legacy compatibility has an explicit deletion condition and is not a permanent architecture layer.
+- Tests cover routing for missing, supported, and unsupported intent versions.


### PR DESCRIPTION
## What changed

- add the accepted Recommendation V2 ubiquitous language in `CONTEXT.md`
- add 35 focused ADRs covering constraints, TMDB-first retrieval, ranking, quality gates, group fairness, Taste Swipe, movie memory, Curated Picks, trace/versioning, and zero-traffic rollout
- add an issue-linked delivery plan for milestones v0.3.0 and v0.4.0

## Why

The previous roadmap mixed audience, match depth, and candidate source while the local DB could still gate recommendation coverage. This design makes TMDB the non-curated candidate universe, treats the local database as cache/enrichment, separates eligibility from quality, and gives each product experience an explicit policy contract.

The tracker has been synchronized under epic #610, including new issues #926–#934 and updated #606, #608, #613, #920, and #923.

## Impact

This PR is documentation-only. It establishes the domain and dependency contract for implementation; it does not change runtime behavior.

## Validation

- `npx --yes oxfmt@0.58.0 --check CONTEXT.md docs/RECOMMENDATION-V2-PLAN.md docs/adr`
- `git diff --cached --check`
